### PR TITLE
bug fix - clear the currentOpenDropdown to avoid setState errors afte…

### DIFF
--- a/components/menu-dropdown/menu-dropdown.jsx
+++ b/components/menu-dropdown/menu-dropdown.jsx
@@ -315,6 +315,9 @@ const MenuDropdown = React.createClass({
 	},
 
 	componentWillUnmount () {
+        if (currentOpenDropdown === this) {
+            currentOpenDropdown = undefined;
+        }
 		this.isUnmounting = true;
 		this.renderOverlay(false);
 	},


### PR DESCRIPTION
Bug fix for SLDSMenuDropdown issue https://github.com/salesforce-ux/design-system-react/issues/761

currentOpenDropdown can end up holding on to unmounted components causing some weirdness with setState(). 

@interactivellama @mvantassel