### PR TITLE
support disabling dates

### DIFF
--- a/components/date-picker/date-picker.jsx
+++ b/components/date-picker/date-picker.jsx
@@ -87,6 +87,10 @@ const Datepicker = React.createClass({
 		 */
 		disabled: PropTypes.bool,
 		/**
+		 * dateDisabled() takes a date as input argument, returns true if given date should be disabled, otherwise returns false.
+		 */
+		dateDisabled: PropTypes.func,
+		/**
 		 * Date formatting function. _Tested with snapshot testing._
 		 */
 		formatter: PropTypes.func,
@@ -236,7 +240,8 @@ const Datepicker = React.createClass({
 				'Thursday',
 				'Friday',
 				'Saturday'
-			]
+			],
+			dateDisabled: () => false
 		};
 	},
 
@@ -406,6 +411,7 @@ const Datepicker = React.createClass({
 			isIsoWeekday={this.props.isIsoWeekday}
 			monthLabels={this.props.monthLabels}
 			onCalendarFocus={this.props.onCalendarFocus}
+			dateDisabled={this.props.dateDisabled}
 			onRequestClose={this.handleRequestClose}
 			onSelectDate={this.handleCalendarChange}
 			ref={() => {

--- a/components/date-picker/private/calendar-wrapper.jsx
+++ b/components/date-picker/private/calendar-wrapper.jsx
@@ -42,6 +42,10 @@ const DatepickerCalendarWrapper = React.createClass({
 		 */
 		className: PropTypes.oneOfType([PropTypes.array, PropTypes.object, PropTypes.string]),
 		/**
+		 * dateDisabled() takes a date as input argument, returns true if given date should be disabled, otherwise returns false.
+		 */
+		dateDisabled: PropTypes.func,
+		/**
 		 * HTML id for component
 		 */
 		id: PropTypes.string,
@@ -196,6 +200,7 @@ const DatepickerCalendarWrapper = React.createClass({
 				/>
 				<Calendar
 					abbreviatedWeekDayLabels={this.props.abbreviatedWeekDayLabels}
+					dateDisabled={this.props.dateDisabled}
 					id={this.props.id}
 					initialDateForCalendarRender={this.state.initialDateForCalendarRender}
 					isIsoWeekday={this.props.isIsoWeekday}

--- a/components/date-picker/private/calendar.jsx
+++ b/components/date-picker/private/calendar.jsx
@@ -20,6 +20,10 @@ const DatepickerCalendar = React.createClass({
 		 */
 		abbreviatedWeekDayLabels: PropTypes.array.isRequired,
 		/**
+		 * dateDisabled() takes a date as input argument, returns true if given date should be disabled, otherwise returns false.
+		 */
+		dateDisabled: PropTypes.func,
+		/**
 		 * HTML id for component
 		 */
 		id: PropTypes.string.isRequired,
@@ -98,6 +102,7 @@ const DatepickerCalendar = React.createClass({
 	},
 
 	handleSelectDate (event, { date }) {
+		if (this.props.dateDisabled(date)) return;
 		this.setState({ selected: date });
 		this.props.onSelectDate(event, { date });
 	},
@@ -233,6 +238,7 @@ const DatepickerCalendar = React.createClass({
 		while (!done) {
 			weeks.push(<Week
 				calendarHasFocus={this.state.calendarHasFocus}
+				dateDisabled={this.props.dateDisabled}
 				firstDayOfWeek={firstDayOfWeek}
 				key={firstDayOfWeek.toString()}
 				focusedDate={this.state.focusedDate}

--- a/components/date-picker/private/day.jsx
+++ b/components/date-picker/private/day.jsx
@@ -62,14 +62,15 @@ const DatepickerCalendarDay = (props) => {
 	const isToday = DateUtil.isToday(props.date);
 	const isSelectedDay = DateUtil.isSameDay(props.date, props.selectedDate);
 	const isFirstDayOfMonth = DateUtil.isFirstDayOfMonth(props.date);
+	const isDisabled = !isCurrentMonth || props.disabled;
 
 	return (
 		<td
-			aria-disabled={!isCurrentMonth}
+			aria-disabled={isDisabled}
 			aria-selected={isSelectedDay}
 			className={classNames({
 				'slds-is-today': isToday,
-				'slds-disabled-text': !isCurrentMonth,
+				'slds-disabled-text': isDisabled,
 				'slds-is-selected': isSelectedDay
 			})}
 			onClick={(event) => {
@@ -115,6 +116,10 @@ DatepickerCalendarDay.propTypes = {
 	 * Date of day
 	 */
 	date: PropTypes.instanceOf(Date).isRequired,
+	/**
+	 * If date is disabled
+	 */
+	disabled: PropTypes.bool,
 	/**
    * Date used to create calendar that is displayed. This is typically the initial day focused when using the keyboard navigation. Focus will be set to this date if available.
    */

--- a/components/date-picker/private/week.jsx
+++ b/components/date-picker/private/week.jsx
@@ -21,6 +21,7 @@ const DatepickerWeek = (props) => {
 		days.push(<Day
 			calendarHasFocus={props.calendarHasFocus}
 			date={date}
+			disabled={props.dateDisabled(date)}
 			focusedDate={props.focusedDate}
 			initialDateForCalendarRender={props.initialDateForCalendarRender}
 			key={date.toString()}
@@ -55,6 +56,10 @@ DatepickerWeek.propTypes = {
    * Is true if calendar day has focus.
    */
 	calendarHasFocus: PropTypes.bool.isRequired,
+	/**
+	 * dateDisabled() takes a date as input argument, returns true if given date should be disabled, otherwise returns false.
+	 */
+	dateDisabled: PropTypes.func,
 	/**
    * First day of week.
    */

--- a/examples/date-picker/stories.jsx
+++ b/examples/date-picker/stories.jsx
@@ -8,6 +8,7 @@ import Default from './default';
 import IsoWeekdays from './iso-weekday';
 import CustomInput from './custom-input';
 import SnaphotDefault from './snapshot-default';
+import WeekdayPicker from './weekday-picker';
 
 storiesOf(DATE_PICKER, module)
 	.addDecorator((getStory) => <div className="slds-p-around--medium">{getStory()}</div>)
@@ -15,4 +16,5 @@ storiesOf(DATE_PICKER, module)
 	.add('ISO weekdays', () => (<IsoWeekdays action={action} />))
 	.add('Custom Input', () => (<CustomInput action={action} />))
 	.add('Inline menu', () => (<Datepicker isInline />))
-	.add('DOM Snapshot', () => (<SnaphotDefault />));
+	.add('DOM Snapshot', () => (<SnaphotDefault />))
+	.add('Weekday picker', () => (<WeekdayPicker />));

--- a/examples/date-picker/weekday-picker.jsx
+++ b/examples/date-picker/weekday-picker.jsx
@@ -1,0 +1,17 @@
+/* eslint-disable no-console, react/prop-types */
+import React from 'react';
+import Datepicker from '~/components/date-picker';
+
+const Example = React.createClass({
+	displayName: 'DatepickerExample',
+
+	render () {
+		return (
+			<Datepicker
+				dateDisabled={date => date.getDay() > 5 || date.getDay() < 1}
+			/>
+		);
+	}
+});
+
+export default Example;	// export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/tests/date-picker/date-picker.test.jsx
+++ b/tests/date-picker/date-picker.test.jsx
@@ -359,4 +359,45 @@ describe('SLDSDatepicker', function () {
 			}, 200);
 		});
 	});
+
+	describe('Disable dates', () => {
+		beforeEach(() => {
+			mountNode = createMountNode({ context: this });
+		});
+
+		afterEach(() => {
+			destroyMountNode({ wrapper, mountNode });
+		});
+
+		it('disable weekends', (done) => {
+			wrapper = mount(
+				<DemoComponent
+					value={new Date(2007, 0, 5)}
+					dateDisabled={date => date.getDay() > 5 || date.getDay() < 1}
+					portalMount={(reactElement, domContainerNode) => {
+						portalWrapper = mount(reactElement, { attachTo: domContainerNode });
+					}}
+					onOpen={() => {
+						const input = wrapper.find('input');
+						expect(input.node.value).to.equal('1/5/2007');
+
+						const disabledDay = portalWrapper.find('.datepicker__month [aria-disabled=true]').first();
+						disabledDay.simulate('click', {});
+
+						expect(input.node.value).to.equal('1/5/2007');
+
+						const day = portalWrapper.find('.datepicker__month [aria-disabled=false]').first();
+						day.simulate('click', {});
+
+						expect(input.node.value).to.equal('1/1/2007');
+						done();
+					}}
+				/>,
+				{ attachTo: mountNode }
+			);
+
+			const trigger = wrapper.find(triggerClassSelector);
+			trigger.simulate('click', {});
+		});
+	});
 });


### PR DESCRIPTION
Added prop `dateDisabled`, which is a callback function that determines whether a date should be disabled.

A few things need to consider:
* Disabled dates and dates that are not in current month are in the same style, which may cause confusion.
* What happens if `value` is set to an disabled date? In this PR, it is allowed.

Fixes #909 842