### PR TITLE
Use the `options` from the same props as the `value`

### DIFF
--- a/components/menu-picklist/index.jsx
+++ b/components/menu-picklist/index.jsx
@@ -116,14 +116,14 @@ const MenuPicklist = React.createClass({
 		window.addEventListener('click', this.closeOnClick, false);
 
 		this.setState({
-			selectedIndex: this.getIndexByValue(this.props.value)
+			selectedIndex: this.getIndexByValue(this.props)
 		});
 	},
 
 	componentWillReceiveProps (nextProps) {
-		if (this.props.value !== nextProps.value) {
+		if (this.props.value !== nextProps.value || this.props.options.length !== nextProps.length) {
 			this.setState({
-				selectedIndex: this.getIndexByValue(nextProps.value)
+				selectedIndex: this.getIndexByValue(nextProps)
 			});
 		}
 	},
@@ -142,11 +142,11 @@ const MenuPicklist = React.createClass({
 		return `SLDS${this.getId()}ClickEvent`;
 	},
 
-	getIndexByValue (value) {
+	getIndexByValue ({ value, options } = this.props) {
 		let foundIndex = -1;
 
-		if (this.props.options && this.props.options.length) {
-			this.props.options.some((element, index) => {
+		if (options && options.length) {
+			options.some((element, index) => {
 				if (element && element.value === value) {
 					foundIndex = index;
 					return true;


### PR DESCRIPTION
This PR is to fix an issue that @rbmoore was having where the value might be available before the options are. In the previous incarnation of the Picklist if you set the value before you received the final set of options the selected index method would never be updated.

Note that in the long run there might be value in updating the component to a more standard controlled / uncontrolled pattern.