### PR TITLE
Set modal role back to dialog

### DIFF
--- a/components/SLDSModal/index.jsx
+++ b/components/SLDSModal/index.jsx
@@ -131,7 +131,7 @@ module.exports = React.createClass( {
             onClick={this.isPrompt() ? undefined : this.closeModal}
           >
           <div
-            role='document'
+            role='dialog'
             className='slds-modal__container'
             onClick={this.handleModalClick}
             >


### PR DESCRIPTION
This is following a discussion with Jesse Hausler, Principal Accessibility Specialist, who recommends `role="dialog"` instead of `role="document"`.
