### PR TITLE
A11y tweaks

### DIFF
--- a/components/SLDSModal/index.jsx
+++ b/components/SLDSModal/index.jsx
@@ -210,10 +210,10 @@ module.exports = React.createClass( {
     if(hasHeader) {
       header = (
         <div className={cx(headerClass)}>
+          <SLDSButton label='Close' variant='icon-inverse' iconName='close' iconSize='large' className='slds-modal__close' onClick={this.closeModal} />
           {this.props.toast}
           <h2 className={cx(titleClass)}>{this.props.title}</h2>
           {this.props.tagline ? <p className="slds-m-top--x-small">{this.props.tagline}</p>:null}
-          <SLDSButton label='Close' variant='icon-inverse' iconName='close' iconSize='large' className='slds-modal__close' onClick={this.closeModal} />
         </div>
       )
     }else{


### PR DESCRIPTION
- Allow NVDA to enter document mode where reading keys work (with `role='document'`), because `role='dialog'` should contain only form controls which causes NVDA gets into "Form" mode. Note that they still need to hit "tab" once to enter reading mode, but it's better than nothing.
- Close button should usually be first to allow the user to go back to the previous focus quickly if they opened the modal by mistake

Note that I will propagate these changes to the SLDS tomorrow (/cc @stefsullrew).
