### PR TITLE
add "title" attribute to string nodes (span)

### DIFF
--- a/components/utilities/highlighter/index.jsx
+++ b/components/utilities/highlighter/index.jsx
@@ -18,7 +18,7 @@ const Highlighter = (props) => {
 	if (props.search) {
 		let children;
 		if (typeof props.children === 'string') {
-			children = (<ReactHighlighter className={props.className} matchClass={null} matchElement="mark" search={props.search}>
+			children = (<ReactHighlighter className={props.className} matchClass={null} matchElement="mark" search={props.search} title={props.children}>
 				{props.children}
 			</ReactHighlighter>);
 		} else {
@@ -26,7 +26,7 @@ const Highlighter = (props) => {
 				nodeArr.map((element) => {
 					let newElement;
 					if (typeof element === 'string') {
-						newElement = (<ReactHighlighter key={element} className={props.className} matchClass={null} matchElement="mark" search={props.search}>
+						newElement = (<ReactHighlighter key={element} className={props.className} matchClass={null} matchElement="mark" search={props.search} title={element}>
 							{element}
 						</ReactHighlighter>);
 					} else {
@@ -46,6 +46,10 @@ const Highlighter = (props) => {
 				{children}
 			</span>
 		);
+	}
+
+	if (typeof props.children === 'string') {
+		return <span className={props.className} title={props.children}>{props.children}</span>;
 	}
 
 	return <span className={props.className}>{props.children}</span>;


### PR DESCRIPTION
Fixes issue #1193 

### Additional description
This adds the title attribute for anything that uses `components/utilities/highlighter`. react-highlighter passes along any additional props so this will work for the Search enabled tree as well.

---
### Reviewer checklist
- [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
- [x] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
- [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at snapshot strings.
- [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
- [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
- [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
- [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
