### PR TITLE
Make icons settings webpack friendly

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+	
+[*]
+indent_style = tab
+trim_trailing_whitespace = false
+max_line_length = 140
+end_of_line = lf

--- a/.editorconfig
+++ b/.editorconfig
@@ -2,6 +2,7 @@ root = true
 	
 [*]
 indent_style = tab
-trim_trailing_whitespace = false
+trim_trailing_whitespace = true
 max_line_length = 140
 end_of_line = lf
+insert_final_newline = true

--- a/README.md
+++ b/README.md
@@ -24,7 +24,30 @@ open http://localhost:9001 http://localhost:8001
 ```
 ### SLDS Icons
 
-Prior to v0.7.0, SLDS icons were inlined and just worked. Now you will need to host the icons and set a path `context` for all child components with `<IconSettings>`:
+Prior to v0.7.0, SLDS icons were inlined and just worked. You now will need to specify where the icons are located.
+
+You can either:
+ - import the individual `sprite` files and assign them to the `<IconSettings>` sprite properties (recommended for webpack).
+
+```
+import IconSettings from 'design-system-react/components/icon-settings';
+
+import standardSprite from '@salesforce-ux/design-system/assets/icons/standard-sprite/svg/symbols.svg';
+import actionSprite from '@salesforce-ux/design-system/assets/icons/action-sprite/svg/symbols.svg';
+...
+...
+
+ReactDOM.render(
+	<IconSettings standardSprite={standardSprite} actionSprite={actionSprite}>
+		<MyApp />
+	</IconSettings>,
+	document.getElementById('app')
+	)
+```
+
+
+**OR**
+- host the icons and set a path `context` for all child components with `<IconSettings>`:
 
 ```
 import IconSettings from 'design-system-react/components/icon-settings';
@@ -42,6 +65,8 @@ ReactDOM.render(
 </svg>
 ```
 
+
+
 ### Example
 
 Add the following line to your `package.json` devDependencies and run `npm install`.
@@ -52,7 +77,7 @@ Add the following line to your `package.json` devDependencies and run `npm insta
 "design-system-react": "git+ssh://git@github.com:salesforce/design-system-react.git#v[VERSION]",
 ```
 
-The bundled files are provided only for convenience. 
+The bundled files are provided only for convenience.
 
 * `design-system-react.min.js` (700KB+) - includes icons in the JavaScript
 * `design-system-react-components.min.js` (~400KB) - no icons.

--- a/components/icon-settings/index.jsx
+++ b/components/icon-settings/index.jsx
@@ -4,6 +4,25 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { ICON_SETTINGS } from '../../utilities/constants';
+
+/**
+ * The Icon Settings component allows for the path to the icons to be specified.
+ * This should be used at the root of the application.
+ *
+ * **Individual sprites**
+ * If you are using webpack it is advised to use the sprite properties
+ * {actionSprite, standardSprite...} to specify the individual sprite paths so that webpack can
+ * easily re-write the paths.
+ * ```
+ * import actionSprite from '......';
+ *
+ * <IconSettings actionSprite={actionSprite} ......>
+ * ```
+ * **Root icon path**
+ * Otherwise use the iconPath to specify the root path to where the icon files will be located in you application
+ * such as `/assets/icons`.
+ */
 class IconSettings extends React.Component {
 	getChildContext () {
 		return {
@@ -21,12 +40,47 @@ class IconSettings extends React.Component {
 	}
 }
 
+IconSettings.displayName = ICON_SETTINGS;
+
 IconSettings.childContextTypes = {
 	iconPath: PropTypes.string,
 	actionSprite: PropTypes.string,
 	customSprite: PropTypes.string,
 	doctypeSprite: PropTypes.string,
 	standardSprite: PropTypes.string,
+	utilitySprite: PropTypes.string
+};
+
+IconSettings.propTypes = {
+	/**
+	 * Path to the root icon folder
+	 * example: `/assets/icons`
+	 */
+	iconPath: PropTypes.string,
+	/**
+	 * Path to the action sprite
+	 * example: '@salesforce-ux/design-system/assets/icons/action-sprite/svg/symbols.svg';
+	 */
+	actionSprite: PropTypes.string,
+	/**
+	 * Path to the custom sprite
+	 * example: '@salesforce-ux/design-system/assets/icons/custom-sprite/svg/symbols.svg';
+	 */
+	customSprite: PropTypes.string,
+	/**
+	 * Path to the doctype sprite
+	 * example: '@salesforce-ux/design-system/assets/icons/doctype-sprite/svg/symbols.svg';
+	 */
+	doctypeSprite: PropTypes.string,
+	/**
+	 * Path to the standard sprite
+	 * example: '@salesforce-ux/design-system/assets/icons/standard-sprite/svg/symbols.svg';
+	 */
+	standardSprite: PropTypes.string,
+	/**
+	 * Path to the utility sprite
+	 * example: '@salesforce-ux/design-system/assets/icons/utility-sprite/svg/symbols.svg';
+	 */
 	utilitySprite: PropTypes.string
 };
 

--- a/components/icon-settings/index.jsx
+++ b/components/icon-settings/index.jsx
@@ -6,7 +6,14 @@ import PropTypes from 'prop-types';
 
 class IconSettings extends React.Component {
 	getChildContext () {
-		return { iconPath: this.props.iconPath };
+		return {
+			iconPath: this.props.iconPath,
+			actionSprite: this.props.actionSprite,
+			customSprite: this.props.customSprite,
+			doctypeSprite: this.props.doctypeSprite,
+			standardSprite: this.props.standardSprite,
+			utilitySprite: this.props.utilitySprite
+		};
 	}
 
 	render () {
@@ -15,8 +22,12 @@ class IconSettings extends React.Component {
 }
 
 IconSettings.childContextTypes = {
-	iconPath: PropTypes.string
+	iconPath: PropTypes.string,
+	actionSprite: PropTypes.string,
+	customSprite: PropTypes.string,
+	doctypeSprite: PropTypes.string,
+	standardSprite: PropTypes.string,
+	utilitySprite: PropTypes.string
 };
 
 export default IconSettings;
-

--- a/components/utilities/utility-icon/check-props.js
+++ b/components/utilities/utility-icon/check-props.js
@@ -8,8 +8,10 @@ let checkProps = function () {};
 
 if (process.env.NODE_ENV !== 'production') {
 	checkProps = function (COMPONENT, props) {
-		const modifiedPath = props.path || props.context.iconPath;
-		urlExists(COMPONENT, `${modifiedPath}/${props.category}-sprite/svg/symbols.svg#${props.name}`);
+		if (!props.context[`${props.category}Sprite`]) {
+			const modifiedPath = props.path || props.context.iconPath;
+			urlExists(COMPONENT, `${modifiedPath}/${props.category}-sprite/svg/symbols.svg#${props.name}`);
+		}
 	};
 }
 

