### PR TITLE
Prevent Global Nav menus from flipping

### DIFF
--- a/components/global-navigation-bar/dropdown.jsx
+++ b/components/global-navigation-bar/dropdown.jsx
@@ -92,7 +92,7 @@ GlobalNavigationBarDropdown.propTypes = {
 	*/
 	id: PropTypes.string,
 	/**
-	 * This prop is passed into the List for the menu. Pass null to make it the size of the content, or a string with an integer from here: https://www.lightningdesignsystem.com/components/menus/#flavor-dropdown-height
+	 * Provided to List to indicate number of items visible in the List. Pass `null` to display all items, or a string containing one of the numeric option values listed under [Dropdown Height](https://www.lightningdesignsystem.com/components/menus/#flavor-dropdown-height) at the right (eg. '5').
 	 */
 	length: PropTypes.oneOf([null, '5', '7', '10']),
 	/**

--- a/components/menu-dropdown/menu-dropdown.jsx
+++ b/components/menu-dropdown/menu-dropdown.jsx
@@ -123,7 +123,7 @@ const MenuDropdown = React.createClass({
 		 * This prop is passed onto the triggering `Button`. Prevent dropdown menu from opening. Also applies disabled styling to trigger button.
 		 */
 		disabled: PropTypes.bool,
-		/* Prevents the dropdown from changing position based on the viewport/window. If set to true your dropdowns can extend outside the viewport _and_ overflow outside of a scrolling parent. If this happens, you may consider making the dropdowns contents scrollable.
+		/* Prevents the dropdown from changing position based on the viewport/window. If set to true your dropdowns can extend outside the viewport _and_ overflow outside of a scrolling parent. If this happens, you might want to consider making the dropdowns contents scrollable to fit the menu on the screen.
 		*/
 		hasStaticAlignment: PropTypes.bool,
 		/**


### PR DESCRIPTION
- Add `hasStaticAlignment` to dropdown
- Default global nav menu to `hasStaticAlignment` to true to prevent

Fixes #662.

A confirm the same position unit test would be possible. I'm not sure how to manipulate a phantomJS screen size though, so it might take a while.

To manually test:
- `npm start` in master 
- Review http://localhost:9001/?selectedKind=SLDSGlobalNavigationBar&selectedStory=Base&full=0&down=1&left=1&panelRight=0
- Resize the browser to 600 px high. Menu should be on top of nav item.
- Reload same page with this branch and the menu should extend beyond the bottom. of the viewport and dropdown and not up.
