### PR TITLE
Pass assistiveText from MenuDropdown to trigger button and add test

### DIFF
--- a/components/menu-dropdown/button-trigger.jsx
+++ b/components/menu-dropdown/button-trigger.jsx
@@ -107,6 +107,7 @@ const Trigger = createReactClass({
 	render () {
 		// The following are required for use with dropdown. Any other custom props for `Button` should be set with a `Button` child of this component, and are technically just here for backwards compatibility. See `children` prop description for more information.
 		const {
+			assistiveText,
 			children,	// eslint-disable-line no-unused-vars
 			className,
 			id,
@@ -159,6 +160,7 @@ const Trigger = createReactClass({
 			>
 				{/* eslint-disable jsx-a11y/no-static-element-interactions */}
 				<Button
+					assistiveText={assistiveText}
 					className={className}
 					aria-expanded={isOpen}
 					aria-haspopup

--- a/tests/menu-dropdown/dropdown.test.jsx
+++ b/tests/menu-dropdown/dropdown.test.jsx
@@ -371,6 +371,11 @@ describe('SLDSMenuDropdown: ', () => {
 			removeDropdownTrigger(btn);
 		});
 
+		it('<button> has assistiveText', () => {
+			const asstText = btn.getElementsByClassName('slds-assistive-text')[0].textContent;
+			expect(asstText).to.equal('more options');
+		});
+
 		it('<ul> has role menu & aria-labelledby', () => {
 			Simulate.click(btn, {});
 			const ulRole = getMenu(body).querySelector('ul').getAttribute('role');


### PR DESCRIPTION
We were accepting the `assistiveText` prop in Dropdown but just didn't pass it down to the trigger.