### PR TITLE
Adding attribute to not show selected item in lookup component

### DIFF
--- a/components/lookup/index.jsx
+++ b/components/lookup/index.jsx
@@ -173,7 +173,7 @@ const Lookup = React.createClass({
 		/**
 		 * Index of current selected item. To clear the selection, pass in -1.
 		 */
-		selectedItem: PropTypes.number,
+		selectedItem: PropTypes.number
 
 	},
 


### PR DESCRIPTION
This PR's purpose is to introduce an attribute on existing lookup component to NOT show selected item(piller) once user select from the list menu. 

Lightning Report team would like to have this use case. To proper explain the use case, please see the attached gif for better explanation. 

Here we are using the lookup component, however whenever user select a option in the list. We will make some server call and re-generate the options and passed it to lookup component. 
In the meantime, we don't want the lookup to show the selected piller since next time user click to trigger the menu list, the options won't show the previous selected item anymore.

@interactivellama  Please review. Let us know if you have any concerns. FYI @garygong @tbrendanmurray  

![pillerfix 1](https://cloud.githubusercontent.com/assets/9015361/23766515/0198bbda-04ba-11e7-8cda-0752a7022a5b.gif)

