### PR TITLE
Add Dropdown custom content onClick handler

### DIFF
--- a/components/menu-dropdown/menu-dropdown.jsx
+++ b/components/menu-dropdown/menu-dropdown.jsx
@@ -391,6 +391,15 @@ const MenuDropdown = React.createClass({
 		}
 	},
 
+	handleClickCustomContent () {
+		this.setFocus();
+		this.handleClose();
+
+		if (this.props.onSelect) {
+			this.props.onSelect();
+		}
+	},
+
 	handleSelect (index) {
 		this.setState({ selectedIndex: index });
 
@@ -515,7 +524,11 @@ const MenuDropdown = React.createClass({
 			if (child && child.type.displayName === LIST) {
 				customContentWithListPropInjection.push(this.renderDefaultPopoverContent(child.props));
 			} else {
-				customContentWithListPropInjection.push(child);
+				const clonedCustomContent = React.cloneElement(child, {
+					onClick: this.handleClickCustomContent,
+					key: shortid.generate()
+				});
+				customContentWithListPropInjection.push(clonedCustomContent);
 			}
 		});
 		if (customContentWithListPropInjection.length === 0) {

--- a/stories/dropdown/index.jsx
+++ b/stories/dropdown/index.jsx
@@ -35,21 +35,27 @@ const getDropdownCustomTrigger = (props) => (
 	</Dropdown>
 );
 
-const getDropdownCustomContent = (props) => (
-	<Dropdown {...props} >
-		<div id="custom-dropdown-menu-content">
-			<div className="slds-m-around--medium">
-				<div className="slds-tile slds-tile--board slds-m-horizontal--small">
-					<p className="tile__title slds-text-heading--small">Art Vandelay</p>
-					<div className="slds-tile__detail">
-						<p className="slds-truncate">
-							<a className="slds-m-right--medium" href="#">Settings</a>
-							<a href="#" >Log Out</a>
-						</p>
-					</div>
+/* eslint-disable react/prop-types */
+/* eslint-disable no-script-url */
+const DropdownCustomContent = (props) => (
+	<div id="custom-dropdown-menu-content">
+		<div className="slds-m-around--medium">
+			<div className="slds-tile slds-tile--board slds-m-horizontal--small">
+				<p className="tile__title slds-text-heading--small">Art Vandelay</p>
+				<div className="slds-tile__detail">
+					<p className="slds-truncate">
+						<a className="slds-m-right--medium" href="javascript:void(0)" onClick={props.onClick}>Settings</a>
+						<a href="javascript:void(0)" onClick={props.onClick}>Log Out</a>
+					</p>
 				</div>
 			</div>
 		</div>
+	</div>
+);
+
+const getDropdownCustomContent = (props) => (
+	<Dropdown {...props} >
+		<DropdownCustomContent />
 		<List options={[{ label: 'Custom Content Option' }, ...options]} />
 	</Dropdown>
 );

--- a/stories/global-header/index.jsx
+++ b/stories/global-header/index.jsx
@@ -13,6 +13,22 @@ import { GLOBAL_HEADER } from '../../utilities/constants';
 
 import globalNavigationBar from '../global-navigation-bar';
 
+const HeaderProfileCustomContent = (props) => (
+	<div id="custom-dropdown-menu-content">
+		<div className="slds-m-around--medium">
+			<div className="slds-tile slds-tile--board slds-m-horizontal--small">
+				<p className="tile__title slds-text-heading--small">Art Vandelay</p>
+				<div className="slds-tile__detail">
+					<p className="slds-truncate">
+						<a className="slds-m-right--medium" href="javascript:void(0)" onClick={props.onClick}>Settings</a>
+						<a href="javascript:void(0)" onClick={props.onClick}>Log Out</a>
+					</p>
+				</div>
+			</div>
+		</div>
+	</div>
+);
+
 /* eslint-disable react/display-name */
 const GlobalHeaderDemo = (props) => (
 	<GlobalHeader
@@ -70,19 +86,7 @@ const GlobalHeaderDemo = (props) => (
 			onClick={action('Profile Clicked')}
 			onSelect={action('Profile Selected')}
 		>
-			<div id="custom-dropdown-menu-content">
-				<div className="slds-m-around--medium">
-					<div className="slds-tile slds-tile--board slds-m-horizontal--small">
-						<p className="tile__title slds-text-heading--small">Art Vandelay</p>
-						<div className="slds-tile__detail">
-							<p className="slds-truncate">
-								<a className="slds-m-right--medium" href="#">Settings</a>
-								<a href="#" >Log Out</a>
-							</p>
-						</div>
-					</div>
-				</div>
-			</div>
+			<HeaderProfileCustomContent />
 		</GlobalHeaderProfile>
 	</GlobalHeader>
 );

--- a/tests/menu-dropdown/dropdown.test.jsx
+++ b/tests/menu-dropdown/dropdown.test.jsx
@@ -60,21 +60,27 @@ describe('SLDSMenuDropdown: ', () => {
 	const createDropdownIcon = (props) => React.createElement(Dropdown, assign({}, iconOnlyProps, props));
 	createDropdownIcon.displayName = 'createDropdownIcon';
 
-	const createDropdownWithCustomChildren = (props) => (
-		<Dropdown {...assign({}, defaultProps, props)} >
-			<div id="custom-dropdown-menu-content">
-				<div className="slds-m-around--medium">
-					<div className="slds-tile slds-tile--board slds-m-horizontal--small">
-						<p className="tile__title slds-text-heading--small">Art Vandelay</p>
-						<div className="slds-tile__detail">
-							<p className="slds-truncate">
-								<a className="slds-m-right--medium" href="#">Settings</a>
-								<a href="#" >Log Out</a>
-							</p>
-						</div>
+	/* eslint-disable react/prop-types */
+	const DropdownCustomContent = (props) => (
+		<div id="custom-dropdown-menu-content">
+			<div className="slds-m-around--medium">
+				<div className="slds-tile slds-tile--board slds-m-horizontal--small">
+					<p className="tile__title slds-text-heading--small">Art Vandelay</p>
+					<div className="slds-tile__detail">
+						<p className="slds-truncate">
+							<a id="custom-dropdown-menu-content-link" className="slds-m-right--medium" href="#" onClick={props.onClick}>Settings</a>
+							<a href="#" onClick={props.onClick}>Log Out</a>
+						</p>
 					</div>
 				</div>
 			</div>
+		</div>
+	);
+	DropdownCustomContent.displayName = 'DropdownCustomContent';
+
+	const createDropdownWithCustomChildren = (props) => (
+		<Dropdown {...assign({}, defaultProps, props)} >
+			<DropdownCustomContent />
 			<List options={[{ label: 'Custom Content Option' }, ...options]} />
 		</Dropdown>
 	);
@@ -109,6 +115,13 @@ describe('SLDSMenuDropdown: ', () => {
 			Simulate.click(btn, {});
 			const customContent = getMenu(body).querySelector('#custom-dropdown-menu-content');
 			expect(customContent).to.not.equal(undefined);
+		});
+
+		it('closes when custom content is clicked', () => {
+			Simulate.click(btn, {});
+			const customContentLink = getMenu(body).querySelector('#custom-dropdown-menu-content').querySelector('#custom-dropdown-menu-content-link');
+			Simulate.click(customContentLink, {});
+			expect(getMenu(body)).to.equal(null);
 		});
 
 		it('has additional ListItem from list child\'s options prop', () => {


### PR DESCRIPTION
Fixes #685.

This duplicates the functionality that is already passed down to `List`via onSelect and passes down handleClickCustomContent down to the custom content children.

This allows clicking settings or logout to close the menu in the profile menu.
![screen shot 2016-09-22 at 2 43 22 pm](https://cloud.githubusercontent.com/assets/1290832/18761448/fa2409ba-80d2-11e6-932d-84d18ec501fd.png)

This is related to #440. This does not implement an `isOpen` prop though. I did implement an `isOpen` prop for dropdown, but it's not in this code. 
