### PR TITLE
fix(combobox): Fix example to use placeholderReadOnly

### DIFF
--- a/examples/combobox/readonly-multiple.jsx
+++ b/examples/combobox/readonly-multiple.jsx
@@ -52,7 +52,7 @@ class Example extends React.Component {
 					}}
 					labels={{
 						label: 'Search',
-						placeholder: 'Search Salesforce'
+						placeholderReadOnly: 'Select companies'
 					}}
 					multiple
 					options={accounts}

--- a/examples/combobox/readonly-single.jsx
+++ b/examples/combobox/readonly-single.jsx
@@ -46,7 +46,7 @@ class Example extends React.Component {
 					}}
 					labels={{
 						label: 'Search',
-						placeholder: 'Search Salesforce'
+						placeholderReadOnly: 'Select company'
 					}}
 					options={accounts}
 					selection={this.state.selection}


### PR DESCRIPTION
Current examples use "placeholder" to no effect. Examples should use "placeholderReadOnly".