### PR TITLE
removed the duplicate label key on the default props

### DIFF
--- a/components/SLDSDropdownBase/index.jsx
+++ b/components/SLDSDropdownBase/index.jsx
@@ -35,7 +35,6 @@ module.exports = React.createClass( {
 
   getDefaultProps(){
     return {
-      label:'Button',
       variant:'neutral',
       placeholder: 'Select an Option',
       disabled: false,


### PR DESCRIPTION
This was causing our strict js parser to throw a fatal error.

@madpotato, who should I get to review and merge?
