### PR TITLE
NavLink: set default href to JS:void, change callback args to not modify immutable synthetic event

### DIFF
--- a/components/global-navigation-bar/link.jsx
+++ b/components/global-navigation-bar/link.jsx
@@ -36,6 +36,7 @@ const GlobalNavigationBarLink = (props) => {
 	const {
 		active,
 		className,
+		href,
 		label,
 		onClick,
 		...other
@@ -45,14 +46,16 @@ const GlobalNavigationBarLink = (props) => {
 		if (isFunction(onClick)) {
 			EventUtil.trap(event);
 
-			event.href = props.href;
-			onClick(event);
+			const hrefCheck = href === 'javascript:void(0);' ? undefined : href; // eslint-disable-line no-script-url
+
+			onClick(event, hrefCheck);
 		}
 	}
 
 	return (
 		<li className={classNames('slds-context-bar__item', { 'slds-is-active': active })}>
 			<a
+				href={href}
 				className={classNames('slds-context-bar__label-action', className)}
 				onClick={handleClick}
 				{...other}
@@ -87,6 +90,10 @@ GlobalNavigationBarLink.propTypes = {
 	 * `function (event)` - fires when the link is clicked. If set, `href` will be ignored, but includes the `href` of the link in the event object.
 	 */
 	onClick: PropTypes.func
+};
+
+GlobalNavigationBarLink.defaultProps = {
+	href: 'javascript:void(0);' // eslint-disable-line no-script-url
 };
 
 module.exports = GlobalNavigationBarLink;

--- a/stories/global-navigation-bar/index.jsx
+++ b/stories/global-navigation-bar/index.jsx
@@ -43,7 +43,7 @@ const getGlobalNavigationBar = (props, primaryRegionProps) => (
 		</GlobalNavigationBarRegion>
 		<GlobalNavigationBarRegion region="secondary" navigation>
 			<GlobalNavigationBarLink
-				href="#"
+				href="http://google.com"
 				label="Home"
 				id="home-link"
 				onClick={linkClicked('Home link clicked')}
@@ -56,18 +56,15 @@ const getGlobalNavigationBar = (props, primaryRegionProps) => (
 				options={dropdownCollection}
 			/>
 			<GlobalNavigationBarLink
-				href="#"
 				label="Menu Item 2"
 				onClick={linkClicked('Link clicked')}
 			/>
 			<GlobalNavigationBarLink
 				active
-				href="#"
 				label="Menu Item 3"
 				onClick={linkClicked('Link clicked')}
 			/>
 			<GlobalNavigationBarLink
-				href="#"
 				label="Menu Item 4"
 				onClick={linkClicked('Link clicked')}
 			/>
@@ -105,7 +102,6 @@ const getGlobalNavigationBarCustomCloud = (props, primaryRegionProps) => (
 		</GlobalNavigationBarRegion>
 		<GlobalNavigationBarRegion region="secondary" navigation>
 			<GlobalNavigationBarLink
-				href="#"
 				label="Overview"
 				id="overview-link"
 				onClick={linkClicked('Overview link clicked')}
@@ -129,7 +125,6 @@ const getGlobalNavigationBarCustomCloud = (props, primaryRegionProps) => (
 				options={dropdownCollection}
 			/>
 			<GlobalNavigationBarLink
-				href="#"
 				label="A/B Testing"
 				onClick={linkClicked('A/B Testing Link clicked')}
 			/>
@@ -140,19 +135,16 @@ const getGlobalNavigationBarCustomCloud = (props, primaryRegionProps) => (
 				options={dropdownCollection}
 			/>
 			<GlobalNavigationBarLink
-				href="#"
 				label="Admin"
 				onClick={linkClicked('Admin Link clicked')}
 			/>
 			<GlobalNavigationBarLink
-				href="#"
 				label="Audience Builder"
 				onClick={linkClicked('Audience Builder Link clicked')}
 			/>
 		</GlobalNavigationBarRegion>
 		<GlobalNavigationBarRegion region="tertiary">
 			<GlobalNavigationBarLink
-				href="#"
 				label="Actions"
 				onClick={linkClicked('Link clicked')}
 			/>
@@ -180,7 +172,6 @@ const getGlobalNavigationBarCustomCloudOverviewAcive = (props, primaryRegionProp
 		</GlobalNavigationBarRegion>
 		<GlobalNavigationBarRegion region="secondary" navigation>
 			<GlobalNavigationBarLink
-				href="#"
 				label="Overview"
 				id="overview-link"
 				active
@@ -205,7 +196,6 @@ const getGlobalNavigationBarCustomCloudOverviewAcive = (props, primaryRegionProp
 				options={dropdownCollection}
 			/>
 			<GlobalNavigationBarLink
-				href="#"
 				label="A/B Testing"
 				onClick={linkClicked('A/B Testing Link clicked')}
 			/>
@@ -216,19 +206,16 @@ const getGlobalNavigationBarCustomCloudOverviewAcive = (props, primaryRegionProp
 				options={dropdownCollection}
 			/>
 			<GlobalNavigationBarLink
-				href="#"
 				label="Admin"
 				onClick={linkClicked('Admin Link clicked')}
 			/>
 			<GlobalNavigationBarLink
-				href="#"
 				label="Audience Builder"
 				onClick={linkClicked('Audience Builder Link clicked')}
 			/>
 		</GlobalNavigationBarRegion>
 		<GlobalNavigationBarRegion region="tertiary">
 			<GlobalNavigationBarLink
-				href="#"
 				label="Actions"
 				onClick={linkClicked('Link clicked')}
 			/>

--- a/tests/global-navigation-bar/global-navigation-bar.test.js
+++ b/tests/global-navigation-bar/global-navigation-bar.test.js
@@ -194,27 +194,40 @@ describe('Global Navigation Bar: ', () => {
 	// TODO still need Dropdown covered. Should be added to Dropdown tests, once special context bar dropdown features are merged into Dropdown
 
 	describe('GlobalNavigationLink child component', () => {
-		it('GlobalNavigationBarLink has attributes and onClick runs callback', function () {
-			const linkClicked = sinon.spy();
+		let linkClicked;
+		let link;
+
+		beforeEach(function () {
+			linkClicked = sinon.spy();
 			const instance = (
 				<GlobalNavigationBarLink
+					href="http://google.com"
 					label="Home"
 					id="home-link"
 					onClick={linkClicked('Home link clicked')}
 				/>
 			);
 			this.wrapper = mount(instance, { attachTo: document.body.appendChild(document.createElement('div')) });
-			const link = this.wrapper.find('#home-link');
+			link = this.wrapper.find('#home-link');
+		});
+
+		afterEach(function () {
+			this.wrapper.unmount();
+		});
+
+		it('GlobalNavigationBarLink has attributes and onClick runs callback', function () {
 			expect(link.text()).to.equal('Home');
 			link.simulate('click');
 			expect(linkClicked.calledOnce).to.be.true;
+		});
 
-			this.wrapper.unmount();
+		it('renders href if passed', () => {
+			expect(link).to.have.attr('href', 'http://google.com');
 		});
 	});
 
 	describe('GlobalNavigationButton child component', () => {
-		it('GlobalNavigationBarLink has attributes and onClick runs callback', function () {
+		it('GlobalNavigationBarButton has attributes and onClick runs callback', function () {
 			const buttonClicked = sinon.spy();
 			const instance = (
 				<GlobalNavigationBarButton


### PR DESCRIPTION
Solution for #476.

**Potential breaking change**

The `href` was getting tacked onto the `event` object and sent to the callback. Apparently, React's `SyntheticEvent` is reused for performance and cannot be modified. 

This PR changes the functionality to set the `href` directly on the `<a>` (with the default of `javascript:void(0);`). When the anchor is clicked, the event is trapped (stopping the redirection) and the `href` is sent to the callback as the second argument. 
