### PR TITLE
Remove id generator from button component (let parent generate if needed)

### DIFF
--- a/components/button/index.jsx
+++ b/components/button/index.jsx
@@ -17,11 +17,6 @@ import omit from 'lodash.omit';
 
 import { BUTTON } from '../../utilities/constants';
 
-// ### shortid
-// [npmjs.com/package/shortid](https://www.npmjs.com/package/shortid)
-// shortid is a short, non-sequential, url-friendly, unique id generator
-import shortid from 'shortid';
-
 const displayName = BUTTON;
 const propTypes = {
 	/**
@@ -96,7 +91,6 @@ const propTypes = {
 	variant: React.PropTypes.oneOf(['base', 'neutral', 'brand', 'destructive', 'icon'])
 };
 const defaultProps = {
-	id: shortid.generate(),
 	disabled: false,
 	hint: false,
 	iconSize: 'medium',

--- a/stories/button/index.jsx
+++ b/stories/button/index.jsx
@@ -19,6 +19,7 @@ storiesOf(BUTTON, module)
 	.addDecorator(getStory => <div className="slds-p-around--medium">{getStory()}</div>)
 	.add('Base', () => getButton({ label: 'Base', variant: 'base' }))
 	.add('Neutral', () => getButton({ label: 'Neutral' }))
+	.add('Neutral with id', () => getButton({ label: 'Neutral', id: 'custom-id' }))
 	.add('Neutral Icon', () => getButton({
 		label: 'Neutral Icon',
 		iconName: 'download',

--- a/tests/button/button.test.jsx
+++ b/tests/button/button.test.jsx
@@ -44,6 +44,7 @@ describe('SLDSButton: ', () => {
 
 		beforeEach(() => {
 			cmp = getButton({
+				id: 'custom-id',
 				text: 'Brand',
 				theme: 'brand'
 			});
@@ -60,6 +61,10 @@ describe('SLDSButton: ', () => {
 
 		it('renders correct variant styles', () => {
 			expect(btn.className).to.include('slds-button--neutral');
+		});
+
+		it('renders custom id', () => {
+			expect(btn.getAttribute('id')).to.equal('custom-id');
 		});
 	});
 


### PR DESCRIPTION
*_Do this linting PR first #504 *_

Fixes #356 by removing the `id` generator

@interactivellama and I decided that buttons do not need to generate their own unique ids since they will most likely need to be passed an `id` from other components for `aria-controls`
