### PR TITLE
964: Change React.PropTypes to prop-types

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ We'll review your code, suggest any needed changes, and merge it in. Thank you.
 - All new props / features need tests to prevent regressions in the future. Please review the [testing readme](/tests/README.md)
 - Stories are stored in [examples folder](/examples) along with Documentation site examples. To add a story to the interactive examples on the [documentation site](https://react.lightningdesignsystem.com/components/), add the JSX file to [examples/index.js](/examples/index.js). All examples that are present for a component in the [SLDS website](https://www.lightningdesignsystem.com/) or it's internal site should be created as a Storybook story _and_ listed in `examples/index.js`.
 - Prop description tables on the documentation site are generated from propType comments within the component. All props should have a _Tested with snapshot testing._ or _Tested with Mocha framework._ notice in them.
-- Introductory component descriptions are generated from the comment before the component declaration. 
+- Introductory component descriptions are generated from the comment before the component declaration.
 
 ## The review process
 This is an internal open-source project. You may be asked to review code submitted by others. To do this:
@@ -27,7 +27,7 @@ This is an internal open-source project. You may be asked to review code submitt
 - `npm install`
 - Pull down the pull requested branch. It will be within the contributor's forked repository. For instance, `git checkout -b interactivellama-data-table-width master` then `git pull git@github.com:interactivellama/design-system-react.git data-table-width`. You could also create an additional remote and pull down the branch directly.
 - `npm start` and review the appropriate React Story example at `http://localhost:9001/`. Open `http://localhost:8001/` and confirm that tests are passing in your environment.
-- Check that any modified or added examples for the documentation site are working and are present in `examples/index.js`. See [Releasing](#Releasing) for instructions. 
+- Check that any modified or added examples for the documentation site are working and are present in `examples/index.js`. See [Releasing](#Releasing) for instructions.
 
 ## Concepts and Best Practices
 #### What we've learned about building React components for the enterprise
@@ -69,7 +69,7 @@ This is an internal open-source project. You may be asked to review code submitt
 
 - <a name="limit-extra-div" href="#limit-extra-div">#</a> **Limit the use of grouping `div` elements.** React components can only have one HTML node / JSX / function return value. A component's render function should have one HTML node as its parent JSX element. Please limit use of extra wrapping `div` elements in order to align with SLDS markup. Other options include creating additional sub-components or passing an array of components to the parent component to render.
 
-- <a name="avoid-mixins" href="#avoid-mixins">#</a> **Avoid implied mixins.** Instead, import and use shared code and external libraries as libraries, or use higher-order components in order to more easily trace the code execution. 
+- <a name="avoid-mixins" href="#avoid-mixins">#</a> **Avoid implied mixins.** Instead, import and use shared code and external libraries as libraries, or use higher-order components in order to more easily trace the code execution.
 
 - <a name="avoid-dependencies" href="#avoid-dependencies">#</a> **Avoid external dependencies.** Do not add external dependencies _to production dependencies_ list unless absolutely necessary. Always consider the "total cost of ownership" for all dependencies.
 
@@ -93,7 +93,7 @@ This is an internal open-source project. You may be asked to review code submitt
 - <a name="boolean-prop-prefix" href="#boolean-prop-prefix">#</a> **Use boolean prefixes.** If a prop is a boolean, please prefix with `is` or `can` or suffix it with `-able`. Never default a prop to `true`.
 
 ### Use "the good parts"
-- <a name="rest-operators-with-jsx" href="#rest-operators-with-jsx">#</a> Be careful with [rest operators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters) when passively applying unnamed and unknown props to JSX nodes. This concept allows flexibility to the consuming developer, but is difficult to track for maintainers. If rest operators should be used, be sure to deconstruct each one that is actually needed by the JSX nodes, so that the rest operator only handles "unknown props" passed in from the outside developer. In short, don't utilize any properties in the `...props` object within the component. After using `const { active, className, ...rest } = props;` do not go back to using `this.prop.*` anywhere in the render function. 
+- <a name="rest-operators-with-jsx" href="#rest-operators-with-jsx">#</a> Be careful with [rest operators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters) when passively applying unnamed and unknown props to JSX nodes. This concept allows flexibility to the consuming developer, but is difficult to track for maintainers. If rest operators should be used, be sure to deconstruct each one that is actually needed by the JSX nodes, so that the rest operator only handles "unknown props" passed in from the outside developer. In short, don't utilize any properties in the `...props` object within the component. After using `const { active, className, ...rest } = props;` do not go back to using `this.prop.*` anywhere in the render function.
 
 - <a name="rest-operators-with-jsx-delete" href="#rest-operators-with-jsx-delete">#</a> If a rest operator is already present in your render function and you need to remove additional props so that they do not get passed to a JSX node, use the rest operator along with `// eslint-disable-line no-unused-vars` to remove the prop from `...rest`.
 
@@ -119,21 +119,21 @@ Unless you have an accessiblity guru in your department (knowledge of implementi
 - [ARIA 1.1](https://www.w3.org/TR/wai-aria-1.1/) - Recommendation Candidate for the new ARIA Spec.
 - [ARIA in HTML](http://w3c.github.io/html-aria/) - Super useful reference to answer the question "Should I put ARIA on this?". Often a native HTML element will have an implicit role, so it's not required, _nor recommended_ to be added.
 - [HTML 5.1](https://www.w3.org/TR/html51/) - This is at the Recommendation Candidate stage, so it is very unlikely to change. Please notice the places where it informs of ARIA role for each element, the implicit roles, may not be 100% accurate. The document authors state that the ARIA in HTML spec above is the definitive source of truth for that bit and they'll fix up 5.1 when they find stuff that's not correct.
-- [eBay MIND patterns](https://ebay.gitbooks.io/mindpatterns/content/) - Nice to digest content. Most up to date functional base components our team has found so far with [examples](http://ianmcburnie.github.io/mindpatterns/). This does not mean they are correct, though. 
+- [eBay MIND patterns](https://ebay.gitbooks.io/mindpatterns/content/) - Nice to digest content. Most up to date functional base components our team has found so far with [examples](http://ianmcburnie.github.io/mindpatterns/). This does not mean they are correct, though.
 
 ### Be kind to future contributors and write tests
 
 - All external APIs should be tested, so that breaking changes can be detected. If a breaking change doesn't cause at least one test to fail, then add a test.
     - All `props` should be tested. It is OK to test multiple props in the same test for optmization as long as they are isolated and do not affect each other (for instance `id`, `classname`, and `style`).
-    - All event callbacks should be tested along with any data object keys outside of the synthetic event to confirm the data. The data object, if present, is typically the second parameter of an event callback. 
+    - All event callbacks should be tested along with any data object keys outside of the synthetic event to confirm the data. The data object, if present, is typically the second parameter of an event callback.
     - All mouse and keyboard interactions should be tested.
-- Components should have 90%+ test coverage. Coverage can be determined by reviewing the coverage summary at the end of `npm test`. High test coverage does not imply correct logic, but low coverage implies low test quality/quantity. 
+- Components should have 90%+ test coverage. Coverage can be determined by reviewing the coverage summary at the end of `npm test`. High test coverage does not imply correct logic, but low coverage implies low test quality/quantity.
 - Test should run correctly in headless browsers (`npm test`) and within a "real" browser (`npm start` -> `http://localhost:8001/`)
 - For more specifics about testing please review the [testing module walkthough](tests/README.md).
 
 ## Controlled and Uncontrolled Components
-- All new components should be controlled at first and then uncontrolled support added later if needed. 
-- All Design System React components should be able to be "controlled"--that is expose a callback and expect their parent to control them with props. 
+- All new components should be controlled at first and then uncontrolled support added later if needed.
+- All Design System React components should be able to be "controlled"--that is expose a callback and expect their parent to control them with props.
 - Prefix callbacks that occur before an event with `onRequest`. Prefix callbacks that occur as a result of an event with `on`. The close button in a Popover will call `onRequestClose` while the Popover will call `onClose` after the Popover has been closed. This is because closing isn't guarenteed with `onRequestClose`, since the parent component will decide.
 - Please note that if controlled by its parent, a component will appear broken if just copied and pasted into an application without a parent to control its props.
 - Controlled components can be stateless components, but entirely stateless components do complicate DOM selectors for the consuming applications.
@@ -151,15 +151,15 @@ User input will have no effect on the rendered element because React has declare
 ```javascript
 class MyForm extends React.Component {
   constructor(props) {
-    super(props);    
+    super(props);
     this.state = {value: 'Hello!'};
     this.handleChange = this.handleChange.bind(this);
   }
-  
+
   handleChange(event) {
     this.setState({value: event.target.value});
   }
-  
+
   render() {
     return (
       <input
@@ -211,7 +211,7 @@ const DemoComponent = React.createClass({
     /**
      * The description of this prop (will appear in the documentation site).
      */
-    title: React.PropTypes.string.isRequired
+    title: PropTypes.string.isRequired
   },
 
   // These values will also be visible in the documentation site.
@@ -404,7 +404,7 @@ render () {
 // better
 render () {
   return (
-    <div className={classnames('MyComponent', 
+    <div className={classnames('MyComponent',
       `MyComponent--${this.props.active}`,
       `MyComponent--${this.props.variant}`,
     )} />

--- a/components/app-launcher/index.jsx
+++ b/components/app-launcher/index.jsx
@@ -8,7 +8,8 @@
 // ## Dependencies
 
 // ### React
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### classNames
 import classNames from 'classnames';

--- a/components/app-launcher/section.jsx
+++ b/components/app-launcher/section.jsx
@@ -8,8 +8,7 @@
 // ### React
 import React from 'react';
 
-// Removes the need for `React.PropTypes.prop`
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 // ### isFunction
 import isFunction from 'lodash.isfunction';

--- a/components/app-launcher/tile.jsx
+++ b/components/app-launcher/tile.jsx
@@ -6,7 +6,8 @@
 // ## Dependencies
 
 // ### React
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### classNames
 import classNames from 'classnames';

--- a/components/breadcrumb/index.jsx
+++ b/components/breadcrumb/index.jsx
@@ -10,6 +10,7 @@
 
 // ### React
 import React from 'react';
+import PropTypes from 'prop-types';
 
 // ## Constants
 import { BREADCRUMB } from '../../utilities/constants';
@@ -43,11 +44,11 @@ Breadcrumb.propTypes = {
 	/**
 	 * The assistive text for the breadcrumb trail
 	 */
-	assistiveText: React.PropTypes.string,
+	assistiveText: PropTypes.string,
 	/**
 	 * An array of react elements presumably anchor elements.
 	 */
-	trail: React.PropTypes.array
+	trail: PropTypes.array
 };
 
 Breadcrumb.defaultProps = {

--- a/components/button-stateful/index.jsx
+++ b/components/button-stateful/index.jsx
@@ -7,7 +7,8 @@
 // ## Dependencies
 
 // ### React
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### classNames
 import classNames from 'classnames';

--- a/components/button/index.jsx
+++ b/components/button/index.jsx
@@ -4,7 +4,8 @@
 // Implements the [Button design pattern](https://lightningdesignsystem.com/components/buttons/) in React.
 // Based on SLDS v2.2.1
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import ButtonIcon from '../icon/button-icon';
 import PopoverTooltip from '../popover-tooltip';
@@ -113,7 +114,7 @@ const Button = React.createClass({
 		 * HTML title attribute
 		 */
 		title: PropTypes.string,
-		variant: React.PropTypes.oneOf(['base', 'link', 'neutral', 'brand', 'destructive', 'success', 'icon'])
+		variant: PropTypes.oneOf(['base', 'link', 'neutral', 'brand', 'destructive', 'success', 'icon'])
 	},
 
 	getDefaultProps () {

--- a/components/card/empty.jsx
+++ b/components/card/empty.jsx
@@ -4,9 +4,7 @@
 // ### React
 // React is an external dependency of the project.
 import React from 'react';
-
-// Removes the need for `PropTypes`.
-const { PropTypes } = React;
+import PropTypes from 'prop-types';
 
 import { CARD_EMPTY } from '../../utilities/constants';
 

--- a/components/card/filter.jsx
+++ b/components/card/filter.jsx
@@ -2,14 +2,11 @@
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 
 // ### React
-// React is an external dependency of the project.
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import Input from '../forms/input';
 import InputIcon from '../icon/input-icon';
-
-// Removes the need for `PropTypes`.
-const { PropTypes } = React;
 
 import { CARD_FILTER } from '../../utilities/constants';
 

--- a/components/card/index.jsx
+++ b/components/card/index.jsx
@@ -7,8 +7,8 @@
 // Based on SLDS v2.2.1
 
 // ### React
-// React is an external dependency of the project.
 import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### classNames
 // [github.com/JedWatson/classnames](https://github.com/JedWatson/classnames)
@@ -21,9 +21,6 @@ import Header from './private/header';
 import Body from './private/body';
 import Footer from './private/footer';
 import Empty from './empty';
-
-// Removes the need for `PropTypes`.
-const { PropTypes } = React;
 
 import { CARD } from '../../utilities/constants';
 

--- a/components/card/private/body.jsx
+++ b/components/card/private/body.jsx
@@ -2,8 +2,8 @@
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 
 // ### React
-// React is an external dependency of the project.
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import { CARD_BODY } from '../../../utilities/constants';
 
@@ -27,15 +27,15 @@ CardBody.propTypes = {
 	/**
 	 * Elements to place in the body.
 	 */
-	children: React.PropTypes.node,
+	children: PropTypes.node,
 	/**
 	 * CSS classes to be added to the card.
 	 */
-	className: React.PropTypes.oneOfType([React.PropTypes.array, React.PropTypes.object, React.PropTypes.string]),
+	className: PropTypes.oneOfType([PropTypes.array, PropTypes.object, PropTypes.string]),
 	/**
 	 * Set the HTML `id` of the body.
 	 */
-	id: React.PropTypes.string
+	id: PropTypes.string
 };
 
 export default CardBody;

--- a/components/card/private/footer.jsx
+++ b/components/card/private/footer.jsx
@@ -2,8 +2,8 @@
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 
 // ### React
-// React is an external dependency of the project.
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import { CARD_FOOTER } from '../../../utilities/constants';
 
@@ -19,7 +19,7 @@ CardFooter.propTypes = {
 	/**
 	 * Elements to place in the footer.
 	 */
-	children: React.PropTypes.node
+	children: PropTypes.node
 };
 
 export default CardFooter;

--- a/components/card/private/header.jsx
+++ b/components/card/private/header.jsx
@@ -2,8 +2,8 @@
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 
 // ### React
-// React is an external dependency of the project.
 import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### classNames
 // [github.com/JedWatson/classnames](https://github.com/JedWatson/classnames)
@@ -13,9 +13,6 @@ import classnames from 'classnames';
 
 // ## Children
 import MediaObject from '../../media-object';
-
-// Removes the need for `PropTypes`.
-const { PropTypes } = React;
 
 import { CARD_HEADER } from '../../../utilities/constants';
 

--- a/components/data-table/cell.jsx
+++ b/components/data-table/cell.jsx
@@ -2,7 +2,8 @@
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 
 // ### React
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### classNames
 import classNames from 'classnames';

--- a/components/data-table/column.jsx
+++ b/components/data-table/column.jsx
@@ -2,7 +2,8 @@
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 
 // ### React
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 // ## Constants
 import { DATA_TABLE_COLUMN } from '../../utilities/constants';
@@ -40,7 +41,7 @@ DataTableColumn.propTypes = {
 	 * </DataTable>
 	 * ```
 	 */
-	children: React.PropTypes.element,
+	children: PropTypes.element,
 	/**
 	 * The column label. If a `string` is not passed in, no `title` attribute will be rendered.
 	 */

--- a/components/data-table/highlight-cell.jsx
+++ b/components/data-table/highlight-cell.jsx
@@ -3,6 +3,7 @@
 
 // ### React
 import React from 'react';
+import PropTypes from 'prop-types';
 
 // ## Children
 import DataTableCell from './cell';
@@ -10,9 +11,6 @@ import Highlighter from '../utilities/highlighter';
 
 // ## Constants
 import { DATA_TABLE_CELL } from '../../utilities/constants';
-
-// Removes the need for `PropTypes`.
-const { PropTypes } = React;
 
 /**
  * A Cell renderer for the DataTable that automatically highlights search text.
@@ -33,9 +31,9 @@ DataTableHighlightCell.propTypes = {
 	 * The contents of the cell. Equivalent to `props.item[props.property]`
 	 */
 	children: PropTypes.oneOfType([
-		React.PropTypes.string,
-		React.PropTypes.number,
-		React.PropTypes.bool
+		PropTypes.string,
+		PropTypes.number,
+		PropTypes.bool
 	]),
 	/**
 	 * The string of text (or Regular Expression) to highlight.

--- a/components/data-table/index.jsx
+++ b/components/data-table/index.jsx
@@ -9,6 +9,7 @@
 
 // ### React
 import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### shortid
 // [npmjs.com/package/shortid](https://www.npmjs.com/package/shortid)
@@ -42,9 +43,6 @@ import DataTableRowActions from './row-actions';
 
 // ## Constants
 import { DATA_TABLE, DATA_TABLE_CELL, DATA_TABLE_HEAD, DATA_TABLE_ROW } from '../../utilities/constants';
-
-// Removes the need for `PropTypes`.
-const { PropTypes } = React;
 
 // Safely get the length of an array, returning 0 for invalid input.
 const count = (array) => (isArray(array) ? array.length : 0);

--- a/components/data-table/private/head.jsx
+++ b/components/data-table/private/head.jsx
@@ -3,6 +3,7 @@
 
 // ### React
 import React from 'react';
+import PropTypes from 'prop-types';
 
 // ## Children
 import Checkbox from '../../forms/checkbox';
@@ -10,9 +11,6 @@ import HeaderCell from './header-cell';
 
 // ## Constants
 import { DATA_TABLE_HEAD } from '../../../utilities/constants';
-
-// Removes the need for `PropTypes`.
-const { PropTypes } = React;
 
 /**
  * Used internally, provides header row rendering to the DataTable.
@@ -52,7 +50,7 @@ const DataTableHead = React.createClass({
 	},
 
 	componentWillMount () {
-		
+
 	},
 
 	// ### Render

--- a/components/data-table/private/header-cell.jsx
+++ b/components/data-table/private/header-cell.jsx
@@ -3,6 +3,7 @@
 
 // ### React
 import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### classNames
 import classNames from 'classnames';
@@ -15,9 +16,6 @@ import Icon from '../../icon';
 
 // ## Constants
 import { DATA_TABLE_HEADER_CELL } from '../../../utilities/constants';
-
-// Removes the need for `PropTypes`.
-const { PropTypes } = React;
 
 /**
  * Used internally, renders each individual column heading.

--- a/components/data-table/private/row.jsx
+++ b/components/data-table/private/row.jsx
@@ -3,6 +3,7 @@
 
 // ### React
 import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### classNames
 import classNames from 'classnames';
@@ -15,9 +16,6 @@ import Checkbox from '../../forms/checkbox';
 
 // ## Constants
 import { DATA_TABLE_ROW, DATA_TABLE_ROW_ACTIONS, DATA_TABLE_CELL } from '../../../utilities/constants';
-
-// Removes the need for `PropTypes`.
-const { PropTypes } = React;
 
 /**
  * Used internally, provides row rendering to the DataTable.
@@ -45,7 +43,7 @@ const DataTableRow = React.createClass({
 		 */
 		fixedLayout: PropTypes.bool,
 		id: PropTypes.string.isRequired,
-		item: React.PropTypes.object.isRequired,
+		item: PropTypes.object.isRequired,
 		onToggle: PropTypes.func,
 		rowActions: PropTypes.element,
 		selection: PropTypes.array

--- a/components/data-table/row-actions.jsx
+++ b/components/data-table/row-actions.jsx
@@ -3,6 +3,7 @@
 
 // ### React
 import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### isFunction
 import isFunction from 'lodash.isfunction';
@@ -15,9 +16,6 @@ import EventUtil from '../../utilities/event';
 
 // ## Constants
 import { DATA_TABLE_ROW_ACTIONS } from '../../utilities/constants';
-
-// Removes the need for `PropTypes`.
-const { PropTypes } = React;
 
 /**
  * RowActions provide a mechanism for defining a menu to display alongside each row in the DataTable.

--- a/components/date-picker/private/calendar-wrapper.jsx
+++ b/components/date-picker/private/calendar-wrapper.jsx
@@ -1,8 +1,8 @@
 /* Copyright (c) 2015-present, salesforce.com, inc. All rights reserved */
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 
-
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import Calendar from './calendar';
 import CalendarNavigation from './navigation';
@@ -79,7 +79,7 @@ class DatepickerCalendarWrapper extends React.Component {
 		/**
 		 * Currently selected date
 		 */
-		selectedDate: React.PropTypes.instanceOf(Date),
+		selectedDate: PropTypes.instanceOf(Date),
 		/**
 		 * Component reference / DOM node for selected day.
 		 */

--- a/components/date-picker/private/calendar.jsx
+++ b/components/date-picker/private/calendar.jsx
@@ -1,8 +1,8 @@
 /* Copyright (c) 2015-present, salesforce.com, inc. All rights reserved */
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 
-
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import Week from './week';
 import DateUtil from '../../../utilities/date';
 

--- a/components/date-picker/private/day.jsx
+++ b/components/date-picker/private/day.jsx
@@ -1,8 +1,8 @@
 /* Copyright (c) 2015-present, salesforce.com, inc. All rights reserved */
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 
-
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import EventUtil from '../../../utilities/event';
 import DateUtil from '../../../utilities/date';

--- a/components/date-picker/private/navigation.jsx
+++ b/components/date-picker/private/navigation.jsx
@@ -1,8 +1,8 @@
 /* Copyright (c) 2015-present, salesforce.com, inc. All rights reserved */
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 
-
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import YearPicklist from './year-picklist';
 import Button from '../../button';
 

--- a/components/date-picker/private/week.jsx
+++ b/components/date-picker/private/week.jsx
@@ -1,8 +1,8 @@
 /* Copyright (c) 2015-present, salesforce.com, inc. All rights reserved */
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 
-
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import Day from './day';
 

--- a/components/date-picker/private/year-picklist.jsx
+++ b/components/date-picker/private/year-picklist.jsx
@@ -1,8 +1,8 @@
 /* Copyright (c) 2015-present, salesforce.com, inc. All rights reserved */
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 
-
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import MenuPicklist from '../../menu-picklist';
 
 const DatepickerYearSelector = React.createClass({

--- a/components/filter/index.jsx
+++ b/components/filter/index.jsx
@@ -11,7 +11,8 @@
 // ## Dependencies
 
 // ### React
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### assign
 import assign from 'lodash.assign';

--- a/components/forms/checkbox/index.jsx
+++ b/components/forms/checkbox/index.jsx
@@ -7,6 +7,7 @@
 
 // ### React
 import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### isFunction
 import isFunction from 'lodash.isfunction';
@@ -25,10 +26,6 @@ import classNames from 'classnames';
 
 // This component's `checkProps` which issues warnings to developers about properties when in development mode (similar to React's built in development tools)
 import checkProps from './check-props';
-
-
-// Remove the need for `React.PropTypes`
-const { PropTypes } = React;
 
 import { FORMS_CHECKBOX } from '../../../utilities/constants';
 

--- a/components/forms/input/index.jsx
+++ b/components/forms/input/index.jsx
@@ -8,8 +8,8 @@
 //
 
 // ### React
-// React is an external dependency of the project.
 import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### classNames
 // [github.com/JedWatson/classnames](https://github.com/JedWatson/classnames)
@@ -26,9 +26,6 @@ import shortid from 'shortid';
 import InputIcon from '../../icon/input-icon';
 // This component's `checkProps` which issues warnings to developers about properties when in development mode (similar to React's built in development tools)
 import checkProps from './check-props';
-
-// Remove the need for `React.PropTypes`
-const { PropTypes } = React;
 
 import { FORMS_INPUT } from '../../../utilities/constants';
 

--- a/components/forms/input/inline.jsx
+++ b/components/forms/input/inline.jsx
@@ -8,7 +8,8 @@
 // ## Dependencies
 
 // ### React
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 
 // ### isFunction

--- a/components/forms/input/search.jsx
+++ b/components/forms/input/search.jsx
@@ -8,7 +8,8 @@
 // ## Dependencies
 
 // ### React
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 // ## Children
 import Input from './index';
@@ -71,7 +72,7 @@ Search.propTypes = {
 	/**
 	 * This event fires when enter is pressed in the `input` or the search button is clicked.
 	 */
-	onSearch: React.PropTypes.func,
+	onSearch: PropTypes.func,
 	/**
 	 * Placeholder for the input
 	 */

--- a/components/global-header/dropdown.jsx
+++ b/components/global-header/dropdown.jsx
@@ -6,7 +6,8 @@
 // ## Dependencies
 
 // ### React
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### Dropdown
 import MenuDropdown from '../menu-dropdown';

--- a/components/global-header/index.jsx
+++ b/components/global-header/index.jsx
@@ -9,7 +9,8 @@
 // ## Dependencies
 
 // ### React
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### Event Helpers
 import { EventUtil } from '../../utilities';

--- a/components/global-header/private/dropdown-trigger.jsx
+++ b/components/global-header/private/dropdown-trigger.jsx
@@ -6,7 +6,8 @@
 // ## Dependencies
 
 // ### React
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### classNames
 // [github.com/JedWatson/classnames](https://github.com/JedWatson/classnames)

--- a/components/global-header/profile.jsx
+++ b/components/global-header/profile.jsx
@@ -6,7 +6,8 @@
 // ## Dependencies
 
 // ### React
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### classnames
 import classnames from 'classnames';

--- a/components/global-navigation-bar/button.jsx
+++ b/components/global-navigation-bar/button.jsx
@@ -6,7 +6,8 @@
 // ## Dependencies
 
 // ### React
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### classNames
 import classNames from 'classnames';

--- a/components/global-navigation-bar/dropdown-trigger.jsx
+++ b/components/global-navigation-bar/dropdown-trigger.jsx
@@ -6,7 +6,8 @@
 // ## Dependencies
 
 // ### React
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### classNames
 import classNames from 'classnames';
@@ -30,7 +31,7 @@ const GlobalNavigationDropdownTrigger = React.createClass({
 		/**
 		 * Whether the item is active or not.
 		 */
-		active: React.PropTypes.bool,
+		active: PropTypes.bool,
 		/**
 		 * Allows alignment of active item with active application background color.
 		 */

--- a/components/global-navigation-bar/dropdown.jsx
+++ b/components/global-navigation-bar/dropdown.jsx
@@ -6,7 +6,8 @@
 // ## Dependencies
 
 // ### React
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### Dropdown
 import MenuDropdown from '../menu-dropdown';
@@ -58,7 +59,7 @@ GlobalNavigationBarDropdown.propTypes = {
 	/**
 	 * Whether the item is active or not.
 	 */
-	active: React.PropTypes.bool,
+	active: PropTypes.bool,
 	/**
 	 * Allows alignment of active item with active application background color.
 	 */

--- a/components/global-navigation-bar/index.jsx
+++ b/components/global-navigation-bar/index.jsx
@@ -9,7 +9,8 @@
 // ## Dependencies
 
 // ### React
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### classNames
 import classNames from 'classnames';

--- a/components/global-navigation-bar/label.jsx
+++ b/components/global-navigation-bar/label.jsx
@@ -6,7 +6,8 @@
 // ## Dependencies
 
 // ### React
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### classNames
 import classNames from 'classnames';

--- a/components/global-navigation-bar/link.jsx
+++ b/components/global-navigation-bar/link.jsx
@@ -6,7 +6,8 @@
 // ## Dependencies
 
 // ### React
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### classNames
 import classNames from 'classnames';

--- a/components/global-navigation-bar/region.jsx
+++ b/components/global-navigation-bar/region.jsx
@@ -6,7 +6,8 @@
 // ## Dependencies
 
 // ### React
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### classNames
 import classNames from 'classnames';

--- a/components/icon/button-icon/index.jsx
+++ b/components/icon/button-icon/index.jsx
@@ -2,7 +2,8 @@
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 
 // ### React
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### classNames
 // [github.com/JedWatson/classnames](https://github.com/JedWatson/classnames)

--- a/components/icon/index.jsx
+++ b/components/icon/index.jsx
@@ -8,7 +8,8 @@
 // ## Dependencies
 
 // ### React
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### classNames
 // [github.com/JedWatson/classnames](https://github.com/JedWatson/classnames)

--- a/components/icon/input-icon/index.jsx
+++ b/components/icon/input-icon/index.jsx
@@ -2,7 +2,8 @@
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 
 // ### React
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### classNames
 // [github.com/JedWatson/classnames](https://github.com/JedWatson/classnames)

--- a/components/lookup/index.jsx
+++ b/components/lookup/index.jsx
@@ -9,7 +9,8 @@
 // ## Dependencies
 
 // ### React
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import escapeRegExp from 'lodash.escaperegexp';
 import isEqual from 'lodash.isequal';

--- a/components/lookup/private/item.jsx
+++ b/components/lookup/private/item.jsx
@@ -1,8 +1,8 @@
 /* Copyright (c) 2015-present, salesforce.com, inc. All rights reserved */
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import Icon from '../../icon';
 import { EventUtil } from '../../../utilities';
@@ -11,18 +11,18 @@ import cx from 'classnames';
 
 const displayName = 'Lookup-Menu-Item';
 const propTypes = {
-	data: React.PropTypes.object,
-	handleItemFocus: React.PropTypes.func,
-	href: React.PropTypes.string,
-	iconCategory: React.PropTypes.string,
-	id: React.PropTypes.string,
-	index: React.PropTypes.number,
-	isActive: React.PropTypes.bool,
-	isDisabled: React.PropTypes.bool,
-	listItemLabelRenderer: React.PropTypes.func,
-	onSelect: React.PropTypes.func,
-	searchTerm: React.PropTypes.string,
-	setFocus: React.PropTypes.func
+	data: PropTypes.object,
+	handleItemFocus: PropTypes.func,
+	href: PropTypes.string,
+	iconCategory: PropTypes.string,
+	id: PropTypes.string,
+	index: PropTypes.number,
+	isActive: PropTypes.bool,
+	isDisabled: PropTypes.bool,
+	listItemLabelRenderer: PropTypes.func,
+	onSelect: PropTypes.func,
+	searchTerm: PropTypes.string,
+	setFocus: PropTypes.func
 };
 
 class Item extends React.Component {

--- a/components/lookup/private/menu.jsx
+++ b/components/lookup/private/menu.jsx
@@ -1,24 +1,24 @@
 /* Copyright (c) 2015-present, salesforce.com, inc. All rights reserved */
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import Item from './item';
 
 const displayName = 'Lookup-Menu';
 const propTypes = {
-	boldRegex: React.PropTypes.instanceOf(RegExp),
-	emptyMessage: React.PropTypes.string,
-	filterWith: React.PropTypes.func,
-	focusIndex: React.PropTypes.number,
-	getListLength: React.PropTypes.func,
-	iconCategory: React.PropTypes.string,
-	items: React.PropTypes.array,
-	label: React.PropTypes.string,
-	listLength: React.PropTypes.number,
-	searchTerm: React.PropTypes.string,
-	setFocus: React.PropTypes.func
+	boldRegex: PropTypes.instanceOf(RegExp),
+	emptyMessage: PropTypes.string,
+	filterWith: PropTypes.func,
+	focusIndex: PropTypes.number,
+	getListLength: PropTypes.func,
+	iconCategory: PropTypes.string,
+	items: PropTypes.array,
+	label: PropTypes.string,
+	listLength: PropTypes.number,
+	searchTerm: PropTypes.string,
+	setFocus: PropTypes.func
 };
 const defaultProps = {
 	emptyMessage: 'No matches found.'

--- a/components/lookup/section-divider.jsx
+++ b/components/lookup/section-divider.jsx
@@ -1,13 +1,13 @@
 /* Copyright (c) 2015-present, salesforce.com, inc. All rights reserved */
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import { EventUtil } from '../../utilities';
 
 const displayName = 'LookupDefaultSectionDivider';
 const propTypes = {
-	data: React.PropTypes.object
+	data: PropTypes.object
 };
 
 class DefaultSectionDivider extends React.Component {

--- a/components/media-object/index.jsx
+++ b/components/media-object/index.jsx
@@ -2,17 +2,14 @@
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 
 // ### React
-// React is an external dependency of the project.
 import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### classNames
 // [github.com/JedWatson/classnames](https://github.com/JedWatson/classnames)
 // This project uses `classnames`, "a simple javascript utility for conditionally
 // joining classNames together."
 import classnames from 'classnames';
-
-// Removes the need for `PropTypes`.
-const { PropTypes } = React;
 
 import { MEDIA_OBJECT } from '../../utilities/constants';
 

--- a/components/menu-dropdown/button-trigger.jsx
+++ b/components/menu-dropdown/button-trigger.jsx
@@ -5,7 +5,8 @@
 
 // ### React
 // React is an external dependency of the project.
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import Button from '../button';
 
 // ### classNames

--- a/components/menu-dropdown/menu-dropdown.jsx
+++ b/components/menu-dropdown/menu-dropdown.jsx
@@ -8,7 +8,8 @@
 // Based on SLDS v2.1.0-rc.2
 
 // ### React
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 
 // ### classNames

--- a/components/menu-picklist/index.jsx
+++ b/components/menu-picklist/index.jsx
@@ -9,7 +9,8 @@
 // Based on SLDS v2.1.0-rc.2
 
 // ### React
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 // This component's `checkProps` which issues warnings to developers about properties
 // when in development mode (similar to React's built in development tools)

--- a/components/modal/index.jsx
+++ b/components/modal/index.jsx
@@ -7,7 +7,8 @@
 // Implements the [Modal design pattern](https://lightningdesignsystem.com/components/modals/) in React.
 // Based on SLDS v2.2.1
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 
 import Button from '../button';
@@ -53,7 +54,7 @@ const propTypes = {
 	/**
 	 * Custom styles for the modal's body. This is the element that has overflow rules and should be used to set a static height if desired.
 	 */
-	contentStyle: React.PropTypes.object,
+	contentStyle: PropTypes.object,
 	/**
 	 * If true, modal footer buttons render left and right. An example use case would be for "back" and "next" buttons.
 	 */

--- a/components/navigation/index.jsx
+++ b/components/navigation/index.jsx
@@ -4,7 +4,8 @@
 // Implements the [Navigation design pattern](https://lightningdesignsystem.com/components/navigation/) in React.
 // Based on SLDS v2.2.1
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### classNames
 // [github.com/JedWatson/classnames](https://github.com/JedWatson/classnames)
@@ -52,7 +53,7 @@ const Navigation = React.createClass({
 		/**
 		 * Determines component style. _Tested with snapshot testing._
 		 */
-		variant: React.PropTypes.oneOf(['default', 'shade'])
+		variant: PropTypes.oneOf(['default', 'shade'])
 	},
 
 	getDefaultProps () {

--- a/components/navigation/private/item.jsx
+++ b/components/navigation/private/item.jsx
@@ -2,7 +2,8 @@
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### classNames
 // [github.com/JedWatson/classnames](https://github.com/JedWatson/classnames)

--- a/components/notification/index.jsx
+++ b/components/notification/index.jsx
@@ -2,6 +2,7 @@
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 
 import classNames from 'classnames';
@@ -13,34 +14,34 @@ const propTypes = {
 	/**
 	 * Custom classes applied to Notification element.
 	 */
-	className: React.PropTypes.string,
+	className: PropTypes.string,
 	/**
 	 * Message for Notification.
 	 */
-	content: React.PropTypes.node.isRequired,
+	content: PropTypes.node.isRequired,
 	/**
 	 * If true, close button appears for users to dismiss Notification.
 	 */
-	dismissible: React.PropTypes.bool,
+	dismissible: PropTypes.bool,
 	/**
 	 * If duration exists, the Notification will disappear after that amount of time.
 	 */
-	duration: React.PropTypes.number,
+	duration: PropTypes.number,
 	/**
 	 * Name of the icon. Visit <a href='http://www.lightningdesignsystem.com/resources/icons'>Lighning Design System Icons</a> to reference icon names.
 	 */
-	iconName: React.PropTypes.string,
-	isOpen: React.PropTypes.bool.isRequired,
-	onDismiss: React.PropTypes.func,
+	iconName: PropTypes.string,
+	isOpen: PropTypes.bool.isRequired,
+	onDismiss: PropTypes.func,
 	/**
 	 * Styling for Notification background.
 	 */
-	texture: React.PropTypes.bool,
+	texture: PropTypes.bool,
 	/**
 	 * Styling for Notification background color. Please reference <a href='http://www.lightningdesignsystem.com/components/utilities/themes/#color'>Lighning Design System Themes > Color</a>.
 	 */
-	theme: React.PropTypes.oneOf(['success', 'warning', 'error', 'offline']),
-	variant: React.PropTypes.oneOf(['alert', 'toast']).isRequired
+	theme: PropTypes.oneOf(['success', 'warning', 'error', 'offline']),
+	variant: PropTypes.oneOf(['alert', 'toast']).isRequired
 };
 
 const defaultProps = {

--- a/components/page-header/index.jsx
+++ b/components/page-header/index.jsx
@@ -9,6 +9,7 @@
 // ## Dependencies
 
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Info from './private/info';
 import Title from './private/title';
@@ -28,75 +29,75 @@ const propTypes = {
 	/**
 	 * Optional class name
 	 */
-	className: React.PropTypes.string,
+	className: PropTypes.string,
 	/**
 	 * The type of component
 	 */
-	variant: React.PropTypes.string,
+	variant: PropTypes.string,
 	/**
 	 * The info property can be a string or a React element
 	 */
-	label: React.PropTypes.oneOfType([
-		React.PropTypes.string,
-		React.PropTypes.element
+	label: PropTypes.oneOfType([
+		PropTypes.string,
+		PropTypes.element
 	]),
 	/**
 	 * The title property can be a string or a React element
 	 */
-	title: React.PropTypes.oneOfType([
-		React.PropTypes.string,
-		React.PropTypes.element
+	title: PropTypes.oneOfType([
+		PropTypes.string,
+		PropTypes.element
 	]),
 	/**
 	 * The info property can be a string or a React element
 	 */
-	info: React.PropTypes.oneOfType([
-		React.PropTypes.string,
-		React.PropTypes.element
+	info: PropTypes.oneOfType([
+		PropTypes.string,
+		PropTypes.element
 	]),
 	/**
 	 * The page header icon
 	 */
-	icon: React.PropTypes.element,
+	icon: PropTypes.element,
 	/**
 	 * Name of the icon. Visit <a href="http://www.lightningdesignsystem.com/resources/icons">Lightning Design System Icons</a> to reference icon names.
 	 */
-	iconName: React.PropTypes.string,
+	iconName: PropTypes.string,
 	/**
 	 * The icons category
 	 */
-	iconCategory: React.PropTypes.oneOf(['action', 'custom', 'doctype', 'standard', 'utility']),
+	iconCategory: PropTypes.oneOf(['action', 'custom', 'doctype', 'standard', 'utility']),
 	/**
 	 * If omitted, icon position is centered.
 	 */
-	iconPosition: React.PropTypes.oneOf(['left', 'right']),
-	iconSize: React.PropTypes.oneOf(['x-small', 'small', 'medium', 'large']),
+	iconPosition: PropTypes.oneOf(['left', 'right']),
+	iconSize: PropTypes.oneOf(['x-small', 'small', 'medium', 'large']),
 	/**
 	 * For icon variants, please reference <a href='http://www.lightningdesignsystem.com/components/buttons/#icon'>Lightning Design System Icons</a>.
 	 */
-	iconVariant: React.PropTypes.oneOf(['container', 'border', 'border-filled', 'small', 'more']),
+	iconVariant: PropTypes.oneOf(['container', 'border', 'border-filled', 'small', 'more']),
 	/**
 	 * Content to appear on the right hand side of the page header
 	 */
-	contentRight: React.PropTypes.oneOfType([
-		React.PropTypes.string,
-		React.PropTypes.element
+	contentRight: PropTypes.oneOfType([
+		PropTypes.string,
+		PropTypes.element
 	]),
 	/**
 	 * An array of buttons which appear on the component's right hand side.
 	 */
-	details: React.PropTypes.array,
+	details: PropTypes.array,
 	/**
 	 * Nav content which appears in the upper right hand corner.
 	 */
-	navRight: React.PropTypes.oneOfType([
-		React.PropTypes.string,
-		React.PropTypes.element
+	navRight: PropTypes.oneOfType([
+		PropTypes.string,
+		PropTypes.element
 	]),
 	/**
 	 * An array of react elements presumably anchor <a> elements.
 	 */
-	trail: React.PropTypes.array
+	trail: PropTypes.array
 };
 
 const defaultProps = {

--- a/components/page-header/private/base/index.jsx
+++ b/components/page-header/private/base/index.jsx
@@ -1,7 +1,8 @@
 /* Copyright (c) 2015-present, salesforce.com, inc. All rights reserved */
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import MediaObject from '../../../media-object';
 
 const displayName = 'PageHeaderBase';

--- a/components/page-header/private/detail-block.jsx
+++ b/components/page-header/private/detail-block.jsx
@@ -3,6 +3,7 @@
 
 
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import PopoverTooltip from '../../popover-tooltip';
 
@@ -11,26 +12,26 @@ const propTypes = {
 	/**
 	 * Optional class name
 	 */
-	className: React.PropTypes.string,
+	className: PropTypes.string,
 	/**
 	 * label
 	 */
-	label: React.PropTypes.oneOfType([
-		React.PropTypes.string,
-		React.PropTypes.element
+	label: PropTypes.oneOfType([
+		PropTypes.string,
+		PropTypes.element
 	]),
 	/**
 	 * The content property can be a string or a React element
 	 */
-	content: React.PropTypes.oneOfType([
-		React.PropTypes.string,
-		React.PropTypes.element
+	content: PropTypes.oneOfType([
+		PropTypes.string,
+		PropTypes.element
 	]),
 	/**
 	 * Sets whether the fields truncate
 	 */
-	truncate: React.PropTypes.bool,
-	flavor: React.PropTypes.string
+	truncate: PropTypes.bool,
+	flavor: PropTypes.string
 };
 
 const defaultProps = {

--- a/components/page-header/private/detail-row.jsx
+++ b/components/page-header/private/detail-row.jsx
@@ -2,20 +2,21 @@
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import DetailBlock from './detail-block';
 
 const displayName = 'PageHeaderDetailRow';
 const propTypes = {
-	children: React.PropTypes.node,
+	children: PropTypes.node,
 	/**
 	 * Optional class name
 	 */
-	className: React.PropTypes.string,
+	className: PropTypes.string,
 	/**
 	 * An array of detail blocks
 	 */
-	details: React.PropTypes.array
+	details: PropTypes.array
 };
 const defaultProps = {};
 

--- a/components/page-header/private/info.jsx
+++ b/components/page-header/private/info.jsx
@@ -1,7 +1,8 @@
 /* Copyright (c) 2015-present, salesforce.com, inc. All rights reserved */
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 const displayName = 'PageHeaderInfo';

--- a/components/page-header/private/object-home/index.jsx
+++ b/components/page-header/private/object-home/index.jsx
@@ -1,7 +1,8 @@
 /* Copyright (c) 2015-present, salesforce.com, inc. All rights reserved */
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import MediaObject from '../../../media-object';
 
 const displayName = 'PageHeaderObjectHome';
@@ -9,9 +10,9 @@ const propTypes = {
 	/**
 	 * Content to appear on the right hand side of the page header
 	 */
-	contentRight: React.PropTypes.oneOfType([
-		React.PropTypes.string,
-		React.PropTypes.element
+	contentRight: PropTypes.oneOfType([
+		PropTypes.string,
+		PropTypes.element
 	]),
 	/**
 	 * Icon node passed by PageHeader
@@ -35,7 +36,7 @@ const propTypes = {
 	/**
 	 * Title node passed by PageHeader
 	 */
-	title: React.PropTypes.node
+	title: PropTypes.node
 };
 
 const ObjectHome = (props) => (<div>

--- a/components/page-header/private/record-home/index.jsx
+++ b/components/page-header/private/record-home/index.jsx
@@ -1,7 +1,8 @@
 /* Copyright (c) 2015-present, salesforce.com, inc. All rights reserved */
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import DetailRow from '../detail-row';
 import MediaObject from '../../../media-object';
 

--- a/components/page-header/private/related-list/index.jsx
+++ b/components/page-header/private/related-list/index.jsx
@@ -2,34 +2,35 @@
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 const displayName = 'PageHeaderRelatedList';
 const propTypes = {
   /**
    * Icon node passed by PageHeader
    */
-	icon: React.PropTypes.node,
+	icon: PropTypes.node,
   /**
    * Title node passed by PageHeader
    */
-	title: React.PropTypes.node,
+	title: PropTypes.node,
   /**
    * Info node passed by PageHeader
    */
-	info: React.PropTypes.node,
+	info: PropTypes.node,
   /**
    * Content to appear on the right hand side of the page header
    */
-	contentRight: React.PropTypes.oneOfType([
-		React.PropTypes.string,
-		React.PropTypes.element
+	contentRight: PropTypes.oneOfType([
+		PropTypes.string,
+		PropTypes.element
 	]),
   /**
    * Nav content which appears in the upper right hand corner.
    */
-	navRight: React.PropTypes.oneOfType([
-		React.PropTypes.string,
-		React.PropTypes.element
+	navRight: PropTypes.oneOfType([
+		PropTypes.string,
+		PropTypes.element
 	])
 };
 const defaultProps = {};

--- a/components/page-header/private/title.jsx
+++ b/components/page-header/private/title.jsx
@@ -2,6 +2,7 @@
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 const displayName = 'PageHeaderTitle';
@@ -9,19 +10,19 @@ const propTypes = {
   /**
    * Sets whether the title will truncate its content responsively.
    */
-	truncate: React.PropTypes.bool,
+	truncate: PropTypes.bool,
   /**
    * Sets the vertical alignment on the title
    */
-	align: React.PropTypes.oneOf(['top', 'middle', 'bottom']),
+	align: PropTypes.oneOf(['top', 'middle', 'bottom']),
   /**
    * The title string (required)
    */
-	title: React.PropTypes.string.isRequired,
+	title: PropTypes.string.isRequired,
   /**
    * Optional class name
    */
-	className: React.PropTypes.string
+	className: PropTypes.string
 };
 const defaultProps = {
 	truncate: true,

--- a/components/panel/filtering/group.jsx
+++ b/components/panel/filtering/group.jsx
@@ -9,7 +9,8 @@
 // ## Dependencies
 
 // ### React
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import PanelFilteringFooter from './private/panel-footer';
 import PanelHeader from './private/panel-header';
@@ -159,7 +160,7 @@ PanelFilterGroup.propTypes = {
 	/**
 	 * Adds in default Panel header and footer
 	 */
-	variant: React.PropTypes.oneOf(['panel'])
+	variant: PropTypes.oneOf(['panel'])
 };
 
 PanelFilterGroup.defaultProps = {

--- a/components/panel/filtering/list-heading.jsx
+++ b/components/panel/filtering/list-heading.jsx
@@ -9,7 +9,8 @@
 // ## Dependencies
 
 // ### React
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### classNames
 import classNames from 'classnames';

--- a/components/panel/filtering/list.jsx
+++ b/components/panel/filtering/list.jsx
@@ -9,7 +9,8 @@
 // ## Dependencies
 
 // ### React
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### shortid
 // [npmjs.com/package/shortid](https://www.npmjs.com/package/shortid)

--- a/components/panel/filtering/private/panel-footer.jsx
+++ b/components/panel/filtering/private/panel-footer.jsx
@@ -9,7 +9,8 @@
 // ## Dependencies
 
 // ### React
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import Button from '../../../button';
 

--- a/components/panel/filtering/private/panel-header.jsx
+++ b/components/panel/filtering/private/panel-header.jsx
@@ -9,7 +9,8 @@
 // ## Dependencies
 
 // ### React
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import Button from '../../../button';
 

--- a/components/panel/index.jsx
+++ b/components/panel/index.jsx
@@ -9,7 +9,8 @@
 // ## Dependencies
 
 // ### React
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### classNames
 import classNames from 'classnames';

--- a/components/popover/popover.jsx
+++ b/components/popover/popover.jsx
@@ -7,7 +7,8 @@
 // Implements the [Popover design pattern](https://www.lightningdesignsystem.com/components/popovers) in React.
 
 // ### React
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### assign
 import assign from 'lodash.assign';

--- a/components/spinner/index.jsx
+++ b/components/spinner/index.jsx
@@ -7,16 +7,13 @@
 // Implements the [Spinner design pattern - 2.1.0-beta.3 (204)](https://latest-204.lightningdesignsystem.com/components/spinners) in React.
 
 // ### React
-// React is an external dependency of the project.
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import classNames from 'classnames';
 
 // ## Constants
 import { SPINNER } from '../../utilities/constants';
-
-// Removes the need for `PropTypes`.
-const { PropTypes } = React;
 
 // ### Prop Types
 const PROP_TYPES = {

--- a/components/tabs/index.jsx
+++ b/components/tabs/index.jsx
@@ -8,9 +8,8 @@
 // ## Dependencies
 
 // ### React
-import React, {
-	PropTypes
-}                      from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### findDOMNode
 import { findDOMNode } from 'react-dom';
@@ -119,7 +118,7 @@ const Tabs = React.createClass({
 		/**
 		 * If the Tabs should be scopped, defaults to false
 		 */
-		variant: React.PropTypes.oneOf(['default', 'scoped']),
+		variant: PropTypes.oneOf(['default', 'scoped']),
 
 		/**
 		 * The Tab (and corresponding TabPanel) that is currently selected.

--- a/components/tabs/private/tab-panel.jsx
+++ b/components/tabs/private/tab-panel.jsx
@@ -8,7 +8,8 @@
 // ## Dependencies
 
 // ### React
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### classNames
 import classNames from 'classnames';
@@ -84,7 +85,7 @@ TabPanel.propTypes = {
 	/**
 	 * If the Tabs should be scopped, defaults to false
 	 */
-	variant: React.PropTypes.oneOf(['default', 'scoped']),
+	variant: PropTypes.oneOf(['default', 'scoped']),
 
 	/**
 	 * The HTML ID of the `<Tab />` that controls this panel.

--- a/components/tabs/private/tab.jsx
+++ b/components/tabs/private/tab.jsx
@@ -6,7 +6,8 @@
 // ## Dependencies
 
 // ### React
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### classNames
 import classNames from 'classnames';
@@ -65,15 +66,15 @@ const Tab = React.createClass({
 		/**
 		 * The string or element that is shown as both the title and the label for this tab.
 		 */
-		children: React.PropTypes.oneOfType([
-			React.PropTypes.string,
-			React.PropTypes.element
+		children: PropTypes.oneOfType([
+			PropTypes.string,
+			PropTypes.element
 		]),
 
 		/**
 		 * If the Tabs should be scopped, defaults to false
 		 */
-		variant: React.PropTypes.oneOf(['default', 'scoped'])
+		variant: PropTypes.oneOf(['default', 'scoped'])
 	},
 
 	getDefaultProps () {

--- a/components/tabs/private/tabs-list.jsx
+++ b/components/tabs/private/tabs-list.jsx
@@ -8,7 +8,8 @@
 // ## Dependencies
 
 // ### React
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### classNames
 import classNames from 'classnames';
@@ -65,7 +66,7 @@ TabsList.propTypes = {
 	/**
 	 * If the Tabs should be scopped, defaults to false
 	 */
-	variant: React.PropTypes.oneOf(['default', 'scoped'])
+	variant: PropTypes.oneOf(['default', 'scoped'])
 };
 
 export default TabsList;

--- a/components/time-picker/index.jsx
+++ b/components/time-picker/index.jsx
@@ -6,7 +6,8 @@
 // ## Dependencies
 
 // ### React
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### isDate
 import isDate from 'lodash.isdate';

--- a/components/time-picker/private/dropdown-trigger.jsx
+++ b/components/time-picker/private/dropdown-trigger.jsx
@@ -6,7 +6,8 @@
 // ## Dependencies
 
 // ### React
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### Children
 import Input from '../../forms/input';

--- a/components/tooltip/index.jsx
+++ b/components/tooltip/index.jsx
@@ -8,7 +8,8 @@
 // Based on SLDS v2.1.0-rc3
 
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 
 import classNames from 'classnames';

--- a/components/tooltip/trigger.jsx
+++ b/components/tooltip/trigger.jsx
@@ -2,6 +2,7 @@
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 
 import classNames from 'classnames';
@@ -10,7 +11,7 @@ import omit from 'lodash.omit';
 
 const displayName = 'Tooltip.Trigger';
 const propTypes = {
-	tooltip: React.PropTypes.node
+	tooltip: PropTypes.node
 };
 const defaultProps = {
 };
@@ -107,7 +108,7 @@ class Trigger extends React.Component {
 					openByDefault: true
 				})];
 			}
-      
+
 			return this.getMouseEventTarget();
 		}
 	}

--- a/components/tree/index.jsx
+++ b/components/tree/index.jsx
@@ -8,7 +8,8 @@
 // ## Dependencies
 
 // ### React
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 // Child components
 import Branch from './private/branch';
@@ -106,7 +107,7 @@ Tree.propTypes = {
 	/**
 	 * This is the tree's heading and describes its contents. It can be hidden, see `assistiveText`.
 	 * */
-	heading: React.PropTypes.string,
+	heading: PropTypes.string,
 	/**
 	 * HTML `id` of primary element that has `.slds-tree` on it. This component has a wrapping container element outside of `.slds-tree`.
 	 */

--- a/components/tree/private/branch.jsx
+++ b/components/tree/private/branch.jsx
@@ -8,7 +8,8 @@
 // ## Dependencies
 
 // ### React
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import Button from '../../button';
 

--- a/components/tree/private/item.jsx
+++ b/components/tree/private/item.jsx
@@ -8,7 +8,8 @@
 // ## Dependencies
 
 // ### React
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import Button from '../../button';
 

--- a/components/utilities/dialog/index.jsx
+++ b/components/utilities/dialog/index.jsx
@@ -3,7 +3,8 @@
 
 
 // Dialog
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 
 // ### classNames

--- a/components/utilities/highlighter/index.jsx
+++ b/components/utilities/highlighter/index.jsx
@@ -3,15 +3,13 @@
 
 // ### React
 import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### ReactHighlighter
 import ReactHighlighter from 'react-highlighter';
 
 // ## Constants
 import { HIGHLIGHTER } from '../../../utilities/constants';
-
-// Removes the need for `PropTypes`.
-const { PropTypes } = React;
 
 /**
  * A utility component that highlights occurrences of a particular pattern in its contents.
@@ -37,9 +35,9 @@ Highlighter.propTypes = {
 	 * The full string to display.
 	 */
 	children: PropTypes.oneOfType([
-		React.PropTypes.string,
-		React.PropTypes.number,
-		React.PropTypes.bool
+		PropTypes.string,
+		PropTypes.number,
+		PropTypes.bool
 	]),
 	className: PropTypes.string,
 	/**

--- a/components/utilities/menu-list/index.jsx
+++ b/components/utilities/menu-list/index.jsx
@@ -8,6 +8,7 @@
 
 // ### React
 import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### classNames
 import classNames from 'classnames';
@@ -17,9 +18,6 @@ import ListItem from './item';
 
 // ## Constants
 import { LIST } from '../../../utilities/constants';
-
-// Removes the need for `PropTypes`.
-const { PropTypes } = React;
 
 /**
  * Component description.

--- a/components/utilities/menu-list/item-label.jsx
+++ b/components/utilities/menu-list/item-label.jsx
@@ -8,6 +8,7 @@
 
 // ### React
 import React from 'react';
+import PropTypes from 'prop-types';
 
 // ## Constants
 import { LIST_ITEM_LABEL } from '../../../utilities/constants';
@@ -25,13 +26,13 @@ const ListItemLabel = (props) => (
 ListItemLabel.displayName = LIST_ITEM_LABEL;
 
 ListItemLabel.propTypes = {
-	data: React.PropTypes.object,
-	icon: React.PropTypes.node,
-	index: React.PropTypes.number,
-	inverted: React.PropTypes.bool,
-	isSelected: React.PropTypes.bool,
-	label: React.PropTypes.string,
-	value: React.PropTypes.any
+	data: PropTypes.object,
+	icon: PropTypes.node,
+	index: PropTypes.number,
+	inverted: PropTypes.bool,
+	isSelected: PropTypes.bool,
+	label: PropTypes.string,
+	value: PropTypes.any
 };
 
 ListItemLabel.defaultProps = {

--- a/components/utilities/menu-list/item.jsx
+++ b/components/utilities/menu-list/item.jsx
@@ -8,6 +8,7 @@
 
 // ### React
 import React from 'react';
+import PropTypes from 'prop-types';
 
 // ### classNames
 import classNames from 'classnames';
@@ -23,9 +24,6 @@ import { EventUtil } from '../../../utilities';
 
 // ## Constants
 import { LIST_ITEM } from '../../../utilities/constants';
-
-// Removes the need for `PropTypes`.
-const { PropTypes } = React;
 
 /**
  * Component description.

--- a/components/utilities/truncate/index.jsx
+++ b/components/utilities/truncate/index.jsx
@@ -2,6 +2,7 @@
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import memoize from 'lodash.memoize';
 
@@ -20,14 +21,14 @@ const TextTruncate = React.createClass({
 	displayName: 'TextTruncate',
 
 	propTypes: {
-		containerClassName: React.PropTypes.string,
-		line: React.PropTypes.number,
-		prefix: React.PropTypes.string,
-		suffix: React.PropTypes.string,
-		text: React.PropTypes.string,
-		textTruncateChild: React.PropTypes.node,
-		truncateText: React.PropTypes.string,
-		wrapper: React.PropTypes.func
+		containerClassName: PropTypes.string,
+		line: PropTypes.number,
+		prefix: PropTypes.string,
+		suffix: PropTypes.string,
+		text: PropTypes.string,
+		textTruncateChild: PropTypes.node,
+		truncateText: PropTypes.string,
+		wrapper: PropTypes.func
 	},
 
 	getDefaultProps () {

--- a/components/utilities/utility-icon/index.jsx
+++ b/components/utilities/utility-icon/index.jsx
@@ -1,7 +1,8 @@
 /* Copyright (c) 2015-present, salesforce.com, inc. All rights reserved */
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 // This component's `checkProps` which issues warnings to developers about properties
 // when in development mode (similar to React's built in development tools)

--- a/examples/app-launcher/stories.jsx
+++ b/examples/app-launcher/stories.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { storiesOf, action } from '@kadira/storybook';
 
 import { APP_LAUNCHER } from '../../utilities/constants';
 
-const { PropTypes } = React;
 
 import AppLauncher from '../../components/app-launcher';
 import AppLauncherTile from '../../components/app-launcher/tile';

--- a/examples/card/stories.jsx
+++ b/examples/card/stories.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import uniqueId from 'lodash.uniqueid';
 import { storiesOf, action } from '@kadira/storybook';
 

--- a/examples/filter/assistive-text.jsx
+++ b/examples/filter/assistive-text.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import Panel from '~/components/panel'; // `~` is replaced with design-system-react at runtime
 import FilterGroup from '~/components/panel/filtering/group';

--- a/examples/filter/default.jsx
+++ b/examples/filter/default.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import Panel from '~/components/panel'; // `~` is replaced with design-system-react at runtime
 import FilterGroup from '~/components/panel/filtering/group';

--- a/examples/filter/error.jsx
+++ b/examples/filter/error.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import Panel from '~/components/panel'; // `~` is replaced with design-system-react at runtime
 import FilterGroup from '~/components/panel/filtering/group';

--- a/examples/filter/locked.jsx
+++ b/examples/filter/locked.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import Panel from '~/components/panel'; // `~` is replaced with design-system-react at runtime
 import FilterGroup from '~/components/panel/filtering/group';

--- a/examples/filter/new.jsx
+++ b/examples/filter/new.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import Panel from '~/components/panel'; // `~` is replaced with design-system-react at runtime
 import FilterGroup from '~/components/panel/filtering/group';

--- a/examples/filter/permanant.jsx
+++ b/examples/filter/permanant.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import Panel from '~/components/panel'; // `~` is replaced with design-system-react at runtime
 import FilterGroup from '~/components/panel/filtering/group';

--- a/examples/tabs/stories.jsx
+++ b/examples/tabs/stories.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { storiesOf, action } from '@kadira/storybook';
 
 import { TABS } from '../../utilities/constants';
@@ -277,8 +278,8 @@ const DemoTabsOutsideControl = React.createClass({
 		/**
 		 * The Tab (and corresponding TabPanel) that is selected when the component renders. Defaults to `0`.
 		 */
-		whichOneSelectedYo: React.PropTypes.number,
-		prevOneSelectedYo: React.PropTypes.number
+		whichOneSelectedYo: PropTypes.number,
+		prevOneSelectedYo: PropTypes.number
 	},
 
 	getInitialState () {

--- a/examples/tree/default.jsx
+++ b/examples/tree/default.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Tree from '~/components/tree';
 
 const sampleNodes = {
@@ -268,11 +269,11 @@ const TreeExample = React.createClass({
 
 	// ### Prop Types
 	propTypes: {
-		exampleNodesIndex: React.PropTypes.string,
-		noBranchSelection: React.PropTypes.bool,
-		searchTerm: React.PropTypes.string,
-		searchable: React.PropTypes.bool,
-		singleSelection: React.PropTypes.bool
+		exampleNodesIndex: PropTypes.string,
+		noBranchSelection: PropTypes.bool,
+		searchTerm: PropTypes.string,
+		searchable: PropTypes.bool,
+		singleSelection: PropTypes.bool
 	},
 
 	getDefaultProps () {

--- a/examples/tree/stories.jsx
+++ b/examples/tree/stories.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { storiesOf, action } from '@kadira/storybook';
 
 import { TREE } from '../../utilities/constants';

--- a/tests/README.md
+++ b/tests/README.md
@@ -65,7 +65,8 @@ Here is a well-commented sample test file which you can copy/paste into a new fi
 /* eslint-disable react/display-name */
 
 // Import your external dependencies
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import chai, { expect } from 'chai';
 import chaiEnzyme from 'chai-enzyme';
 

--- a/tests/date-picker/date-picker.test.jsx
+++ b/tests/date-picker/date-picker.test.jsx
@@ -1,5 +1,6 @@
 // Import your external dependencies
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import chai, { expect } from 'chai';
 import chaiEnzyme from 'chai-enzyme';
 import { mount } from 'enzyme';

--- a/tests/filter/filter.test.jsx
+++ b/tests/filter/filter.test.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import chai, { expect } from 'chai';
 import chaiEnzyme from 'chai-enzyme';
 import { mount } from 'enzyme';

--- a/tests/icon/icon.test.jsx
+++ b/tests/icon/icon.test.jsx
@@ -3,7 +3,8 @@
 /* eslint-disable prefer-arrow-callback */
 /* eslint-disable no-unused-expressions */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import chai, { expect } from 'chai';
 import chaiEnzyme from 'chai-enzyme';

--- a/tests/navigation/navigation.test.jsx
+++ b/tests/navigation/navigation.test.jsx
@@ -12,7 +12,8 @@
 /* eslint-disable react/display-name */
 
 // Import your external dependencies
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import chai, { expect } from 'chai';
 import chaiEnzyme from 'chai-enzyme';
 

--- a/tests/popover/popover.test.jsx
+++ b/tests/popover/popover.test.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import chai, { expect } from 'chai';
 import chaiEnzyme from 'chai-enzyme';
 import { mount } from 'enzyme';

--- a/tests/tabs/tabs.test.jsx
+++ b/tests/tabs/tabs.test.jsx
@@ -1,5 +1,6 @@
 // Import your external dependencies
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import TestUtils from 'react-addons-test-utils';
 import chai, { expect } from 'chai';
 import chaiEnzyme from 'chai-enzyme';
@@ -42,7 +43,7 @@ const COMPONENT_CSS_CLASSES = {
  */
 const TabsDemoComponent = React.createClass({
 	displayName: 'TabsDemoComponent',
-	
+
 	// ### Prop Types
 	propTypes: {
 		/**
@@ -56,7 +57,7 @@ const TabsDemoComponent = React.createClass({
 		/**
 		 * HTML `id` attribute of primary element that has `.slds-tabs--default` on it. Optional: If one is not supplied, a `shortid` will be created.
 		 */
-		id: React.PropTypes.string
+		id: PropTypes.string
 	},
 
 	render () {

--- a/tests/tree/tree.test.jsx
+++ b/tests/tree/tree.test.jsx
@@ -3,7 +3,8 @@
 /* eslint-disable prefer-arrow-callback */
 /* eslint-disable no-unused-expressions */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import chai, { expect } from 'chai';
 import chaiEnzyme from 'chai-enzyme';


### PR DESCRIPTION
Refactor `React.PropTypes` to `prop-types` to ready for 16.x and Fiber
Some trailing whitespace removal was included