### PR TITLE
Tabs: Add scoped variant 

### DIFF
--- a/components/tabs/index.jsx
+++ b/components/tabs/index.jsx
@@ -62,7 +62,6 @@ function isTabDisabled (node) {
 	return node.getAttribute('aria-disabled') === 'true';
 }
 
-
 /**
  * Tabs keeps related content in a single container that is shown and hidden through navigation.
  */
@@ -125,6 +124,11 @@ const Tabs = React.createClass({
 		onSelect: PropTypes.func,
 
 		/**
+		 * If the Tabs should be scopped, defaults to false
+		 */
+		variant: React.PropTypes.oneOf(['default', 'scoped']),
+
+		/**
 		 * The Tab (and corresponding TabPanel) that is currently selected.
 		 */
 		selectedIndex: PropTypes.number
@@ -132,7 +136,8 @@ const Tabs = React.createClass({
 
 	getDefaultProps () {
 		return {
-			defaultSelectedIndex: 0
+			defaultSelectedIndex: 0,
+			variant: 'default'
 		};
 	},
 
@@ -143,10 +148,14 @@ const Tabs = React.createClass({
 	componentWillMount () {
 		// If no `id` is supplied in the props we generate one. An HTML ID is _required_ for several elements in a tabs component in order to leverage ARIA attributes for accessibility.
 		this.generatedId = shortid.generate();
-
+		this.flavor = this.getVariant();
 		this.setState({
 			selectedIndex: this.props.defaultSelectedIndex
 		});
+	},
+
+	getVariant () {
+		return this.props.variant === 'scoped' ? 'scoped' : 'default';
 	},
 
 	handleClick (e) {
@@ -308,13 +317,14 @@ const Tabs = React.createClass({
 
 		return (
 			// `parentId` gets consumed by TabsList, adding a suffix of `-tabs__nav`
-			<TabsList id={parentId}>
+			<TabsList id={parentId} variant={this.getVariant()}>
 				{children.map((child, index) => {
 					const ref = `tabs-${index}`;
 					const id = `${parentId}-slds-tabs--tab-${index}`;
 					const panelId = `${parentId}-slds-tabs--panel-${index}`;
 					const selected = this.getSelectedIndex() === index;
 					const focus = selected && this.state.focus;
+					const variant = this.getVariant();
 					return (
 						<Tab
 							key={index}
@@ -324,6 +334,7 @@ const Tabs = React.createClass({
 							id={id}
 							panelId={panelId}
 							disabled={child.props.disabled}
+							variant={variant}
 						>
 							{child.props.label}
 						</Tab>
@@ -342,6 +353,7 @@ const Tabs = React.createClass({
 			const tabId = `${parentId}-slds-tabs--tab-${index}`;
 			const id = `${parentId}-slds-tabs--panel-${index}`;
 			const selected = selectedIndex === index;
+			const variant = this.getVariant();
 
 			return (
 				<TabPanel
@@ -350,6 +362,7 @@ const Tabs = React.createClass({
 					selected={selected}
 					id={id}
 					tabId={tabId}
+					variant={variant}
 				>
 					{children[index]}
 				</TabPanel>
@@ -363,6 +376,7 @@ const Tabs = React.createClass({
 		const {
 			className,
 			id = this.generatedId,
+			variant = this.getVariant,
 			...attributes
 			} = this.props;
 
@@ -381,12 +395,16 @@ const Tabs = React.createClass({
 			<div
 				id={id}
 				className={classNames(
-					'slds-tabs--default',
+					{
+						'slds-tabs--default': variant === 'default',
+						'slds-tabs--scoped': variant === 'scoped'
+					},
 					className
 				)}
 				onClick={this.handleClick}
 				onKeyDown={this.handleKeyDown}
 				data-tabs
+				variant={variant}
 				{...attributes}
 			>
 				{this.renderTabsList(id)}

--- a/components/tabs/tab-panel.jsx
+++ b/components/tabs/tab-panel.jsx
@@ -22,21 +22,23 @@ import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import { TAB_PANEL } from '../../utilities/constants';
 
-const TabPanel = ({ className, children, selected, id, tabId, ...attributes }) => (
+const TabPanel = ({ className, children, variant, selected, id, tabId, ...attributes }) => (
 	<div
 		{...attributes}
 		className={classNames(
-			'slds-tabs--default__content',
 			className,
 			{
 				'slds-show': selected,
-				'slds-hide': !selected
+				'slds-hide': !selected,
+				'slds-tabs--default__content': variant === 'default',
+				'slds-tabs--scoped__content': variant === 'scoped'
 			}
 		)}
 		role="tabpanel"
 		id={id}
 		aria-selected={selected ? 'true' : 'false'}
 		aria-labelledby={tabId}
+		variant={variant}
 	>
 		{children.props.children}
 	</div>
@@ -90,12 +92,18 @@ TabPanel.propTypes = {
 	selected: PropTypes.bool,
 
 	/**
+	 * If the Tabs should be scopped, defaults to false
+	 */
+	variant: React.PropTypes.oneOf(['default', 'scoped']),
+
+	/**
 	 * The HTML ID of the `<Tab />` that controls this panel.
 	 */
 	tabId: PropTypes.string
 };
 
 TabPanel.defaultProps = {
+	variant: 'default',
 	selected: false
 };
 

--- a/components/tabs/tab.jsx
+++ b/components/tabs/tab.jsx
@@ -73,7 +73,12 @@ const Tab = React.createClass({
 		/**
 		 * The string that is shown as both the title and the label for this tab.
 		 */
-		children: PropTypes.string
+		children: PropTypes.string,
+
+		/**
+		 * If the Tabs should be scopped, defaults to false
+		 */
+		variant: React.PropTypes.oneOf(['default', 'scoped'])
 	},
 
 	getDefaultProps () {
@@ -81,7 +86,8 @@ const Tab = React.createClass({
 			focus: false,
 			selected: false,
 			activeTabClassName: 'slds-active',
-			disabledTabClassName: 'slds-disabled'
+			disabledTabClassName: 'slds-disabled',
+			variant: 'default'
 		};
 	},
 
@@ -109,20 +115,21 @@ const Tab = React.createClass({
 			className,
 			children,
 			id,
+			variant,
 			...attributes } = this.props;
 
 		delete attributes.focus;
-
 		return (
 			<li
 				{...attributes}
 				className={classNames(
-					'slds-tabs--default__item',
 					'slds-text-title--caps',
 					className,
 					{
 						[activeTabClassName]: selected,
-						[disabledTabClassName]: disabled
+						[disabledTabClassName]: disabled,
+						'slds-tabs--default__item': variant === 'default',
+						'slds-tabs--scoped__item': variant === 'scoped'
 					}
 				)}
 				role="tab"
@@ -134,7 +141,14 @@ const Tab = React.createClass({
 				title={children}
 			>
 				<a
-					className="slds-tabs--default__link"
+					className={classNames(
+						{
+							[activeTabClassName]: selected,
+							[disabledTabClassName]: disabled,
+							'slds-tabs--default__link': variant === 'default',
+							'slds-tabs--scoped__link': variant === 'scoped'
+						}
+					)}
 					href="javascript:void(0);" // eslint-disable-line no-script-url
 					role="presentation"
 					tabIndex="-1"

--- a/components/tabs/tabs-list.jsx
+++ b/components/tabs/tabs-list.jsx
@@ -27,16 +27,21 @@ const TabsList = ({
 	id,
 	className,
 	children,
+	variant,
 	...attributes
 }) => (
 	<ul
 		id={`${id}-slds-tabs__nav`}
 		{...attributes}
 		className={classNames(
-			'slds-tabs--default__nav',
-			className
+			className,
+			{
+				'slds-tabs--default__nav': variant === 'default',
+				'slds-tabs--scoped__nav': variant === 'scoped'
+			}
 		)}
 		role="tablist"
+		variant={variant}
 	>
 		{children}
 	</ul>
@@ -65,7 +70,12 @@ TabsList.propTypes = {
 	children: PropTypes.oneOfType([
 		PropTypes.object,
 		PropTypes.array
-	])
+	]),
+
+	/**
+	 * If the Tabs should be scopped, defaults to false
+	 */
+	variant: React.PropTypes.oneOf(['default', 'scoped'])
 };
 
 module.exports = TabsList;

--- a/stories/tabs/index.jsx
+++ b/stories/tabs/index.jsx
@@ -126,6 +126,32 @@ const getTabsNested = () => (
 );
 /* eslint-enable react/display-name */
 
+/* eslint-disable react/display-name */
+const getTabsScoped = () => (
+	<div>
+		<h2 className="slds-text-heading--large">Scoped Tabs Demo</h2>
+		<Tabs id="scoped-tabs-demo" variant="scoped">
+			<Panel label="Tab 1">
+				<h2 className="slds-text-heading--medium">This is my tab 1 contents!</h2>
+				<p>And they&rsquo;re amazing.</p>
+				<p>It's awesome.</p>
+				<p>You can use your <var>TAB</var> and <var>ARROW</var> keys to navigate around. Try it!</p>
+				<p className="slds-box slds-theme--info slds-m-top--large">
+					(You might have to hit shift+tab to put the focus onto the tab bar ;)
+				</p>
+			</Panel>
+			<Panel label="Tab 2">
+				<h2 className="slds-text-heading--medium">This is my tab 2 contents!</h2>
+				<p>And they&rsquo;re also amazing.</p>
+			</Panel>
+			<Panel label="Tab 3">
+				<h2 className="slds-text-heading--medium">This is my tab 3 contents!</h2>
+				<p>And they&rsquo;re quite spectacular.</p>
+			</Panel>
+		</Tabs>
+	</div>
+);
+/* eslint-enable react/display-name */
 
 const DemoTabsConditional = React.createClass({
 	displayName: 'DemoTabsConditional',
@@ -448,6 +474,7 @@ storiesOf(TABS, module)
 	.add('Outside Control', () => <DemoTabsOutsideControl className="controlled-yo" />)
 	.add('Conditional', () => <DemoTabsConditional className="conditional-yo" />)
 	.add('Unique Generated IDs', () => getTabsMoreThanOneAllowGeneratedID())
+	.add('Scoped', () => getTabsScoped())
 	;
 
 module.exports = getTabs;

--- a/styles/tabs/tab.css
+++ b/styles/tabs/tab.css
@@ -1,18 +1,24 @@
-.slds-tabs--default .slds-tabs--default__item.slds-disabled {
+.slds-tabs--default .slds-tabs--default__item.slds-disabled,
+.slds-tabs--scoped .slds-tabs--scoped__item.slds-disabled {
   opacity: 0.5;
 }
-.slds-tabs--default .slds-tabs--default__item.slds-disabled > a:hover, .slds-tabs--default .slds-tabs--default__item.slds-disabled > a.slds-tabs--default__link:focus {
+.slds-tabs--default .slds-tabs--default__item.slds-disabled > a:hover,
+.slds-tabs--scoped .slds-tabs--scoped__item.slds-disabled > a:hover,
+.slds-tabs--default .slds-tabs--default__item.slds-disabled > a.slds-tabs--default__link:focus,
+.slds-tabs--scoped .slds-tabs--scoped__item.slds-disabled > a.slds-tabs--scoped__link:focus {
   cursor: not-allowed;
   text-decoration: none;
   border-color: transparent;
   color: inherit;
 }
-.slds-tabs--default .slds-tabs--default__item.slds-disabled.slds-active a.slds-tabs--default__link {
+.slds-tabs--default .slds-tabs--default__item.slds-disabled.slds-active a.slds-tabs--default__link,
+.slds-tabs--scoped .slds-tabs--scoped__item.slds-disabled.slds-active a.slds-tabs--scoped__link {
   cursor: not-allowed;
   border-color: transparent;
   color: inherit;
 }
-.slds-tabs--default .slds-tabs--default__item.slds-disabled.slds-active a.slds-tabs--default__link:focus {
+.slds-tabs--default .slds-tabs--default__item.slds-disabled.slds-active a.slds-tabs--default__link:focus,
+.slds-tabs--scoped .slds-tabs--scoped__item.slds-disabled.slds-active a.slds-tabs--scoped__link:focus {
   cursor: not-allowed;
   color: inherit;
 }


### PR DESCRIPTION
Fixes #733

---

Adds new scoped variant, used like:

`<Tabs id="scoped-tabs-demo" variant="scoped">`

<img width="612" alt="screenshot 2016-11-02 15 15 59" src="https://cloud.githubusercontent.com/assets/362417/19943773/50fe9ca8-a10f-11e6-830e-aa445793ca69.png">
