### PR TITLE
Move icons repo to looser major version

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
   "devDependencies": {
     "@kadira/storybook": "^2.22.0",
     "@salesforce-ux/design-system": "git+ssh://git@github.com/salesforce-ux/design-system-internal.git#v2.4.0-alpha.1-dist",
-    "@salesforce-ux/icons": "^7.19.0",
+    "@salesforce-ux/icons": "7.x",
     "async": "^2.0.0-rc.5",
     "babel": "^6.5.2",
     "babel-cli": "^6.9.0",


### PR DESCRIPTION
npm install runs on release (in the new process PR'd today), so this should keep the  inline icons up to date. App teams expect all icons on SLDS site to be present in the latest release.

Although apps should be moving to external icons that will bring in icons directly from SLDS repo.