### PR TITLE
Change DataTable to use child.type.displayName for Columns

### DIFF
--- a/components/data-table/index.jsx
+++ b/components/data-table/index.jsx
@@ -195,7 +195,7 @@ const DataTable = React.createClass({
 		let RowActions = null;
 
 		React.Children.forEach(this.props.children, (child) => {
-			if (child && child.type === DataTableColumn) {
+			if (child && child.type.displayName === DataTableColumn.displayName) {
 				const {
 					children,
 					...columnProps


### PR DESCRIPTION
Issues have come up when using Webpack 3 (although that may not be the issue). This brings the component in line with the other component "type compares" that use `displayName`.