--- a/components/utilities/utility-icon/index.jsx
+++ b/components/utilities/utility-icon/index.jsx
@@ -44,9 +44,19 @@ const UtilityIcon = ({
 		inlineData = inlineIcons[category][name.toLowerCase()];
 		inlineData.viewBox = inlineIcons[category].viewBox;
 	}
+	
+	let modifiedPath;
 
-	// Use inline icons if the icon object is present, otherwise use external URLs for icons.
-	const modifiedPath = path || (context.iconPath && `${context.iconPath}/${category}-sprite/svg/symbols.svg#${name}`);
+	if (path) {
+		// Use inline icons if the icon object is present
+		modifiedPath = path;
+	} else if (context[`${category}Sprite`]) {
+		// Use specified sprite file from the icon settings
+		modifiedPath = `${context[`${category}Sprite`]}#${name}`;
+	} else {
+		// Otherwise use external URLs for icons.
+		modifiedPath = context.iconPath && `${context.iconPath}/${category}-sprite/svg/symbols.svg#${name}`;
+	}
 
 	return inlineData
 		? (<Svg data={inlineData} name={name} {...rest} />)
@@ -79,7 +89,12 @@ UtilityIcon.defaultProps = {
 };
 
 UtilityIcon.contextTypes = {
-	iconPath: PropTypes.string
+	iconPath: PropTypes.string,
+	actionSprite: PropTypes.string,
+	customSprite: PropTypes.string,
+	doctypeSprite: PropTypes.string,
+	standardSprite: PropTypes.string,
+	utilitySprite: PropTypes.string
 };
 
 export default UtilityIcon;

--- a/examples/component-docs.json
+++ b/examples/component-docs.json
@@ -2140,6 +2140,13 @@
                 "returns": null
             },
             {
+                "name": "getTargetElement",
+                "docblock": null,
+                "modifiers": [],
+                "params": [],
+                "returns": null
+            },
+            {
                 "name": "isSelected",
                 "docblock": null,
                 "modifiers": [],
@@ -2192,18 +2199,6 @@
                 "docblock": null,
                 "modifiers": [],
                 "params": [],
-                "returns": null
-            },
-            {
-                "name": "getInlineMenu",
-                "docblock": null,
-                "modifiers": [],
-                "params": [
-                    {
-                        "name": "{ menuRenderer }",
-                        "type": null
-                    }
-                ],
                 "returns": null
             },
             {
@@ -2417,6 +2412,18 @@
                 "returns": null
             },
             {
+                "name": "setInputRef",
+                "docblock": null,
+                "modifiers": [],
+                "params": [
+                    {
+                        "name": "component",
+                        "type": null
+                    }
+                ],
+                "returns": null
+            },
+            {
                 "name": "renderBase",
                 "docblock": "Combobox variant subrenders\n(these can probably be broken into function components\nif state is passed in as a prop)",
                 "modifiers": [],
@@ -2538,19 +2545,19 @@
                     "computed": false
                 }
             },
