### PR TITLE
Make App Launcher Tile More tooltip trigger a span

### DIFF
--- a/components/app-launcher/tile.jsx
+++ b/components/app-launcher/tile.jsx
@@ -26,7 +26,6 @@ import Truncate from '../utilities/truncate';
 import isFunction from 'lodash.isfunction';
 
 // ## Children
-import Button from '../button';
 import Highlighter from '../utilities/highlighter';
 import PopoverTooltip from '../popover-tooltip';
 
@@ -83,17 +82,15 @@ const AppLauncherTile = (props) => {
 						suffix={props.moreLabel}
 						text={props.description}
 						textTruncateChild={
-							<span>
-								<PopoverTooltip
-									align="bottom"
-									content={<Highlighter
-										search={props.search}
-									>{props.description}</Highlighter>
-								}
-								>
-									<span className="slds-text-link" tabIndex="0">{props.moreLabel}</span>
-								</PopoverTooltip>
-							</span>
+							<PopoverTooltip
+								align="bottom"
+								content={<Highlighter
+									search={props.search}
+								>{props.description}</Highlighter>
+							}
+							>
+								<div className="slds-app-launcher__tile-more slds-text-link" tabIndex="0">{props.moreLabel}</div>
+							</PopoverTooltip>
 						}
 						wrapper={(text, textTruncateChild) =>
 							<div>

--- a/tests/app-launcher/tile.test.jsx
+++ b/tests/app-launcher/tile.test.jsx
@@ -50,8 +50,8 @@ describe('SLDS APP LAUNCHER TILE *******************************************', (
 		handles.body = handles.tile.find('.slds-app-launcher__tile-body');
 		handles.description = handles.body.find('div').at(1);
 		handles.icon = handles.tile.find('.slds-app-launcher__tile-figure');
-		handles.more = handles.tile.find('.slds-button .slds-button--icon-bare .slds-text-link');
-		handles.title = handles.tile.find('span.slds-text-link');
+		handles.more = handles.tile.find('.slds-app-launcher__tile-body .slds-app-launcher__tile-more');
+		handles.title = handles.tile.find('.slds-app-launcher__tile-body').childAt(0);
 	}
 
 	function cleanDom () {
@@ -155,7 +155,8 @@ describe('SLDS APP LAUNCHER TILE *******************************************', (
 		});
 
 		it('renders custom more link', () => {
-			expect(handles.more.find('span').at(0).text()).to.equal('MORE!');
+			// Enzyme is unable to find React inserted `<span>` tags due to text wrapping. Therefore the DOM transversal.
+			expect(handles.more.node.children[1].textContent).to.equal('MORE!');
 		});
 
 		it('long descriptions use Tooltip activated by hover', () => {


### PR DESCRIPTION
Fixes #634. Replaced button with a `span` that has tab index in order to make the HTML valid HTML. This meant that the tags and DOM changed, so the DOM traversal tests needed to be updated, too.

The `slds-app-launcher__tile-more` is not part of SLDS and only present to easily find the node since there are spans all over the place in React when the span is wrapped in a tooltip which is wrapped in truncate which is wrapped in highlight (the higher-order component concept is getting a little intense there), and the heading has the same exact classes as the more trigger.
