### PR TITLE
Global search to use left side icon

### DIFF
--- a/components/global-header/search.jsx
+++ b/components/global-header/search.jsx
@@ -27,7 +27,7 @@ import { GLOBAL_HEADER_SEARCH } from '../../utilities/constants';
  */
 const GlobalHeaderSearch = (props) => (
 	<div className="slds-global-header__item slds-global-header__item--search">
-		<Lookup {...props} />
+		<Lookup iconPosition="left" {...props} />
 	</div>
 );
 

--- a/components/lookup/index.jsx
+++ b/components/lookup/index.jsx
@@ -76,6 +76,13 @@ const propTypes = {
 	 * Name of icon. Please refer to <a href='http://www.lightningdesignsystem.com/resources/icons'>Lightning Design System Icons</a> to view icon names.
 	 */
 	iconName: PropTypes.string,
+	/**
+	 * Determines whether the input's icon will display that icon on the left or the right.
+	 */
+	iconPosition: PropTypes.oneOf([
+		'left',
+		'right'
+	]),
 	label: PropTypes.string,
 	/**
 	 * Custom component that overrides the default Lookup Item component.
@@ -93,6 +100,10 @@ const propTypes = {
 	 * Lookup item data.
 	 */
 	options: PropTypes.array.isRequired,
+	/**
+	 * Text that will appear in an empty input.
+	 */
+	placeholder: PropTypes.string,
 	/**
 	 * If true, adds asterisk next to input label to indicate it is a required field.
 	 */
@@ -462,7 +473,7 @@ class Lookup extends React.Component {
 	renderInput() {
 		return (
 			<span>
-				<InputIcon name='search' onClick={this.focusInput.bind(this)} />
+				<InputIcon name="search" onClick={this.focusInput.bind(this)} />
 				<input
 					aria-activedescendant={this.state.currentFocus ? this.state.currentFocus:''}
 					aria-autocomplete='list'
@@ -476,6 +487,7 @@ class Lookup extends React.Component {
 					onFocus={this.handleFocus.bind(this)}
 					onKeyDown={this.handleKeyDown.bind(this)}
 					ref={this.inputRefName()}
+					placeholder={this.props.placeholder}
 					role='combobox'
 					type='text'
 					value={this.state.searchTerm}
@@ -547,7 +559,7 @@ class Lookup extends React.Component {
 	render() {
 		const formElementControlClasses = {
 			'slds-form-element__control': true,
-			'slds-input-has-icon slds-input-has-icon--right': !this.isSelected(),
+			[`slds-input-has-icon slds-input-has-icon--${this.props.iconPosition}`]: !this.isSelected()
 		};
 
 		return (

--- a/stories/global-header/index.jsx
+++ b/stories/global-header/index.jsx
@@ -17,6 +17,7 @@ storiesOf(GLOBAL_HEADER, module)
 		<GlobalHeader logoSrc={logo} onSkipToContent={action('Skip to Main Content')} onSkipToNav={action('Skip to Navigation')}>
 			<GlobalHeaderSearch
 				onSelect={action('Search Selected')}
+				placeholder="Search Salesforce"
 				options={[
 					{ label: 'Email' },
 					{ label: 'Mobile' }


### PR DESCRIPTION
Partial fix to #525

<img width="1428" alt="screen_shot_2016-08-02_at_9 47 26_am" src="https://cloud.githubusercontent.com/assets/1290832/17369342/facbeed0-5965-11e6-8917-6d7a339522b9.png">

![screenshot 2016-08-03 00 13 14](https://cloud.githubusercontent.com/assets/1290832/17369363/0eb48812-5966-11e6-9b13-d6c650b033a6.png)
(but just the logo and the lookup)

**Removed SF name from logo**
