### PR TITLE
Input: correct spelling and usage of aria-labelledby

### DIFF
--- a/components/forms/input/index.jsx
+++ b/components/forms/input/index.jsx
@@ -59,7 +59,7 @@ const Input = React.createClass({
 		'aria-describedby': PropTypes.string,
 		'aria-expanded': PropTypes.bool,
 		'aria-haspopup': PropTypes.bool,
-		'aria-labeledby': PropTypes.string,
+		'aria-labelledby': PropTypes.string,
 		/**
 		 * An HTML ID that is shared with ARIA-supported devices with the
 		 * `aria-controls` attribute in order to relate the input with
@@ -298,6 +298,7 @@ const Input = React.createClass({
 						aria-activedescendant={this.props['aria-activedescendant']}
 						aria-autocomplete={this.props['aria-autocomplete']}
 						aria-controls={this.props['aria-controls']}
+						aria-labelledby={this.props['aria-labelledby']}
 						aria-describedby={this.getErrorId()}
 						aria-expanded={this.props['aria-expanded']}
 						aria-owns={this.props['aria-owns']}

--- a/tests/date-picker/__snapshots__/datepicker.snapshot-test.jsx.snap
+++ b/tests/date-picker/__snapshots__/datepicker.snapshot-test.jsx.snap
@@ -26,6 +26,7 @@ exports[`test Datepicker
         aria-controls={undefined}
         aria-describedby={undefined}
         aria-expanded={undefined}
+        aria-labelledby={undefined}
         aria-owns={undefined}
         aria-required={undefined}
         className="slds-input"
@@ -792,6 +793,7 @@ exports[`test Datepicker
         aria-controls={undefined}
         aria-describedby={undefined}
         aria-expanded={undefined}
+        aria-labelledby={undefined}
         aria-owns={undefined}
         aria-required={undefined}
         className="slds-input"
@@ -1556,6 +1558,7 @@ exports[`test Datepicker Default DOM Snapshot 1`] = `
         aria-controls={undefined}
         aria-describedby={undefined}
         aria-expanded={undefined}
+        aria-labelledby={undefined}
         aria-owns={undefined}
         aria-required={undefined}
         className="slds-input"


### PR DESCRIPTION
Fixes two small issues in `Input`:
1. `aria-labelledby` was spelled as `aria-labeledby`
2. `aria-labelledby` was not set on `input` element

@interactivellama , please review