### PR TITLE
Add functionality for Lookup onSelect callback prop to block clicking items

### DIFF
--- a/components/SLDSLookup/index.jsx
+++ b/components/SLDSLookup/index.jsx
@@ -207,13 +207,16 @@ class SLDSLookup extends React.Component {
 
   selectItemByIndex(index){
     if(index >= 0 && index < this.state.items.length){
-      this.setState({
-        selectedIndex: index,
-        searchTerm: ""
-      });
+      let canSelect = true
       const data = this.state.items[index].data;
       if(this.props.onSelect){
-        this.props.onSelect(data);
+        canSelect = this.props.onSelect(data);
+      }
+      if(canSelect !== false){
+        this.setState({
+          selectedIndex: index,
+          searchTerm: ""
+        });
       }
     }
   }


### PR DESCRIPTION
This is the PR for #240. Simply first fire the callback and if it returns not false (undefined is allowed to allow for the maximum compatibility with probable existing code), then go ahead with updating state. This is much nicer than capturing a click event and stopping propagation somewhere before in the event propagation chain.

@madpotato @donnieberg you guys are my contacts for the repo. Also sorry for the late PR. I forgot this is tied to my personal email, so I didn't notice that you responded to the issue I opened.
