### PR TITLE
Convert all components to createReactClass

### DIFF
--- a/components/app-launcher/index.jsx
+++ b/components/app-launcher/index.jsx
@@ -9,6 +9,7 @@
 
 // ### React
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
 // ### classNames
@@ -60,7 +61,7 @@ import { APP_LAUNCHER } from '../../utilities/constants';
  * ```
  */
 
-const AppLauncher = React.createClass({
+const AppLauncher = createReactClass({
 	// ### Display Name
 	// Always use the canonical component name as the React display name.
 	displayName: APP_LAUNCHER,

--- a/components/app-launcher/section.jsx
+++ b/components/app-launcher/section.jsx
@@ -7,6 +7,7 @@
 
 // ### React
 import React from 'react';
+import createReactClass from 'create-react-class';
 
 import PropTypes from 'prop-types';
 
@@ -27,7 +28,7 @@ import { APP_LAUNCHER_SECTION } from '../../utilities/constants';
 /**
  * App Launcher Sections allow users to categorize App Tiles as well as toggle their display
  */
-const AppLauncherSection = React.createClass({
+const AppLauncherSection = createReactClass({
 	// ### Display Name
 	// Always use the canonical component name as the React display name.
 	displayName: APP_LAUNCHER_SECTION,

--- a/components/button/index.jsx
+++ b/components/button/index.jsx
@@ -5,6 +5,7 @@
 // Based on SLDS v2.2.1
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import ButtonIcon from '../icon/button-icon';
@@ -17,7 +18,7 @@ import { BUTTON } from '../../utilities/constants';
  * Either a <code>label</code> or <code>assistiveText</code> is required; see the Prop Details table below.
  * For buttons that maintain selected/unselected states, use the <a href="#/button-stateful">ButtonStateful</a> component.
  */
-const Button = React.createClass({
+const Button = createReactClass({
 	displayName: BUTTON,
 
 	propTypes: {

--- a/components/data-table/index.jsx
+++ b/components/data-table/index.jsx
@@ -9,6 +9,7 @@
 
 // ### React
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
 // ### shortid
@@ -48,7 +49,7 @@ const count = (array) => (Array.isArray(array) ? array.length : 0);
  * DataTables support the display of structured data in rows and columns with an HTML table. To sort, filter or paginate the table, simply update the data passed in the items to the table and it will re-render itself appropriately. The table will throw a sort event as needed, and helper components for paging and filtering are coming soon.
  *
  */
-const DataTable = React.createClass({
+const DataTable = createReactClass({
 	// ### Display Name
 	// Always use the canonical component name as the React display name.
 	displayName: DATA_TABLE,

--- a/components/data-table/private/head.jsx
+++ b/components/data-table/private/head.jsx
@@ -3,6 +3,7 @@
 
 // ### React
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
 // ## Children
@@ -15,7 +16,7 @@ import { DATA_TABLE_HEAD } from '../../../utilities/constants';
 /**
  * Used internally, provides header row rendering to the DataTable.
  */
-const DataTableHead = React.createClass({
+const DataTableHead = createReactClass({
 	// ### Display Name
 	// Always use the canonical component name as the React display name.
 	displayName: DATA_TABLE_HEAD,

--- a/components/data-table/private/header-cell.jsx
+++ b/components/data-table/private/header-cell.jsx
@@ -3,6 +3,7 @@
 
 // ### React
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
 // ### classNames
@@ -20,7 +21,7 @@ import { DATA_TABLE_HEADER_CELL } from '../../../utilities/constants';
 /**
  * Used internally, renders each individual column heading.
  */
-const DataTableHeaderCell = React.createClass({
+const DataTableHeaderCell = createReactClass({
 	// ### Display Name
 	// Always use the canonical component name as the React display name.
 	displayName: DATA_TABLE_HEADER_CELL,

--- a/components/data-table/private/row.jsx
+++ b/components/data-table/private/row.jsx
@@ -3,6 +3,7 @@
 
 // ### React
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
 // ### classNames
@@ -20,7 +21,7 @@ import { DATA_TABLE_ROW, DATA_TABLE_ROW_ACTIONS, DATA_TABLE_CELL } from '../../.
 /**
  * Used internally, provides row rendering to the DataTable.
  */
-const DataTableRow = React.createClass({
+const DataTableRow = createReactClass({
 	// ### Display Name
 	// Always use the canonical component name as the React display name.
 	displayName: DATA_TABLE_ROW,

--- a/components/data-table/row-actions.jsx
+++ b/components/data-table/row-actions.jsx
@@ -3,6 +3,7 @@
 
 // ### React
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
 // ### isFunction
@@ -20,7 +21,7 @@ import { DATA_TABLE_ROW_ACTIONS } from '../../utilities/constants';
 /**
  * RowActions provide a mechanism for defining a menu to display alongside each row in the DataTable.
  */
-const DataTableRowActions = React.createClass({
+const DataTableRowActions = createReactClass({
 	// ### Display Name
 	// Always use the canonical component name as the React display name.
 	displayName: DATA_TABLE_ROW_ACTIONS,

--- a/components/date-picker/private/calendar.jsx
+++ b/components/date-picker/private/calendar.jsx
@@ -2,11 +2,12 @@
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import Week from './week';
 import DateUtil from '../../../utilities/date';
 
-const DatepickerCalendar = React.createClass({
+const DatepickerCalendar = createReactClass({
 	displayName: 'SLDSDatepickerCalendar',
 
 	propTypes: {

--- a/components/date-picker/private/navigation.jsx
+++ b/components/date-picker/private/navigation.jsx
@@ -2,13 +2,14 @@
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import YearPicklist from './year-picklist';
 import Button from '../../button';
 
 import DateUtil from '../../../utilities/date';
 
-const DatepickerMonthNavigation = React.createClass({
+const DatepickerMonthNavigation = createReactClass({
 	displayName: 'SLDSDatepickerMonthNavigation',
 
 	propTypes: {

--- a/components/date-picker/private/year-picklist.jsx
+++ b/components/date-picker/private/year-picklist.jsx
@@ -2,10 +2,11 @@
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import MenuPicklist from '../../menu-picklist';
 
-const DatepickerYearSelector = React.createClass({
+const DatepickerYearSelector = createReactClass({
 	displayName: 'SLDSDatepickerYearSelector',
 
 	propTypes: {

--- a/components/filter/index.jsx
+++ b/components/filter/index.jsx
@@ -12,6 +12,7 @@
 
 // ### React
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
 // ### assign
@@ -34,7 +35,7 @@ import { FILTER } from '../../utilities/constants';
 /**
  * A Filter is a popover with custom trigger. It can be used by [Panel Filtering](/components/panels/). Menus within a Filter Popover will need to not have "portal mounts" and be inline.
  */
-const Filter = React.createClass({
+const Filter = createReactClass({
 	displayName: FILTER,
 
 	propTypes: {

--- a/components/forms/checkbox/index.jsx
+++ b/components/forms/checkbox/index.jsx
@@ -7,6 +7,7 @@
 
 // ### React
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
 // ### isFunction
@@ -32,7 +33,7 @@ import { FORMS_CHECKBOX } from '../../../utilities/constants';
 /**
  * The ability to style checkboxes with CSS varies across browsers. Using this component ensures checkboxes look the same everywhere.
  */
-const Checkbox = React.createClass({
+const Checkbox = createReactClass({
 	// ### Display Name
 	// Always use the canonical component name as the React display name.
 	displayName: FORMS_CHECKBOX,

--- a/components/forms/input/index.jsx
+++ b/components/forms/input/index.jsx
@@ -9,6 +9,7 @@
 
 // ### React
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
 // ### classNames
@@ -32,7 +33,7 @@ import checkProps from './check-props';
 import { FORMS_INPUT } from '../../../utilities/constants';
 
 // ## InputDefinition
-const Input = React.createClass({
+const Input = createReactClass({
 	// ### Display Name
 	// Always use the canonical component name as the React display name.
 	displayName: FORMS_INPUT,

--- a/components/forms/input/inline.jsx
+++ b/components/forms/input/inline.jsx
@@ -9,6 +9,7 @@
 
 // ### React
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
 // ### isFunction
@@ -28,7 +29,7 @@ import { FORMS_INLINE_EDIT } from '../../../utilities/constants';
 /**
  * An inline input is rendered as a label by default. When clicked (or tabbed in), it's rendered as an input. When the focus is lost, the current input value is saved and the input is rendered as a label again.
  */
-const InlineEdit = React.createClass({
+const InlineEdit = createReactClass({
 	// ### Display Name
 	// Always use the canonical component name as the React display name.
 	displayName: FORMS_INLINE_EDIT,

--- a/components/forms/textarea/index.jsx
+++ b/components/forms/textarea/index.jsx
@@ -9,6 +9,7 @@
 
 // ### React
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
 // ### classNames
@@ -29,7 +30,7 @@ import checkProps from './check-props';
 import { FORMS_TEXTAREA } from '../../../utilities/constants';
 
 // ## TextareaDefinition
-const Textarea = React.createClass({
+const Textarea = createReactClass({
 	// ### Display Name
 	// Always use the canonical component name as the React display name.
 	displayName: FORMS_TEXTAREA,

--- a/components/global-header/index.jsx
+++ b/components/global-header/index.jsx
@@ -10,6 +10,7 @@
 
 // ### React
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
 // ### Event Helpers
@@ -32,7 +33,7 @@ import { GLOBAL_HEADER, GLOBAL_HEADER_PROFILE, GLOBAL_HEADER_SEARCH, GLOBAL_HEAD
  * </SLDSGlobalHeader>
  * ```
  */
