### PR TITLE
Removes babel-eslint as a dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "babel": "^6.5.2",
     "babel-cli": "^6.9.0",
     "babel-core": "^6.9.0",
-    "babel-eslint": "^6.1.0",
     "babel-loader": "^6.2.2",
     "babel-plugin-import-noop": "^1.0.1",
     "babel-plugin-root-import": "^5.0.0",


### PR DESCRIPTION
It is already installed by eslint-config-slds and only used by that module.