+            "hasStaticAlignment": {
+                "type": {
+                    "name": "bool"
+                },
+                "required": false,
+                "description": "By default, dialogs will flip their alignment (such as bottom to top) if they extend beyond a boundary element such as a scrolling parent or a window/viewpoint. This is the opposite of \"flippable.\""
+            },
             "id": {
                 "type": {
                     "name": "string"
                 },
                 "required": false,
                 "description": "HTML id for component. _Tested with snapshot testing._"
-            },
-            "isInline": {
-                "type": {
-                    "name": "bool"
-                },
-                "required": false,
-                "description": "Renders menu within the wrapping trigger as a sibling of the input. By default, you will have an absolutely positioned container at an elevated z-index. _Tested with snapshot testing._"
             },
             "labels": {
                 "type": {
@@ -2577,6 +2584,31 @@
                 },
                 "required": false,
                 "description": "Accepts a custom menu item rendering function that becomes a custom component. The checkmark is still rendered in readonly variants. This function is passed the following props:\n* `assistiveText`: Object, `assistiveText` prop that is passed into Combobox\n* `option`: Object, option data for item being rendered that is passed into Combobox\n* `selected`: Boolean, allows rendering of `assistiveText.optionSelectedInMenu` in Readonly Combobox\n\n_Tested with snapshot testing._"
+            },
+            "menuPosition": {
+                "type": {
+                    "name": "enum",
+                    "value": [
+                        {
+                            "value": "'absolute'",
+                            "computed": false
+                        },
+                        {
+                            "value": "'overflowBoundaryElement'",
+                            "computed": false
+                        },
+                        {
+                            "value": "'relative'",
+                            "computed": false
+                        }
+                    ]
+                },
+                "required": false,
+                "description": "Please select one of the following:\n* `absolute` - (default) The dialog will use `position: absolute` and style attributes to position itself. This allows inverted placement or flipping of the dialog.\n* `overflowBoundaryElement` - The dialog will overflow scrolling parents. Use on elements that are aligned to the left or right of their target and don't care about the target being within a scrolling parent. Typically this is a popover or tooltip. Dropdown menus can usually open up and down if no room exists. In order to achieve this a portal element will be created and attached to `body`. This element will render into that detached render tree.\n* `relative` - No styling or portals will be used. Menus will be positioned relative to their triggers. This is a great choice for HTML snapshot testing.",
+                "defaultValue": {
+                    "value": "'absolute'",
+                    "computed": false
+                }
             },
             "multiple": {
                 "type": {
@@ -3225,7 +3257,7 @@
         ]
     },
     "date-picker": {
-        "description": "A date picker is a non text input form element. You can select a single date from a popup or inline calendar. The date picker supplied by this library comes with an input by default, but other components could be passed in as children--however, pairing with other components is untested.\n\nThe calendar is rendered with time/dates based on local browser time of the client. All dates are in local user timezones. Another way to put it is if a user selects a date, they are selecting midnight their time on that day and not mightnight in UTC. If this component is being used in conjuction with a timezone input, you may want to convert dates provided to UTC in that timezone.\n\nThis component is wrapped in a [higher order component to listen for clicks outside itself](https://github.com/kentor/react-click-outside) and thus requires use of `ReactDOM`.\n\nThis component may use a portalMount (a disconnected React subtree mount) within an absolutely positioned DOM node created with [Drop](http://github.hubspot.com/drop/).",
+        "description": "A date picker is a non text input form element. You can select a single date from a popup or inline calendar. The date picker supplied by this library comes with an input by default, but other components could be passed in as children--however, pairing with other components is untested.\n\nThe calendar is rendered with time/dates based on local browser time of the client. All dates are in local user timezones. Another way to put it is if a user selects a date, they are selecting midnight their time on that day and not mightnight in UTC. If this component is being used in conjuction with a timezone input, you may want to convert dates provided to UTC in that timezone.\n\nThis component is wrapped in a [higher order component to listen for clicks outside itself](https://github.com/kentor/react-click-outside) and thus requires use of `ReactDOM`.",
         "methods": [
             {
                 "name": "getId",
@@ -3291,18 +3323,6 @@
                 "returns": null
             },
             {
-                "name": "getInlineMenu",
-                "docblock": null,
-                "modifiers": [],
-                "params": [
-                    {
-                        "name": "{ labels, assistiveText }",
-                        "type": null
-                    }
-                ],
-                "returns": null
-            },
-            {
                 "name": "handleClose",
                 "docblock": null,
                 "modifiers": [],
@@ -3313,7 +3333,16 @@
                 "name": "handleOpen",
                 "docblock": null,
                 "modifiers": [],
-                "params": [],
+                "params": [
+                    {
+                        "name": "event",
+                        "type": null
+                    },
+                    {
+                        "name": "{ portal }",
+                        "type": null
+                    }
+                ],
                 "returns": null
             },
             {
@@ -3359,6 +3388,18 @@
                 "params": [
                     {
                         "name": "event",
+                        "type": null
+                    }
+                ],
+                "returns": null
+            },
+            {
+                "name": "setInputRef",
+                "docblock": null,
+                "modifiers": [],
+                "params": [
+                    {
+                        "name": "component",
                         "type": null
                     }
                 ],
@@ -3424,13 +3465,6 @@
                 "required": false,
                 "description": "CSS classes to be added to tag with `slds-datepicker`. If you are looking for the outer DOM node (slds-dropdown-trigger), please review `triggerClassName`. _Tested with snapshot testing._"
             },
-            "constrainToScrollParent": {
-                "type": {
-                    "name": "bool"
-                },
-                "required": false,
-                "description": "If true, constrains the menu to the scroll parent. Has no effect if `isInline` is `true`. _Not tested._"
-            },
             "disabled": {
                 "type": {
                     "name": "bool"
@@ -3481,13 +3515,6 @@
                 "required": false,
                 "description": "HTML id for component _Tested with snapshot testing._"
             },
-            "isInline": {
-                "type": {
-                    "name": "bool"
-                },
-                "required": false,
-                "description": "Renders menu within the wrapping trigger as a sibling of the input. By default, you will have an absolutely positioned container at an elevated z-index."
-            },
             "labels": {
                 "type": {
                     "name": "custom",
@@ -3513,6 +3540,31 @@
                 },
                 "required": false,
                 "description": "Makes Monday the first day of the week. _Tested with snapshot testing._"
+            },
+            "menuPosition": {
+                "type": {
+                    "name": "enum",
+                    "value": [
+                        {
+                            "value": "'absolute'",
+                            "computed": false
+                        },
+                        {
+                            "value": "'overflowBoundaryElement'",
+                            "computed": false
+                        },
+                        {
+                            "value": "'relative'",
+                            "computed": false
+                        }
+                    ]
+                },
+                "required": false,
+                "description": "Please select one of the following:\n* `absolute` - (default) The dialog will use `position: absolute` and style attributes to position itself. This allows inverted placement or flipping of the dialog.\n* `overflowBoundaryElement` - The dialog will overflow scrolling parents. Use on elements that are aligned to the left or right of their target and don't care about the target being within a scrolling parent. Typically this is a popover or tooltip. Dropdown menus can usually open up and down if no room exists. In order to achieve this a portal element will be created and attached to `body`. This element will render into that detached render tree.\n* `relative` - No styling or portals will be used. Menus will be positioned relative to their triggers. This is a great choice for HTML snapshot testing.",
+                "defaultValue": {
+                    "value": "'absolute'",
+                    "computed": false
+                }
             },
             "onCalendarFocus": {
                 "type": {
@@ -3566,13 +3618,6 @@
                     "value": "function(str) {\n    return new Date(str);\n}",
                     "computed": false
                 }
-            },
-            "portalMount": {
-                "type": {
-                    "name": "func"
-                },
-                "required": false,
-                "description": "Absolutely positioned DOM nodes, such as a datepicker dialog, may need their own React DOM tree root. They may need their alignment \"flipped\" if extended beyond the window or outside the bounds of an overflow-hidden scrolling modal. This library's portal mounts are added as a child node of `body`. This prop will be triggered instead of the default `ReactDOM.mount()` when this dialog is mounted. This prop is useful for testing and simliar to a \"callback ref.\" Two arguments,`reactElement` and `domContainerNode` are passed in. Consider the following code that bypasses the internal mount and uses an Enzyme wrapper to mount the React root tree to the DOM.\n\n```\n<Datepicker\n            isOpen\n            portalMount={(reactElement, domContainerNode) => {\n                portalWrapper = Enzyme.mount(reactElement, { attachTo: domContainerNode });\n            }}\n            onOpen={() => {\n                expect(portalWrapper.find(`#my-heading`)).to.exist;\n                done();\n            }}\n        />\n        ```\n_Tested with Mocha framework._"
             },
             "relativeYearFrom": {
                 "type": {
@@ -3810,6 +3855,58 @@
         "SLDS-component-path": "/components/icons",
         "dependencies": []
     },
+    "icon-settings": {
+        "description": "The Icon Settings component allows for the path to the icons to be specified.\nThis should be used at the root of the application.\n\n**Individual sprites**\nIf you are using webpack it is advised to use the sprite properties\n{actionSprite, standardSprite...} to specify the individual sprite paths so that webpack can\neasily re-write the paths.\n```\nimport actionSprite from '......';\n\n<IconSettings actionSprite={actionSprite} ......>\n```\n**Root icon path**\nOtherwise use the iconPath to specify the root path to where the icon files will be located in you application\nsuch as `/assets/icons`.",
+        "methods": [],
+        "props": {
+            "iconPath": {
+                "type": {
+                    "name": "string"
+                },
+                "required": false,
+                "description": "Path to the root icon folder\nexample: `/assets/icons`"
+            },
+            "actionSprite": {
+                "type": {
+                    "name": "string"
+                },
+                "required": false,
+                "description": "Path to the action sprite\nexample: '@salesforce-ux/design-system/assets/icons/action-sprite/svg/symbols.svg';"
+            },
+            "customSprite": {
+                "type": {
+                    "name": "string"
+                },
+                "required": false,
+                "description": "Path to the custom sprite\nexample: '@salesforce-ux/design-system/assets/icons/custom-sprite/svg/symbols.svg';"
+            },
+            "doctypeSprite": {
+                "type": {
+                    "name": "string"
+                },
+                "required": false,
+                "description": "Path to the doctype sprite\nexample: '@salesforce-ux/design-system/assets/icons/doctype-sprite/svg/symbols.svg';"
+            },
+            "standardSprite": {
+                "type": {
+                    "name": "string"
+                },
+                "required": false,
+                "description": "Path to the standard sprite\nexample: '@salesforce-ux/design-system/assets/icons/standard-sprite/svg/symbols.svg';"
+            },
+            "utilitySprite": {
+                "type": {
+                    "name": "string"
+                },
+                "required": false,
+                "description": "Path to the utility sprite\nexample: '@salesforce-ux/design-system/assets/icons/utility-sprite/svg/symbols.svg';"
+            }
+        },
+        "route": "icon-settings",
+        "display-name": "Icon Settings",
+        "SLDS-component-path": "/components/icons-settings",
+        "dependencies": []
+    },
     "filter": {
         "description": "A Filter is a popover with custom trigger. It can be used by [Panel Filtering](/components/panels/). Menus within a Filter Popover will need to not have \"portal mounts\" and be inline.",
         "methods": [
@@ -3923,7 +4020,7 @@
                     "name": "node"
                 },
                 "required": false,
-                "description": "Contents of popover. That is the dropdowns and inputs that set the filter criteria. **Dropdowns, Picklists and other menus must use `isInline` to work properly within a Popover due to existence of portal mounts in menus that are not inline.**"
+                "description": "Contents of popover. That is the dropdowns and inputs that set the filter criteria."
             },
             "className": {
                 "type": {
@@ -5268,7 +5365,7 @@
                             "required": false,
                             "description": "Offset adds pixels to the absolutely positioned dropdown menu in the format: ([vertical]px [horizontal]px).",
                             "defaultValue": {
-                                "value": "'-12px -16px'",
+                                "value": "'12px 16px'",
                                 "computed": false
                             }
                         },
@@ -6072,7 +6169,7 @@
         "dependencies": []
     },
     "menu-dropdown": {
-        "description": "The MenuDropdown component is a variant of the Lightning Design System Menu component. This component\nmay require a polyfill such as [classList](https://github.com/yola/classlist-polyfill) due to\n[react-onclickoutside](https://github.com/Pomax/react-onclickoutside) if Internet Explorer 11\nsupport is needed.\n\nThis component is wrapped in a [higher order component to listen for clicks outside itself](https://github.com/kentor/react-click-outside) and thus requires use of `ReactDOM`.\n\nThis component may use a portalMount (a disconnected React subtree mount) within an absolutely positioned DOM node created with [Drop](http://github.hubspot.com/drop/).",
+        "description": "The MenuDropdown component is a variant of the Lightning Design System Menu component. This component\nmay require a polyfill such as [classList](https://github.com/yola/classlist-polyfill) due to\n[react-onclickoutside](https://github.com/Pomax/react-onclickoutside) if Internet Explorer 11\nsupport is needed.\n\nThis component is wrapped in a [higher order component to listen for clicks outside itself](https://github.com/kentor/react-click-outside) and thus requires use of `ReactDOM`.",
         "methods": [
             {
                 "name": "getId",
@@ -6679,13 +6776,6 @@
                 "required": false,
                 "description": "A unique ID is needed in order to support keyboard navigation, ARIA support, and connect the dropdown to the triggering button."
             },
-            "isInline": {
-                "type": {
-                    "name": "bool"
-                },
-                "required": false,
-                "description": "Renders menu within the wrapping trigger as a sibling of the button. By default, you will have an absolutely positioned container at an elevated z-index."
-            },
             "isOpen": {
                 "type": {
                     "name": "bool"
@@ -6739,6 +6829,31 @@
                 },
                 "required": false,
                 "description": "This prop is passed into the List for the menu. Pass null to make it the size of the content, or a string with an integer from here: https://www.lightningdesignsystem.com/components/menus/#flavor-dropdown-height"
+            },
+            "menuPosition": {
+                "type": {
+                    "name": "enum",
+                    "value": [
+                        {
+                            "value": "'absolute'",
+                            "computed": false
+                        },
+                        {
+                            "value": "'overflowBoundaryElement'",
+                            "computed": false
+                        },
+                        {
+                            "value": "'relative'",
+                            "computed": false
+                        }
+                    ]
+                },
+                "required": false,
+                "description": "Please select one of the following:\n* `absolute` - (default) The dialog will use `position: absolute` and style attributes to position itself. This allows inverted placement or flipping of the dialog.\n* `overflowBoundaryElement` - The dialog will overflow scrolling parents. Use on elements that are aligned to the left or right of their target and don't care about the target being within a scrolling parent. Typically this is a popover or tooltip. Dropdown menus can usually open up and down if no room exists. In order to achieve this a portal element will be created and attached to `body`. This element will render into that detached render tree.\n* `relative` - No styling or portals will be used. Menus will be positioned relative to their triggers. This is a great choice for HTML snapshot testing.",
+                "defaultValue": {
+                    "value": "'absolute'",
+                    "computed": false
+                }
             },
             "menuStyle": {
                 "type": {
@@ -7003,13 +7118,6 @@
                             "required": false,
                             "description": "A unique ID is needed in order to support keyboard navigation, ARIA support, and connect the dropdown to the triggering button. This is provided by the `MenuDropdown`. Please use `MenuDropdown` to set."
                         },
-                        "isInline": {
-                            "type": {
-                                "name": "bool"
-                            },
-                            "required": false,
-                            "description": "Renders menu within the wrapping trigger as a sibling of the button. By default, you will have an absolutely positioned container at an elevated z-index."
-                        },
                         "isOpen": {
                             "type": {
                                 "name": "bool"
@@ -7127,7 +7235,7 @@
         ]
     },
     "modal": {
-        "description": "The Modal component is used for the Lightning Design System Modal and Notification > Prompt components. The Modal opens from a state change outside of the component itself (pass this state to the <code>isOpen</code> prop). For more details on the Prompt markup, please review the <a href=\"http://www.lightningdesignsystem.com/components/notifications#prompt\">Notifications > Prompt</a>.\n\nBy default, `Modal` will add `aria-hidden=true` to the `body` tag, but this disables some assistive technologies. To prevent this you can add the following to your application with `#mount` being the root node of your application that you would like to hide from assistive technologies when the `Modal` is open.\n```\nimport settings from 'design-system-react/components/settings';\nsettings.setAppElement('#mount');\n```\n\nThis component uses a portalMount (a disconnected React subtree mount) to create a modal as a child of `body`.\nWhen dynamically generating a `Button` that will be used to toggle a `Modal`, you may see the parent page scroll down. If `parentSelector` points to the `Button`, the `Modal` will display, but will not be clickable. The `Modal` has been rendered inside the `Button` and its event listeners. To fix these issues, define a DOM element with an ID along with the `Button`. Set the `Modal`'s `parentSelector` to that DOM element's `id`.\n```\n<div id={`toggleButtonFor-${modalId}`} style={{zIndex: '2'}} />\n<Button onClick={this.toggleModal} />\n...\n<Modal parentSelector={() => document.querySelector(`#toggleButtonFor-${modalId}`)} />\n```",
+        "description": "The Modal component is used for the Lightning Design System Modal and Notification > Prompt components. The Modal opens from a state change outside of the component itself (pass this state to the <code>isOpen</code> prop). For more details on the Prompt markup, please review the <a href=\"http://www.lightningdesignsystem.com/components/notifications#prompt\">Notifications > Prompt</a>.\n\nBy default, `Modal` will add `aria-hidden=true` to the `body` tag, but this disables some assistive technologies. To prevent this you can add the following to your application with `#mount` being the root node of your application that you would like to hide from assistive technologies when the `Modal` is open.\n```\nimport settings from 'design-system-react/components/settings';\nsettings.setAppElement('#mount');\n```\nThis component uses a portalMount (a disconnected React subtree mount) to create a modal as a child of `body`.",
         "displayName": "Modal",
         "methods": [
             {
@@ -7859,7 +7967,7 @@
         ]
     },
     "popover": {
-        "description": "The Popover component is a non-modal dialog. It should be paired with a clickable trigger such as a `Button`. It traps focus from the page and must be exited if focus needs to be outside the Popover. Use a `Tooltip` if there are no call to actions within the dialog. A `Tooltip` does not need to be clicked.",
+        "description": "The Popover component is a non-modal dialog. It should be paired with a clickable trigger such as a `Button`. It traps focus from the page and must be exited if focus needs to be outside the Popover. Use a `Tooltip` if there are no call to actions within the dialog. A `Tooltip` does not need to be clicked. Multiple popovers open at the same time, each with focus trap is not supported.",
         "methods": [
             {
                 "name": "getId",
@@ -8022,6 +8130,18 @@
                 "returns": null
             },
             {
+                "name": "setMenuRef",
+                "docblock": null,
+                "modifiers": [],
+                "params": [
+                    {
+                        "name": "component",
+                        "type": null
+                    }
+                ],
+                "returns": null
+            },
+            {
                 "name": "renderDialog",
                 "docblock": null,
                 "modifiers": [],
@@ -8044,6 +8164,18 @@
                 "params": [
                     {
                         "name": "isOpen",
+                        "type": null
+                    }
+                ],
+                "returns": null
+            },
+            {
+                "name": "setContainerRef",
+                "docblock": null,
+                "modifiers": [],
+                "params": [
+                    {
+                        "name": "component",
                         "type": null
                     }
                 ],
@@ -8258,12 +8390,30 @@
                 "required": false,
                 "description": "This function is triggered when the user clicks outside the Popover or clicks the close button. You will want to define this if Popover is to be a controlled component. Most of the time you will want wnat to set `isOpen` to `false` when this is triggered unless you need to validate something."
             },
-            "portalMount": {
+            "position": {
                 "type": {
-                    "name": "func"
+                    "name": "enum",
+                    "value": [
+                        {
+                            "value": "'absolute'",
+                            "computed": false
+                        },
+                        {
+                            "value": "'overflowBoundaryElement'",
+                            "computed": false
+                        },
+                        {
+                            "value": "'relative'",
+                            "computed": false
+                        }
+                    ]
                 },
                 "required": false,
-                "description": "Absolutely positioned DOM nodes, such as a popover dialog, may need their own React DOM tree root. They may need their alignment \"flipped\" if extended beyond the window or outside the bounds of an overflow-hidden scrolling modal. This library's portal mounts are added as a child node of `body`. This prop will be triggered instead of the default `ReactDOM.mount()` when this dialog is mounted. This prop is useful for testing and simliar to a \"callback ref.\" Two arguments,`reactElement` and `domContainerNode` are passed in. Consider the following code that bypasses the internal mount and uses an Enzyme wrapper to mount the React root tree to the DOM.\n\n```\n<Popover\n                isOpen\n                portalMount={(reactElement, domContainerNode) => {\n                    portalWrapper = Enzyme.mount(reactElement, { attachTo: domContainerNode });\n                }}\n                onOpen={() => {\n                    expect(portalWrapper.find(`#my-heading`)).to.exist;\n                    done();\n                }}\n            />\n            ```"
+                "description": "Please select one of the following:\n* `absolute` - (default) The dialog will use `position: absolute` and style attributes to position itself. This allows inverted placement or flipping of the dialog.\n* `overflowBoundaryElement` - The dialog will overflow scrolling parents. Use on elements that are aligned to the left or right of their target and don't care about the target being within a scrolling parent. Typically this is a popover or tooltip. Dropdown menus can usually open up and down if no room exists. In order to achieve this a portal element will be created and attached to `body`. This element will render into that detached render tree.\n* `relative` - No styling or portals will be used. Menus will be positioned relative to their triggers. This is a great choice for HTML snapshot testing.",
+                "defaultValue": {
+                    "value": "'absolute'",
+                    "computed": false
+                }
             },
             "style": {
                 "type": {
@@ -9151,6 +9301,18 @@
                 "modifiers": [],
                 "params": [],
                 "returns": null
+            },
+            {
+                "name": "saveTriggerRef",
+                "docblock": null,
+                "modifiers": [],
+                "params": [
+                    {
+                        "name": "component",
+                        "type": null
+                    }
+                ],
+                "returns": null
             }
         ],
         "props": {
@@ -9233,12 +9395,12 @@
                     "computed": false
                 }
             },
-            "flippable": {
+            "hasStaticAlignment": {
                 "type": {
                     "name": "bool"
                 },
                 "required": false,
-                "description": "Constrains tooltip to window. If the tooltip is near the bottom, then it may appear about the trigger, despite the value of `align`."
+                "description": "By default, dialogs will flip their alignment (such as bottom to top) if they extend beyond a boundary element such as a scrolling parent or a window/viewpoint. This is the opposite of \"flippable.\""
             },
             "hoverCloseDelay": {
                 "type": {
@@ -9282,6 +9444,31 @@
                 },
                 "required": false,
                 "description": "CSS classes to be added to tag with `slds-tooltip-trigger`."
+            },
+            "position": {
+                "type": {
+                    "name": "enum",
+                    "value": [
+                        {
+                            "value": "'absolute'",
+                            "computed": false
+                        },
+                        {
+                            "value": "'overflowBoundaryElement'",
+                            "computed": false
+                        },
+                        {
+                            "value": "'relative'",
+                            "computed": false
+                        }
+                    ]
+                },
+                "required": false,
+                "description": "Please select one of the following:\n* `absolute` - (default) The dialog will use `position: absolute` and style attributes to position itself. This allows inverted placement or flipping of the dialog.\n* `overflowBoundaryElement` - The dialog will overflow scrolling parents. Use on elements that are aligned to the left or right of their target and don't care about the target being within a scrolling parent. Typically this is a popover or tooltip. Dropdown menus can usually open up and down if no room exists. In order to achieve this a portal element will be created and attached to `body`. This element will render into that detached render tree.\n* `relative` - No styling or portals will be used. Menus will be positioned relative to their triggers. This is a great choice for HTML snapshot testing.",
+                "defaultValue": {
+                    "value": "'absolute'",
+                    "computed": false
+                }
             },
             "triggerStyle": {
                 "type": {
@@ -9996,13 +10183,6 @@
                 "required": false,
                 "description": ""
             },
-            "isInline": {
-                "type": {
-                    "name": "bool"
-                },
-                "required": false,
-                "description": "Renders menu within the wrapping trigger as a sibling of the button. By default, you will have an absolutely positioned container at an elevated z-index."
-            },
             "label": {
                 "type": {
                     "name": "string"
@@ -10016,6 +10196,31 @@
                 },
                 "required": false,
                 "description": "Custom element that overrides the default Menu Item component."
+            },
+            "menuPosition": {
+                "type": {
+                    "name": "enum",
+                    "value": [
+                        {
+                            "value": "'absolute'",
+                            "computed": false
+                        },
+                        {
+                            "value": "'overflowBoundaryElement'",
+                            "computed": false
+                        },
+                        {
+                            "value": "'relative'",
+                            "computed": false
+                        }
+                    ]
+                },
+                "required": false,
+                "description": "Please select one of the following:\n* `absolute` - (default) The dialog will use `position: absolute` and style attributes to position itself. This allows inverted placement or flipping of the dialog.\n* `overflowBoundaryElement` - The dialog will overflow scrolling parents. Use on elements that are aligned to the left or right of their target and don't care about the target being within a scrolling parent. Typically this is a popover or tooltip. Dropdown menus can usually open up and down if no room exists. In order to achieve this a portal element will be created and attached to `body`. This element will render into that detached render tree.\n* `relative` - No styling or portals will be used. Menus will be positioned relative to their triggers. This is a great choice for HTML snapshot testing.",
+                "defaultValue": {
+                    "value": "'absolute'",
+                    "computed": false
+                }
             },
             "onDateChange": {
                 "type": {

--- a/examples/icon-settings/iconPath.jsx
+++ b/examples/icon-settings/iconPath.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import createReactClass from 'create-react-class';
+import IconSettings from '~/components/icon-settings';
+import Icon from '~/components/icon'; // `~` is replaced with design-system-react at runtime
+
+const Example = createReactClass({
+	displayName: 'IconSettingsExample',
+
+	render () {
+		return (
+			<IconSettings iconPath="/assets/icons">
+				<div className="slds-grid slds-grid--pull-padded slds-grid--vertical-align-center">
+					<div className="slds-col--padded">
+						<Icon
+							assistiveText="Account"
+							category="standard"
+							name="account"
+							size="small"
+						/>
+					</div>
+					<div className="slds-col--padded">
+						<Icon
+							assistiveText="Announcement"
+							category="utility"
+							name="announcement"
+							size="small"
+						/>
+					</div>
+					<div className="slds-col--padded">
+						<Icon
+							assistiveText="Description"
+							category="action"
+							name="description"
+							size="small"
+						/>
+					</div>
+					<div className="slds-col--padded">
+						<Icon
+							assistiveText="XML"
+							category="doctype"
+							name="xml"
+							size="small"
+						/>
+					</div>
+					<div className="slds-col--padded">
+						<Icon
+							assistiveText="custom5"
+							category="custom"
+							name="custom5"
+							size="small"
+						/>
+					</div>
+				</div>
+			</IconSettings>
+		);
+	}
+});
+
+
+export default Example;	// export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/examples/icon-settings/sprite.jsx
+++ b/examples/icon-settings/sprite.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import createReactClass from 'create-react-class';
+import Icon from '~/components/icon'; // `~` is replaced with design-system-react at runtime
+import IconSettings from '~/components/icon-settings';
+
+import actionSprite from '@salesforce-ux/design-system/assets/icons/action-sprite/svg/symbols.svg';
+import customSprite from '@salesforce-ux/design-system/assets/icons/custom-sprite/svg/symbols.svg';
+import utilitySprite from '@salesforce-ux/design-system/assets/icons/utility-sprite/svg/symbols.svg';
+import standardSprite from '@salesforce-ux/design-system/assets/icons/standard-sprite/svg/symbols.svg';
+import doctypeSprite from '@salesforce-ux/design-system/assets/icons/doctype-sprite/svg/symbols.svg';
+
+const Example = createReactClass({
+	displayName: 'IconSettingsExample',
+
+	render () {
+		return (
+			<IconSettings standardSprite={standardSprite} utilitySprite={utilitySprite} actionSprite={actionSprite} doctypeSprite={doctypeSprite} customSprite={customSprite}>
+				<div className="slds-grid slds-grid--pull-padded slds-grid--vertical-align-center">
+					<div className="slds-col--padded">
+						<Icon
+							assistiveText="Account"
+							category="standard"
+							name="account"
+							size="small"
+						/>
+					</div>
+					<div className="slds-col--padded">
+						<Icon
+							assistiveText="Announcement"
+							category="utility"
+							name="announcement"
+							size="small"
+						/>
+					</div>
+					<div className="slds-col--padded">
+						<Icon
+							assistiveText="Description"
+							category="action"
+							name="description"
+							size="small"
+						/>
+					</div>
+					<div className="slds-col--padded">
+						<Icon
+							assistiveText="XML"
+							category="doctype"
+							name="xml"
+							size="small"
+						/>
+					</div>
+					<div className="slds-col--padded">
+						<Icon
+							assistiveText="custom5"
+							category="custom"
+							name="custom5"
+							size="small"
+						/>
+					</div>
+				</div>
+			</IconSettings>
+		);
+	}
+});
+
+
+export default Example;	// export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/examples/icon-settings/stories.jsx
+++ b/examples/icon-settings/stories.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import { ICON_SETTINGS } from '../../utilities/constants';
+
+import Sprite from './sprite';
+import IconPath from './iconPath';
+
+
+storiesOf(ICON_SETTINGS, module)
+.addDecorator((getStory) => <div className="slds-p-around--medium">{getStory()}</div>)
+	.add('Base: Icon path', () => (<IconPath />))
+	.add('Base: Sprite imports', () => (<Sprite />));

--- a/examples/index.js
+++ b/examples/index.js
@@ -75,6 +75,10 @@ const documentationSiteLiveExamples = {
 		require('raw-loader!design-system-react/examples/icon/colors.jsx'),
 		require('raw-loader!design-system-react/examples/icon/sizes.jsx')
 	],
+	'icon-settings': [
+		require('raw-loader!design-system-react/examples/icon-settings/iconPath.jsx'),
+		require('raw-loader!design-system-react/examples/icon-settings/sprite.jsx')
+	],
 	'forms-input-inline': [
 		require('raw-loader!design-system-react/examples/forms/input/inline/default.jsx')
 	],

--- a/examples/stories.js
+++ b/examples/stories.js
@@ -22,6 +22,7 @@ export InlineInput from './forms/input/inline/stories';
 export Search from './forms/input/search/stories';
 export GlobalHeader from './global-header/stories';
 export Icon from './icon/stories';
+export IconSettings from './icon-settings/stories';
 export Lookup from './lookup/stories';
 export MediaObject from './media-object/stories';
 export Modal from './modal/stories';

--- a/package.json
+++ b/package.json
@@ -305,6 +305,12 @@
       "display-name": "Icons",
       "SLDS-component-path": "/components/icons"
     },
+	{
+	  "component": "icon-settings",
+	  "status": "prod",
+	  "display-name": "Icon Settings",
+	  "SLDS-component-path": "/components/icons-settings"
+	},
     {
       "component": "filter",
       "status": "prototype",

--- a/tests/accordion/__snapshots__/accordion.snapshot-test.jsx.snap
+++ b/tests/accordion/__snapshots__/accordion.snapshot-test.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Base DOM Snapshot 1`] = `
-<IconSettings
+<SLDSIconSettings
   iconPath="/assets/icons"
 >
   <SLDSAccordion
@@ -149,7 +149,7 @@ exports[`Base DOM Snapshot 1`] = `
       Accordion details - C
     </SLDSAccordionPanel>
   </SLDSAccordion>
-</IconSettings>
+</SLDSIconSettings>
 `;
 
 exports[`Base HTML Snapshot 1`] = `
@@ -188,7 +188,7 @@ exports[`Base HTML Snapshot 1`] = `
 `;
 
 exports[`Base Open DOM Snapshot 1`] = `
-<IconSettings
+<SLDSIconSettings
   iconPath="/assets/icons"
 >
   <SLDSAccordion
@@ -211,7 +211,7 @@ exports[`Base Open DOM Snapshot 1`] = `
       Accordion details - B
     </SLDSAccordionPanel>
   </SLDSAccordion>
-</IconSettings>
+</SLDSIconSettings>
 `;
 
 exports[`Base Open HTML Snapshot 1`] = `

--- a/tests/alert/__snapshots__/alert.snapshot-test.jsx.snap
+++ b/tests/alert/__snapshots__/alert.snapshot-test.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Alert Custom Class Name DOM Snapshot 1`] = `
-<IconSettings
+<SLDSIconSettings
   iconPath="/assets/icons"
 >
   <SLDSAlertContainer
@@ -31,7 +31,7 @@ exports[`Alert Custom Class Name DOM Snapshot 1`] = `
       variant="info"
     />
   </SLDSAlertContainer>
-</IconSettings>
+</SLDSIconSettings>
 `;
 
 exports[`Alert Custom Class Name HTML Snapshot 1`] = `
@@ -43,7 +43,7 @@ exports[`Alert Custom Class Name HTML Snapshot 1`] = `
 `;
 
 exports[`Alert Dismissable DOM Snapshot 1`] = `
-<IconSettings
+<SLDSIconSettings
   iconPath="/assets/icons"
 >
   <SLDSAlertContainer>
@@ -72,7 +72,7 @@ exports[`Alert Dismissable DOM Snapshot 1`] = `
       variant="info"
     />
   </SLDSAlertContainer>
-</IconSettings>
+</SLDSIconSettings>
 `;
 
 exports[`Alert Dismissable HTML Snapshot 1`] = `
@@ -83,7 +83,7 @@ exports[`Alert Dismissable HTML Snapshot 1`] = `
 `;
 
 exports[`Alert Error DOM Snapshot 1`] = `
-<IconSettings
+<SLDSIconSettings
   iconPath="/assets/icons"
 >
   <SLDSAlertContainer>
@@ -110,7 +110,7 @@ exports[`Alert Error DOM Snapshot 1`] = `
       variant="error"
     />
   </SLDSAlertContainer>
-</IconSettings>
+</SLDSIconSettings>
 `;
 
 exports[`Alert Error HTML Snapshot 1`] = `
@@ -122,7 +122,7 @@ exports[`Alert Error HTML Snapshot 1`] = `
 `;
 
 exports[`Alert Info DOM Snapshot 1`] = `
-<IconSettings
+<SLDSIconSettings
   iconPath="/assets/icons"
 >
   <SLDSAlertContainer>
@@ -149,7 +149,7 @@ exports[`Alert Info DOM Snapshot 1`] = `
       variant="info"
     />
   </SLDSAlertContainer>
-</IconSettings>
+</SLDSIconSettings>
 `;
 
 exports[`Alert Info HTML Snapshot 1`] = `
@@ -161,7 +161,7 @@ exports[`Alert Info HTML Snapshot 1`] = `
 `;
 
 exports[`Alert Offline DOM Snapshot 1`] = `
-<IconSettings
+<SLDSIconSettings
   iconPath="/assets/icons"
 >
   <SLDSAlertContainer>
@@ -181,7 +181,7 @@ exports[`Alert Offline DOM Snapshot 1`] = `
       variant="offline"
     />
   </SLDSAlertContainer>
-</IconSettings>
+</SLDSIconSettings>
 `;
 
 exports[`Alert Offline HTML Snapshot 1`] = `
@@ -193,7 +193,7 @@ exports[`Alert Offline HTML Snapshot 1`] = `
 `;
 
 exports[`Alert Warning DOM Snapshot 1`] = `
-<IconSettings
+<SLDSIconSettings
   iconPath="/assets/icons"
 >
   <SLDSAlertContainer>
@@ -213,7 +213,7 @@ exports[`Alert Warning DOM Snapshot 1`] = `
       variant="warning"
     />
   </SLDSAlertContainer>
-</IconSettings>
+</SLDSIconSettings>
 `;
 
 exports[`Alert Warning HTML Snapshot 1`] = `

--- a/tests/button-group/__snapshots__/button-group.snapshot-test.jsx.snap
+++ b/tests/button-group/__snapshots__/button-group.snapshot-test.jsx.snap
@@ -371,7 +371,7 @@ exports[`Button Group Checkbox Snapshot 1`] = `
 
 exports[`Button Group MoreIcon Snapshot 1`] = `
 <ButtonGroupExample>
-  <IconSettings
+  <SLDSIconSettings
     iconPath="/assets/icons"
   >
     <SLDSButtonGroup
@@ -605,6 +605,6 @@ exports[`Button Group MoreIcon Snapshot 1`] = `
         </OnClickOutside(SLDSMenuDropdown)>
       </div>
     </SLDSButtonGroup>
-  </IconSettings>
+  </SLDSIconSettings>
 </ButtonGroupExample>
 `;

--- a/tests/combobox/__snapshots__/combobox.snapshot-test.jsx.snap
+++ b/tests/combobox/__snapshots__/combobox.snapshot-test.jsx.snap
@@ -73,7 +73,7 @@ exports[`Base Custom Menu Item Open HTML Snapshot 1`] = `
 `;
 
 exports[`Base Open DOM Snapshot 1`] = `
-<IconSettings
+<SLDSIconSettings
   iconPath="/assets/icons"
 >
   <SLDSCombobox
@@ -131,7 +131,7 @@ exports[`Base Open DOM Snapshot 1`] = `
     value=""
     variant="base"
   />
-</IconSettings>
+</SLDSIconSettings>
 `;
 
 exports[`Base Open HTML Snapshot 1`] = `
@@ -160,7 +160,7 @@ exports[`Base Open HTML Snapshot 1`] = `
 `;
 
 exports[`Base Selected DOM Snapshot 1`] = `
-<IconSettings
+<SLDSIconSettings
   iconPath="/assets/icons"
 >
   <SLDSCombobox
@@ -232,7 +232,7 @@ exports[`Base Selected DOM Snapshot 1`] = `
     value=""
     variant="base"
   />
-</IconSettings>
+</SLDSIconSettings>
 `;
 
 exports[`Base Selected HTML Snapshot 1`] = `
@@ -258,7 +258,7 @@ exports[`Base Selected HTML Snapshot 1`] = `
 `;
 
 exports[`Inline Multiple Selection DOM Snapshot 1`] = `
-<IconSettings
+<SLDSIconSettings
   iconPath="/assets/icons"
 >
   <OnClickOutside(SLDSCombobox)
@@ -392,7 +392,7 @@ exports[`Inline Multiple Selection DOM Snapshot 1`] = `
     value=""
     variant="inline-listbox"
   />
-</IconSettings>
+</SLDSIconSettings>
 `;
 
 exports[`Inline Multiple Selection HTML Snapshot 1`] = `
@@ -409,7 +409,7 @@ exports[`Inline Multiple Selection HTML Snapshot 1`] = `
 `;
 
 exports[`Inline Multiple Selection Selected DOM Snapshot 1`] = `
-<IconSettings
+<SLDSIconSettings
   iconPath="/assets/icons"
 >
   <OnClickOutside(SLDSCombobox)
@@ -546,7 +546,7 @@ exports[`Inline Multiple Selection Selected DOM Snapshot 1`] = `
     value=""
     variant="inline-listbox"
   />
-</IconSettings>
+</SLDSIconSettings>
 `;
 
 exports[`Inline Multiple Selection Selected HTML Snapshot 1`] = `
@@ -577,7 +577,7 @@ exports[`Inline Multiple Selection Selected HTML Snapshot 1`] = `
 `;
 
 exports[`Inline Single Selection DOM Snapshot 1`] = `
-<IconSettings
+<SLDSIconSettings
   iconPath="/assets/icons"
 >
   <OnClickOutside(SLDSCombobox)
@@ -710,7 +710,7 @@ exports[`Inline Single Selection DOM Snapshot 1`] = `
     value=""
     variant="inline-listbox"
   />
-</IconSettings>
+</SLDSIconSettings>
 `;
 
 exports[`Inline Single Selection HTML Snapshot 1`] = `
@@ -727,7 +727,7 @@ exports[`Inline Single Selection HTML Snapshot 1`] = `
 `;
 
 exports[`Inline Single Selection Selected DOM Snapshot 1`] = `
-<IconSettings
+<SLDSIconSettings
   iconPath="/assets/icons"
 >
   <OnClickOutside(SLDSCombobox)
@@ -863,7 +863,7 @@ exports[`Inline Single Selection Selected DOM Snapshot 1`] = `
     value=""
     variant="inline-listbox"
   />
-</IconSettings>
+</SLDSIconSettings>
 `;
 
 exports[`Inline Single Selection Selected HTML Snapshot 1`] = `
@@ -883,7 +883,7 @@ exports[`Inline Single Selection Selected HTML Snapshot 1`] = `
 `;
 
 exports[`Readonly Multiple Selection DOM Snapshot 1`] = `
-<IconSettings
+<SLDSIconSettings
   iconPath="/assets/icons"
 >
   <OnClickOutside(SLDSCombobox)
@@ -967,7 +967,7 @@ exports[`Readonly Multiple Selection DOM Snapshot 1`] = `
     value=""
     variant="readonly"
   />
-</IconSettings>
+</SLDSIconSettings>
 `;
 
 exports[`Readonly Multiple Selection HTML Snapshot 1`] = `
@@ -986,7 +986,7 @@ exports[`Readonly Multiple Selection HTML Snapshot 1`] = `
 `;
 
 exports[`Readonly Multiple Selection Multiple Items Selected DOM Snapshot 1`] = `
-<IconSettings
+<SLDSIconSettings
   iconPath="/assets/icons"
 >
   <OnClickOutside(SLDSCombobox)
@@ -1085,7 +1085,7 @@ exports[`Readonly Multiple Selection Multiple Items Selected DOM Snapshot 1`] = 
     value=""
     variant="readonly"
   />
-</IconSettings>
+</SLDSIconSettings>
 `;
 
 exports[`Readonly Multiple Selection Multiple Items Selected HTML Snapshot 1`] = `
@@ -1112,7 +1112,7 @@ exports[`Readonly Multiple Selection Multiple Items Selected HTML Snapshot 1`] =
 `;
 
 exports[`Readonly Multiple Selection Single Item Selected DOM Snapshot 1`] = `
-<IconSettings
+<SLDSIconSettings
   iconPath="/assets/icons"
 >
   <OnClickOutside(SLDSCombobox)
@@ -1205,7 +1205,7 @@ exports[`Readonly Multiple Selection Single Item Selected DOM Snapshot 1`] = `
     value=""
     variant="readonly"
   />
-</IconSettings>
+</SLDSIconSettings>
 `;
 
 exports[`Readonly Multiple Selection Single Item Selected HTML Snapshot 1`] = `
@@ -1314,7 +1314,7 @@ exports[`Readonly Single Selection Custom Menu Item Open HTML Snapshot 1`] = `
 `;
 
 exports[`Readonly Single Selection DOM Snapshot 1`] = `
-<IconSettings
+<SLDSIconSettings
   iconPath="/assets/icons"
 >
   <OnClickOutside(SLDSCombobox)
@@ -1396,7 +1396,7 @@ exports[`Readonly Single Selection DOM Snapshot 1`] = `
     value=""
     variant="readonly"
   />
-</IconSettings>
+</SLDSIconSettings>
 `;
 
 exports[`Readonly Single Selection HTML Snapshot 1`] = `
@@ -1415,7 +1415,7 @@ exports[`Readonly Single Selection HTML Snapshot 1`] = `
 `;
 
 exports[`Readonly Single Selection Selected DOM Snapshot 1`] = `
-<IconSettings
+<SLDSIconSettings
   iconPath="/assets/icons"
 >
   <OnClickOutside(SLDSCombobox)
@@ -1506,7 +1506,7 @@ exports[`Readonly Single Selection Selected DOM Snapshot 1`] = `
     value=""
     variant="readonly"
   />
-</IconSettings>
+</SLDSIconSettings>
 `;
 
 exports[`Readonly Single Selection Selected HTML Snapshot 1`] = `
@@ -1525,7 +1525,7 @@ exports[`Readonly Single Selection Selected HTML Snapshot 1`] = `
 `;
 
 exports[`Readonly Single Selection Selected Open DOM Snapshot 1`] = `
-<IconSettings
+<SLDSIconSettings
   iconPath="/assets/icons"
 >
   <OnClickOutside(SLDSCombobox)
@@ -1617,7 +1617,7 @@ exports[`Readonly Single Selection Selected Open DOM Snapshot 1`] = `
     value=""
     variant="readonly"
   />
-</IconSettings>
+</SLDSIconSettings>
 `;
 
 exports[`Readonly Single Selection Selected Open HTML Snapshot 1`] = `

--- a/tests/filter/__snapshots__/filter.snapshot-test.jsx.snap
+++ b/tests/filter/__snapshots__/filter.snapshot-test.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AssistiveText Filter 1`] = `
-<IconSettings
+<SLDSIconSettings
   iconPath="/assets/icons"
 >
   <SLDSFilter
@@ -68,7 +68,7 @@ exports[`AssistiveText Filter 1`] = `
       variant="readonly"
     />
   </SLDSFilter>
-</IconSettings>
+</SLDSIconSettings>
 `;
 
 exports[`AssistiveText Filter HTML Snapshot 1`] = `
@@ -80,7 +80,7 @@ exports[`AssistiveText Filter HTML Snapshot 1`] = `
 `;
 
 exports[`Error Filter Base Snapshot 1`] = `
-<IconSettings
+<SLDSIconSettings
   iconPath="/assets/icons"
 >
   <SLDSFilter
@@ -126,11 +126,11 @@ exports[`Error Filter Base Snapshot 1`] = `
       value="all-products"
     />
   </SLDSFilter>
-</IconSettings>
+</SLDSIconSettings>
 `;
 
 exports[`Filter Base Snapshot 1`] = `
-<IconSettings
+<SLDSIconSettings
   iconPath="/assets/icons"
 >
   <SLDSFilter
@@ -196,7 +196,7 @@ exports[`Filter Base Snapshot 1`] = `
       variant="readonly"
     />
   </SLDSFilter>
-</IconSettings>
+</SLDSIconSettings>
 `;
 
 exports[`Filter Base with custom className Snapshot 1`] = `
@@ -208,7 +208,7 @@ exports[`Filter Base with custom className Snapshot 1`] = `
 `;
 
 exports[`LockedFilter Base Snapshot 1`] = `
-<IconSettings
+<SLDSIconSettings
   iconPath="/assets/icons"
 >
   <SLDSFilter
@@ -254,11 +254,11 @@ exports[`LockedFilter Base Snapshot 1`] = `
       value="all-products"
     />
   </SLDSFilter>
-</IconSettings>
+</SLDSIconSettings>
 `;
 
 exports[`NewFilter Base Snapshot 1`] = `
-<IconSettings
+<SLDSIconSettings
   iconPath="/assets/icons"
 >
   <SLDSFilter
@@ -304,11 +304,11 @@ exports[`NewFilter Base Snapshot 1`] = `
       value="all-products"
     />
   </SLDSFilter>
-</IconSettings>
+</SLDSIconSettings>
 `;
 
 exports[`Permanant Filter Base Snapshot 1`] = `
-<IconSettings
+<SLDSIconSettings
   iconPath="/assets/icons"
 >
   <SLDSFilter
@@ -354,5 +354,5 @@ exports[`Permanant Filter Base Snapshot 1`] = `
       value="all-products"
     />
   </SLDSFilter>
-</IconSettings>
+</SLDSIconSettings>
 `;

--- a/tests/panel/__snapshots__/filtering.snapshot-test.jsx.snap
+++ b/tests/panel/__snapshots__/filtering.snapshot-test.jsx.snap
@@ -40,7 +40,7 @@ exports[`Panel Filtering Default HTML Snapshot 1`] = `
 `;
 
 exports[`Panel Filtering Default Snapshot 1`] = `
-<IconSettings
+<SLDSIconSettings
   iconPath="/assets/icons"
 >
   <SLDSPanel
@@ -198,5 +198,5 @@ exports[`Panel Filtering Default Snapshot 1`] = `
       </SLDSFilterList>
     </SLDSFilterGroup>
   </SLDSPanel>
-</IconSettings>
+</SLDSIconSettings>
 `;

--- a/tests/toast/__snapshots__/toast.snapshot-test.jsx.snap
+++ b/tests/toast/__snapshots__/toast.snapshot-test.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Alert Custom Class Name DOM Snapshot 1`] = `
-<IconSettings
+<SLDSIconSettings
   iconPath="/assets/icons"
 >
   <SLDSToastContainer
@@ -23,7 +23,7 @@ exports[`Alert Custom Class Name DOM Snapshot 1`] = `
       variant="info"
     />
   </SLDSToastContainer>
-</IconSettings>
+</SLDSIconSettings>
 `;
 
 exports[`Alert Custom Class Name HTML Snapshot 1`] = `
@@ -37,7 +37,7 @@ exports[`Alert Custom Class Name HTML Snapshot 1`] = `
 `;
 
 exports[`Alert Error DOM Snapshot 1`] = `
-<IconSettings
+<SLDSIconSettings
   iconPath="/assets/icons"
 >
   <SLDSToastContainer>
@@ -55,7 +55,7 @@ exports[`Alert Error DOM Snapshot 1`] = `
       variant="error"
     />
   </SLDSToastContainer>
-</IconSettings>
+</SLDSIconSettings>
 `;
 
 exports[`Alert Error HTML Snapshot 1`] = `
@@ -69,7 +69,7 @@ exports[`Alert Error HTML Snapshot 1`] = `
 `;
 
 exports[`Alert Error With details DOM Snapshot 1`] = `
-<IconSettings
+<SLDSIconSettings
   iconPath="/assets/icons"
 >
   <SLDSToastContainer>
@@ -88,7 +88,7 @@ exports[`Alert Error With details DOM Snapshot 1`] = `
       variant="error"
     />
   </SLDSToastContainer>
-</IconSettings>
+</SLDSIconSettings>
 `;
 
 exports[`Alert Error With details HTML Snapshot 1`] = `
@@ -103,7 +103,7 @@ exports[`Alert Error With details HTML Snapshot 1`] = `
 `;
 
 exports[`Alert Info DOM Snapshot 1`] = `
-<IconSettings
+<SLDSIconSettings
   iconPath="/assets/icons"
 >
   <SLDSToastContainer>
@@ -123,7 +123,7 @@ exports[`Alert Info DOM Snapshot 1`] = `
       variant="info"
     />
   </SLDSToastContainer>
-</IconSettings>
+</SLDSIconSettings>
 `;
 
 exports[`Alert Info HTML Snapshot 1`] = `
@@ -137,7 +137,7 @@ exports[`Alert Info HTML Snapshot 1`] = `
 `;
 
 exports[`Alert Success DOM Snapshot 1`] = `
-<IconSettings
+<SLDSIconSettings
   iconPath="/assets/icons"
 >
   <SLDSToastContainer>
@@ -163,7 +163,7 @@ exports[`Alert Success DOM Snapshot 1`] = `
       variant="success"
     />
   </SLDSToastContainer>
-</IconSettings>
+</SLDSIconSettings>
 `;
 
 exports[`Alert Success HTML Snapshot 1`] = `
@@ -177,7 +177,7 @@ exports[`Alert Success HTML Snapshot 1`] = `
 `;
 
 exports[`Alert Warning DOM Snapshot 1`] = `
-<IconSettings
+<SLDSIconSettings
   iconPath="/assets/icons"
 >
   <SLDSToastContainer>
@@ -195,7 +195,7 @@ exports[`Alert Warning DOM Snapshot 1`] = `
       variant="warning"
     />
   </SLDSToastContainer>
-</IconSettings>
+</SLDSIconSettings>
 `;
 
 exports[`Alert Warning HTML Snapshot 1`] = `

--- a/utilities/constants.js
+++ b/utilities/constants.js
@@ -52,6 +52,7 @@ export const GLOBAL_NAVIGATION_BAR_APP_LAUNCHER = 'SLDSGlobalNavigationBarAppLau
 export const GRID = 'SLDSGrid';
 export const HIGHLIGHTER = 'SLDSHighlighter';
 export const ICON = 'SLDSIcon';
+export const ICON_SETTINGS = 'SLDSIconSettings';
 export const ICON_INPUT = 'SLDSIconInput';
 export const LIST = 'SLDSList';
 export const LIST_ITEM = 'SLDSListItem';


### PR DESCRIPTION
When using webpack it's a pain to use the icons. You need to either manually copy the sprites or use a copy loader. 

Allowing the sprites to be assigned in the icon settings means webpack can re-write the urls and you don't need to co-ordinate a copy and path assignment.

```javascript
import utilitySprite from '@salesforce-ux/design-system/assets/icons/utility-sprite/svg/symbols.svg';
import customSprite from '@salesforce-ux/design-system/assets/icons/custom-sprite/svg/symbols.svg';

() => (
    <IconSettings utilitySprite={utilitySprite} customSprite={customSprite}>
    
    </IconSettings>
)
```