### PR TITLE
Fix selected item bug in Lookup.

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,6 +2,10 @@
 # React Components: design-system-react
 # Release notes
 
+## Release 0.3.3
+**Bug Fix**
+- Lookup component had a bug where updating the selectedItem prop did not work. Now it does. To clear the item, pass in -1.
+
 ## Release 0.3.2
 
 **MAJOR CHANGES**

--- a/components/lookup/index.jsx
+++ b/components/lookup/index.jsx
@@ -110,7 +110,7 @@ const propTypes = {
 	required: PropTypes.bool,
 	searchTerm: PropTypes.string,
 	/**
-	 * Index of current selected item.
+	 * Index of current selected item. To clear the selection, pass in -1.
 	 */
 	selectedItem: PropTypes.number
 };
@@ -167,6 +167,9 @@ class Lookup extends React.Component {
 	componentWillReceiveProps (newProps) {
 		if (newProps.options) {
 			this.modifyItems(newProps.options);
+		}
+		if (newProps.selectedItem !== this.props.selectedItem) {
+			this.setState({ selectedIndex: newProps.selectedItem });
 		}
 	}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "design-system-react",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Salesforce Lightning Design System React components",
   "license": "BSD-3-Clause",
   "engines": {

--- a/stories/lookup/index.jsx
+++ b/stories/lookup/index.jsx
@@ -3,12 +3,14 @@ import { storiesOf, action } from '@kadira/storybook';
 
 import { LOOKUP } from '../../utilities/constants';
 import Lookup from '../../components/lookup';
+import SLDSButton from '../../components/button';
 
 const DemoLookup = React.createClass({
 	displayName: 'DemoLookup',
 
 	getInitialState () {
 		return {
+			currentSelected: 2,
 			options: [
 				{ label: 'File 1' },
 				{ label: 'File 2' },
@@ -18,23 +20,29 @@ const DemoLookup = React.createClass({
 		};
 	},
 
+	clearSelected() {
+		this.setState({ currentSelected: -1 });
+	},
+
 	render () {
 		return (
+			<div>
+				<SLDSButton onClick={this.clearSelected}>Clear Selected</SLDSButton>
 			<Lookup
 				{...this.props}
 				modal={false}
 				onChange={action('change')}
 				onSelect={this.handleSelect}
 				options={this.state.options}
-				selectedItem={this.state.selectedItem}
+				selectedItem={this.state.currentSelected}
 			/>
+			</div>
 		);
 	},
 
 	handleSelect (selectedItem, ...rest) {
 		action('select')(selectedItem, ...rest);
-
-		this.setState({ selectedItem });
+		this.setState({ currentSelected: this.state.options.indexOf(selectedItem) });
 	}
 });
 


### PR DESCRIPTION
 Can now clear the selected item by passing in `-1` to prop, `selectedItem`.

Fixes Issue:  https://github.com/salesforce-ux/design-system-react/issues/416
