### PR TITLE
Prevent submitting form when open dialog

### DIFF
--- a/components/date-picker/date-picker.jsx
+++ b/components/date-picker/date-picker.jsx
@@ -341,7 +341,8 @@ class Datepicker extends React.Component {
 		}
 	}
 
-	openDialog () {
+	openDialog (evt) {
+		evt.preventDefault();
 		if (this.props.onRequestOpen) {
 			this.props.onRequestOpen();
 		} else {


### PR DESCRIPTION
When date picker is under `<form>`, clicking on icon will trigger the form submit.