### PR TITLE
Added isRequired to required props for Icon

### DIFF
--- a/lib/SLDSIcons/Icon/index.js
+++ b/lib/SLDSIcons/Icon/index.js
@@ -41,16 +41,16 @@ var propTypes = {
    * declare this prop as assistiveText="".
    */
   assistiveText: _react2['default'].PropTypes.string,
-  category: _react2['default'].PropTypes.oneOf(["action", "custom", "doctype", "standard", "utility"]),
+  category: _react2['default'].PropTypes.oneOf(["action", "custom", "doctype", "standard", "utility"]).isRequired,
   /**
    * css classes that are applied to the svg
    */
-  className: _react2['default'].PropTypes.string,
+  className: _react2['default'].PropTypes.string.isRequired,
   /**
    * name of the icon. Visit <a href="http://www.lightningdesignsystem.com/resources/icons">Lightning Design System - Icons</a> to reference icon names.
    */
-  name: _react2['default'].PropTypes.string,
-  size: _react2['default'].PropTypes.oneOf(["x-small", "small", "large"])
+  name: _react2['default'].PropTypes.string.isRequired,
+  size: _react2['default'].PropTypes.oneOf(["x-small", "small", "large"]).isRequired
 };
 var defaultProps = {
   category: 'standard'


### PR DESCRIPTION
@madpotato @donnieberg

It makes sense to specify when prop types are required so the dev can be warned. I started with Icon.

Happy to continue with the other components once you peeps concur!

Donielle - should we also add this to the prop table? I think it'd be useful.
