### PR TITLE
Focus input if menu was actually open and not just requested to close

### DIFF
--- a/components/date-picker/date-picker.jsx
+++ b/components/date-picker/date-picker.jsx
@@ -313,10 +313,10 @@ class Datepicker extends React.Component {
 
 		if (this.getIsOpen()) {
 			this.setState({ isOpen: false });
-		}
-
-		if (this.inputRef) {
-			this.inputRef.focus();
+			
+			if (this.inputRef) {
+				this.inputRef.focus();
+			}
 		}
 	}
 


### PR DESCRIPTION
Hello,

I faced an issue with Datepicker which was already referenced in an old ticket (#877).
I made the following change : for me the focus to the input should be done only if the related Dialog was previously opened to avoid unexpected effect if the Datepicker was not being used.
Sorry, I'm not really accustomed to contributing to opensource projects in github. Do not hesitate if I miss a step in the contributing process

Related to #877

Kévin