### PR TITLE
added trailing slashes on links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@
 ## Overview
 Welcome to the project! :wave: This is an internal open source project and contributions are expected from production teams consuming this library. There is only one engineer 100%-aligned to this project at this moment. All other contributors are on production teams that ship end-product with releases dates, too.
 
-Please visit [Design System React](https://react.lightningdesignsystem.com/) for documentation and examples of using the Design System React components. The documentation site has a [Getting Started Guide](https://react.lightningdesignsystem.com/getting-started) and a [FAQ](https://react.lightningdesignsystem.com/faq) page. If you are new to this project or React, please review the [Concepts and Best Practices](https://react.lightningdesignsystem.com/contributing#concepts-and-best-practices) section of the [Contributing](https://react.lightningdesignsystem.com/contributing) page. It will help you with the approach of this library and offer some suggestions for your own components.
+Please visit [Design System React](https://react.lightningdesignsystem.com/) for documentation and examples of using the Design System React components. The documentation site has a [Getting Started Guide](https://react.lightningdesignsystem.com/getting-started/) and a [FAQ](https://react.lightningdesignsystem.com/faq/) page. If you are new to this project or React, please review the [Concepts and Best Practices](https://react.lightningdesignsystem.com/contributing/#concepts-and-best-practices) section of the [Contributing](https://react.lightningdesignsystem.com/contributing/) page. It will help you with the approach of this library and offer some suggestions for your own components.
 
 The Design System React library is the [React](https://facebook.github.io/react/) implementation of the [Lightning Design System](https://www.lightningdesignsystem.com/). Each Design System React component is a specific variant of a component from Lightning Design System. For example, `SLDSMenuDropdown` represents [Lightning Design System Menu > Dropdown](http://www.lightningdesignsystem.com/components/menus/#dropdown),
 and `SLDSLookup` represents [Lightning Design System Lookup > Base](http://www.lightningdesignsystem.com/components/lookups/#base).
 
 #### Multiple packages for different module loaders
 
-_It is highly recommended that you `npm install` the `-es` suffixed package tag and import the individual [ECMAScript 6](https://github.com/lukehoban/es6features/blob/master/README.md) source files in `./components/`._ If you do this, you will need to enable your ES5 transpiler to allow [stage-1 and higher proposed features](https://babeljs.io/docs/plugins/preset-stage-1/). If you are using Babel, it may be helpful to install the [NPM module](https://www.npmjs.com/package/babel-preset-stage-1) `babel-preset-stage-1` into your project and review the `.babelrc` file in this project. 
+_It is highly recommended that you `npm install` the `-es` suffixed package tag and import the individual [ECMAScript 6](https://github.com/lukehoban/es6features/blob/master/README.md) source files in `./components/`._ If you do this, you will need to enable your ES5 transpiler to allow [stage-1 and higher proposed features](https://babeljs.io/docs/plugins/preset-stage-1/). If you are using Babel, it may be helpful to install the [NPM module](https://www.npmjs.com/package/babel-preset-stage-1) `babel-preset-stage-1` into your project and review the `.babelrc` file in this project.
 
-If you are looking for a a [CommonJS](https://nodejs.org/docs/latest/api/modules.html)-compatible package, use the package tag that does not have a suffix. 
+If you are looking for a a [CommonJS](https://nodejs.org/docs/latest/api/modules.html)-compatible package, use the package tag that does not have a suffix.
 
 ### Run local development and testing server
 
@@ -40,11 +40,11 @@ npm run dist
 
 ## Getting Started
 
-Note: `design-system-react` is optimized for React 0.14.x and uses Lightning Design System 2.1.3. You can find a more complete [getting started guide](https://react.lightningdesignsystem.com/getting-started) on the documentation site.
+Note: `design-system-react` is optimized for React 0.14.x and uses Lightning Design System 2.1.3. You can find a more complete [getting started guide](https://react.lightningdesignsystem.com/getting-started/) on the documentation site.
 
 ### New to React?
 
-Take a look at our [recommended reading list](https://react.lightningdesignsystem.com/resources) on the documentation site and level up on your knowledge. The reading list also includes helpful articles on Redux, Webpack, ES6, and structuring your app. The [Concepts and Best Practices](https://react.lightningdesignsystem.com/contributing#concepts-and-best-practices) section of the [Contributing](https://react.lightningdesignsystem.com/contributing) page will help you understand the approach of this library and offer some suggestions for your own components, too.
+Take a look at our [recommended reading list](https://react.lightningdesignsystem.com/resources/) on the documentation site and level up on your knowledge. The reading list also includes helpful articles on Redux, Webpack, ES6, and structuring your app. The [Concepts and Best Practices](https://react.lightningdesignsystem.com/contributing/#concepts-and-best-practices) section of the [Contributing](https://react.lightningdesignsystem.com/contributing/) page will help you understand the approach of this library and offer some suggestions for your own components, too.
 
 ### NPM
 
@@ -82,7 +82,7 @@ Note: the SLDSPopoverTooltip requires a focusable element as a child (ie. either
 ```
 
 ## FAQ
-Read our [FAQ](https://react.lightningdesignsystem.com/faq) on the documentation site.
+Read our [FAQ](https://react.lightningdesignsystem.com/faq/) on the documentation site.
 
 ## Contributing to the code base
 


### PR DESCRIPTION
@interactivellama When going through the README some of the links were broken so I updated them by adding a trailing "/" to the ones that needed them.

For example:
https://react.lightningdesignsystem.com/getting-started => https://react.lightningdesignsystem.com/getting-started/