### PR TITLE
Fix icon when tree branch is expanded

### DIFF
--- a/components/tree/private/branch.jsx
+++ b/components/tree/private/branch.jsx
@@ -161,7 +161,7 @@ const renderBranch = (children, props) => {
 				{/* eslint-enable jsx-a11y/no-static-element-interactions */}
 				<Button
 					assistiveText="Toggle"
-					iconName={props.node.expanded? 'chevrondown':'chevronright'}
+					iconName={props.node.expanded ? 'chevrondown' : 'chevronright'}
 					iconSize="small"
 					variant="icon"
 					className="slds-m-right--small"


### PR DESCRIPTION
can you please review? use chevron down as a indicator of a expanded tree branch @interactivellama @donnieberg Thank you.