### PR TITLE
Initial state of DataTable sort is null, unless prop is passed

### DIFF
--- a/components/data-table/column-check-props.js
+++ b/components/data-table/column-check-props.js
@@ -1,0 +1,21 @@
+/* Copyright (c) 2015-present, salesforce.com, inc. All rights reserved */
+/* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
+/* eslint-disable import/no-mutable-exports */
+
+import ifOneThenBothRequiredProperty from '../../utilities/warning/if-one-then-both-required-property';
+
+let checkProps = function () {};
+
+if (process.env.NODE_ENV !== 'production') {
+	checkProps = function (COMPONENT, props) {
+		/* eslint-disable max-len */
+		// Deprecated and changed to another property
+		ifOneThenBothRequiredProperty(COMPONENT, props, {
+			isSorted: props.isSorted,
+			sortDirection: props.sortDirection
+		});
+		/* eslint-enable max-len */
+	};
+}
+
+export default checkProps;

--- a/components/data-table/column.jsx
+++ b/components/data-table/column.jsx
@@ -43,6 +43,10 @@ DataTableColumn.propTypes = {
 	 */
 	children: PropTypes.element,
 	/**
+	 * Selects this column as the currently sorted column.
+	 */
+	isSorted: PropTypes.bool,
+	/**
 	 * The column label. If a `string` is not passed in, no `title` attribute will be rendered.
 	 */
 	label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
@@ -59,7 +63,7 @@ DataTableColumn.propTypes = {
 	 */
 	sortable: PropTypes.bool,
 	/**
-	 * The current sort direction. If left out the component will track this internally.
+	 * The current sort direction. If left out the component will track this internally. Required if `isSorted` is true.
 	 */
 	sortDirection: PropTypes.oneOf(['desc', 'asc']),
 	/**

--- a/components/data-table/private/header-cell.jsx
+++ b/components/data-table/private/header-cell.jsx
@@ -15,8 +15,11 @@ import isFunction from 'lodash.isfunction';
 // ## Children
 import Icon from '../../icon';
 
+// This component's `checkProps` which issues warnings to developers about properties when in development mode (similar to React's built in development tools)
+import checkProps from '../column-check-props';
+
 // ## Constants
-import { DATA_TABLE_HEADER_CELL } from '../../../utilities/constants';
+import { DATA_TABLE_HEADER_CELL, DATA_TABLE_COLUMN } from '../../../utilities/constants';
 
 /**
  * Used internally, renders each individual column heading.
@@ -74,8 +77,19 @@ const DataTableHeaderCell = createReactClass({
 
 	getInitialState () {
 		return {
-			sortDirection: 'asc'
+			sortDirection: null
 		};
+	},
+
+	componentDidMount () {
+		checkProps(DATA_TABLE_COLUMN, this.props);
+	},
+
+	componentDidUpdate (prevProps) {
+		// reset sort state when another column is sorted
+		if (prevProps.isSorted === true && this.props.isSorted === false) {
+			this.setState({ sortDirection: null }); // eslint-disable-line react/no-did-update-set-state
+		}
 	},
 
 	// ### Render
@@ -118,7 +132,7 @@ const DataTableHeaderCell = createReactClass({
 							<Icon
 								className="slds-is-sortable__icon"
 								category="utility"
-								name={sortDirection === 'desc' || !sortDirection ? 'arrowdown' : 'arrowup'}
+								name={sortDirection === 'desc' ? 'arrowdown' : 'arrowup'}
 								size="x-small"
 							/>
 							{sortDirection

--- a/examples/data-table/advanced.jsx
+++ b/examples/data-table/advanced.jsx
@@ -24,6 +24,9 @@ const Example = createReactClass({
 	getInitialState () {
 		return {
 			sortColumn: 'opportunityName',
+			sortColumnDirection: {
+				opportunityName: 'asc'
+			},
 			items: [
 				{
 					id: '8IKZHZZV80',
@@ -31,7 +34,7 @@ const Example = createReactClass({
 					accountName: 'Acme',
 					closeDate: '4/10/15',
 					stage: 'Value Proposition',
-					confidence: '30%',
+					confidence: '70%',
 					amount: '$25,000,000',
 					contact: 'jrogers@acme.com'
 				}, {
@@ -40,7 +43,7 @@ const Example = createReactClass({
 					accountName: 'Acme',
 					closeDate: '1/31/15',
 					stage: 'Prospecting',
-					confidence: '60%',
+					confidence: '30%',
 					amount: '$5,000,000',
 					contact: 'bob@acme.com'
 				},
@@ -50,7 +53,7 @@ const Example = createReactClass({
 					accountName: 'salesforce.com',
 					closeDate: '1/31/15 3:45PM',
 					stage: 'Id. Decision Makers',
-					confidence: '70%',
+					confidence: '60%',
 					amount: '$25,000',
 					contact: 'nathan@salesforce.com'
 				}
@@ -87,6 +90,7 @@ const Example = createReactClass({
 							primaryColumn
 							property="opportunityName"
 							sortable
+							sortDirection={this.state.sortColumnDirection.opportunityName}
 							width="10rem"
 						>
 							<CustomDataTableCell />
@@ -109,6 +113,7 @@ const Example = createReactClass({
 							label="Confidence"
 							property="confidence"
 							sortable
+							sortDirection={this.state.sortColumnDirection.confidence}
 						/>
 						<DataTableColumn
 							label="Amount"
@@ -155,11 +160,13 @@ const Example = createReactClass({
 		const sortDirection = sortColumn.sortDirection;
 		const newState = {
 			sortColumn: sortProperty,
+			sortColumnDirection: {
+				[sortProperty]: sortDirection
+			},
 			items: [...this.state.items]
 		};
 
 		// needs to work in both directions
-
 		newState.items = newState.items.sort((a, b) => {
 			let val = 0;
 
@@ -170,7 +177,9 @@ const Example = createReactClass({
 				val = -1;
 			}
 
-			if (sortDirection === 'desc') val *= -1;
+			if (sortDirection === 'desc') {
+				val *= -1;
+			}
 
 			return val;
 		});

--- a/examples/data-table/advanced.jsx
+++ b/examples/data-table/advanced.jsx
@@ -64,7 +64,7 @@ const Example = createReactClass({
 				accountName: 'salesforce.com',
 				closeDate: '1/31/15 3:45PM',
 				stage: 'Id. Decision Makers',
-				confidence: '70%',
+				confidence: '60%',
 				amount: '$25,000',
 				contact: 'nathan@salesforce.com'
 			}]

--- a/tests/data-table/__snapshots__/data-table.snapshot-test.jsx.snap
+++ b/tests/data-table/__snapshots__/data-table.snapshot-test.jsx.snap
@@ -28,7 +28,7 @@ exports[`DataTable Advanced HTML Snapshot 1`] = `
           <th class=\\"\\" scope=\\"col\\">
             <div class=\\"slds-truncate\\">Stage</div>
           </th>
-          <th class=\\"slds-is-sortable\\" focusable=\\"true\\" scope=\\"col\\"><a href=\\"javascript:void(0)\\" class=\\"slds-th__action slds-text-link--reset\\" tabindex=\\"0\\"><span class=\\"slds-assistive-text\\">Sort </span><span class=\\"slds-truncate\\" title=\\"Confidence\\">Confidence</span><span><svg aria-hidden=\\"true\\" class=\\"slds-is-sortable__icon slds-icon slds-icon--x-small slds-icon-text-default\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#arrowup\\"></use></svg></span><span class=\\"slds-assistive-text\\" aria-live=\\"assertive\\" aria-atomic=\\"true\\">Sorted Ascending</span></a></th>
+          <th class=\\"slds-is-sortable\\" focusable=\\"true\\" scope=\\"col\\"><a href=\\"javascript:void(0)\\" class=\\"slds-th__action slds-text-link--reset\\" tabindex=\\"0\\"><span class=\\"slds-assistive-text\\">Sort </span><span class=\\"slds-truncate\\" title=\\"Confidence\\">Confidence</span><span><svg aria-hidden=\\"true\\" class=\\"slds-is-sortable__icon slds-icon slds-icon--x-small slds-icon-text-default\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#arrowup\\"></use></svg></span></a></th>
           <th
             class=\\"\\" scope=\\"col\\">
             <div class=\\"slds-truncate\\">Amount</div>
@@ -66,7 +66,7 @@ exports[`DataTable Advanced HTML Snapshot 1`] = `
           <div class=\\"slds-truncate\\" title=\\"Value Proposition\\">Value Proposition</div>
         </td>
         <td role=\\"gridcell\\">
-          <div class=\\"slds-truncate\\" title=\\"30%\\">30%</div>
+          <div class=\\"slds-truncate\\" title=\\"70%\\">70%</div>
         </td>
         <td role=\\"gridcell\\">
           <div class=\\"slds-truncate\\" title=\\"$25,000,000\\">$25,000,000</div>
@@ -103,7 +103,7 @@ exports[`DataTable Advanced HTML Snapshot 1`] = `
           <div class=\\"slds-truncate\\" title=\\"Prospecting\\">Prospecting</div>
         </td>
         <td role=\\"gridcell\\">
-          <div class=\\"slds-truncate\\" title=\\"60%\\">60%</div>
+          <div class=\\"slds-truncate\\" title=\\"30%\\">30%</div>
         </td>
         <td role=\\"gridcell\\">
           <div class=\\"slds-truncate\\" title=\\"$5,000,000\\">$5,000,000</div>
@@ -140,7 +140,7 @@ exports[`DataTable Advanced HTML Snapshot 1`] = `
           <div class=\\"slds-truncate\\" title=\\"Id. Decision Makers\\">Id. Decision Makers</div>
         </td>
         <td role=\\"gridcell\\">
-          <div class=\\"slds-truncate\\" title=\\"70%\\">70%</div>
+          <div class=\\"slds-truncate\\" title=\\"60%\\">60%</div>
         </td>
         <td role=\\"gridcell\\">
           <div class=\\"slds-truncate\\" title=\\"$25,000\\">$25,000</div>

--- a/tests/data-table/data-table.browser-test.jsx
+++ b/tests/data-table/data-table.browser-test.jsx
@@ -265,10 +265,10 @@ describe('DataTable: ', function () {
 	describe('Sortable', function () {
 		afterEach(removeTable);
 
-		it('calls onSort when a sortable column is clicked', function (done) {
+		it('first clicked on sortable column header should result in ascending sort', function (done) {
 			this.onSort = (data) => {
 				data.property.should.equal('count');
-				data.sortDirection.should.equal('desc');
+				data.sortDirection.should.equal('asc');
 				done();
 			};
 

--- a/utilities/warning/if-one-then-both-required-property.js
+++ b/utilities/warning/if-one-then-both-required-property.js
@@ -1,0 +1,35 @@
+/* Copyright (c) 2015-present, salesforce.com, inc. All rights reserved */
+/* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
+
+/* eslint-disable import/no-mutable-exports */
+
+// This function will deliver an error message to the browser console one property is used but not both that are required. Either use neither or both properties.
+import warning from 'warning';
+
+let ifOneThenBothRequiredProperty;
+
+if (process.env.NODE_ENV !== 'production') {
+	const hasWarned = {};
+
+	ifOneThenBothRequiredProperty = function (control, props, selectedProps, comment) {
+		const additionalComment = comment ? ` ${comment}` : '';
+		let bothOrNoneAreSet = false;
+		const keys = Object.keys(selectedProps);
+		const values = Object.values(selectedProps);
+		const allTruthy = values.every((element) => !!element);
+		const allFalsey = values.every((element) => !element);
+
+		bothOrNoneAreSet = allTruthy || allFalsey;
+
+		if (!hasWarned[control]) {
+			/* eslint-disable max-len */
+			warning(bothOrNoneAreSet, `[Design System React] If one of the following props are used, then both of the following properties are required by ${control}: [${keys.join()}].${additionalComment}`);
+			/* eslint-enable max-len */
+			hasWarned[control] = !!selectedProps;
+		}
+	};
+} else {
+	ifOneThenBothRequiredProperty = function () {};
+}
+
+export default ifOneThenBothRequiredProperty;


### PR DESCRIPTION
Fixes: #1162

- Default column sort has been ascending since February, this changes it back to null which allows for initial order to be unsorted, but show an ascending arrow on mouse hover.
- isSorted is added to the public props
- sortDirection is required if isSorted is truthy (this should error out if you aren't using both props now)
- if isSorted switches to false, then column sort state gets reset, this allows the arrow on the previously sorted column to revert to ascending.

I'd love to remove state out of here, but that'd be a breaking change. Currently this should behave as it has (that is incorrectly) without change UNLESS `isSorted` and `sortDirection` is used which is the recommended solution

The new UX pattern is that all sortable, unsorted columns should:
* become ascending sort when clicked
* then on second click be descending
* will reset to first click is ascending, if another column is sorted instead