### PR TITLE
Fix story Lookup standard w/ accounts not loading

### DIFF
--- a/examples/lookup/stories.jsx
+++ b/examples/lookup/stories.jsx
@@ -69,8 +69,8 @@ const DemoLookupAccounts = createReactClass({
 		return (
 			<Lookup
 				{...this.props}
-				footerRenderer={DefaultFooter}
-				headerRenderer={DefaultHeader}
+				footerRenderer={Footer}
+				headerRenderer={Header}
 				onChange={action('change')}
 				onSelect={this.handleSelect}
 				options={this.state.options}


### PR DESCRIPTION
The lookup still looks a bit off, but from my understanding this is now deprecated? Either way thought we should still make sure the storybook for it at least loads.