### PR TITLE
Updates SLDS docs path in trees/index.jsx

### DIFF
--- a/components/tree/index.jsx
+++ b/components/tree/index.jsx
@@ -11,7 +11,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 // # Tree Component (PROTOTYPE)
 
-// THIS IS A PROTOTYPE and does NOT meet accessibility standards. It implements the [Tree design pattern](https://www.lightningdesignsystem.com/components/tree/) in React.
+// THIS IS A PROTOTYPE and does NOT meet accessibility standards. It implements the [Tree design pattern](https://www.lightningdesignsystem.com/components/trees/) in React.
 
 // ## Dependencies
 


### PR DESCRIPTION
Fixes #727 

Changes `components/tree/` to `components/trees/` in the SLDS docs path.

**Side Note:** They really ought to have not broken the old URL when they changed it. 😠 
