### PR TITLE
Filter: Make a11y text prop one object

### DIFF
--- a/components/filter/index.jsx
+++ b/components/filter/index.jsx
@@ -42,17 +42,16 @@ const Filter = React.createClass({
 		 */
 		align: PropTypes.oneOf(['left', 'right']),
 		/**
-		 * Assistive text for removing a filter. The default is `Remove Filter: ${this.props.property} ${this.props.predicate}`.
+		 * **Assistive text for accessibility**
+		 * * `removeFilter`: Assistive text for removing a filter. The default is `Remove Filter: this.props.property this.props.predicate`.
+		 * * `editFilter`: Assistive text for changing a filter.
+		 * * `editFilterHeading`: Assistive text for Popover heading.
 		 */
-		assistiveTextRemoveFilter: PropTypes.string,
-		/**
-		 * Assistive text for changing a filter.
-		 */
-		assistiveTextEditFilter: PropTypes.string,
-		/**
-		 * Assistive text for Popover heading.
-		 */
-		assistiveTextEditFilterHeading: PropTypes.string,
+		assistiveText: PropTypes.shape({
+			editFilter: PropTypes.string,
+			editFilterHeading: PropTypes.string,
+			removeFilter: PropTypes.string
+		}),
 		/**
 		 * Contents of popover. That is the dropdowns and inputs that set the filter criteria. **Dropdowns, Picklists and other menus must use `isInline` to work properly within a Popover due to existence of portal mounts in menus that are not inline.**
 		 */
@@ -113,8 +112,10 @@ const Filter = React.createClass({
 	getDefaultProps () {
 		return {
 			align: 'left',
-			assistiveTextEditFilter: 'Edit filter:',
-			assistiveTextEditFilterHeading: 'Choose filter criteria',
+			assistiveText: {
+				editFilter: 'Edit filter:',
+				editFilterHeading: 'Choose filter criteria'
+			},
 			predicate: 'New Filter'
 		};
 	},
@@ -159,13 +160,13 @@ const Filter = React.createClass({
 		}
 	},
 
-	getCustomPopoverProps () {
+	getCustomPopoverProps ({ assistiveText }) {
 		/*
 		 * Generate the popover props based on passed in popover props. Using the default behavior if not provided by passed in popover
 		 */
 		const popoverBody = (
 			<div>
-				<h4 className="slds-assistive-text" id={`${this.getId()}-popover-heading`}>{this.props.assistiveTextEditFilterHeading}</h4>
+				<h4 className="slds-assistive-text" id={`${this.getId()}-popover-heading`}>{assistiveText.editFilterHeading}</h4>
 				{this.props.children}
 				<div className="slds-m-top--small slds-text-align--right">
 					<Button
@@ -199,8 +200,19 @@ const Filter = React.createClass({
 	},
 
 	render () {
+		/* Remove at next breaking change */
+		const assistiveText = {
+			editFilter: this.props.assistiveTextEditFilter // eslint-disable-line react/prop-types
+				|| this.props.assistiveText.editFilter,
+			editFilterHeading: this.props.assistiveTextEditFilterHeading // eslint-disable-line react/prop-types
+				|| this.props.assistiveText.editFilterHeading,
+			removeFilter: this.props.assistiveTextRemoveFilter // eslint-disable-line react/prop-types
+				|| this.props.assistiveText.removeFilter
+				|| `Remove Filter: ${this.props.property} ${this.props.predicate}`
+		};
+
 		/* TODO: Button wrapper for property and predictate should be transitioned to `Button` component. `Button` needs to take custom children first though. */
-		const popoverProps = this.getCustomPopoverProps();
+		const popoverProps = this.getCustomPopoverProps({ assistiveText });
 		return (
 			<div
 				className={classNames(
@@ -223,7 +235,7 @@ const Filter = React.createClass({
 						onClick={this.handleFilterClick}
 						aria-describedby={this.props.isError ? `${this.getId()}-error` : undefined}
 					>
-						<span className="slds-assistive-text">{this.props.assistiveTextEditFilter}</span>
+						<span className="slds-assistive-text">{assistiveText.editFilter}</span>
 						{this.props.property ? <p className="slds-text-body--small">{this.props.property}</p> : null}
 						<p>{this.props.predicate}</p>
 					</button>
@@ -237,19 +249,17 @@ const Filter = React.createClass({
 					<p>{this.props.predicate}</p>
 				</button>
 				}
-				{// Close button
+				{// Remove button
 					!this.props.isPermanent && !this.props.isLocked
 					? <Button
-						assistiveText={this.props.assistiveTextRemoveFilter
-							|| `Remove Filter: ${this.props.property} ${this.props.predicate}`}
+						assistiveText={assistiveText.removeFilter}
 						hint
 						iconCategory="utility"
 						iconName="close"
 						iconSize="small"
 						iconVariant="bare"
 						onClick={this.handleRemove}
-						title={this.props.assistiveTextRemoveFilter
-							|| `Remove Filter: ${this.props.property} ${this.props.predicate}`}
+						title={assistiveText.removeFilter}
 						variant="icon"
 					/>
 				: null}

--- a/examples/filter/assistive-text.jsx
+++ b/examples/filter/assistive-text.jsx
@@ -1,0 +1,95 @@
+import React, { PropTypes } from 'react';
+
+import Panel from '~/components/panel'; // `~` is replaced with design-system-react at runtime
+import FilterGroup from '~/components/panel/filtering/group';
+import FilterList from '~/components/panel/filtering/list';
+import FilterListHeading from '~/components/panel/filtering/list-heading';
+import Filter from '~/components/filter';
+
+import Picklist from '~/components/menu-picklist';
+
+const options = {
+	'show-me': [
+		{ label: 'All Products', value: 'all-products' },
+		{ label: 'All Wackamoles', value: 'all-Wackamoles' }
+	]
+};
+
+const Example = React.createClass({
+	displayName: 'FilterExample',
+
+	propTypes () {
+		return {
+			align: PropTypes.string
+		};
+	},
+
+	getInitialState () {
+		return {
+			'show-me': {
+				selectedPicklistItem: options['show-me'][0],
+				selectedItem: options['show-me'][0],
+				isActive: true
+			}
+		};
+	},
+
+	onChangePredicate (event, { id }) {
+		const idSuffix = id.split('sample-panel-filtering-')[1];
+		this.setState({
+			[idSuffix]: {
+				...this.state[idSuffix],
+				selectedItem: this.state[idSuffix].selectedPicklistItem
+			}
+		});
+	},
+
+	onSelectPicklist (selectedItem, id) {
+		this.setState({
+			[id]: {
+				...this.state[id],
+				selectedPicklistItem: selectedItem
+			}
+		});
+	},
+
+	onRemove (event, { id }) {
+		const idSuffix = id.split('sample-panel-filtering-')[1];
+		this.setState({
+			[idSuffix]: {
+				...this.state[idSuffix],
+				isActive: false
+			}
+		});
+	},
+
+	render () {
+		return this.state['show-me'].isActive && (
+			<Filter
+				assistiveText={{ editFilter: 'editFilter-TEST',
+					editFilterHeading: 'editFilterHeading-TEST',
+					removeFilter: 'removeFilter-TEST' }}
+				align={this.props.align}
+				id="sample-panel-filtering-show-me"
+				onChange={this.onChangePredicate}
+				onRemove={this.onRemove}
+				property="Show Me"
+				predicate={this.state['show-me'].selectedItem.label}
+				{...this.props}
+			>
+				<Picklist
+					isInline
+					label="Show Me"
+					onSelect={(selectedItem) => {
+						this.onSelectPicklist(selectedItem, 'show-me');
+					}}
+					options={options['show-me']}
+					placeholder="Select record type"
+					value={this.state['show-me'].selectedPicklistItem.value}
+				/>
+			</Filter>
+		);
+	}
+});
+
+export default Example;	// export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/examples/filter/stories.jsx
+++ b/examples/filter/stories.jsx
@@ -7,6 +7,7 @@ import NewFilter from './new';
 import LockedFilter from './locked';
 import PermanantFilter from './permanant';
 import ErrorFilter from './error';
+import AssistiveTextFilter from './assistive-text';
 
 /* eslint-disable react/display-name */
 /* eslint-disable react/prop-types */
@@ -42,4 +43,8 @@ storiesOf(FILTER, module)
 	.add('Filter Align Right', () => (
 		<CustomAlignment align="right">
 			<Default align="right" />
+		</CustomAlignment>))
+	.add('AssistiveTextFilter', () => (
+		<CustomAlignment>
+			<AssistiveTextFilter />
 		</CustomAlignment>));

--- a/tests/filter/__snapshots__/filter.snapshot-test.jsx.snap
+++ b/tests/filter/__snapshots__/filter.snapshot-test.jsx.snap
@@ -1,8 +1,61 @@
+exports[`test AssistiveText Filter 1`] = `
+<SLDSFilter
+  align="left"
+  assistiveText={
+    Object {
+      "editFilter": "editFilter-TEST",
+      "editFilterHeading": "editFilterHeading-TEST",
+      "removeFilter": "removeFilter-TEST",
+    }
+  }
+  id="sample-panel-filtering-show-me"
+  onChange={[Function]}
+  onRemove={[Function]}
+  predicate="All Products"
+  property="Show Me">
+  <SLDSMenuPicklist
+    checkmark={true}
+    inheritTargetWidth={true}
+    isInline={true}
+    label="Show Me"
+    onSelect={[Function]}
+    options={
+      Array [
+        Object {
+          "label": "All Products",
+          "value": "all-products",
+        },
+        Object {
+          "label": "All Wackamoles",
+          "value": "all-Wackamoles",
+        },
+      ]
+    }
+    placeholder="Select record type"
+    value="all-products" />
+</SLDSFilter>
+`;
+
+exports[`test AssistiveText Filter HTML Snapshot 1`] = `
+"<div class=\"slds-filters__item slds-grid slds-grid--vertical-align-center\">
+  <div class=\"slds-grow\" style=\"display:inline;\"><button class=\"slds-button--reset slds-grow slds-has-blur-focus\" aria-haspopup=\"true\" aria-expanded=\"false\" id=\"sample-panel-filtering-show-me\" tabindex=\"0\"><span class=\"slds-assistive-text\">Edit filter:</span><p class=\"slds-text-body--small\">Show Me</p><p>All Products</p></button></div>
+  <button
+    class=\"slds-button slds-button--icon slds-button--icon-bare slds-button--icon-small\" title=\"Remove Filter: Show Me All Products\"><svg aria-hidden=\"true\" class=\"slds-button__icon slds-button__icon--hint\" viewBox=\"0 0 24 24\" name=\"close\"><path d=\"M14.3 11.7l6-6c.3-.3.3-.7 0-1l-.9-1c-.3-.2-.7-.2-1 0l-6 6.1c-.2.2-.5.2-.7 0l-6-6.1c-.3-.3-.7-.3-1 0l-1 1c-.2.2-.2.7 0 .9l6.1 6.1c.2.2.2.4 0 .6l-6.1 6.1c-.3.3-.3.7 0 1l1 1c.2.2.7.2.9 0l6.1-6.1c.2-.2.4-.2.6 0l6.1 6.1c.2.2.7.2.9 0l1-1c.3-.3.3-.7 0-1l-6-6c-.2-.2-.2-.5 0-.7z\"></path></svg>
+    <span
+      class=\"slds-assistive-text\">Remove Filter: Show Me All Products</span>
+      </button>
+</div>"
+`;
+
 exports[`test Error Filter Base Snapshot 1`] = `
 <SLDSFilter
   align="left"
-  assistiveTextEditFilter="Edit filter:"
-  assistiveTextEditFilterHeading="Choose filter criteria"
+  assistiveText={
+    Object {
+      "editFilter": "Edit filter:",
+      "editFilterHeading": "Choose filter criteria",
+    }
+  }
   id="sample-panel-filtering-show-me"
   isError={true}
   onChange={[Function]}
@@ -35,8 +88,12 @@ exports[`test Error Filter Base Snapshot 1`] = `
 exports[`test Filter Base Snapshot 1`] = `
 <SLDSFilter
   align="left"
-  assistiveTextEditFilter="Edit filter:"
-  assistiveTextEditFilterHeading="Choose filter criteria"
+  assistiveText={
+    Object {
+      "editFilter": "Edit filter:",
+      "editFilterHeading": "Choose filter criteria",
+    }
+  }
   id="sample-panel-filtering-show-me"
   onChange={[Function]}
   onRemove={[Function]}
@@ -79,8 +136,12 @@ exports[`test Filter Base with custom className Snapshot 1`] = `
 exports[`test LockedFilter Base Snapshot 1`] = `
 <SLDSFilter
   align="left"
-  assistiveTextEditFilter="Edit filter:"
-  assistiveTextEditFilterHeading="Choose filter criteria"
+  assistiveText={
+    Object {
+      "editFilter": "Edit filter:",
+      "editFilterHeading": "Choose filter criteria",
+    }
+  }
   id="sample-panel-filtering-show-me"
   isLocked={true}
   onChange={[Function]}
@@ -113,8 +174,12 @@ exports[`test LockedFilter Base Snapshot 1`] = `
 exports[`test NewFilter Base Snapshot 1`] = `
 <SLDSFilter
   align="left"
-  assistiveTextEditFilter="Edit filter:"
-  assistiveTextEditFilterHeading="Choose filter criteria"
+  assistiveText={
+    Object {
+      "editFilter": "Edit filter:",
+      "editFilterHeading": "Choose filter criteria",
+    }
+  }
   id="sample-panel-filtering-show-me"
   isNew={true}
   onChange={[Function]}
@@ -147,8 +212,12 @@ exports[`test NewFilter Base Snapshot 1`] = `
 exports[`test Permanant Filter Base Snapshot 1`] = `
 <SLDSFilter
   align="left"
-  assistiveTextEditFilter="Edit filter:"
-  assistiveTextEditFilterHeading="Choose filter criteria"
+  assistiveText={
+    Object {
+      "editFilter": "Edit filter:",
+      "editFilterHeading": "Choose filter criteria",
+    }
+  }
   id="sample-panel-filtering-show-me"
   isPermanent={true}
   onChange={[Function]}

--- a/tests/filter/filter.snapshot-test.jsx
+++ b/tests/filter/filter.snapshot-test.jsx
@@ -8,6 +8,7 @@ import NewFilter from '../../examples/filter/new';
 import LockedFilter from '../../examples/filter/locked';
 import PermanantFilter from '../../examples/filter/permanant';
 import ErrorFilter from '../../examples/filter/error';
+import AssistiveTextFilter from '../../examples/filter/assistive-text';
 
 test('Filter Base Snapshot', () => {
 	const domTree = toJson(shallow(
@@ -44,7 +45,18 @@ test('Error Filter Base Snapshot', () => {
 	expect(domTree).toMatchSnapshot();
 });
 
+test('AssistiveText Filter', () => {
+	const domTree = toJson(shallow(
+		<AssistiveTextFilter />
+	));
+	expect(domTree).toMatchSnapshot();
+});
+
 test('Filter Base with custom className Snapshot', () => {
 	expect(renderMarkup(Default,
 		{ className: 'MY_CUSTOM_CLASS_NAME' })).toMatchSnapshot();
+});
+
+test('AssistiveText Filter HTML Snapshot', () => {
+	expect(renderMarkup(Default)).toMatchSnapshot();
 });

--- a/tests/panel/__snapshots__/filtering.snapshot-test.jsx.snap
+++ b/tests/panel/__snapshots__/filtering.snapshot-test.jsx.snap
@@ -63,8 +63,12 @@ exports[`test Panel Filtering Default Snapshot 1`] = `
     <SLDSFilterList>
       <SLDSFilter
         align="left"
-        assistiveTextEditFilter="Edit filter:"
-        assistiveTextEditFilterHeading="Choose filter criteria"
+        assistiveText={
+          Object {
+            "editFilter": "Edit filter:",
+            "editFilterHeading": "Choose filter criteria",
+          }
+        }
         id="sample-panel-filtering-show-me"
         isPermanent={true}
         onChange={[Function]}
@@ -99,8 +103,12 @@ exports[`test Panel Filtering Default Snapshot 1`] = `
     <SLDSFilterList>
       <SLDSFilter
         align="left"
-        assistiveTextEditFilter="Edit filter:"
-        assistiveTextEditFilterHeading="Choose filter criteria"
+        assistiveText={
+          Object {
+            "editFilter": "Edit filter:",
+            "editFilterHeading": "Choose filter criteria",
+          }
+        }
         id="sample-panel-filtering-created-date"
         onChange={[Function]}
         onRemove={[Function]}
@@ -129,8 +137,12 @@ exports[`test Panel Filtering Default Snapshot 1`] = `
       </SLDSFilter>
       <SLDSFilter
         align="left"
-        assistiveTextEditFilter="Edit filter:"
-        assistiveTextEditFilterHeading="Choose filter criteria"
+        assistiveText={
+          Object {
+            "editFilter": "Edit filter:",
+            "editFilterHeading": "Choose filter criteria",
+          }
+        }
         id="sample-panel-filtering-list-price"
         onChange={[Function]}
         onRemove={[Function]}


### PR DESCRIPTION
Open for comment. Works in backwards compatible way, not needed to be in 1.x branch

Introduces `assistiveText` prop object. I know in the Marketing Cloud an object is how i118n is received anyway, so the same pattern continuation.

I believe this is helpful for developers in finding the prop they need and will make sure that it's not overlooked or that all a11y text props are added.

Partial fix for: https://github.com/salesforce-ux/design-system-react/issues/901

Doc output:
![screen shot 2017-04-14 at 1 39 14 pm](https://cloud.githubusercontent.com/assets/1290832/25053987/eb79a470-2117-11e7-9133-131bfe7515d7.png)
