### PR TITLE
Lookup search icon default should be on right side

### DIFF
--- a/components/lookup/index.jsx
+++ b/components/lookup/index.jsx
@@ -127,7 +127,7 @@ const defaultProps = {
 	constrainToScrollParent: true,
 	filterWith: defaultFilter,
 	flippable: false,
-	iconPosition: 'left',
+	iconPosition: 'right',
 	modal: false,
 	required: false,
 	searchTerm: ''


### PR DESCRIPTION
per https://www.lightningdesignsystem.com/components/lookups/

it’s only left in global nav

Fixes #586.
