### PR TITLE
Make inline input’s edit icon small

### DIFF
--- a/components/forms/input/inline.jsx
+++ b/components/forms/input/inline.jsx
@@ -125,6 +125,7 @@ const InlineEdit = React.createClass({
 				disabled={disabled}
 				iconName="edit"
 				iconPosition="right"
+				iconSize="small"
 				variant="icon"
 			/>
 		);


### PR DESCRIPTION
Fixes #422.

Color is determined by SLDS. 

From what I can tell an Inline input does not exist in SLDS and needs to be revisited, but I think that is a different issue and will make another issue to re-visit this.

In the patterns I can find, the edit icon is next to the label. One version is inline like DSR's, but is pulled to the right.
