### PR TITLE
Allow Jest and Eslint to pass tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "async": "^2.0.0-rc.5",
     "babel-cli": "^6.24.1",
     "babel-core": "^6.24.0",
+    "babel-eslint": "^7.2.3",
     "babel-jest": "^20.0.3",
     "babel-loader": "^6.4.1",
     "babel-plugin-import-noop": "^1.0.1",
@@ -164,7 +165,8 @@
     "lint-staged"
   ],
   "pre-push": [
-
+    "validate",
+    "test"
   ],
   "components": [
     {


### PR DESCRIPTION
- Jest is only having issues with ES6 in TravisCI. I've been unable to duplicate locally.
- also getting eslint not found too.