-const GlobalHeader = React.createClass({
+const GlobalHeader = createReactClass({
 	displayName: GLOBAL_HEADER,
 
 	propTypes: {

--- a/components/global-header/private/dropdown-trigger.jsx
+++ b/components/global-header/private/dropdown-trigger.jsx
@@ -7,6 +7,7 @@
 
 // ### React
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
 // ### classNames
@@ -24,7 +25,7 @@ import { MENU_DROPDOWN_TRIGGER } from '../../../utilities/constants';
 /**
 *  The Dropdown Button Trigger renders the default trigger button for the dropdown menu. If this component has children, it does not render itself to the DOM. Instead, it renders its child element, `Button`, and all that child's properties. This component may be used as a template to create custom triggers that do not use `Button`.
 */
-const GlobalHeaderDropdownTrigger = React.createClass({
+const GlobalHeaderDropdownTrigger = createReactClass({
 	// TODO: Make this a stateless component, however dropdowns break when this component becomes stateless.
 
 	// ### Display Name

--- a/components/global-navigation-bar/dropdown-trigger.jsx
+++ b/components/global-navigation-bar/dropdown-trigger.jsx
@@ -7,6 +7,7 @@
 
 // ### React
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
 // ### classNames
@@ -20,7 +21,7 @@ import { MENU_DROPDOWN_TRIGGER } from '../../utilities/constants';
 /**
 *  The Dropdown Button Trigger renders the default trigger button for the dropdown menu. If this component has children, it does not render itself to the DOM. Instead, it renders its child element, `Button`, and all that child's properties. This component may be used as a template to create custom triggers that do not use `Button`.
 */
-const GlobalNavigationDropdownTrigger = React.createClass({
+const GlobalNavigationDropdownTrigger = createReactClass({
 	// ### Display Name
 	// Always use the canonical component name (set in the core) as the React
 	// display name.

--- a/components/global-navigation-bar/region.jsx
+++ b/components/global-navigation-bar/region.jsx
@@ -7,6 +7,7 @@
 
 // ### React
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
 // ### classNames
@@ -63,7 +64,7 @@ const renderTertiary = (dividerClass, className, children) =>
 /**
  * Regions make up a GlobalNavigation Bar and typically contain links and dropdowns. The Primary region contains the AppSwitcher, Application Name, and Object Switcher. The secondary region typically has navigation betweens sections of the application. The tertiary region is aligned to the right side of the screen and contains shortcuts or actions.
  */
-const Region = React.createClass({
+const Region = createReactClass({
 	displayName: GLOBAL_NAVIGATION_BAR_REGION,
 
 	propTypes: {

--- a/components/lookup/lookup.jsx
+++ b/components/lookup/lookup.jsx
@@ -10,6 +10,7 @@
 
 // ### React
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import escapeRegExp from 'lodash.escaperegexp';
 import isEqual from 'lodash.isequal';
@@ -49,7 +50,7 @@ const defaultFilter = (term, item) => {
  *
  * This component may use a portalMount (a disconnected React subtree mount) within an absolutely positioned DOM node created with [Drop](http://github.hubspot.com/drop/).
  */
-const Lookup = React.createClass({
+const Lookup = createReactClass({
 	displayName: LOOKUP,
 
 	propTypes: {

--- a/components/media-object/index.jsx
+++ b/components/media-object/index.jsx
@@ -3,6 +3,7 @@
 
 // ### React
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
 // ### classNames
@@ -23,7 +24,7 @@ export const cssClasses = {
 /**
  * When you need text and a figure next to each other, use a media object.
  */
-const MediaObject = React.createClass({
+const MediaObject = createReactClass({
 	// ### Display Name
 	// Always use the canonical component name as the React display name.
 	displayName: MEDIA_OBJECT,

--- a/components/menu-dropdown/button-trigger.jsx
+++ b/components/menu-dropdown/button-trigger.jsx
@@ -6,6 +6,7 @@
 // ### React
 // React is an external dependency of the project.
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import Button from '../button';
 
@@ -21,7 +22,7 @@ import { MENU_DROPDOWN_TRIGGER } from '../../utilities/constants';
 /**
  *  The Dropdown Button Trigger renders the default trigger button for the dropdown menu. If this component has children, it does not render itself to the DOM. Instead, it renders its child element, `Button`, and all that child's properties. This component may be used as a template to create custom triggers that do not use `Button`.
  */
-const Trigger = React.createClass({
+const Trigger = createReactClass({
 	// ### Display Name
 	// Always use the canonical component name (set in the core) as the React
 	// display name.

--- a/components/menu-dropdown/menu-dropdown.jsx
+++ b/components/menu-dropdown/menu-dropdown.jsx
@@ -9,6 +9,7 @@
 
 // ### React
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 
@@ -84,7 +85,7 @@ const DropdownNubbinPositions = [
  * This component may use a portalMount (a disconnected React subtree mount) within an absolutely positioned DOM node created with [Drop](http://github.hubspot.com/drop/).
 
  */
-const MenuDropdown = React.createClass({
+const MenuDropdown = createReactClass({
 	// ### Display Name
 	// Always use the canonical component name as the React display name.
 	displayName: MENU_DROPDOWN,

--- a/components/menu-picklist/index.jsx
+++ b/components/menu-picklist/index.jsx
@@ -10,6 +10,7 @@
 
 // ### React
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
 // This component's `checkProps` which issues warnings to developers about properties
@@ -48,7 +49,7 @@ import { MENU_PICKLIST } from '../../utilities/constants';
 /**
  * The MenuPicklist component is a variant of the Lightning Design System Menu component.
  */
-const MenuPicklist = React.createClass({
+const MenuPicklist = createReactClass({
 	// ### Display Name
 	// Always use the canonical component name as the React display name.
 	displayName: MENU_PICKLIST,

--- a/components/modal/private/manager.jsx
+++ b/components/modal/private/manager.jsx
@@ -3,6 +3,7 @@
 
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import ReactDOM from 'react-dom';
 
 import Button from '../../button';
@@ -32,7 +33,7 @@ const customStyles = {
 	}
 };
 
-const Manager = React.createClass({
+const Manager = createReactClass({
 	getDefaultProps () {
 		return {
 			title: '',

--- a/components/navigation/index.jsx
+++ b/components/navigation/index.jsx
@@ -5,6 +5,7 @@
 // Based on SLDS v2.2.1
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
 // ### classNames
@@ -26,7 +27,7 @@ import Item from './private/item';
 /**
  * Navigation represents a list of links that either take the user to another page or parts of the page the user is in.
  */
-const Navigation = React.createClass({
+const Navigation = createReactClass({
 	displayName: NAVIGATION,
 
 	propTypes: {

--- a/components/panel/filtering/list.jsx
+++ b/components/panel/filtering/list.jsx
@@ -10,6 +10,7 @@
 
 // ### React
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
 // ### shortid
@@ -23,7 +24,7 @@ import { PANEL_FILTER_LIST } from '../../../utilities/constants';
 /**
  * A list of Filters. This is a higher order component for filters that decorates the filter to work within a Filtering Panel. It also adds support for a Filter error label.
  */
-const PanelFilterList = React.createClass({
+const PanelFilterList = createReactClass({
 	displayName: PANEL_FILTER_LIST,
 
 	propTypes () {

--- a/components/popover/popover.jsx
+++ b/components/popover/popover.jsx
@@ -8,6 +8,7 @@
 
 // ### React
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
 // ### assign
@@ -72,7 +73,7 @@ const PopoverNubbinPositions = [
 /**
  * The Popover component is a non-modal dialog. It should be paired with a clickable trigger such as a `Button`. It traps focus from the page and must be exited if focus needs to be outside the Popover. Use a `Tooltip` if there are no call to actions within the dialog. A `Tooltip` does not need to be clicked.
  */
-const Popover = React.createClass({
+const Popover = createReactClass({
 	// ### Display Name
 	// Always use the canonical component name as the React display name.
 	displayName: POPOVER,

--- a/components/spinner/index.jsx
+++ b/components/spinner/index.jsx
@@ -1,7 +1,6 @@
 /* Copyright (c) 2015-present, salesforce.com, inc. All rights reserved */
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 
-
 // # Spinner Component --- SLDS for React
 
 // Implements the [Spinner design pattern - 2.1.0-beta.3 (204)](https://latest-204.lightningdesignsystem.com/components/spinners) in React.

--- a/components/tabs/private/tab.jsx
+++ b/components/tabs/private/tab.jsx
@@ -7,6 +7,7 @@
 
 // ### React
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
 // ### classNames
@@ -18,7 +19,7 @@ import { TAB } from '../../../utilities/constants';
 // Temporary hack until included in SLDS
 import '!style-loader!css-loader!../../../styles/tabs/tab.css'; // eslint-disable-line import/no-unresolved
 
-const Tab = React.createClass({
+const Tab = createReactClass({
 	displayName: TAB,
 
 	propTypes: {

--- a/components/time-picker/index.jsx
+++ b/components/time-picker/index.jsx
@@ -7,6 +7,7 @@
 
 // ### React
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
 // ### isDate
@@ -27,7 +28,7 @@ import { TIME_PICKER } from '../../utilities/constants';
 /**
 *  Component description.
 */
-const Timepicker = React.createClass({
+const Timepicker = createReactClass({
 	// ### Display Name
 	// Always use the canonical component name as the React display name.
 	displayName: TIME_PICKER,

--- a/components/time-picker/private/dropdown-trigger.jsx
+++ b/components/time-picker/private/dropdown-trigger.jsx
@@ -7,6 +7,7 @@
 
 // ### React
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
 // ### Children
@@ -21,7 +22,7 @@ import { MENU_DROPDOWN_TRIGGER } from '../../../utilities/constants';
 /**
 *  Component description.
 */
-const TimepickerDropdownTrigger = React.createClass({
+const TimepickerDropdownTrigger = createReactClass({
 	// ### Display Name
 	// Always use the canonical component name (set in the core) as the React
 	// display name.

--- a/components/utilities/dialog/index.jsx
+++ b/components/utilities/dialog/index.jsx
@@ -4,6 +4,7 @@
 
 // Dialog
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 
@@ -27,7 +28,7 @@ import { DIALOG } from '../../../utilities/constants';
 
 /* Dialog creates a new top-level React tree and injects its child into it. This is necessary for proper styling (especially positioning). A dialog is a non-modal container that separates content from the rest of the web application. This library uses the Drop library (https://github.com/HubSpot/drop which is based on TetherJS) to absolutely position and align content to another item on the page. This component is not meant for external consumption or part of the published component API.
 */
-const Dialog = React.createClass({
+const Dialog = createReactClass({
 
 	displayName: DIALOG,
 

--- a/components/utilities/menu-list/index.jsx
+++ b/components/utilities/menu-list/index.jsx
@@ -8,6 +8,7 @@
 
 // ### React
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
 // ### classNames
@@ -22,7 +23,7 @@ import { LIST } from '../../../utilities/constants';
 /**
  * Component description.
  */
-const List = React.createClass({
+const List = createReactClass({
 	displayName: LIST,
 
 	propTypes: {

--- a/components/utilities/menu-list/item.jsx
+++ b/components/utilities/menu-list/item.jsx
@@ -8,6 +8,7 @@
 
 // ### React
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
 // ### classNames
@@ -28,7 +29,7 @@ import { LIST_ITEM } from '../../../utilities/constants';
 /**
  * Component description.
  */
-const ListItem = React.createClass({
+const ListItem = createReactClass({
 	displayName: LIST_ITEM,
 
 	propTypes: {

--- a/components/utilities/truncate/index.jsx
+++ b/components/utilities/truncate/index.jsx
@@ -2,6 +2,7 @@
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
 import memoize from 'lodash.memoize';
@@ -17,7 +18,7 @@ const measureWidth = memoize((text, font) => {
 	return canvasContext.measureText(text).width;
 });
 
-const TextTruncate = React.createClass({
+const TextTruncate = createReactClass({
 	displayName: 'TextTruncate',
 
 	propTypes: {

--- a/components/utilities/utility-icon/svg.jsx
+++ b/components/utilities/utility-icon/svg.jsx
@@ -2,8 +2,9 @@
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 
-const Svg = React.createClass({
+const Svg = createReactClass({
 	displayName: 'Svg',
 
 	getPaths (paths) {

--- a/examples/app-launcher/default.jsx
+++ b/examples/app-launcher/default.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import AppLauncher from '~/components/app-launcher'; // `~` is replaced with design-system-react at runtime
 import AppLauncherTile from '~/components/app-launcher/tile';
 import AppLauncherSection from '~/components/app-launcher/section';
@@ -10,7 +11,7 @@ import Icon from '~/components/icon';
 import Button from '~/components/button';
 import Search from '~/components/forms/input/search';
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'AppLauncherExample',
 
 	render () {

--- a/examples/app-launcher/stories.jsx
+++ b/examples/app-launcher/stories.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import { storiesOf, action } from '@kadira/storybook';
 
@@ -31,7 +32,7 @@ const smallTileDemoStyles = {
 	paddingRight: '.5rem'
 };
 
-const DemoAppLauncherTile = React.createClass({
+const DemoAppLauncherTile = createReactClass({
 	displayName: 'DemoAppLauncherTile',
 
 	propTypes: {
@@ -54,7 +55,7 @@ const DemoAppLauncherTile = React.createClass({
 	}
 });
 
-const DemoAppLauncherSmallTile = React.createClass({
+const DemoAppLauncherSmallTile = createReactClass({
 	displayName: 'DemoAppLauncherSmallTile',
 
 	render () {
@@ -69,7 +70,7 @@ const DemoAppLauncherSmallTile = React.createClass({
 	}
 });
 
-const DemoAppLauncherTileWithIconNode = React.createClass({
+const DemoAppLauncherTileWithIconNode = createReactClass({
 	displayName: 'DemoAppLauncherTileWithIconNode',
 
 	propTypes: {
@@ -94,7 +95,7 @@ const DemoAppLauncherTileWithIconNode = React.createClass({
 	}
 });
 
-const DemoAppLauncherTileWithIconText = React.createClass({
+const DemoAppLauncherTileWithIconText = createReactClass({
 	displayName: 'DemoAppLauncherTileWithIconText',
 
 	propTypes: {
@@ -116,7 +117,7 @@ const DemoAppLauncherTileWithIconText = React.createClass({
 	}
 });
 
-const DemoAppLauncherTileWithTruncatedText = React.createClass({
+const DemoAppLauncherTileWithTruncatedText = createReactClass({
 	displayName: 'DemoAppLauncherTileWithTruncatedText',
 
 	propTypes: {
@@ -138,7 +139,7 @@ const DemoAppLauncherTileWithTruncatedText = React.createClass({
 	}
 });
 
-const DemoAppLauncherTileWithDescriptionHeading = React.createClass({
+const DemoAppLauncherTileWithDescriptionHeading = createReactClass({
 	displayName: 'DemoAppLauncherTileWithDescriptionHeading',
 
 	propTypes: {
@@ -167,7 +168,7 @@ const DemoAppLauncherTileWithDescriptionHeading = React.createClass({
 	}
 });
 
-const DemoAppLauncherTileWithSearchText = React.createClass({
+const DemoAppLauncherTileWithSearchText = createReactClass({
 	displayName: 'DemoAppLauncherTileWithSearchText',
 
 	propTypes: {
@@ -191,7 +192,7 @@ const DemoAppLauncherTileWithSearchText = React.createClass({
 	}
 });
 
-const DemoAppLauncherSection = React.createClass({
+const DemoAppLauncherSection = createReactClass({
 	displayName: 'DemoAppLauncherSection',
 
 	render () {
@@ -211,7 +212,7 @@ const DemoAppLauncherSection = React.createClass({
 	}
 });
 
-const DemoAppLauncherSectionWithSmallTiles = React.createClass({
+const DemoAppLauncherSectionWithSmallTiles = createReactClass({
 	displayName: 'DemoAppLauncherSectionWithSmallTiles',
 
 	render () {
@@ -231,7 +232,7 @@ const DemoAppLauncherSectionWithSmallTiles = React.createClass({
 	}
 });
 
-const DemoAppLauncher = React.createClass({
+const DemoAppLauncher = createReactClass({
 	displayName: 'DemoAppLauncher',
 
 	getInitialState () {
@@ -314,7 +315,7 @@ const DemoAppLauncher = React.createClass({
 	}
 });
 
-const DemoAppLauncherNoHeaderButton = React.createClass({
+const DemoAppLauncherNoHeaderButton = createReactClass({
 	displayName: 'DemoAppLauncherNoHeaderButton',
 
 	getInitialState () {
@@ -365,7 +366,7 @@ const DemoAppLauncherNoHeaderButton = React.createClass({
 	}
 });
 
-const DemoAppLauncherNoSearch = React.createClass({
+const DemoAppLauncherNoSearch = createReactClass({
 	displayName: 'DemoAppLauncherNoSearch',
 
 	getInitialState () {
@@ -411,7 +412,7 @@ const DemoAppLauncherNoSearch = React.createClass({
 	}
 });
 
-const DemoAppLauncherWithSeveralSections = React.createClass({
+const DemoAppLauncherWithSeveralSections = createReactClass({
 	displayName: 'DemoAppLauncherWithSeveralSections',
 
 	onSearch () {

--- a/examples/breadcrumb/base.jsx
+++ b/examples/breadcrumb/base.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import BreadCrumb from '~/components/breadcrumb'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'BreadCrumbExample',
 
 	render () {

--- a/examples/breadcrumb/one-item.jsx
+++ b/examples/breadcrumb/one-item.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import BreadCrumb from '~/components/breadcrumb'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'BreadCrumbExample',
 
 	render () {

--- a/examples/button-group/checkbox-error.jsx
+++ b/examples/button-group/checkbox-error.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import ButtonGroup from '~/components/button-group';
 import Checkbox from '~/components/forms/checkbox';
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'ButtonGroupExample',
 
 	render () {

--- a/examples/button-group/checkbox.jsx
+++ b/examples/button-group/checkbox.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import ButtonGroup from '~/components/button-group';
 import Checkbox from '~/components/forms/checkbox';
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'ButtonGroupExample',
 
 	render () {

--- a/examples/button-group/icon-group.jsx
+++ b/examples/button-group/icon-group.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import ButtonGroup from '~/components/button-group';
 import ButtonStateful from '~/components/button-stateful';
 import Dropdown from '~/components/menu-dropdown';
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'ButtonGroupExample',
 
 	render () {

--- a/examples/button-group/more-icon.jsx
+++ b/examples/button-group/more-icon.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import ButtonGroup from '~/components/button-group';
 import Button from '~/components/button';
 import Dropdown from '~/components/menu-dropdown';
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'ButtonGroupExample',
 
 	render () {

--- a/examples/button-stateful/icon-text.jsx
+++ b/examples/button-stateful/icon-text.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import ButtonStateful from '~/components/button-stateful'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'ButtonStatefulExample',
 
 	render () {

--- a/examples/button-stateful/icon.jsx
+++ b/examples/button-stateful/icon.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import ButtonStateful from '~/components/button-stateful'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'ButtonStatefulExample',
 
 	render () {

--- a/examples/button/base-neutral.jsx
+++ b/examples/button/base-neutral.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Button from '~/components/button'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'ButtonExample',
 
 	render () {

--- a/examples/button/brand-disabled-destructive-inverse.jsx
+++ b/examples/button/brand-disabled-destructive-inverse.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Button from '~/components/button'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'ButtonExample',
 
 	render () {

--- a/examples/button/button-icons.jsx
+++ b/examples/button/button-icons.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Button from '~/components/button'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'ButtonExample',
 
 	render () {

--- a/examples/card/related-list-with-table.jsx
+++ b/examples/card/related-list-with-table.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Button from '~/components/button'; // `~` is replaced with design-system-react at runtime
 import Card from '~/components/card';
 import CardEmpty from '~/components/card/empty';
@@ -13,7 +14,7 @@ const sampleItems = [
 	{ name: 'Cloud City' }
 ];
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'CardExample',
 
 	getInitialState () {

--- a/examples/card/stories.jsx
+++ b/examples/card/stories.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import uniqueId from 'lodash.uniqueid';
 import { storiesOf, action } from '@kadira/storybook';
@@ -22,7 +23,7 @@ const sampleItems = [
 	{ name: 'Cloud City' }
 ];
 
-const DemoCard = React.createClass({
+const DemoCard = createReactClass({
 	displayName: 'DemoCard',
 
 	propTypes: {

--- a/examples/data-table/advanced.jsx
+++ b/examples/data-table/advanced.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import DataTable from '~/components/data-table'; // `~` is replaced with design-system-react at runtime
 import DataTableColumn from '~/components/data-table/column';
 import DataTableCell from '~/components/data-table/cell';
@@ -16,7 +17,7 @@ const CustomDataTableCell = ({ children, ...props }) => (
 );
 CustomDataTableCell.displayName = DataTableCell.displayName;
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'DataTableExample',
 
 	getInitialState () {

--- a/examples/data-table/basic.jsx
+++ b/examples/data-table/basic.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import DataTable from '~/components/data-table'; // `~` is replaced with design-system-react at runtime
 import DataTableColumn from '~/components/data-table/column';
 import DataTableCell from '~/components/data-table/cell';
@@ -63,7 +64,7 @@ const columns = [
 	</DataTableColumn>
 ];
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'DataTableExample',
 
 	getInitialState () {

--- a/examples/date-picker/custom-input.jsx
+++ b/examples/date-picker/custom-input.jsx
@@ -1,9 +1,10 @@
 /* eslint-disable no-console, react/prop-types */
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Datepicker from '~/components/date-picker';
 import Input from '~/components/forms/input';
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'DatepickerExample',
 
 	getInitialState () {

--- a/examples/date-picker/default.jsx
+++ b/examples/date-picker/default.jsx
@@ -1,8 +1,9 @@
 /* eslint-disable no-console, react/prop-types */
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Datepicker from '~/components/date-picker';
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'DatepickerExample',
 
 	render () {

--- a/examples/date-picker/iso-weekday.jsx
+++ b/examples/date-picker/iso-weekday.jsx
@@ -1,8 +1,9 @@
 /* eslint-disable no-console, react/prop-types */
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Datepicker from '~/components/date-picker';
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'DatepickerExample',
 
 	render () {

--- a/examples/date-picker/snapshot-default.jsx
+++ b/examples/date-picker/snapshot-default.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-console, react/prop-types */
 import React from 'react';
+import createReactClass from 'create-react-class';
 
 // Higher Order Components such as `react-onclickoutside` use the DOM and Jest snapshot testing must be DOMless
 import Datepicker from '~/components/date-picker/date-picker';
@@ -8,7 +9,7 @@ import globalSettings from '../../components/settings';
 
 globalSettings.setIconsPath('/assets/icons');
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'DatepickerExample',
 
 	render () {

--- a/examples/date-picker/weekday-picker.jsx
+++ b/examples/date-picker/weekday-picker.jsx
@@ -1,8 +1,9 @@
 /* eslint-disable no-console, react/prop-types */
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Datepicker from '~/components/date-picker';
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'DatepickerExample',
 
 	render () {

--- a/examples/filter/assistive-text.jsx
+++ b/examples/filter/assistive-text.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
 import Panel from '~/components/panel'; // `~` is replaced with design-system-react at runtime
@@ -16,7 +17,7 @@ const options = {
 	]
 };
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'FilterExample',
 
 	propTypes () {

--- a/examples/filter/default.jsx
+++ b/examples/filter/default.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
 import Panel from '~/components/panel'; // `~` is replaced with design-system-react at runtime
@@ -16,7 +17,7 @@ const options = {
 	]
 };
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'FilterExample',
 
 	propTypes () {

--- a/examples/filter/error.jsx
+++ b/examples/filter/error.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
 import Panel from '~/components/panel'; // `~` is replaced with design-system-react at runtime
@@ -16,7 +17,7 @@ const options = {
 	]
 };
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'FilterExample',
 
 	propTypes () {

--- a/examples/filter/locked.jsx
+++ b/examples/filter/locked.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
 import Panel from '~/components/panel'; // `~` is replaced with design-system-react at runtime
@@ -16,7 +17,7 @@ const options = {
 	]
 };
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'FilterExample',
 
 	propTypes () {

--- a/examples/filter/new.jsx
+++ b/examples/filter/new.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
 import Panel from '~/components/panel'; // `~` is replaced with design-system-react at runtime
@@ -16,7 +17,7 @@ const options = {
 	]
 };
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'FilterExample',
 
 	propTypes () {

--- a/examples/filter/permanant.jsx
+++ b/examples/filter/permanant.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
 import Panel from '~/components/panel'; // `~` is replaced with design-system-react at runtime
@@ -16,7 +17,7 @@ const options = {
 	]
 };
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'FilterExample',
 
 	propTypes () {

--- a/examples/forms/checkbox/default.jsx
+++ b/examples/forms/checkbox/default.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Checkbox from '~/components/forms/checkbox'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'CheckboxExample',
 
 	render () {

--- a/examples/forms/checkbox/error.jsx
+++ b/examples/forms/checkbox/error.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Checkbox from '~/components/forms/checkbox'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'CheckboxExample',
 
 	render () {

--- a/examples/forms/checkbox/snapshot-base.jsx
+++ b/examples/forms/checkbox/snapshot-base.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 
 // `~` is replaced with design-system-react at runtime
 import Checkbox from '~/components/forms/checkbox';
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'CheckboxExample',
 
 	render () {

--- a/examples/forms/checkbox/snapshot-toggle.jsx
+++ b/examples/forms/checkbox/snapshot-toggle.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 
 
 // `~` is replaced with design-system-react at runtime
 import Checkbox from '~/components/forms/checkbox';
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'CheckboxExample',
 
 	render () {

--- a/examples/forms/checkbox/stories.jsx
+++ b/examples/forms/checkbox/stories.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { storiesOf, action } from '@kadira/storybook';
 
 import { FORMS_CHECKBOX } from '../../../utilities/constants';
 import Checkbox from '../../../components/forms/checkbox';
 import Button from '../../../components/button';
 
-const CheckboxIndeterminate = React.createClass({
+const CheckboxIndeterminate = createReactClass({
 	displayName: `${FORMS_CHECKBOX}_INDETERMINATE`,
 
 	getInitialState () {

--- a/examples/forms/checkbox/toggle.jsx
+++ b/examples/forms/checkbox/toggle.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 
 // `~` is replaced with design-system-react at runtime
 import Checkbox from '~/components/forms/checkbox';
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'CheckboxExample',
 
 	render () {

--- a/examples/forms/input/default.jsx
+++ b/examples/forms/input/default.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Input from '~/components/forms/input'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'InputExample',
 
 	render () {

--- a/examples/forms/input/disabled.jsx
+++ b/examples/forms/input/disabled.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Input from '~/components/forms/input'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'InputExample',
 
 	render () {

--- a/examples/forms/input/error.jsx
+++ b/examples/forms/input/error.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Input from '~/components/forms/input'; // `~` is replaced with design-system-react at runtime
 import InputIcon from '~/components/icon/input-icon'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'InputExample',
 
 	render () {

--- a/examples/forms/input/icons.jsx
+++ b/examples/forms/input/icons.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Input from '~/components/forms/input'; // `~` is replaced with design-system-react at runtime
 import InputIcon from '~/components/icon/input-icon'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'InputExample',
 
 	render () {

--- a/examples/forms/input/inline/default.jsx
+++ b/examples/forms/input/inline/default.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import InlineEdit from '~/components/forms/input/inline'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'InlineEditExample',
 
 	getInitialState () {

--- a/examples/forms/input/inline/stories.jsx
+++ b/examples/forms/input/inline/stories.jsx
@@ -1,12 +1,13 @@
 /* eslint-disable indent */
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { storiesOf, action } from '@kadira/storybook';
 
 import { FORMS_INLINE_EDIT } from '../../../../utilities/constants';
 import InlineEdit from '../../../../components/forms/input/inline';
 
-const DemoInlineEdit = React.createClass({
+const DemoInlineEdit = createReactClass({
 	displayName: 'DemoInlineEdit',
 
 	getInitialState () {

--- a/examples/forms/input/read-only.jsx
+++ b/examples/forms/input/read-only.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Input from '~/components/forms/input'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'InputExample',
 	render () {
 		return (

--- a/examples/forms/textarea/default.jsx
+++ b/examples/forms/textarea/default.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Textarea from '~/components/forms/textarea'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'TextareaExample',
 
 	render () {

--- a/examples/forms/textarea/disabled.jsx
+++ b/examples/forms/textarea/disabled.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Textarea from '~/components/forms/textarea'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'TextareaExample',
 
 	render () {

--- a/examples/forms/textarea/error.jsx
+++ b/examples/forms/textarea/error.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Textarea from '~/components/forms/textarea'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'TextareaExample',
 
 	render () {

--- a/examples/global-header/default.jsx
+++ b/examples/global-header/default.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import GlobalHeader from '~/components/global-header'; // `~` is replaced with design-system-react at runtime
 import GlobalHeaderButton from '~/components/global-header/button';
 import GlobalHeaderDropdown from '~/components/global-header/dropdown';
 import GlobalHeaderProfile from '~/components/global-header/profile';
 import GlobalHeaderSearch from '~/components/global-header/search';
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'GlobalHeaderExample',
 
 	render () {

--- a/examples/global-navigation-bar/default.jsx
+++ b/examples/global-navigation-bar/default.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import GlobalNavigationBar from '~/components/global-navigation-bar'; // `~` is replaced with design-system-react at runtime
 import GlobalNavigationBarRegion from '~/components/global-navigation-bar/region';
 import GlobalNavigationBarDropdown from '~/components/global-navigation-bar/dropdown';
@@ -11,7 +12,7 @@ import AppLauncher from '~/components/app-launcher';
 import AppLauncherSection from '~/components/app-launcher/section';
 import AppLauncherTile from '~/components/app-launcher/tile';
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'GlobalNavigationBarExample',
 
 	render () {

--- a/examples/icon/action.jsx
+++ b/examples/icon/action.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Icon from '~/components/icon'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'IconExample',
 
 	render () {

--- a/examples/icon/categories.jsx
+++ b/examples/icon/categories.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Icon from '~/components/icon'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'IconExample',
 
 	render () {

--- a/examples/icon/color-base.jsx
+++ b/examples/icon/color-base.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Icon from '~/components/icon'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'IconExample',
 
 	render () {

--- a/examples/icon/color-default.jsx
+++ b/examples/icon/color-default.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Icon from '~/components/icon'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'IconExample',
 
 	render () {

--- a/examples/icon/color-error.jsx
+++ b/examples/icon/color-error.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Icon from '~/components/icon'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'IconExample',
 
 	render () {

--- a/examples/icon/color-warning.jsx
+++ b/examples/icon/color-warning.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Icon from '~/components/icon'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'IconExample',
 
 	render () {

--- a/examples/icon/colors.jsx
+++ b/examples/icon/colors.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Icon from '~/components/icon'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'IconExample',
 
 	render () {

--- a/examples/icon/custom.jsx
+++ b/examples/icon/custom.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Icon from '~/components/icon'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'IconExample',
 
 	render () {

--- a/examples/icon/doctype.jsx
+++ b/examples/icon/doctype.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Icon from '~/components/icon'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'IconExample',
 
 	render () {

--- a/examples/icon/external-path.jsx
+++ b/examples/icon/external-path.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Icon from '~/components/icon'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'IconExample',
 
 	render () {

--- a/examples/icon/sizes-extra-small.jsx
+++ b/examples/icon/sizes-extra-small.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Icon from '~/components/icon'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'IconExample',
 
 	render () {

--- a/examples/icon/sizes-large.jsx
+++ b/examples/icon/sizes-large.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Icon from '~/components/icon'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'IconExample',
 
 	render () {

--- a/examples/icon/sizes-medium.jsx
+++ b/examples/icon/sizes-medium.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Icon from '~/components/icon'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'IconExample',
 
 	render () {

--- a/examples/icon/sizes-small.jsx
+++ b/examples/icon/sizes-small.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Icon from '~/components/icon'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'IconExample',
 
 	render () {

--- a/examples/icon/sizes.jsx
+++ b/examples/icon/sizes.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Icon from '~/components/icon'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'IconExample',
 
 	render () {

--- a/examples/icon/standard.jsx
+++ b/examples/icon/standard.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Icon from '~/components/icon'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'IconExample',
 
 	render () {

--- a/examples/icon/utility.jsx
+++ b/examples/icon/utility.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Icon from '~/components/icon'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'IconExample',
 
 	render () {

--- a/examples/lookup/default.jsx
+++ b/examples/lookup/default.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Lookup from '~/components/lookup'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'LookupExample',
 
 	render () {

--- a/examples/lookup/files.jsx
+++ b/examples/lookup/files.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Lookup from '~/components/lookup'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'LookupExample',
 
 	render () {

--- a/examples/lookup/stories.jsx
+++ b/examples/lookup/stories.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { storiesOf, action } from '@kadira/storybook';
 
 import { LOOKUP } from '../../utilities/constants';
 import Lookup from '../../components/lookup';
 import SLDSButton from '../../components/button';
 
-const DemoLookup = React.createClass({
+const DemoLookup = createReactClass({
 	displayName: 'DemoLookup',
 
 	getInitialState () {
@@ -44,7 +45,7 @@ const DemoLookup = React.createClass({
 	}
 });
 
-const DemoLookupAccounts = React.createClass({
+const DemoLookupAccounts = createReactClass({
 	displayName: 'DemoLookupAccounts',
 
 	getInitialState () {

--- a/examples/lookup/with-selection.jsx
+++ b/examples/lookup/with-selection.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Lookup from '~/components/lookup'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'LookupExample',
 
 	render () {

--- a/examples/media-object/default.jsx
+++ b/examples/media-object/default.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import MediaObject from '~/components/media-object'; // `~` is replaced with design-system-react at runtime
 import Icon from '~/components/icon';
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'MediaObjectExample',
 
 	render () {

--- a/examples/media-object/vertically-centered.jsx
+++ b/examples/media-object/vertically-centered.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import MediaObject from '~/components/media-object'; // `~` is replaced with design-system-react at runtime
 import Icon from '~/components/icon';
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'MediaObjectExample',
 
 	render () {

--- a/examples/menu-dropdown/checkmark.jsx
+++ b/examples/menu-dropdown/checkmark.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Dropdown from '~/components/menu-dropdown'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'MediaObjectExample',
 
 	render () {

--- a/examples/menu-dropdown/custom-trigger.jsx
+++ b/examples/menu-dropdown/custom-trigger.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Dropdown from '~/components/menu-dropdown'; // `~` is replaced with design-system-react at runtime
 import DropdownTrigger from '~/components/menu-dropdown/button-trigger'; // `~` is replaced with design-system-react at runtime
 import Button from '~/components/button/'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'DropdownExample',
 
 	render () {

--- a/examples/menu-dropdown/default-icon-label.jsx
+++ b/examples/menu-dropdown/default-icon-label.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Dropdown from '~/components/menu-dropdown'; // `~` is replaced with design-system-react at runtime
 import DropdownTrigger from '~/components/menu-dropdown/button-trigger'; // `~` is replaced with design-system-react at runtime
 import Button from '~/components/button/'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'DropdownExample',
 
 	render () {

--- a/examples/menu-dropdown/default.jsx
+++ b/examples/menu-dropdown/default.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Dropdown from '~/components/menu-dropdown'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'MediaObjectExample',
 
 	render () {

--- a/examples/menu-dropdown/stories.jsx
+++ b/examples/menu-dropdown/stories.jsx
@@ -2,6 +2,7 @@
 /* eslint-disable react/display-name */
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { storiesOf, action } from '@kadira/storybook';
 
 import { MENU_DROPDOWN } from '../../utilities/constants';
@@ -54,7 +55,7 @@ const getDropdown = (props) => (
 	/>
 );
 
-const DropdownControlled = React.createClass({
+const DropdownControlled = createReactClass({
 	displayName: 'DropdownControlled',
 
 	getInitialState () {

--- a/examples/menu-dropdown/sub-heading.jsx
+++ b/examples/menu-dropdown/sub-heading.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Dropdown from '~/components/menu-dropdown'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'MediaObjectExample',
 
 	render () {

--- a/examples/menu-picklist/base.jsx
+++ b/examples/menu-picklist/base.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Picklist from '~/components/menu-picklist'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'PicklistExample',
 	
 	render () {

--- a/examples/menu-picklist/snapshot-default.jsx
+++ b/examples/menu-picklist/snapshot-default.jsx
@@ -1,10 +1,11 @@
 /* eslint-disable no-console, react/prop-types */
 import React from 'react';
+import createReactClass from 'create-react-class';
 
 // Higher Order Components such as `react-onclickoutside` use the DOM and Jest snapshot testing must be DOMless
 import MenuPicklist from '~/components/menu-picklist';
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'MenuPicklistExample',
 
 	render () {

--- a/examples/menu-picklist/stories.jsx
+++ b/examples/menu-picklist/stories.jsx
@@ -2,6 +2,7 @@
 /* eslint-disable react/display-name */
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { storiesOf, action } from '@kadira/storybook';
 
 import { MENU_PICKLIST } from '../../utilities/constants';
@@ -27,7 +28,7 @@ const getPicklist = (props) => (
 	</div>
 );
 
-const MultipleExample = React.createClass({
+const MultipleExample = createReactClass({
 	displayName: 'MultiplePicklistExample',
 
 	getInitialState () {

--- a/examples/menu-picklist/tooltip-list-item.jsx
+++ b/examples/menu-picklist/tooltip-list-item.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Picklist from '~/components/menu-picklist'; // `~` is replaced with design-system-react at runtime
 import PopoverTooltip from '~/components/popover-tooltip';
 
@@ -12,7 +13,7 @@ const ListItemRenderer = (props) => (
 	</PopoverTooltip>
 );
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'PicklistExample',
 
 	render () {

--- a/examples/modal/header-footer.jsx
+++ b/examples/modal/header-footer.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Modal from '~/components/modal'; // `~` is replaced with design-system-react at runtime
 import Button from '~/components/button';
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'ModalExample',
 
 	getInitialState () {

--- a/examples/modal/menu-contents.jsx
+++ b/examples/modal/menu-contents.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Modal from '~/components/modal'; // `~` is replaced with design-system-react at runtime
 import Button from '~/components/button';
 import Lookup from '~/components/lookup';
 import Picklist from '~/components/menu-picklist';
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'ModalExample',
 
 	getInitialState () {

--- a/examples/modal/modal-custom-parent-node.jsx
+++ b/examples/modal/modal-custom-parent-node.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Modal from '~/components/modal'; // `~` is replaced with design-system-react at runtime
 import Button from '~/components/button';
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'ModalExample',
 
 	getInitialState () {

--- a/examples/modal/prompt.jsx
+++ b/examples/modal/prompt.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Modal from '~/components/modal'; // `~` is replaced with design-system-react at runtime
 import Button from '~/components/button';
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'ModalExample',
 
 	getInitialState () {

--- a/examples/modal/sizes.jsx
+++ b/examples/modal/sizes.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Modal from '~/components/modal'; // `~` is replaced with design-system-react at runtime
 import Button from '~/components/button';
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'ModalExample',
 
 	getInitialState () {

--- a/examples/modal/taglines.jsx
+++ b/examples/modal/taglines.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Modal from '~/components/modal'; // `~` is replaced with design-system-react at runtime
 import Button from '~/components/button';
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'ModalExample',
 
 	getInitialState () {

--- a/examples/navigation/default.jsx
+++ b/examples/navigation/default.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-console, react/prop-types */
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Navigation from '~/components/navigation';
 
 const sampleReportCategories = [
@@ -23,7 +24,7 @@ const sampleReportCategories = [
 	}
 ];
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'NavigationExample',
 
 	getInitialState () {

--- a/examples/navigation/shade.jsx
+++ b/examples/navigation/shade.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-console, react/prop-types */
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Navigation from '~/components/navigation';
 
 const sampleSearchCategories = [
@@ -30,7 +31,7 @@ const sampleSearchCategories = [
 	}
 ];
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'NavigationExample',
 
 	getInitialState () {

--- a/examples/navigation/snapshot-default.jsx
+++ b/examples/navigation/snapshot-default.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-console, react/prop-types */
 import React from 'react';
+import createReactClass from 'create-react-class';
 
 // Higher Order Components such as `react-onclickoutside` use the DOM and Jest snapshot testing must be DOMless
 import Navigation from '~/components/navigation';
@@ -9,7 +10,7 @@ globalSettings.setIconsPath('/assets/icons');
 
 import { sampleReportCategories } from '../../utilities/sample-data/navigation';
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'NavigationExample',
 
 	render () {

--- a/examples/notification/alerts.jsx
+++ b/examples/notification/alerts.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Notification from '~/components/notification'; // `~` is replaced with design-system-react at runtime
 import Button from '~/components/button';
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'NotificationExample',
 	
 	getInitialState () {

--- a/examples/notification/toasts.jsx
+++ b/examples/notification/toasts.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Notification from '~/components/notification';  // `~` is replaced with design-system-react at runtime
 import Button from '~/components/button';
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'NotificationExample',
 	
 	getInitialState () {

--- a/examples/notification/within-modal.jsx
+++ b/examples/notification/within-modal.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Notification from '~/components/notification'; // `~` is replaced with design-system-react at runtime
 import Modal from '~/components/modal';
 import Button from '~/components/button';
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'NotificationExample',
 
 	getInitialState () {

--- a/examples/page-header/object-home.jsx
+++ b/examples/page-header/object-home.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PageHeader from '~/components/page-header'; // `~` is replaced with design-system-react at runtime
 import Button from '~/components/button';
 import ButtonGroup from '~/components/button-group';
 import Dropdown from '~/components/menu-dropdown';
 import DropdownTrigger from '~/components/menu-dropdown/button-trigger';
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'PageHeaderExample',
 
 	render () {

--- a/examples/page-header/record-home.jsx
+++ b/examples/page-header/record-home.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PageHeader from '~/components/page-header'; // `~` is replaced with design-system-react at runtime
 import Button from '~/components/button';
 import ButtonGroup from '~/components/button-group';
 import ButtonStateful from '~/components/button-stateful';
 import Dropdown from '~/components/menu-dropdown';
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'PageHeaderExample',
 
 	render () {

--- a/examples/page-header/related-list.jsx
+++ b/examples/page-header/related-list.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PageHeader from '~/components/page-header'; // `~` is replaced with design-system-react at runtime
 import Button from '~/components/button';
 import ButtonGroup from '~/components/button-group';
 import Dropdown from '~/components/dropdown';
 import DropdownTrigger from '~/components/menu-dropdown/button-trigger';
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'PageHeaderExample',
 
 	render () {

--- a/examples/panel/filtering-error.jsx
+++ b/examples/panel/filtering-error.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 
 import Panel from '~/components/panel'; // `~` is replaced with design-system-react at runtime
 import PanelFilterGroup from '~/components/panel/filtering/group';
@@ -23,7 +24,7 @@ const options = {
 	]
 };
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'PanelExample',
 
 	getInitialState () {

--- a/examples/panel/filtering-locked.jsx
+++ b/examples/panel/filtering-locked.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 
 import Panel from '~/components/panel'; // `~` is replaced with design-system-react at runtime
 import PanelFilterGroup from '~/components/panel/filtering/group';
@@ -23,7 +24,7 @@ const options = {
 	]
 };
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'PanelExample',
 
 	getInitialState () {

--- a/examples/panel/filtering.jsx
+++ b/examples/panel/filtering.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 
 import Panel from '~/components/panel'; // `~` is replaced with design-system-react at runtime
 import PanelFilterGroup from '~/components/panel/filtering/group';
@@ -27,7 +28,7 @@ const options = {
 	]
 };
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'PanelExample',
 
 	getInitialState () {

--- a/examples/popover/alternative-header.jsx
+++ b/examples/popover/alternative-header.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Popover from '~/components/popover'; // `~` is replaced with design-system-react at runtime
 import Button from '~/components/button';
 import Icon from '../../components/icon';
@@ -45,7 +46,7 @@ const panelContent = (<div>
 </div>
 );
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'PopoverExample',
 
 	render () {

--- a/examples/popover/controlled-with-footer.jsx
+++ b/examples/popover/controlled-with-footer.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Popover from '~/components/popover'; // `~` is replaced with design-system-react at runtime
 import Button from '~/components/button';
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'PopoverExample',
 
 	getInitialState () {

--- a/examples/popover/header.jsx
+++ b/examples/popover/header.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Popover from '~/components/popover'; // `~` is replaced with design-system-react at runtime
 import Button from '~/components/button';
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'PopoverExample',
 
 	render () {

--- a/examples/progress-indicator/default.jsx
+++ b/examples/progress-indicator/default.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import ProgressIndicator from '~/components/progress-indicator'; // `~` is replaced with design-system-react at runtime
 
 const steps = [
@@ -13,7 +14,7 @@ const handleStepEvent = function (event, data) {
 	console.log(data);
 };
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'ProgressIndicatorDefault',
 
 	render () {

--- a/examples/progress-indicator/modal.jsx
+++ b/examples/progress-indicator/modal.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { storiesOf, action } from '@kadira/storybook';
 
 import ProgressIndicator from '~/components/progress-indicator'; // `~` is replaced with design-system-react at runtime
@@ -39,7 +40,7 @@ const modalContent = (
 	<div className="slds-modal__content slds-grow slds-p-around_medium" id="modal-content-id-1" style={{ height: '640px' }} />
 );
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'ProgressIndicatorModal',
 
 	render () {

--- a/examples/progress-indicator/stepError.jsx
+++ b/examples/progress-indicator/stepError.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import ProgressIndicator from '~/components/progress-indicator'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'ProgressIndicatorStepError',
 
 	render () {

--- a/examples/progress-indicator/stories.jsx
+++ b/examples/progress-indicator/stories.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { storiesOf, action } from '@kadira/storybook';
 
 import ProgressIndicator from '~/components/progress-indicator';
@@ -32,7 +33,7 @@ const manySteps = [
 	{ id: 'i', label: 'tooltip label #9' }
 ];
 
-const ExampleProgressIndicator = React.createClass({
+const ExampleProgressIndicator = createReactClass({
 	displayName: 'ProgressIndicatorDefault',
 
 	render () {

--- a/examples/tabs/default.jsx
+++ b/examples/tabs/default.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Tabs from '~/components/tabs'; // `~` is replaced with design-system-react at runtime
 import TabsPanel from '~/components/tabs/panel';
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'TabsExample',
 	
 	render () {

--- a/examples/tabs/scoped.jsx
+++ b/examples/tabs/scoped.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Tabs from '~/components/tabs'; // `~` is replaced with design-system-react at runtime
 import TabsPanel from '~/components/tabs/panel';
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'TabsExample',
 	
 	render () {

--- a/examples/tabs/stories.jsx
+++ b/examples/tabs/stories.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import { storiesOf, action } from '@kadira/storybook';
 
@@ -153,7 +154,7 @@ const getTabsScoped = () => (
 );
 /* eslint-enable react/display-name */
 
-const DemoTabsConditional = React.createClass({
+const DemoTabsConditional = createReactClass({
 	displayName: 'DemoTabsConditional',
 
 	// ### Prop Types
@@ -262,7 +263,7 @@ const DemoTabsConditional = React.createClass({
 	}
 });
 
-const DemoTabsOutsideControl = React.createClass({
+const DemoTabsOutsideControl = createReactClass({
 	displayName: 'DemoTabsOutsideControl',
 
 	// ### Prop Types
@@ -496,7 +497,7 @@ const getCustomContentTabs = () => {
 };
 /* eslint-enable react/display-name */
 
-const DemoTabsInterceptSelect = React.createClass({
+const DemoTabsInterceptSelect = createReactClass({
 	displayName: 'DemoTabsInterceptSelect',
 
 	getInitialState () {

--- a/examples/time-picker/default.jsx
+++ b/examples/time-picker/default.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import Timepicker from '~/components/time-picker'; // `~` is replaced with design-system-react at runtime
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'TabsExample',
 	
 	render () {

--- a/examples/tooltip/base.jsx
+++ b/examples/tooltip/base.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PopoverTooltip from '~/components/popover-tooltip'; // `~` is replaced with design-system-react at runtime
 import Icon from '~/components/icon';
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'TooltipExample',
 	
 	render () {

--- a/examples/tooltip/button-group.jsx
+++ b/examples/tooltip/button-group.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PopoverTooltip from '~/components/popover-tooltip'; // `~` is replaced with design-system-react at runtime
 import ButtonGroup from '~/components/button-group';
 import Button from '~/components/button';
 import Dropdown from '~/components/menu-dropdown';
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'TooltipExample',
 	
 	render () {

--- a/examples/tooltip/button.jsx
+++ b/examples/tooltip/button.jsx
@@ -1,9 +1,10 @@
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PopoverTooltip from '~/components/popover-tooltip'; // `~` is replaced with design-system-react at runtime
 import Button from '~/components/button';
 
-const Example = React.createClass({
+const Example = createReactClass({
 	displayName: 'TooltipExample',
 	
 	render () {

--- a/examples/tree/default.jsx
+++ b/examples/tree/default.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import Tree from '~/components/tree';
 
@@ -264,7 +265,7 @@ const sampleNodes = {
 };
 
 
-const TreeExample = React.createClass({
+const TreeExample = createReactClass({
 	displayName: 'TreeExample',
 
 	// ### Prop Types

--- a/examples/tree/stories.jsx
+++ b/examples/tree/stories.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import { storiesOf, action } from '@kadira/storybook';
 
@@ -12,7 +13,7 @@ const branchExpandClicked = action;
 const itemClicked = action;
 const treeScrolled = action;
 
-const DemoTree = React.createClass({
+const DemoTree = createReactClass({
 	displayName: 'DemoTree',
 
 	// ### Prop Types

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "airbnb-prop-types": "^2.5.3",
     "babel-preset-stage-1": "^6.22.0",
     "classnames": "^2.1.3",
+    "create-react-class": "^15.6.0",
     "lodash.assign": "^4.0.9",
     "lodash.compact": "^3.0.0",
     "lodash.escaperegexp": "^4.1.1",

--- a/tests/README.md
+++ b/tests/README.md
@@ -66,6 +66,7 @@ Here is a well-commented sample test file which you can copy/paste into a new fi
 
 // Import your external dependencies
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import chai, { expect } from 'chai';
 import chaiEnzyme from 'chai-enzyme';
@@ -90,7 +91,7 @@ chai.use(chaiEnzyme());
  * This wrapping component will be similar to your wrapping component 
  * you will create in the React Storybook for manual testing.
  */
-const DemoComponent = React.createClass({
+const DemoComponent = createReactClass({
   displayName: 'DemoComponent',
   propTypes: {
     sampleProp: PropTypes.string

--- a/tests/date-picker/date-picker.test.jsx
+++ b/tests/date-picker/date-picker.test.jsx
@@ -1,5 +1,6 @@
 // Import your external dependencies
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import chai, { expect } from 'chai';
 import chaiEnzyme from 'chai-enzyme';
@@ -32,7 +33,7 @@ const defaultProps = {
  * This wrapping component will be similar to your wrapping component
  * you will create in the React Storybook for manual testing.
  */
-const DemoComponent = React.createClass({
+const DemoComponent = createReactClass({
 	displayName: 'DatepickerDemoComponent',
 	propTypes: {
 		isOpen: PropTypes.bool

--- a/tests/filter/filter.test.jsx
+++ b/tests/filter/filter.test.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import chai, { expect } from 'chai';
 import chaiEnzyme from 'chai-enzyme';
@@ -39,7 +40,7 @@ const defaultIds = {
  * This wrapping component will be similar to your wrapping component
  * you will create in the React Storybook for manual testing.
  */
-const DemoComponent = React.createClass({
+const DemoComponent = createReactClass({
 	displayName: 'PopoverDemoComponent',
 	propTypes: {
 		isOpen: PropTypes.bool

--- a/tests/icon/icon.test.jsx
+++ b/tests/icon/icon.test.jsx
@@ -4,6 +4,7 @@
 /* eslint-disable no-unused-expressions */
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
 import chai, { expect } from 'chai';
@@ -18,7 +19,7 @@ import globalSettings from '../../components/settings';
 
 globalSettings.setIconsPath('/assets/icons');
 
-const DemoIcon = React.createClass({
+const DemoIcon = createReactClass({
 	displayName: 'DemoIcon',
 
 	render () {

--- a/tests/navigation/navigation.test.jsx
+++ b/tests/navigation/navigation.test.jsx
@@ -13,6 +13,7 @@
 
 // Import your external dependencies
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import chai, { expect } from 'chai';
 import chaiEnzyme from 'chai-enzyme';
@@ -48,7 +49,7 @@ const defaultProps = {
 /* A re-usable demo component fixture outside of `describe` sections
  * can accept props within each test and be unmounted after each tests.
  */
-const DemoComponent = React.createClass({
+const DemoComponent = createReactClass({
 	displayName: 'NavigationDemoComponent',
 	propTypes: {
 		selectedId: PropTypes.string,

--- a/tests/popover/popover.test.jsx
+++ b/tests/popover/popover.test.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import chai, { expect } from 'chai';
 import chaiEnzyme from 'chai-enzyme';
@@ -38,7 +39,7 @@ const defaultIds = {
  * This wrapping component will be similar to your wrapping component
  * you will create in the React Storybook for manual testing.
  */
-const DemoComponent = React.createClass({
+const DemoComponent = createReactClass({
 	displayName: 'PopoverDemoComponent',
 	propTypes: {
 		isOpen: PropTypes.bool

--- a/tests/progress-indicator/progress-indicator.test.jsx
+++ b/tests/progress-indicator/progress-indicator.test.jsx
@@ -13,6 +13,7 @@
 
 // Import your external dependencies
 import React from 'react';
+import createReactClass from 'create-react-class';
 import ReactDOM from 'react-dom';
 import TestUtils from 'react-addons-test-utils';
 import { expect } from 'chai';
@@ -38,7 +39,7 @@ const defaultProps = {
 
 const mockCallback = sinon.spy();
 
-const DemoComponent = React.createClass({
+const DemoComponent = createReactClass({
 	displayName: 'ProgressIndicatorDemoComponent',
 	propTypes: {
 		onStepClick: mockCallback,

--- a/tests/tabs/tabs.test.jsx
+++ b/tests/tabs/tabs.test.jsx
@@ -1,5 +1,6 @@
 // Import your external dependencies
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import TestUtils from 'react-addons-test-utils';
 import chai, { expect } from 'chai';
@@ -41,7 +42,7 @@ const COMPONENT_CSS_CLASSES = {
  * This wrapping component will be similar to your wrapping component
  * you will create in the React Storybook for manual testing.
  */
-const TabsDemoComponent = React.createClass({
+const TabsDemoComponent = createReactClass({
 	displayName: 'TabsDemoComponent',
 
 	// ### Prop Types

--- a/tests/tree/tree.test.jsx
+++ b/tests/tree/tree.test.jsx
@@ -4,6 +4,7 @@
 /* eslint-disable no-unused-expressions */
 
 import React from 'react';
+import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
 import chai, { expect } from 'chai';
@@ -25,7 +26,7 @@ const COMPONENT_CSS_CLASSES = {
 	base: 'slds-tree'
 };
 
-const DemoTree = React.createClass({
+const DemoTree = createReactClass({
 	displayName: 'DemoTree',
 
 	// ### Prop Types


### PR DESCRIPTION
Fixes deprecation warning in React 15.5 and is a polyfill for 16.x.

Eventually all components should be converted to ES6 classes, but this will clear the console warnings in the mean time.