### PR TITLE
DataTable was throwing double events on checkbox click

### DIFF
--- a/components/data-table/head.jsx
+++ b/components/data-table/head.jsx
@@ -65,7 +65,7 @@ const DataTableHead = React.createClass({
 								assistiveText="Select All"
 								checked={this.props.allSelected}
 								name="SelectAll"
-								onChange={this.handleChange}
+								onChange={this.props.onToggleAll}
 							/>
 						</th>
 					)}
@@ -105,10 +105,6 @@ const DataTableHead = React.createClass({
 				</tr>
 			</thead>
 		);
-	},
-
-	handleChange () {
-		this.props.onToggleAll(!this.props.allSelected);
 	},
 
 	getSortHandler (sortable, props, index) {

--- a/components/data-table/index.jsx
+++ b/components/data-table/index.jsx
@@ -231,15 +231,15 @@ const DataTable = React.createClass({
 		);
 	},
 
-	handleToggleAll (selected) {
+	handleToggleAll (selected, e) {
 		if (isFunction(this.props.onChange)) {
 			const selection = selected ? [...this.props.items] : [];
 
-			this.props.onChange(selection);
+			this.props.onChange(selection, e);
 		}
 	},
 
-	handleRowToggle (item, selected) {
+	handleRowToggle (item, selected, e) {
 		if (isFunction(this.props.onChange)) {
 			let selection;
 
@@ -249,7 +249,7 @@ const DataTable = React.createClass({
 				selection = reject(this.props.selection, item);
 			}
 
-			this.props.onChange(selection);
+			this.props.onChange(selection, e);
 		}
 	},
 

--- a/components/data-table/row.jsx
+++ b/components/data-table/row.jsx
@@ -77,6 +77,7 @@ const DataTableRow = React.createClass({
 							checked={isSelected}
 							name="SelectRow"
 							onChange={this.handleToggle}
+							onClick={EventUtil.trap}
 						/>
 					</td>
 				) : null}
@@ -109,7 +110,7 @@ const DataTableRow = React.createClass({
 	handleToggle (selected, e) {
 		EventUtil.trap(e);
 
-		return this.props.onToggle(this.props.item, selected);
+		return this.props.onToggle(this.props.item, selected, e);
 	}
 });
 


### PR DESCRIPTION
Inputs throw both a change and a click event, and we were previously only stopping propagation on the change event but the click was passing through to the table row which was also clickable.

Also passing the event out so it can be used as needed.
