### PR TITLE
Combobox: Prevent default delete/backspace events

### DIFF
--- a/components/combobox/combobox.jsx
+++ b/components/combobox/combobox.jsx
@@ -485,6 +485,7 @@ class Combobox extends React.Component {
    */
 
 	handleRemoveSelectedOption = (event, { option, index }) => {
+		event.preventDefault();
 		const onlyOnePillAndInputExists = this.props.selection.length === 1;
 		const isReadOnlyAndTwoPillsExists = this.props.selection.length === 2
 			&& this.props.variant === 'readonly'


### PR DESCRIPTION
This is so the browser doesn’t go back in it’s page history. Fixes #1090.