### PR TITLE
#1202 - Removed setState call when handling click to set active property

### DIFF
--- a/components/button/index.jsx
+++ b/components/button/index.jsx
@@ -140,17 +140,10 @@ const Button = createReactClass({
 		};
 	},
 
-	getInitialState () {
-		return {
-			active: false
-		};
-	},
-
 	handleClick (event) {
 		if (this.props.onClick) {
 			this.props.onClick(event);
 		}
-		this.setState({ active: !this.state.active });
 	},
 
 	getClassName () {


### PR DESCRIPTION
Fixes issue #1202 

### Additional description
Removing the `active` property from state . since it is not being used. 

---
### Pull Request Review checklist (do not remove)
- [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
- [x] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
- [x] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at snapshot strings.
- [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
- [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
- [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
- [x] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
