### PR TITLE
assistiveText prop for popover-tooltip

### DIFF
--- a/components/popover-tooltip/index.jsx
+++ b/components/popover-tooltip/index.jsx
@@ -30,6 +30,10 @@ const propTypes = {
    */
   content: React.PropTypes.node.isRequired,
   /**
+   * Assistive Text for tooltip trigger.
+   */
+  assistiveText: React.PropTypes.string,
+  /**
    * Delay on Tooltip closing.
    */
   hoverCloseDelay: React.PropTypes.number,

--- a/components/popover-tooltip/trigger.jsx
+++ b/components/popover-tooltip/trigger.jsx
@@ -102,7 +102,9 @@ class Trigger extends React.Component {
       onFocus={this.handleTooltipMouseEnter.bind(this)}
       onMouseOut={this.handleTooltipMouseLeave.bind(this)}
       onBlur={this.handleTooltipMouseLeave.bind(this)}
-    ><span className="slds-assistive-text">{this.props.label || this.props.assistiveText}</span></a>:null;
+    ><span className="slds-assistive-text">
+      {this.props.tooltip.props.assistiveText || this.props.label || this.props.assistiveText}
+    </span></a>:null;
   }
 
   getTooltip(){


### PR DESCRIPTION
When a tooltip is added to a disabled button, a tooltip trigger <a> is rendered inside the button.
The trigger has an assistive text which is assigned to the button label.
In the example below, the dup text is _Edit_

```
<button class=" disabled slds-button slds-button--neutral drop-target drop-enabled drop-out-of-bounds drop-out-of-bounds-right drop-element-attached-top drop-element-attached-center drop-target-attached-bottom drop-target-attached-center" disabled="" data-reactid=".0.3.0.0.0.0.0.0.2.0.1.$action_1">
  <span data-reactid=".0.3.0.0.0.0.0.0.2.0.1.$action_1.3">Edit</span>
  <a href="javascript:void(0)" aria-hidden="true" tabindex="-1" style="background-color:transparent;width:100%;height:100%;position:absolute;left:0px;top:0px;" data-reactid=".0.3.0.0.0.0.0.0.2.0.1.$action_1.5:$MouseEventTarget">
    <span class="slds-assistive-text" data-reactid=".0.3.0.0.0.0.0.0.2.0.1.$action_1.5:$MouseEventTarget.0">Edit</span>
  </a>
  <div aria-describedby=".0.3.0.0.0.0.0.0.2.0.1.$action_1" style="display:inline;" role="tooltip" data-reactid=".0.3.0.0.0.0.0.0.2.0.1.$action_1.5:$tooltip">
    <noscript data-reactid=".0.3.0.0.0.0.0.0.2.0.1.$action_1.5:$tooltip.1">
  </noscript>
 </div>
</button>
```

This is a problem for Lightning Dashboards because it violates "Button must not have duplicate values" accessibility rule: http://sfdc.co/a11y_dom_14
In this PR, I'm introducing `assistiveText` prop for Tooltip. This prop will be used to populate the assistive text of the tooltip trigger. In Dashboards, the prop value has the same text as the tooltip content.

@donnieberg , please review
