### PR TITLE
Fix issue where SLDSTree chevron doesn't point down on expanded branch

### DIFF
--- a/components/tree/private/branch.jsx
+++ b/components/tree/private/branch.jsx
@@ -175,7 +175,7 @@ const renderBranch = (children, props) => {
 				{/* eslint-enable jsx-a11y/no-static-element-interactions */}
 				<Button
 					assistiveText="Toggle"
-					iconName="chevronright"
+					iconName={props.node.expanded ? 'chevrondown' : 'chevronright'}
 					iconSize="small"
 					variant="icon"
 					className="slds-m-right--small"


### PR DESCRIPTION
This fix addresses a bug where the Tree component's chevrons do not point down when the branch is expanded.

It seems the line was (accidentally?) changed sometime recently, so I've just passed the original `iconName` expression back into the chevron Button component.

---

### Pull Request Review checklist (do not remove)

* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at snapshot strings.
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
