### PR TITLE
Fixes Tree single-select story, can now select same node twice in a row.

### DIFF
--- a/examples/tree/stories.jsx
+++ b/examples/tree/stories.jsx
@@ -60,7 +60,7 @@ const DemoTree = createReactClass({
 		if (this.props.singleSelection) {
 			data.node.selected = data.select;
 			this.setState({ selectedNode: data.node });
-			if (this.state.selectedNode && this.state.selectedNode.label !== data.node.label) {
+			if (this.state.selectedNode && this.state.selectedNode.id !== data.node.id) {
 				this.state.selectedNode.selected = undefined;
 			}
 			this.forceUpdate();


### PR DESCRIPTION
Adds additional check to tree story for single selection to only manually unselect the demotree state selection if the selected node itself also changes.

This allows nodes to be re-selected right after de-selecting.

Also renames that key in state because it was confusing using `this.state.singleSelection` to store a _node_ while `this.props.singleSelection` was storing store a `boolean` about whether it should be single select or not.

