### PR TITLE
Add production code lint check to TravisCI

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "heroku-postbuild": "./scripts/heroku-postbuild.sh",
     "icons": "./node_modules/.bin/babel-node scripts/inline-icons.js",
     "link": "./scripts/npm-link.sh",
-    "lint": "npm run lint-non-prod && eslint --config=./.eslintrc \"!(examples|tests)/**/*.{js,jsx}\"",
+    "lint": "eslint --config=./.eslintrc \"**/*.{js,jsx}\"",
     "lint-non-prod": "eslint \"{examples,tests}/**/*.{js,jsx}\"",
     "lint-prod": "eslint --config=./.eslintrc \"{components,utilities}/**/*.{js,jsx}\"",
     "lint-staged": "lint-staged",

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -3,12 +3,20 @@
 # Copyright (c) 2015-present, salesforce.com, inc. All rights reserved
 # Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license
 
+# Mocha framework tests that focus on user interaction
 NODE_ENV=test node_modules/.bin/karma start --single-run "$@"
 if [ $? -eq 0 ]
 then
+  # Jest markup snapshot tests
 	NODE_ENV=test npm run snapshot-test
 	if [ $? -eq 0 ]
 	then
-		NODE_ENV=test npm run build-docs
+		# ESlint tests on files within components and utilities folders. Doc examples and tests are currently excluded.
+		NODE_ENV=test npm run lint-prod
+		if [ $? -eq 0 ]
+		then
+			# React DocGen library build of source comments into a JSON file for documentation site
+			NODE_ENV=test npm run build-docs
+		fi
 	fi
 fi


### PR DESCRIPTION
also makes `npm run lint` check all JS files if needed

@futuremint Thanks for making this possible!

FYI: Example code and test files still have 210 errors at this time.