### PR TITLE
Add aria-disabled to Menu List Item

### DIFF
--- a/components/utilities/menu-list/index.jsx
+++ b/components/utilities/menu-list/index.jsx
@@ -95,6 +95,7 @@ const List = React.createClass({
 						return (
 							<ListItem
 								{...option}
+								aria-disabled={option.disabled}
 								checkmark={this.props.checkmark && (isSingleSelected || isMultipleSelected)}
 								data={option}
 								id={id}

--- a/components/utilities/menu-list/item.jsx
+++ b/components/utilities/menu-list/item.jsx
@@ -32,6 +32,7 @@ const ListItem = React.createClass({
 	displayName: LIST_ITEM,
 
 	propTypes: {
+		'aria-disabled': PropTypes.bool,
 		className: PropTypes.oneOfType([PropTypes.array, PropTypes.object, PropTypes.string]),
 		checkmark: PropTypes.bool,
 		data: PropTypes.object,
@@ -177,6 +178,7 @@ const ListItem = React.createClass({
 					>
 						{/* eslint-disable jsx-a11y/role-supports-aria-props */}
 						<a
+							aria-disabled={this.props['aria-disabled']}
 							href={this.props.href}
 							data-index={this.props.index}
 							onClick={this.handleClick}

--- a/examples/menu-dropdown/stories.jsx
+++ b/examples/menu-dropdown/stories.jsx
@@ -17,7 +17,7 @@ const options = [
 		label: 'A Header',
 		type: 'header'
 	},
-	{ label: 'An option that is Super Super Long', value: 'A0' },
+	{ disabled: true, label: 'An option that is Super Super Long', value: 'A0' },
 	{ label: 'Custom Class', className: 'custom-item-class', value: 'classssss' },
 	{
 		href: 'http://sfdc.co/',
@@ -59,7 +59,8 @@ const DropdownControlled = React.createClass({
 
 	getInitialState () {
 		return {
-			forcedState: undefined
+			forcedState: undefined,
+			menuOptions: options
 		};
 	},
 
@@ -77,6 +78,13 @@ const DropdownControlled = React.createClass({
 		this.setState({ forcedState: false });
 	},
 
+	toggleDisabledOption () {
+			this.setState((prevState, props) => {
+				prevState.menuOptions.splice(1, 1, { disabled: false, label: 'An option that is Super Super Long', value: 'A0' });
+				return { options: prevState.menuOptions };
+			});
+	},
+
 	render () {
 		return (
 			<div className="slds-grid">
@@ -88,13 +96,14 @@ const DropdownControlled = React.createClass({
 						isOpen={this.state.forcedState}
 						onClose={action('Attempt Close')}
 						onOpen={action('Attempt Open')}
-						options={options}
+						options={this.state.menuOptions}
 					/>
 				</div>
 				<div className="slds-col">
 					<Button label="Force Open Dropdown" onClick={this.handleOpen} />
 					<Button label="Force Close Dropdown" onClick={this.handleClose} />
 					<Button label="Reset Dropdown" onClick={this.handleButtonClickReset} />
+					<Button label="Toggle Option A disabled" onClick={this.toggleDisabledOption} />
 				</div>
 			</div>
 		);

--- a/tests/menu-dropdown/dropdown.test.jsx
+++ b/tests/menu-dropdown/dropdown.test.jsx
@@ -24,7 +24,7 @@ describe('SLDSMenuDropdown: ', () => {
 		{ label: 'A super short', value: 'A0' },
 		{ label: 'B Option Super Super Long', value: 'B0' },
 		{ label: 'C Option', value: 'C0' },
-		{ label: 'D Option', value: 'D0' }
+		{ disabled: true, label: 'D Option', value: 'D0' }
 	];
 
 	const renderDropdown = (inst) => {
@@ -276,7 +276,7 @@ describe('SLDSMenuDropdown: ', () => {
 			expect(getMenu(body)).to.equal(null);
 			Simulate.click(btn, {});
 			expect(getMenu(body).className).to.include('slds-dropdown');
-			
+
 			// close
 			Simulate.mouseEnter(btn, {});
 			Simulate.mouseLeave(btn);
@@ -343,6 +343,13 @@ describe('SLDSMenuDropdown: ', () => {
 			const anchorRole = items[1].getAttribute('role');
 			const match = (anchorRole === 'menuitem' || anchorRole === 'menuitemradio' || anchorRole === 'menuitemcheckbox');
 			expect(match).to.be.true;
+		});
+
+		it('if option.disabled, add aria-disabled to <a> that has role menuitem', () => {
+			Simulate.click(btn, {});
+			const items = getMenu(body).querySelectorAll('.slds-dropdown__item a');
+			const lastItemAriaDisabledRole = items[3].getAttribute('aria-disabled');
+			expect(lastItemAriaDisabledRole).to.equal('true');
 		});
 	});
 
@@ -454,7 +461,7 @@ describe('SLDSMenuDropdown: ', () => {
 			expect(selected).to.be.false;
 			const checkItemLengthBefore = getMenu(body).querySelectorAll('.slds-dropdown__item svg').length;
 			expect(checkItemLengthBefore).to.equal(1);
-			
+
 			const items = getMenu(body).querySelectorAll('.slds-dropdown__item');
 			Simulate.click(items[0].querySelector('a'), {});
 			Simulate.click(items[1].querySelector('a'), {});


### PR DESCRIPTION
Request from @jhausler1266 :)

Adds `aria-disabled` to the DOM element with `role=menuitem` if it should be disabled (not focusable/clickable). It also automatically gets SLDS styling for that state. Pass it in through `props.options` like so: `[ { disabled: true, label: "option 1", ... } ]`

@garygong @jinmingyougit I tested the dropdown and it does open if you focus the Dropdown button and hit down arrow. Maybe that bug is in the Analytics component? I'm happy to take a look with you guys.