### PR TITLE
Progress Indicator: Move tooltip to button trigger

### DIFF
--- a/components/progress-indicator/private/step.jsx
+++ b/components/progress-indicator/private/step.jsx
@@ -148,17 +148,17 @@ class Step extends React.Component {
 		}
 
 		return (
-			<PopoverTooltip {...tooltipProps} >
-				<li
-					className={classNames('slds-progress__item', {
-						'slds-is-completed': this.props.isCompleted,
-						'slds-is-active': this.props.isSelected && !this.props.isError,
-						'slds-has-error': this.props.isError
-					})}
-				>
+			<li
+				className={classNames('slds-progress__item', {
+					'slds-is-completed': this.props.isCompleted,
+					'slds-is-active': this.props.isSelected && !this.props.isError,
+					'slds-has-error': this.props.isError
+				})}
+			>
+				<PopoverTooltip {...tooltipProps} >
 					{this.buttonIcon(renderIcon, status, this.props)}
-				</li>
-			</PopoverTooltip>
+				</PopoverTooltip>
+			</li>
 		);
 	}
 }

--- a/tests/progress-indicator/progress-indicator.browser-test.jsx
+++ b/tests/progress-indicator/progress-indicator.browser-test.jsx
@@ -196,7 +196,7 @@ describe('SLDSProgressIndicator: ', () => {
 		it('renders correct assistive text', function () {
 			const item = this.wrapper.find('.slds-progress')
 									.find('.slds-tooltip-trigger')
-									.find('li > span')
+									.find('button > span')
 									.find('.slds-assistive-text')
 									.first();
 			expect(item.text()).to.include('custom tooltip #1');
@@ -246,11 +246,17 @@ describe('SLDSProgressIndicator: ', () => {
 		});
 
 		it('renders assistive text for steps', function () {
-			const item = this.wrapper.find('.slds-progress').find('.slds-tooltip-trigger').find('li')
+			const firstItem = this.wrapper.find('.slds-progress').find('li').find('.slds-tooltip-trigger')
 									.find('.slds-button')
 									.find('.slds-assistive-text')
 									.first();
-			expect(item.text()).to.include('Step');
+			expect(firstItem.text()).to.include('tooltip label');
+
+			const secondItem = this.wrapper.find('.slds-progress').find('li').find('.slds-tooltip-trigger')
+									.find('.slds-button')
+									.find('.slds-assistive-text')
+									.at(1);
+			expect(secondItem.text()).to.include('Step');
 		});
 	});
 


### PR DESCRIPTION
Tooltip triggers should be triggered by focusable elements not an `li`. Fixes #1160.

@jjangsfdc 