### PR TITLE
Run lint fix on commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,15 @@
     "npm": "^3.9.0"
   },
   "lint-staged": {
-    "*.{js,jsx}": "eslint"
+    "*.{js,jsx}": [
+      "./node_modules/.bin/prettier-eslint --write",
+      "git add",
+      "./node_modules/.bin/eslint --max-warnings=0"
+    ],
+    "*.{json,md}": [
+      "./node_modules/.bin/prettier --use-tabs=false --write",
+      "git add"
+    ]
   },
   "scripts": {
     "build-docs": "./node_modules/.bin/babel-node ./scripts/build-docs.js",


### PR DESCRIPTION
- Runs prettier, then eslint fix on staged files before commit, makes eslint error out on commit if warnings exist after lint fix is run.
- Run json and markdown files through prettier, too, on commit.