### PR TITLE
Add Modal classname and additional props to Timepicker

### DIFF
--- a/components/modal/index.jsx
+++ b/components/modal/index.jsx
@@ -62,7 +62,7 @@ const propTypes = {
   /**
    * Custom css classes for modal container.
    */
-  modalClassname: React.PropTypes.string,
+  containerClassName: React.PropTypes.string,
   prompt: React.PropTypes.oneOf(["success", "warning", "error", "wrench", "offline", "info"]),
   size: React.PropTypes.oneOf(["medium", "large"]),
   /**
@@ -229,7 +229,7 @@ class Modal extends React.Component {
     return (
       <div>
         <div aria-hidden="false" role="dialog" className={classNames(componentClassname)} onClick={this.closeModal.bind(this)}>
-          <div className={classNames(this.props.modalClassname, "slds-modal__container")} style={modalStyle}>
+          <div className={classNames(this.props.containerClassName, "slds-modal__container")} style={modalStyle}>
            {this.headerComponent()}
            <div className="slds-modal__content" style={contentStyle} onClick={this.handleModalClick.bind(this)}>
              {this.props.children}

--- a/components/time-picker/index.jsx
+++ b/components/time-picker/index.jsx
@@ -20,11 +20,13 @@ import {KEYS,EventUtil} from '../../utilities';
 
 const displayName = 'Timepicker';
 const propTypes = {
+  constrainToScrollParent: React.PropTypes.bool,
 
   /**
    * Time formatting function
    */
   formatter: React.PropTypes.func,
+  inheritTargetWidth: React.PropTypes.bool,
 
   /**
    * Parsing date string into Date

--- a/tests/modal/modal.test.jsx
+++ b/tests/modal/modal.test.jsx
@@ -56,17 +56,21 @@ describe('SLDSModal: ', function(){
 
     beforeEach(() => {
       closed = false;
-      cmp = getModal({isOpen: true, size: 'large', onRequestClose: () => closed = true});
+      cmp = getModal({isOpen: true, size: 'large', containerClassName: 'my-custom-class', onRequestClose: () => closed = true});
       modal = getModalNode(document.body);
     })
 
     it('renders a noscript', () => {
-      const renderedNode = React.findDOMNode(cmp);
+      const renderedNode = ReactDOM.findDOMNode(cmp);
       expect(renderedNode.firstChild.tagName).to.equal('NOSCRIPT');
     })
 
     it('adds the large class', () => {
       expect(modal.className).to.include('slds-modal--large');
+    })
+
+    it('adds custom classname from modal container prop', () => {
+      expect(modal.firstChild.className).to.include('my-custom-class');
     })
 
     it('calls onRequestClose', () => {


### PR DESCRIPTION
- Fixed bug where timepicker popup position showed up underneath modal container.
- Added modalClassname prop for modal container
- Add test for modalClassname
