### PR TITLE
Fix bug in Button Icon where it didn't render with external icon path

### DIFF
--- a/components/button/index.jsx
+++ b/components/button/index.jsx
@@ -237,7 +237,7 @@ const Button = React.createClass({
 			>
 				{this.props.iconPosition === 'right' ? this.renderLabel() : null}
 
-				{this.props.iconName ? this.renderIcon(this.props.iconName) : null}
+				{this.props.iconName || this.props.iconPath ? this.renderIcon(this.props.iconName) : null}
 				{this.props.iconVariant === 'more'
 				? <ButtonIcon	category="utility" name="down" size="x-small" />
 				: null}

--- a/examples/button/stories.jsx
+++ b/examples/button/stories.jsx
@@ -34,6 +34,12 @@ storiesOf(BUTTON, module)
 		iconName: 'answer',
 		title: 'chat'
 	}))
+	.add('Icon with external path', () => getIconButton({
+		assistiveText: 'Icon',
+		iconSize: 'large',
+		iconPath: '/assets/icons/utility-sprite/svg/symbols.svg#announcement',
+		title: 'announcement'
+	}))
 	.addDecorator((getStory) => (
 		<div className="slds-p-around--medium slds-hint-parent" style={{ backgroundColor: '#16325c' }}>
 			{getStory()}

--- a/examples/component-docs.json
+++ b/examples/component-docs.json
@@ -818,6 +818,30 @@
         "description": "The ButtonStateful component is a variant of the Lightning Design System Button component. It is used for buttons that have a state of unselected or selected.\nFor icon buttons, use <code>variant='icon'</code>. For buttons with labels or buttons with labels and icons, pass data to the state props (ie. <code>stateOne={{iconName: 'add', label: 'Join'}}</code>).",
         "methods": [
             {
+                "name": "handleClick",
+                "docblock": null,
+                "modifiers": [],
+                "params": [
+                    {
+                        "name": "e",
+                        "type": null
+                    }
+                ],
+                "returns": null
+            },
+            {
+                "name": "handleBlur",
+                "docblock": null,
+                "modifiers": [],
+                "params": [
+                    {
+                        "name": "e",
+                        "type": null
+                    }
+                ],
+                "returns": null
+            },
+            {
                 "name": "getClassName",
                 "docblock": null,
                 "modifiers": [],
@@ -5335,7 +5359,15 @@
                 "footer": {
                     "description": "",
                     "displayName": "LookupDefaultFooter",
-                    "methods": [],
+                    "methods": [
+                        {
+                            "name": "handleClick",
+                            "docblock": null,
+                            "modifiers": [],
+                            "params": [],
+                            "returns": null
+                        }
+                    ],
                     "name": "footer",
                     "source": "/components/lookup/footer.jsx"
                 }
@@ -5344,7 +5376,15 @@
                 "header": {
                     "description": "",
                     "displayName": "LookupDefaultHeader",
-                    "methods": [],
+                    "methods": [
+                        {
+                            "name": "handleClick",
+                            "docblock": null,
+                            "modifiers": [],
+                            "params": [],
+                            "returns": null
+                        }
+                    ],
                     "name": "header",
                     "source": "/components/lookup/header.jsx"
                 }
@@ -7323,6 +7363,13 @@
                 "returns": null
             },
             {
+                "name": "onDismiss",
+                "docblock": null,
+                "modifiers": [],
+                "params": [],
+                "returns": null
+            },
+            {
                 "name": "renderAlertContent",
                 "docblock": null,
                 "modifiers": [],
@@ -8660,7 +8707,28 @@
                 "returns": null
             },
             {
+                "name": "handleMouseEnter",
+                "docblock": null,
+                "modifiers": [],
+                "params": [],
+                "returns": null
+            },
+            {
+                "name": "handleMouseLeave",
+                "docblock": null,
+                "modifiers": [],
+                "params": [],
+                "returns": null
+            },
+            {
                 "name": "getTooltipContent",
+                "docblock": null,
+                "modifiers": [],
+                "params": [],
+                "returns": null
+            },
+            {
+                "name": "handleCancel",
                 "docblock": null,
                 "modifiers": [],
                 "params": [],
@@ -8887,6 +8955,18 @@
                 "returns": null
             },
             {
+                "name": "handleClick",
+                "docblock": null,
+                "modifiers": [],
+                "params": [
+                    {
+                        "name": "e",
+                        "type": null
+                    }
+                ],
+                "returns": null
+            },
+            {
                 "name": "setSelected",
                 "docblock": null,
                 "modifiers": [],
@@ -8970,6 +9050,18 @@
                 ],
                 "returns": null,
                 "description": "Determine if a node from event.target is a Tab element for the current Tabs container.\nIf the clicked element is not a Tab, it returns false.\nIf it finds another Tabs container between the Tab and `this`, it returns false."
+            },
+            {
+                "name": "handleKeyDown",
+                "docblock": null,
+                "modifiers": [],
+                "params": [
+                    {
+                        "name": "event",
+                        "type": null
+                    }
+                ],
+                "returns": null
             },
             {
                 "name": "renderTabsList",

--- a/tests/button/button.test.jsx
+++ b/tests/button/button.test.jsx
@@ -128,6 +128,28 @@ describe('SLDSButton: ', () => {
 		});
 	});
 
+	describe('External Path Icon Button renders', () => {
+		let cmp;
+		let use;
+		let svgHref;
+
+		before(() => {
+			cmp = getButton({
+				assistiveText: 'announcement',
+				variant: 'icon',
+				iconPath: '/assets/icons/utility-sprite/svg/symbols.svg#announcement',
+				iconSize: 'large',
+				iconVariant: 'bare'
+			});
+			use = findRenderedDOMComponentWithTag(cmp, 'use');
+			svgHref = use.getAttribute('xlink:href');
+		});
+
+		it('renders svg', () => {
+			expect(svgHref).to.equal('/assets/icons/utility-sprite/svg/symbols.svg#announcement');
+		});
+	});
+
 	describe('Button Clickable', () => {
 		let cmp;
 		let btn;


### PR DESCRIPTION
The `ButtonIcon` was only rendering the Icon if it had `props.iconName`. Changed it to check for either `props.iconName` or `props.iconPath` for external icons.