### PR TITLE
Remove slds media figure when no icon present

### DIFF
--- a/components/page-header/base/index.jsx
+++ b/components/page-header/base/index.jsx
@@ -15,35 +15,43 @@ import omit from 'lodash.omit';
 
 const displayName = 'PageHeaderBase';
 const propTypes = {
-  /**
-   * Icon node passed by PageHeader
-   */
-  icon: React.PropTypes.node,
-  /**
-   * Title node passed by PageHeader
-   */
-  title: React.PropTypes.node,
-  /**
-   * Info node passed by PageHeader
-   */
-  info: React.PropTypes.node,
+	/**
+	 * Icon node passed by PageHeader
+	 */
+	icon: React.PropTypes.node,
+	/**
+	 * Title node passed by PageHeader
+	 */
+	title: React.PropTypes.node,
+	/**
+	 * Info node passed by PageHeader
+	 */
+	info: React.PropTypes.node,
 };
 const defaultProps = {};
 
 class Base extends Component {
-  render() {
-    return (
-      <div className="slds-media slds-media--center">
-        <div className="slds-media__figure">
-          { this.props.icon }
-        </div>
-        <div className="slds-media__body">
-          { this.props.title }
-          { this.props.info }
-        </div>
-      </div>
-    );
-  }
+	renderIcon() {
+		if(this.props.icon) {
+			return (
+				<div className="slds-media__figure">
+					{ this.props.icon }
+				</div>
+			)
+		}
+	}
+
+	render() {
+		return (
+			<div className="slds-media slds-media--center">
+				{this.renderIcon()}
+				<div className="slds-media__body">
+					{ this.props.title }
+					{ this.props.info }
+				</div>
+			</div>
+		);
+	}
 }
 
 Base.displayName = displayName;

--- a/components/page-header/object-home/index.jsx
+++ b/components/page-header/object-home/index.jsx
@@ -14,59 +14,59 @@ import DetailRow from '../detail-row';
 
 const displayName = 'PageHeaderObjectHome';
 const propTypes = {
-  /**
-   * Icon node passed by PageHeader
-   */
-  icon: React.PropTypes.node,
-  /**
-   * Title node passed by PageHeader
-   */
-  title: React.PropTypes.node,
-  /**
-   * Info node passed by PageHeader
-   */
-  info: React.PropTypes.node,
-  /**
-   * Content to appear on the right hand side of the page header
-   */
-  contentRight: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.element,
-  ]),
-  /**
-   * Nav content which appears in the upper right hand corner.
-   */
-  navRight: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.element,
-  ]),
+	/**
+	 * Icon node passed by PageHeader
+	 */
+	icon: React.PropTypes.node,
+	/**
+	 * Title node passed by PageHeader
+	 */
+	title: React.PropTypes.node,
+	/**
+	 * Info node passed by PageHeader
+	 */
+	info: React.PropTypes.node,
+	/**
+	 * Content to appear on the right hand side of the page header
+	 */
+	contentRight: React.PropTypes.oneOfType([
+		React.PropTypes.string,
+		React.PropTypes.element,
+	]),
+	/**
+	 * Nav content which appears in the upper right hand corner.
+	 */
+	navRight: React.PropTypes.oneOfType([
+		React.PropTypes.string,
+		React.PropTypes.element,
+	]),
 };
 const defaultProps = {};
 
 class ObjectHome extends Component {
-  render() {
-    return (
-      <div>
-        <div className="slds-grid">
-          <div className="slds-col slds-has-flexi-truncate">
-            { this.props.label }
-            { this.props.title }
-          </div>
-          <div className="slds-col slds-no-flex slds-grid slds-align-top">
-            { this.props.navRight }
-          </div>
-        </div>
-        <div className="slds-grid">
-          <div className="slds-col slds-align-bottom">
-            { this.props.info }
-          </div>
-          <div className="slds-col slds-no-flex slds-grid slds-align-bottom">
-            { this.props.contentRight }
-          </div>
-        </div>
-      </div>
-    );
-  }
+	render() {
+		return (
+			<div>
+				<div className="slds-grid">
+					<div className="slds-col slds-has-flexi-truncate">
+						{ this.props.label }
+						{ this.props.title }
+					</div>
+					<div className="slds-col slds-no-flex slds-grid slds-align-top">
+						{ this.props.navRight }
+					</div>
+				</div>
+				<div className="slds-grid">
+					<div className="slds-col slds-align-bottom">
+						{ this.props.info }
+					</div>
+					<div className="slds-col slds-no-flex slds-grid slds-align-bottom">
+						{ this.props.contentRight }
+					</div>
+				</div>
+			</div>
+		);
+	}
 }
 
 ObjectHome.displayName = displayName;

