### PR TITLE
'Centers' app launcher search when no button is present

### DIFF
--- a/components/app-launcher/index.jsx
+++ b/components/app-launcher/index.jsx
@@ -178,7 +178,7 @@ const AppLauncher = React.createClass({
 								placeholder={this.props.searchPlaceholderText}
 							/>
 						</div>
-						{this.props.modalHeaderButton}
+						<span>{this.props.modalHeaderButton}</span>
 					</div>
 
 					<div className="slds-modal__content slds-app-launcher__content slds-p-around--medium">

--- a/stories/app-launcher/index.jsx
+++ b/stories/app-launcher/index.jsx
@@ -254,10 +254,30 @@ const DemoAppLauncher = React.createClass({
 	}
 });
 
+const DemoAppLauncherNoHeaderButton = React.createClass({
+	displayName: 'DemoAppLauncherNoHeaderButton',
+
+	render () {
+		return (
+			<GlobalNavigationBar>
+				<GlobalNavigationBarRegion region="primary">
+					<AppLauncher triggerName="App Name" isOpen>
+						<AppLauncherSection title="All Items">
+							<DemoAppLauncherTile />
+							<DemoAppLauncherTileWithIconNode />
+						</AppLauncherSection>
+					</AppLauncher>
+				</GlobalNavigationBarRegion>
+			</GlobalNavigationBar>
+		);
+	}
+});
+
 
 storiesOf(APP_LAUNCHER, module)
 	.addDecorator(getStory => <div className="slds-p-around--medium">{getStory()}</div>)
 	.add('App Launcher', () => <DemoAppLauncher />)
+	.add('App Launcher no header button', () => <DemoAppLauncherNoHeaderButton />)
 	.add('Tile', () => <div style={standardTileDemoStyles}><DemoAppLauncherTile /></div>)
 	.add('Small Tile', () => <div style={smallTileDemoStyles}><DemoAppLauncherSmallTile /></div>)
 	.add('Tile with Icon node', () => <div style={standardTileDemoStyles}><DemoAppLauncherTileWithIconNode /></div>)


### PR DESCRIPTION
Attempt at #466 

This is not 100% centered.. The SLDS pattern does not use columns (`slds-size--1-of-3`) as mentioned [here](https://github.com/salesforce-ux/design-system-react/issues/466#issuecomment-234613572), it uses flexbox. 

I was able to bump the search input toward the center by wrapping the Button in a `<span>` so that when the Button `node` is `undefined`, it still renderes an empty span. However, since the span has no width, the search bar is slightly off center. 

Let me know if you have any ideas on how to make this better, otherwise, it might be good enough until next release when we have the "App Exchange" added.

![screenshot 2016-07-22 14 29 16](https://cloud.githubusercontent.com/assets/1715111/17069093/5ef190c2-501a-11e6-970a-3ac25d368183.png)
