### PR TITLE
Fix Popover focus trap

### DIFF
--- a/utilities/dom-element-focus.js
+++ b/utilities/dom-element-focus.js
@@ -1,10 +1,11 @@
 import findTabbableElement from './tabbable';
+import KEYS from './key-code';
 
 let ancestor = null;
 let focusLaterElement = null;
 
 const handleScopedKeyDown = (event) => {
-	if (!ancestor || event.keyCode !== 9) { // tab key
+	if (!ancestor || event.keyCode !== KEYS.TAB) {
 		return;
 	}
 	const tabbableElements = findTabbableElement(ancestor);


### PR DESCRIPTION
This changes how the popover component traps focus.  This fix is modeled after how react-modal traps focus.  (https://github.com/reactjs/react-modal/blob/9cb8441b7078ddd5189f3c7d997dd3a6086097c5/src/helpers/scopeTab.js)

Fixes https://github.com/salesforce-ux/design-system-react/issues/948

@interactivellama @donnieberg can you take a look?  Thanks