### PR TITLE
access React.Proptypes.boolean in a safe manner

### DIFF
--- a/components/SLDSLookup/index.jsx
+++ b/components/SLDSLookup/index.jsx
@@ -289,8 +289,8 @@ SLDSLookup.propTypes = {
   onItemSelect: React.PropTypes.func,
   onNewItem: React.PropTypes.func,
   onSearchRecords: React.PropTypes.func,
-  modal: React.PropTypes.boolean,
-  disabled: React.PropTypes.boolean,
+  modal: React.PropTypes["boolean"],
+  disabled: React.PropTypes["boolean"],
 };
 
 SLDSLookup.defaultProps = {


### PR DESCRIPTION
Me again. This was causing the parser problems as well. Fixing it as well. @madpotato 
