### PR TITLE
Change pre-commit to pre-push lint/tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "tether-drop": "1.2.2",
     "warning": "^2.1.0"
   },
-  "pre-commit": [
+  "pre-push": [
     "lint",
     "validate",
     "test"


### PR DESCRIPTION
I really like the intent of the `pre-commit` check, but changing branches and having to disable the `package.json:pre-commit` and then re-enable it and then disable it in order to commit is tedious. The npm check almost always fails, because I'm working on plumbing in multiple branches and `node_modules` is not versioned.

Test on `pre-commit` means you can't do WIP commits. 😦  This PR changes the validation to a `pre-push`, so that you can't push to remote until the tests pass. This seems less onerous and allows contributors to commit however they want (and then clean up later before the PR--which is what I usually do). 

**With TravisCI running, I'm not sure we really need commit and push checks, but we can kick that decision down the road some with this update.**
