### PR TITLE
Fix Notification component throwing uncaught type error

### DIFF
--- a/components/notification/index.jsx
+++ b/components/notification/index.jsx
@@ -129,7 +129,7 @@ class Notification extends React.Component {
 					inverse
 					className="slds-notify__close"
 					onClick={this.onDismiss}
-					ref={(dismissBtn) => { this.dismissBtnRef = dismissBtn; }}
+					buttonRef={(dismissBtn) => { this.dismissBtnRef = dismissBtn; }}
 					variant="icon"
 				/>
 			);


### PR DESCRIPTION
'ref' on a component returns an object, not a DOM ref. I think it used to return the DOM node.

https://github.com/salesforce-ux/design-system-react/issues/1057

@rev interactivellama@