### PR TITLE
Make checkbox util import relative

### DIFF
--- a/components/forms/checkbox/index.js
+++ b/components/forms/checkbox/index.js
@@ -21,7 +21,7 @@ import React from 'react';
 import isFunction from 'lodash.isfunction';
 
 // ### Event Helpers
-import { KEYS, EventUtil } from "components/utils";
+import { KEYS, EventUtil } from "../../utils";
 
 // ### classNames
 import classNames from 'classnames';


### PR DESCRIPTION
Library wasn't building for me when the tests run in the browser.

Probably will get fixed in #279 when it's complete, so free free to close this if it's pulled into another PR.
