### PR TITLE
Remove extraneous assistiveText in Datepicker

### DIFF
--- a/components/date-picker/private/calendar-wrapper.jsx
+++ b/components/date-picker/private/calendar-wrapper.jsx
@@ -171,7 +171,7 @@ const DatepickerCalendarWrapper = React.createClass({
 
 	render () {
 		return (
-			<div
+			<div // eslint-disable-line jsx-a11y/no-static-element-interactions
 				className={classNames({
 					'slds-datepicker': this.props.isolated
 				},
@@ -213,8 +213,6 @@ const DatepickerCalendarWrapper = React.createClass({
 					onLastFocusableNodeKeyDown={this.handleLastFocusableNodeKeyDown}
 					weekDayLabels={this.props.weekDayLabels}
 				/>
-				<span id="bn_prev-label" className="slds-assistive-text">{this.props.assistiveTextNextMonth}</span>
-				<span id="bn_next-label" className="slds-assistive-text">{this.props.assistiveTextPreviousMonth}</span>
 			</div>
 		);
 	}

--- a/tests/date-picker/__snapshots__/datepicker.snapshot-test.jsx.snap
+++ b/tests/date-picker/__snapshots__/datepicker.snapshot-test.jsx.snap
@@ -772,16 +772,6 @@ exports[`test Datepicker
           </tbody>
         </table>
       </div>
-      <span
-        className="slds-assistive-text"
-        id="bn_prev-label">
-        CUSTOM next month
-      </span>
-      <span
-        className="slds-assistive-text"
-        id="bn_next-label">
-        CUSTOM previous month
-      </span>
     </div>
   </div>
 </div>
@@ -1548,16 +1538,6 @@ exports[`test Datepicker
           </tbody>
         </table>
       </div>
-      <span
-        className="slds-assistive-text"
-        id="bn_prev-label">
-        Next month
-      </span>
-      <span
-        className="slds-assistive-text"
-        id="bn_next-label">
-        Previous month
-      </span>
     </div>
   </div>
 </div>
@@ -2322,16 +2302,6 @@ exports[`test Datepicker Default DOM Snapshot 1`] = `
           </tbody>
         </table>
       </div>
-      <span
-        className="slds-assistive-text"
-        id="bn_prev-label">
-        Next month
-      </span>
-      <span
-        className="slds-assistive-text"
-        id="bn_next-label">
-        Previous month
-      </span>
     </div>
   </div>
 </div>
@@ -2422,7 +2392,8 @@ exports[`test Datepicker Default HTML Snapshot 1`] = `
                         </tr>
                     </tbody>
                 </table>
-            </div><span id=\"bn_prev-label\" class=\"slds-assistive-text\">Next month</span><span id=\"bn_next-label\" class=\"slds-assistive-text\">Previous month</span></div>
+            </div>
+        </div>
     </div>
 </div>"
 `;


### PR DESCRIPTION
I'm not sure why these two assistiveText items got added. They aren't a part of any button. The fact that the `id`'s are static makes me think it's just old code I didn't catch when I audited the datepicker.