### PR TITLE
Add glob pattern for npm run lint 

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,8 @@
+.git/
+.storybook/
+coverage/
+node_modules/
+storybook/
+
 components/SLDSDateInput
 components/utilities/utility-icon/SVG

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "heroku-prebuild": "./scripts/heroku-prebuild.sh",
     "heroku-postbuild": "./scripts/heroku-postbuild.sh",
     "icons": "./node_modules/.bin/babel-node scripts/inline-icons.js",
-    "lint": "eslint --config=./.eslintrc \"components/**/**\"",
+    "lint": "eslint --config=./.eslintrc \"**/**\"",
     "publish-to-git": "./node_modules/.bin/babel-node scripts/publish-to-git.js",
     "publish-to-edge": "./node_modules/.bin/babel-node scripts/publish-to-git.js --tag=edge",
     "publish-to-upstream": "./node_modules/.bin/babel-node scripts/publish-to-git.js --tag=edge --remote=upstream && ./node_modules/.bin/babel-node scripts/publish-to-git.js --remote=upstream",


### PR DESCRIPTION
I was only getting errors for 3 files when running `npm run lint` until I added this glob pattern. Now I'm getting errors in about 50 files (which is what we want, right now in order to surface issues). No actual lint errors are fixed this PR.

Surfaces issues for fixing for #288.

Icons are added to ignore list, too.
