### PR TITLE
Fix getDefaultProps warning in Tree

### DIFF
--- a/components/navigation/private/item.jsx
+++ b/components/navigation/private/item.jsx
@@ -67,7 +67,7 @@ Item.propTypes = {
 	onSelect: PropTypes.func
 };
 
-Item.getDefaultProps = {
+Item.defaultProps = {
 	isSelected: false
 };
 

--- a/components/tree/private/branch.jsx
+++ b/components/tree/private/branch.jsx
@@ -11,6 +11,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+// ### isFunction
+import isFunction from 'lodash.isfunction';
+
+// ### classNames
+import classNames from 'classnames';
+
+// ### shortid
+import shortid from 'shortid';
+
 import Button from '../../button';
 
 // Child components
@@ -18,17 +27,8 @@ import Item from './item';
 
 import Highlighter from '../../utilities/highlighter';
 
-// ### isFunction
-import isFunction from 'lodash.isfunction';
-
 // ### Event Helpers
 import EventUtil from '../../../utilities/event';
-
-// ### classNames
-import classNames from 'classnames';
-
-// ### shortid
-import shortid from 'shortid';
 
 // ## Constants
 import { TREE_BRANCH } from '../../../utilities/constants';
@@ -185,6 +185,7 @@ const renderBranch = (children, props) => {
 					}}
 				/>
 				{/* eslint-disable no-script-url */}
+				{/* eslint-disable jsx-a11y/no-interactive-element-to-noninteractive-role */}
 				<a
 					id={`${props.htmlId}__label`}
 					href="javascript:void(0)"

--- a/components/tree/private/branch.jsx
+++ b/components/tree/private/branch.jsx
@@ -185,10 +185,10 @@ const renderBranch = (children, props) => {
 					}}
 				/>
 				{/* eslint-disable no-script-url */}
-				{/* eslint-disable jsx-a11y/no-interactive-element-to-noninteractive-role */}
 				<a
 					id={`${props.htmlId}__label`}
 					href="javascript:void(0)"
+					// eslint-disable-next-line jsx-a11y/no-interactive-element-to-noninteractive-role
 					role="presentation"
 					className="slds-truncate"
 				>

--- a/components/tree/private/branch.jsx
+++ b/components/tree/private/branch.jsx
@@ -373,7 +373,7 @@ Branch.propTypes = {
 	treeIndex: PropTypes.string
 };
 
-Branch.getDefaultProps = {
+Branch.defaultProps = {
 	level: 0,
 	label: '',
 	treeIndex: ''

--- a/components/tree/private/item.jsx
+++ b/components/tree/private/item.jsx
@@ -72,9 +72,9 @@ const Item = (props) => {
 					disabled
 				/>
 				{/* eslint-disable no-script-url */}
-				{/* eslint-disable jsx-a11y/no-interactive-element-to-noninteractive-role */}
 				<a
 					href="javascript:void(0)"
+					// eslint-disable-next-line jsx-a11y/no-interactive-element-to-noninteractive-role
 					role="presentation"
 					className="slds-truncate"
 				>

--- a/components/tree/private/item.jsx
+++ b/components/tree/private/item.jsx
@@ -125,7 +125,7 @@ Item.propTypes = {
 	treeIndex: PropTypes.string
 };
 
-Item.getDefaultProps = {
+Item.defaultProps = {
 	selected: false
 };
 

--- a/components/tree/private/item.jsx
+++ b/components/tree/private/item.jsx
@@ -11,15 +11,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import Button from '../../button';
-
 // ### classNames
 import classNames from 'classnames';
 
-import Highlighter from '../../utilities/highlighter';
-
 // ### isFunction
 import isFunction from 'lodash.isfunction';
+
+import Button from '../../button';
+
+import Highlighter from '../../utilities/highlighter';
 
 // ### Event Helpers
 import EventUtil from '../../../utilities/event';
@@ -72,6 +72,7 @@ const Item = (props) => {
 					disabled
 				/>
 				{/* eslint-disable no-script-url */}
+				{/* eslint-disable jsx-a11y/no-interactive-element-to-noninteractive-role */}
 				<a
 					href="javascript:void(0)"
 					role="presentation"


### PR DESCRIPTION
Fixed `Warning: getDefaultProps is only used on classic React.createClass definitions. Use a static property named "defaultProps" instead`