--- a/components/page-header/record-home/index.jsx
+++ b/components/page-header/record-home/index.jsx
@@ -14,59 +14,65 @@ import DetailRow from '../detail-row';
 
 const displayName = 'PageHeaderRecordHome';
 const propTypes = {
-  /**
-   * Icon node passed by PageHeader
-   */
-  icon: React.PropTypes.node,
-  /**
-   * Title node passed by PageHeader
-   */
-  title: React.PropTypes.node,
-  /**
-   * Info node passed by PageHeader
-   */
-  info: React.PropTypes.node,
-  /**
-   * Content to appear on the right hand side of the page header
-   */
-  contentRight: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.element,
-  ]),
-  /**
-   * An array of detail blocks
-   */
-  details: React.PropTypes.array,
+	/**
+	 * Icon node passed by PageHeader
+	 */
+	icon: React.PropTypes.node,
+	/**
+	 * Title node passed by PageHeader
+	 */
+	title: React.PropTypes.node,
+	/**
+	 * Info node passed by PageHeader
+	 */
+	info: React.PropTypes.node,
+	/**
+	 * Content to appear on the right hand side of the page header
+	 */
+	contentRight: React.PropTypes.oneOfType([
+		React.PropTypes.string,
+		React.PropTypes.element,
+	]),
+	/**
+	 * An array of detail blocks
+	 */
+	details: React.PropTypes.array,
 };
 const defaultProps = {};
 
 class RecordHome extends Component {
-  render() {
-    const { details } = this.props;
+	renderIcon() {
+		if(this.props.icon) {
+			return <div className="slds-media__figure">
+				{ this.props.icon }
+			</div>
+		}
+	}
 
-    return (
-      <div>
-        <div className="slds-grid">
-          <div className="slds-col slds-has-flexi-truncate">
-            <div className="slds-media slds-media--center">
-              <div className="slds-media__figure">
-                { this.props.icon }
-              </div>
-              <div className="slds-media__body">
-                { this.props.label }
-                { this.props.title }
-                { this.props.info }
-              </div>
-            </div>
-          </div>
-          <div className="slds-col slds-no-flex slds-grid slds-align-bottom">
-            { this.props.contentRight }
-          </div>
-        </div>
-        <DetailRow details={details} />
-      </div>
-    );
-  }
+	render() {
+		const { details } = this.props;
+
+		return (
+			<div>
+				<div className="slds-grid">
+					<div className="slds-col slds-has-flexi-truncate">
+						<div className="slds-media slds-media--center">
+							{this.renderIcon()}
+							<div className="slds-media__body">
+								{ this.props.label }
+								{ this.props.title }
+								{ this.props.info }
+							</div>
+						</div>
+					</div>
+					<div className="slds-col slds-no-flex slds-grid slds-align-bottom">
+						{ this.props.contentRight }
+					</div>
+				</div>
+				<DetailRow details={details} />
+			</div>
+		);
+	}
 }
 
 RecordHome.displayName = displayName;


### PR DESCRIPTION
If there is no icon passed to page header, the media figure SLDS class still renders and has a margin-right that makes the text alignment off. This fixes that.
