### PR TITLE
Revert "Added isRequired to required props for Icon"

### DIFF
--- a/lib/SLDSIcons/Icon/index.js
+++ b/lib/SLDSIcons/Icon/index.js
@@ -41,16 +41,16 @@ var propTypes = {
    * declare this prop as assistiveText="".
    */
   assistiveText: _react2['default'].PropTypes.string,
-  category: _react2['default'].PropTypes.oneOf(["action", "custom", "doctype", "standard", "utility"]).isRequired,
+  category: _react2['default'].PropTypes.oneOf(["action", "custom", "doctype", "standard", "utility"]),
   /**
    * css classes that are applied to the svg
    */
-  className: _react2['default'].PropTypes.string.isRequired,
+  className: _react2['default'].PropTypes.string,
   /**
    * name of the icon. Visit <a href="http://www.lightningdesignsystem.com/resources/icons">Lightning Design System - Icons</a> to reference icon names.
    */
-  name: _react2['default'].PropTypes.string.isRequired,
-  size: _react2['default'].PropTypes.oneOf(["x-small", "small", "large"]).isRequired
+  name: _react2['default'].PropTypes.string,
+  size: _react2['default'].PropTypes.oneOf(["x-small", "small", "large"])
 };
 var defaultProps = {
   category: 'standard'


### PR DESCRIPTION
Reverts salesforce-ux/design-system-react#105

@madpotato @rickschmoo I have to revert this one because only "name" and "category" are required in the Icon. The size defaults to medium (medium icons are the base icon to be consistent with SLDS). And className isn't required.
