### PR TITLE
Lookup: new props to control modal menu position

### DIFF
--- a/components/SLDSLookup/index.jsx
+++ b/components/SLDSLookup/index.jsx
@@ -61,6 +61,14 @@ const propTypes = {
    * If true, component renders specifically to work inside Modal.
    */
   modal: React.PropTypes.bool,
+  /**
+   * If true, constrains the menu to the scroll parent. Has no effect if modal is false.
+   */
+  constrainToScrollParent: React.PropTypes.bool,
+  /**
+   * If true, the menu is constrained to the window and may be flipped up. Has no effect if modal is false.
+   */
+  flippable: React.PropTypes.bool,
   onBlur: React.PropTypes.func,
   onChange: React.PropTypes.func,
   onSelect: React.PropTypes.func,
@@ -96,6 +104,8 @@ const defaultProps = {
   modal: false,
   required: false,
   searchTerm: "",
+  constrainToScrollParent: true,
+  flippable: false,
 };
 
 
@@ -388,8 +398,8 @@ class SLDSLookup extends React.Component {
       inheritTargetWidth={true}
       closeOnTabKey={true}
       onClose={this.handleCancel.bind(this)}
-      flippable={false}
-      constrainToScrollParent={true}
+      flippable={this.props.flippable}
+      constrainToScrollParent={this.props.constrainToScrollParent}
       targetElement={targetElem}>
       {this.renderMenuContent()}
       </SLDSPopover>;


### PR DESCRIPTION
@madpotato, @donnieberg , please review.
This is for issue #214 

I'm not sure how to best call the props. Maybe their name have to be prefixed with `modalMenu` or something like that.
