### PR TITLE
DO NOT MERGE: Adds a command for files in an npm package

### DIFF
--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -41,6 +41,7 @@ echo "## Copying the components"
 cp -r .tmp .tmp-amd
 cp -r .tmp .tmp-commonjs
 cp -r .tmp .tmp-es
+cp -r .tmp .tmp-npm
 rm -rf .tmp/
 
 cp -r components .tmp-es/components
@@ -50,13 +51,20 @@ cp -r utilities .tmp-es/utilities
 
 echo "## Transpiling with Babel"
 
+# AMD module transpilation
 NODE_ENV=amd ./node_modules/.bin/babel --plugins transform-es2015-modules-amd .tmp-es/components --out-dir .tmp-amd/components
 cp -r styles .tmp-amd/styles
 ./node_modules/.bin/babel --plugins transform-es2015-modules-amd .tmp-es/icons --out-dir .tmp-amd/icons
 NODE_ENV=amd ./node_modules/.bin/babel --plugins transform-es2015-modules-amd .tmp-es/utilities --out-dir .tmp-amd/utilities
 
-
+# CommonJS module transpilation
 NODE_ENV=commonjs ./node_modules/.bin/babel --plugins transform-es2015-modules-commonjs .tmp-es/components --out-dir .tmp-commonjs/components
 cp -r styles .tmp-commonjs/styles
 ./node_modules/.bin/babel --plugins transform-es2015-modules-commonjs .tmp-es/icons --out-dir .tmp-commonjs/icons
 NODE_ENV=commonjs ./node_modules/.bin/babel --plugins transform-es2015-modules-commonjs .tmp-es/utilities --out-dir .tmp-commonjs/utilities
+
+# "Plain" ES6 style transpilation for npm
+./node_modules/.bin/babel --presets=stage-1,react --no-babelrc .tmp-es/components --out-dir .tmp-npm/components
+cp -r styles .tmp-npm/styles
+./node_modules/.bin/babel --presets=stage-1,react --no-babelrc .tmp-es/icons --out-dir .tmp-npm/icons
+./node_modules/.bin/babel --presets=stage-1,react --no-babelrc .tmp-es/utilities --out-dir .tmp-npm/utilities


### PR DESCRIPTION
Fixes issue #1146 

### Additional description

Please review the output of running "npm run dist" in this PR.  It adds an additional temp directory called `.tmp-npm`.  I intend to publish the npm package from that folder.  In its current state this PR uses Babel to down-compile what is in `.tmp-es` to general ES6.  The idea is that we don't want to force any particular babel presets onto our users, but that we can be fairly sure they're using _some kind of_ JS compiler in their toolchain downstream from this package to target different JS versions (such as ES5 or whatever they want).

---
### Reviewer checklist
- [ ] While the contributor's branch is checked out, run `npm run dist` and compare the generated JS files to the source JSX files.
