### PR TITLE
Data Table - added .displayName to actions column

### DIFF
--- a/components/data-table/index.jsx
+++ b/components/data-table/index.jsx
@@ -218,7 +218,7 @@ const DataTable = React.createClass({
 					props,
 					dataTableProps: this.props
 				});
-			} else if (child && child.type === DataTableRowActions) {
+			} else if (child && child.type.displayName === DataTableRowActions.displayName) {
 				RowActions = child;
 			}
 		});


### PR DESCRIPTION
Issues have come up when using Webpack 3 (although that may not be the issue). This brings the component in line with the other component "type compares" that use `displayName`.

Related to #1046