### PR TITLE
Fix tab bug in picklist 

### DIFF
--- a/components/menu-picklist/index.jsx
+++ b/components/menu-picklist/index.jsx
@@ -215,17 +215,22 @@ const MenuPicklist = React.createClass({
 				EventUtil.trap(event);
 			}
 
-			this.handleKeyboardNavigate({
-				isOpen: this.state.isOpen || false,
-				keyCode: event.keyCode,
-				onSelect: this.handleSelect,
-				toggleOpen: this.toggleOpen
-			});
+			if (event.keyCode !== KEYS.TAB) {
+				this.handleKeyboardNavigate({
+					isOpen: this.state.isOpen || false,
+					keyCode: event.keyCode,
+					onSelect: this.handleSelect,
+					toggleOpen: this.toggleOpen
+				});
+			} else {
+				this.handleCancel();
+			}
 		}
 	},
 
 	handleCancel () {
 		this.setFocus();
+		this.handleClose();
 	},
 
 	closeOnClick (event) {

--- a/stories/picklist/index.jsx
+++ b/stories/picklist/index.jsx
@@ -21,7 +21,10 @@ const options = [
 ];
 
 const getPicklist = (props) => (
-	<Picklist {...props} />
+	<div>
+		<Picklist {...props} />
+		<button style={{ padding: '10px', margin: '50px' }}>test</button>
+	</div>
 );
 
 storiesOf(MENU_PICKLIST, module)


### PR DESCRIPTION
The bug was that when you were focused on the picklist button, tabbing would accidentally open the menu instead of moving focus to the next dom element. Also, another bug was that tabbing while the menu was open would not shut it. Now the keyboard behavior mirrors the dropdown menu :)
