### PR TITLE
Allow setting tabIndex on MenuPicklist & MenuDropdown triggers

### DIFF
--- a/components/menu-dropdown/check-props.js
+++ b/components/menu-dropdown/check-props.js
@@ -3,8 +3,9 @@
 /* eslint-disable import/no-mutable-exports */
 
 import deprecatedProperty from '../../utilities/warning/deprecated-property';
-import oneOfRequiredProperty from '../../utilities/warning/one-of-required-property';
 import hasChildrenWithoutDisplayNameOf from '../../utilities/warning/has-children-without-display-name-of';
+import isTriggerTabbable from '../../utilities/warning/is-trigger-tabbable';
+import oneOfRequiredProperty from '../../utilities/warning/one-of-required-property';
 import sunsetProperty from '../../utilities/warning/sunset-property';
 
 import { MENU_DROPDOWN_TRIGGER } from '../../utilities/constants';
@@ -13,6 +14,8 @@ let checkProps = function () {};
 
 if (process.env.NODE_ENV !== 'production') {
 	checkProps = function (COMPONENT, props) {
+		isTriggerTabbable(COMPONENT, { props: { tabIndex: props.tabIndex }, type: { displayName: COMPONENT } }, 'Setting a tabIndex to -1 creates a poor user experience for users of assistive technology. Please reconsider before doing do. Disabling this component or removing it from DOM may be a better option.');
+
 		// Deprecated and changed to another property
 		deprecatedProperty(COMPONENT, props.modal, 'modal', 'isInline', 'In an effort to add clarity to the meaning of the modal prop and to make more props default to false, `isInline` has replaced `modal` and is the reverse of modal.');
 		sunsetProperty(COMPONENT, props.forceOpen, 'forceOpen', 'Please use isOpen instead. It provides a consistent prop that aligns with other componenents.');

--- a/components/menu-dropdown/menu-dropdown.jsx
+++ b/components/menu-dropdown/menu-dropdown.jsx
@@ -298,7 +298,7 @@ const MenuDropdown = React.createClass({
 		 */
 		style: PropTypes.object,
 		/**
-		 * Write "-1" if you don't want the user to tab to the button.
+		 * Set to "1" or higher to change the order this element gets tab focus
 		 */
 		tabIndex: PropTypes.string,
 		/**

--- a/components/menu-picklist/check-props.js
+++ b/components/menu-picklist/check-props.js
@@ -3,11 +3,14 @@
 /* eslint-disable import/no-mutable-exports */
 
 import deprecatedProperty from '../../utilities/warning/deprecated-property';
+import isTriggerTabbable from '../../utilities/warning/is-trigger-tabbable';
 
 let checkProps = function () {};
 
 if (process.env.NODE_ENV !== 'production') {
 	checkProps = function (COMPONENT, props) {
+		isTriggerTabbable(COMPONENT, { props: { tabIndex: props.tabIndex }, type: { displayName: COMPONENT } }, 'Setting a tabIndex to -1 creates a poor user experience for users of assistive technology. Please reconsider before doing do. Disabling this component or removing it from DOM may be a better option.');
+
 		// Deprecated and changed to another property
 		deprecatedProperty(COMPONENT, props.modal, 'modal', 'isInline', 'In an effort to add clarity to the meaning of the modal prop and to make more props default to false, `isInline` has replaced `modal` and is the reverse of modal.');
 	};

--- a/components/menu-picklist/index.jsx
+++ b/components/menu-picklist/index.jsx
@@ -89,7 +89,7 @@ const MenuPicklist = React.createClass({
 		placeholder: PropTypes.string,
 		required: PropTypes.bool,
 		/**
-		 * Set to -1 if you don't want the user to tab to the button.
+		 * Set to 1 or higher to change the order this element gets tab focus
 		 */
 		tabIndex: PropTypes.number,
 		/**

--- a/utilities/warning/is-trigger-tabbable.js
+++ b/utilities/warning/is-trigger-tabbable.js
@@ -14,6 +14,8 @@ import {
 	DATEPICKER,
 	FORMS_INPUT,
 	LOOKUP,
+	MENU_DROPDOWN,
+	MENU_PICKLIST,
 	TIME_PICKER
 } from '../../utilities/constants';
 
@@ -45,12 +47,15 @@ if (process.env.NODE_ENV !== 'production') {
 			&& trigger.type.displayName !== FORMS_INPUT
 			&& trigger.type.displayName !== LOOKUP
 			&& trigger.type.displayName !== TIME_PICKER) {
+			const tabDisabled = childTabIndex === '-1' || childTabIndex === -1;
+			const tabbableByDefault = trigger.type.displayName === MENU_PICKLIST
+				|| trigger.type.displayName === MENU_DROPDOWN;
 			// if it's not one of the above, then check to see if it has a tabIndex
-			if (childTabIndex === '-1' || childTabIndex === undefined) {
+			if (tabDisabled || (childTabIndex === undefined && !tabbableByDefault)) {
 				elementIsTabbable = false;
 				if (!hasWarned[COMPONENT]) {
 					/* eslint-disable max-len */
-					warning(elementIsTabbable, `[Design System React] The element that triggers ${COMPONENT} must be tabbable for  keyboard users. Elements such as anchor, button, input or a DOM element with tabIndex="0" specified are tabbable.${additionalComment}`);
+					warning(elementIsTabbable, `[Design System React] The element that triggers ${COMPONENT} must be tabbable for keyboard users. Elements such as anchor, button, input or a DOM element with tabIndex="0" specified are tabbable. ${additionalComment}`);
 					/* eslint-enable max-len */
 					hasWarned[COMPONENT] = !!elementIsTabbable;
 				}


### PR DESCRIPTION
It would be great to be able to override the tabIndex property on the trigger of MenuPicklist and MenuDropdown.

Let me know if I should create a story for this.  Thanks!