### PR TITLE
Fix focus transfer on close of modal picklist

### DIFF
--- a/components/menu-picklist/index.jsx
+++ b/components/menu-picklist/index.jsx
@@ -273,6 +273,14 @@ const MenuPicklist = React.createClass({
 		if (index === this.state.focusedIndex) this.handleKeyboardFocus(this.state.focusedIndex);
 	},
 
+	// Trigger opens, closes, and recieves focus on close
+	saveRefToTrigger (trigger) {
+		this.button = trigger;
+		if (this.props.buttonRef) {
+			this.props.buttonRef(this.button);
+		}
+	},
+
 	getMenu () {
 		return ReactDOM.findDOMNode(this.list);
 	},
@@ -372,13 +380,7 @@ const MenuPicklist = React.createClass({
 					disabled={this.props.disabled}
 					id={this.getId()}
 					onClick={!this.props.disabled && this.handleClick}
-					ref={(component) => {
-						this.button = component;
-
-						if (this.props.buttonRef) {
-							this.props.buttonRef(this.button);
-						}
-					}}
+					ref={this.saveRefToTrigger}
 					tabIndex={this.state.isOpen ? -1 : 0}
 				>
 					<span className="slds-truncate">{this.renderPlaceholder()}</span>


### PR DESCRIPTION
*If the ref callback is defined as an inline function, it will get called twice during updates, first with null and then again with the DOM element. This is because a new instance of the function is created with each render, so React needs to clear the old ref and set up the new one. You can avoid this by defining the ref callback as a bound method on the class*
https://facebook.github.io/react/docs/refs-and-the-dom.html#caveats

Fixes #929 for modal picklists.

onClose focus transfer of inline picklist is still broken because `<List>` doesn't have an `onCancel` prop (line 303).

@interactivellama , please review