### PR TITLE
Lookup updates

### DIFF
--- a/components/lookup/index.jsx
+++ b/components/lookup/index.jsx
@@ -263,7 +263,7 @@ class Lookup extends React.Component {
 		this.setState({
 			isOpen: false,
 			focusIndex: null,
-			currentFocus: null,
+			currentFocus: null
 		});
 	}
 
@@ -278,7 +278,7 @@ class Lookup extends React.Component {
 		this.setState({
 			isOpen: false,
 			focusIndex: null,
-			currentFocus: null,
+			currentFocus: null
 		});
 	}
 
@@ -487,6 +487,7 @@ class Lookup extends React.Component {
 	getClassName(){
 		return cx(this.props.className, 'slds-lookup', {
 			'slds-has-selection': this.isSelected(),
+			'slds-is-open': this.state.isOpen
 		});
 	}
 

--- a/stories/lookup/index.jsx
+++ b/stories/lookup/index.jsx
@@ -22,6 +22,7 @@ const DemoLookup = React.createClass({
 		return (
 			<Lookup
 				{...this.props}
+				modal={false}
 				onChange={action('change')}
 				onSelect={this.handleSelect}
 				options={this.state.options}


### PR DESCRIPTION
@donnieberg / @SiTaggart: It appears that the Lookup markup wasn't entirely compatible with `v2.1.0-beta.3` so I've added the `slds-is-open` class to at least make the menu render again. There's likely more to do but this should at least be a start.
