### PR TITLE
changes 'more' style to resemble link

### DIFF
--- a/components/app-launcher/tile.jsx
+++ b/components/app-launcher/tile.jsx
@@ -99,7 +99,7 @@ const AppLauncherTile = React.createClass({
 		return (
 			<span>
 				<PopoverTooltip align="bottom" content={<Highlighter search={this.props.search}>{this.props.description}</Highlighter>}>
-					<Button variant="base" iconVariant="bare" label={this.props.moreLabel} tabIndex="0" />
+					<Button className="slds-text-link" variant="base" iconVariant="bare" label={this.props.moreLabel} tabIndex="0" />
 				</PopoverTooltip>
 			</span>
 		);


### PR DESCRIPTION
Fixes #512 

The tooltip child must be a button for accessibility reasons, tooltip requires it.

I simply passed the `slds-text-link` class to the Button. 
