### PR TITLE
Make DefaultSectionDivider a custom renderer in Lookup.

### DIFF
--- a/components/SLDSLookup/Menu/DefaultSectionDivider/index.js
+++ b/components/SLDSLookup/Menu/DefaultSectionDivider/index.js
@@ -10,14 +10,12 @@
 import React from 'react';
 import { EventUtil } from '../../../utils';
 
-const displayName = "LookupDefaultSectionHeader";
+const displayName = "LookupDefaultSectionDivider";
 const propTypes = {
-  data: React.PropTypes.object,
-  key: React.PropTypes.string
-
+  data: React.PropTypes.object
 };
 
-class DefaultSectionHeader extends React.Component {
+class DefaultSectionDivider extends React.Component {
   constructor(props) {
     super(props);
   }
@@ -28,18 +26,17 @@ class DefaultSectionHeader extends React.Component {
 
   render(){
     return (
-      <li className="slds-p-around--x-small"
-        tabIndex="-1"
-      >
-          <span className="slds-m-left--x-small">
-            <strong>{this.props.data.label}</strong>
-          </span>
+      <li className="slds-p-around--x-small slds-lookup__divider" tabIndex="-1">
+        <span className="slds-m-left--x-small">
+          <strong>{this.props.data.label}</strong>
+        </span>
       </li>
     )
   }
 }
 
-DefaultSectionHeader.displayName = displayName;
-DefaultSectionHeader.propTypes = propTypes;
+DefaultSectionDivider.displayName = displayName;
+DefaultSectionDivider.propTypes = propTypes;
 
-module.exports = DefaultSectionHeader;
+module.exports = DefaultSectionDivider;
+

--- a/components/SLDSLookup/Menu/index.js
+++ b/components/SLDSLookup/Menu/index.js
@@ -9,10 +9,7 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-
 import Item from './Item';
-
-import DefaultSectionHeader from './DefaultSectionHeader';
 
 const displayName = 'SLDSLookup-Menu';
 const propTypes = {
@@ -39,9 +36,10 @@ class Menu extends React.Component {
 
   //Set filtered list length in parent to determine active indexes for aria-activedescendent
   componentDidUpdate(prevProps){
-    // make an array of the children of the list but only count the actual items
+    // make an array of the children of the list but only count the actual items (but include section dividers)
     let list = [].slice.call(ReactDOM.findDOMNode(this.refs.list).children)
-      .filter((child) => child.className.indexOf("slds-lookup__item") > -1).length;
+      .filter((child) => (child.className.indexOf("slds-lookup__item") > -1 || child.className.indexOf("slds-lookup__divider") > -1 ))
+      .length;
     this.props.getListLength(list);
     if(
         prevProps.items !== this.props.items ||
@@ -101,6 +99,10 @@ class Menu extends React.Component {
     return this.props.footer;
   }
 
+  renderSectionDivider(){
+    return this.props.sectionDivider;
+  }
+
   renderItems(){
     let focusIndex = this.props.focusIndex;
     return this.state.filteredItems.map((c, i) => {
@@ -113,7 +115,13 @@ class Menu extends React.Component {
         isActive = focusIndex === i  ? true : false;
       }
       if(c.data.type==='section'){
-        return <DefaultSectionHeader data={c.data} key={'section_header_'+i}/>;
+        if(this.props.sectionDividerRenderer){
+          const SectionDivider = this.props.sectionDividerRenderer;
+          return <SectionDivider
+                  data={c.data}
+                  key={'section_header_'+i}
+                  {... this.props} />;
+        }
       }
       return <Item
         boldRegex={this.props.boldRegex}

--- a/components/SLDSLookup/index.jsx
+++ b/components/SLDSLookup/index.jsx
@@ -20,6 +20,7 @@ import {KEYS,EventUtil} from "../utils";
 import Menu from "./Menu";
 import DefaultFooter from "./Menu/DefaultFooter";
 import DefaultHeader from "./Menu/DefaultHeader";
+import DefaultSectionDivider from "./Menu/DefaultSectionDivider";
 import cx from "classnames";
 
 const displayName = "SLDSLookup";
@@ -191,7 +192,6 @@ class SLDSLookup extends React.Component {
     let numFocusable = this.getNumFocusableItems();
     let prevFocusIndex = this.state.focusIndex > 0 ? this.state.focusIndex - 1 : numFocusable;
     const filteredItem = this.refs.menu.getFilteredItemForIndex(prevFocusIndex);
-    console.log('filteredItem', filteredItem);
     if(filteredItem && filteredItem.data.type === 'section'){
       prevFocusIndex === 0 ? prevFocusIndex = numFocusable : prevFocusIndex--;
     }
@@ -376,6 +376,15 @@ class SLDSLookup extends React.Component {
     }
   }
 
+  /*
+  getSectionDivider(){
+    if(this.props.sectionDividerRenderer){
+      const SectionDivider = this.props.sectionDividerRenderer;
+      return <SectionDivider {... this.props} />;
+    }
+  }
+ */
+
   normalizeSearchTerm(string) {
     return (string || '').toString().replace(/^\s+/, '');
   }
@@ -401,6 +410,7 @@ class SLDSLookup extends React.Component {
         listLength={this.state.listLength}
         onSelect={this.selectItem.bind(this)}
         searchTerm={this.state.searchTerm}
+        sectionDividerRenderer={this.props.sectionDividerRenderer}
         setFocus={this.setFocus.bind(this)}
       />;
     }
@@ -528,5 +538,6 @@ SLDSLookup.defaultProps = defaultProps;
 
 module.exports = SLDSLookup;
 module.exports.DefaultHeader = DefaultHeader;
+module.exports.DefaultSectionDivider = DefaultSectionDivider;
 module.exports.DefaultFooter = DefaultFooter;
 

--- a/demo/code-snippets/LookupExamples3.js
+++ b/demo/code-snippets/LookupExamples3.js
@@ -15,5 +15,6 @@
     {type:'section', label:'SECTION 3'},
     {label: "Acme Construction"}
   ]}
+  sectionDividerRenderer={SLDSLookup.DefaultSectionDivider}
 />
 

--- a/lib/SLDSLookup/Menu/DefaultSectionDivider/index.js
+++ b/lib/SLDSLookup/Menu/DefaultSectionDivider/index.js
@@ -23,23 +23,21 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   */
 
-var displayName = "LookupDefaultSectionHeader";
+var displayName = "LookupDefaultSectionDivider";
 var propTypes = {
-  data: _react2.default.PropTypes.object,
-  key: _react2.default.PropTypes.string
-
+  data: _react2.default.PropTypes.object
 };
 
-var DefaultSectionHeader = function (_React$Component) {
-  _inherits(DefaultSectionHeader, _React$Component);
+var DefaultSectionDivider = function (_React$Component) {
+  _inherits(DefaultSectionDivider, _React$Component);
 
-  function DefaultSectionHeader(props) {
-    _classCallCheck(this, DefaultSectionHeader);
+  function DefaultSectionDivider(props) {
+    _classCallCheck(this, DefaultSectionDivider);
 
-    return _possibleConstructorReturn(this, Object.getPrototypeOf(DefaultSectionHeader).call(this, props));
+    return _possibleConstructorReturn(this, Object.getPrototypeOf(DefaultSectionDivider).call(this, props));
   }
 
-  _createClass(DefaultSectionHeader, [{
+  _createClass(DefaultSectionDivider, [{
     key: 'handleMouseDown',
     value: function handleMouseDown(event) {
       _utils.EventUtil.trapImmediate(event);
@@ -49,9 +47,7 @@ var DefaultSectionHeader = function (_React$Component) {
     value: function render() {
       return _react2.default.createElement(
         'li',
-        { className: 'slds-p-around--x-small',
-          tabIndex: '-1'
-        },
+        { className: 'slds-p-around--x-small slds-lookup__divider', tabIndex: '-1' },
         _react2.default.createElement(
           'span',
           { className: 'slds-m-left--x-small' },
@@ -65,10 +61,10 @@ var DefaultSectionHeader = function (_React$Component) {
     }
   }]);
 
-  return DefaultSectionHeader;
+  return DefaultSectionDivider;
 }(_react2.default.Component);
 
-DefaultSectionHeader.displayName = displayName;
-DefaultSectionHeader.propTypes = propTypes;
+DefaultSectionDivider.displayName = displayName;
+DefaultSectionDivider.propTypes = propTypes;
 
-module.exports = DefaultSectionHeader;
+module.exports = DefaultSectionDivider;

--- a/lib/SLDSLookup/Menu/index.js
+++ b/lib/SLDSLookup/Menu/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _react = require('react');
@@ -13,10 +15,6 @@ var _reactDom2 = _interopRequireDefault(_reactDom);
 var _Item = require('./Item');
 
 var _Item2 = _interopRequireDefault(_Item);
-
-var _DefaultSectionHeader = require('./DefaultSectionHeader');
-
-var _DefaultSectionHeader2 = _interopRequireDefault(_DefaultSectionHeader);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -69,9 +67,9 @@ var Menu = function (_React$Component) {
   _createClass(Menu, [{
     key: 'componentDidUpdate',
     value: function componentDidUpdate(prevProps) {
-      // make an array of the children of the list but only count the actual items
+      // make an array of the children of the list but only count the actual items (but include section dividers)
       var list = [].slice.call(_reactDom2.default.findDOMNode(this.refs.list).children).filter(function (child) {
-        return child.className.indexOf("slds-lookup__item") > -1;
+        return child.className.indexOf("slds-lookup__item") > -1 || child.className.indexOf("slds-lookup__divider") > -1;
       }).length;
       this.props.getListLength(list);
       if (prevProps.items !== this.props.items || prevProps.filter !== this.props.filter || prevProps.searchTerm !== this.props.searchTerm) {
@@ -136,6 +134,11 @@ var Menu = function (_React$Component) {
       return this.props.footer;
     }
   }, {
+    key: 'renderSectionDivider',
+    value: function renderSectionDivider() {
+      return this.props.sectionDivider;
+    }
+  }, {
     key: 'renderItems',
     value: function renderItems() {
       var _this2 = this;
@@ -151,7 +154,13 @@ var Menu = function (_React$Component) {
           isActive = focusIndex === i ? true : false;
         }
         if (c.data.type === 'section') {
-          return _react2.default.createElement(_DefaultSectionHeader2.default, { data: c.data, key: 'section_header_' + i });
+          if (_this2.props.sectionDividerRenderer) {
+            var SectionDivider = _this2.props.sectionDividerRenderer;
+            return _react2.default.createElement(SectionDivider, _extends({
+              data: c.data,
+              key: 'section_header_' + i
+            }, _this2.props));
+          }
         }
         return _react2.default.createElement(
           _Item2.default,

--- a/lib/SLDSLookup/index.js
+++ b/lib/SLDSLookup/index.js
@@ -46,6 +46,10 @@ var _DefaultHeader = require("./Menu/DefaultHeader");
 
 var _DefaultHeader2 = _interopRequireDefault(_DefaultHeader);
 
+var _DefaultSectionDivider = require("./Menu/DefaultSectionDivider");
+
+var _DefaultSectionDivider2 = _interopRequireDefault(_DefaultSectionDivider);
+
 var _classnames = require("classnames");
 
 var _classnames2 = _interopRequireDefault(_classnames);
@@ -246,7 +250,6 @@ var SLDSLookup = function (_React$Component) {
       var numFocusable = this.getNumFocusableItems();
       var prevFocusIndex = this.state.focusIndex > 0 ? this.state.focusIndex - 1 : numFocusable;
       var filteredItem = this.refs.menu.getFilteredItemForIndex(prevFocusIndex);
-      console.log('filteredItem', filteredItem);
       if (filteredItem && filteredItem.data.type === 'section') {
         prevFocusIndex === 0 ? prevFocusIndex = numFocusable : prevFocusIndex--;
       }
@@ -451,6 +454,16 @@ var SLDSLookup = function (_React$Component) {
         }));
       }
     }
+
+    /*
+    getSectionDivider(){
+      if(this.props.sectionDividerRenderer){
+        const SectionDivider = this.props.sectionDividerRenderer;
+        return <SectionDivider {... this.props} />;
+      }
+    }
+    */
+
   }, {
     key: "normalizeSearchTerm",
     value: function normalizeSearchTerm(string) {
@@ -481,6 +494,7 @@ var SLDSLookup = function (_React$Component) {
           listLength: this.state.listLength,
           onSelect: this.selectItem.bind(this),
           searchTerm: this.state.searchTerm,
+          sectionDividerRenderer: this.props.sectionDividerRenderer,
           setFocus: this.setFocus.bind(this)
         });
       }
@@ -640,4 +654,5 @@ SLDSLookup.defaultProps = defaultProps;
 
 module.exports = SLDSLookup;
 module.exports.DefaultHeader = _DefaultHeader2.default;
+module.exports.DefaultSectionDivider = _DefaultSectionDivider2.default;
 module.exports.DefaultFooter = _DefaultFooter2.default;


### PR DESCRIPTION
Making section dividers in the Lookup Menu more customizable. Users can pass in their own react components to the `sectionDividerRenderer` prop or use the default `Lookup.DefaultSectionDivider` following the same pattern as DefaultHeader and DefaultFooter.
