### PR TITLE
Add Trailing comma to iterables

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -173,8 +173,6 @@
     // TODO: Should be removed
     "react/no-unused-state": "off",
     // TODO: Should be removed
-    "react/jsx-curly-brace-presence": "off",
-    // TODO: Should be removed
     "react/prop-types": "off",
     // TODO: Should be removed
     "react/prefer-es6-class": "off",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -130,7 +130,7 @@
     "class-methods-use-this": "warn",
     // We are open to changing this to always use a trailing comma,
     // in order to make re-sorting easier
-    "comma-dangle": [2, "never"],
+    "comma-dangle": [2, "only-multiline"],
     // TODO: Should be removed
     "func-names": "off",
     // May consider removing

--- a/components/accordion/__docs__/site-stories.js
+++ b/components/accordion/__docs__/site-stories.js
@@ -4,7 +4,7 @@
 /* eslint-disable global-require */
 
 const siteStories = [
-	require('raw-loader!@salesforce/design-system-react/components/accordion/__examples__/base.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/accordion/__examples__/base.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/accordion/__examples__/base.jsx
+++ b/components/accordion/__examples__/base.jsx
@@ -13,19 +13,19 @@ class Example extends React.Component {
 				{
 					id: '1',
 					summary: 'Accordion Summary',
-					details: 'Accordion details - A'
+					details: 'Accordion details - A',
 				},
 				{
 					id: '2',
 					summary: 'Accordion Summary',
-					details: 'Accordion details - B'
+					details: 'Accordion details - B',
 				},
 				{
 					id: '3',
 					summary: 'Accordion Summary',
-					details: 'Accordion details - C'
-				}
-			]
+					details: 'Accordion details - C',
+				},
+			],
 		};
 	}
 
@@ -43,7 +43,7 @@ class Example extends React.Component {
 					if (option.label === 'delete') {
 						this.setState((state) => ({
 							...state,
-							items: state.items.filter((item) => item.id !== selectedItem.id)
+							items: state.items.filter((item) => item.id !== selectedItem.id),
 						}));
 					} else if (console) {
 						console.log('onSelect', event, option);
@@ -52,16 +52,16 @@ class Example extends React.Component {
 				options={[
 					{
 						label: 'delete',
-						value: 'A0'
+						value: 'A0',
 					},
 					{
 						label: 'redo',
-						value: 'B0'
+						value: 'B0',
 					},
 					{
 						label: 'activate',
-						value: 'C0'
-					}
+						value: 'C0',
+					},
 				]}
 				iconSize="x-small"
 			/>
@@ -73,8 +73,8 @@ class Example extends React.Component {
 			...state,
 			expandedPanels: {
 				...state.expandedPanels,
-				[data.id]: !state.expandedPanels[data.id]
-			}
+				[data.id]: !state.expandedPanels[data.id],
+			},
 		}));
 		if (this.props.action) {
 			const dataAsArray = Object.keys(data).map((id) => data[id]);

--- a/components/accordion/__examples__/snapshot/base-open.jsx
+++ b/components/accordion/__examples__/snapshot/base-open.jsx
@@ -12,14 +12,14 @@ export default class Example extends React.Component {
 				{
 					id: '1',
 					summary: 'Accordion Summary',
-					details: 'Accordion details - A'
+					details: 'Accordion details - A',
 				},
 				{
 					id: '2',
 					summary: 'Accordion Summary',
-					details: 'Accordion details - B'
-				}
-			]
+					details: 'Accordion details - B',
+				},
+			],
 		};
 	}
 
@@ -28,8 +28,8 @@ export default class Example extends React.Component {
 			...state,
 			expandedPanels: {
 				...state.expandedPanels,
-				[data.id]: !state.expandedPanels[data.id]
-			}
+				[data.id]: !state.expandedPanels[data.id],
+			},
 		}));
 		console.log('onClick', data);
 	}

--- a/components/accordion/__tests__/accordion.browser-test.jsx
+++ b/components/accordion/__tests__/accordion.browser-test.jsx
@@ -11,7 +11,7 @@ import { mount } from 'enzyme';
 
 import {
 	createMountNode,
-	destroyMountNode
+	destroyMountNode,
 } from '../../../tests/enzyme-helpers';
 
 import Accordion from '../../accordion';
@@ -41,19 +41,19 @@ class AccordionExample extends React.Component {
 				{
 					id: '1',
 					summary: 'Accordion Summary',
-					details: 'Accordion details - A'
+					details: 'Accordion details - A',
 				},
 				{
 					id: '2',
 					summary: 'Accordion Summary',
-					details: 'Accordion details - B'
+					details: 'Accordion details - B',
 				},
 				{
 					id: '3',
 					summary: 'Accordion Summary',
-					details: 'Accordion details - C'
-				}
-			]
+					details: 'Accordion details - C',
+				},
+			],
 		};
 	}
 
@@ -71,7 +71,7 @@ class AccordionExample extends React.Component {
 					if (option.label === 'delete') {
 						this.setState((state) => ({
 							...state,
-							items: state.items.filter((item) => item.id !== selectedItem.id)
+							items: state.items.filter((item) => item.id !== selectedItem.id),
 						}));
 					} else if (console) {
 						console.log('onSelect', event, option);
@@ -80,16 +80,16 @@ class AccordionExample extends React.Component {
 				options={[
 					{
 						label: 'delete',
-						value: 'A0'
+						value: 'A0',
 					},
 					{
 						label: 'redo',
-						value: 'B0'
+						value: 'B0',
 					},
 					{
 						label: 'activate',
-						value: 'C0'
-					}
+						value: 'C0',
+					},
 				]}
 				iconSize="x-small"
 			/>
@@ -101,8 +101,8 @@ class AccordionExample extends React.Component {
 			...state,
 			expandedPanels: {
 				...state.expandedPanels,
-				[id]: !state.expandedPanels[id]
-			}
+				[id]: !state.expandedPanels[id],
+			},
 		}));
 	}
 
@@ -156,7 +156,7 @@ describe('Accordion', function () {
 
 		it('renders `panelContentActions` component, if passed', () => {
 			wrapper = mount(<AccordionExample />, {
-				attachTo: mountNode
+				attachTo: mountNode,
 			});
 			const panelContentActions = wrapper.find(
 				'div .slds-dropdown-trigger .slds-dropdown-trigger--click'

--- a/components/accordion/__tests__/accordion.snapshot-test.jsx
+++ b/components/accordion/__tests__/accordion.snapshot-test.jsx
@@ -7,11 +7,11 @@ import SnapshotBaseOpen from '../__examples__/snapshot/base-open';
 testDOMandHTML({
 	name: 'Base',
 	test,
-	Component: SnapshotBase
+	Component: SnapshotBase,
 });
 
 testDOMandHTML({
 	name: 'Base Open',
 	test,
-	Component: SnapshotBaseOpen
+	Component: SnapshotBaseOpen,
 });

--- a/components/accordion/index.jsx
+++ b/components/accordion/index.jsx
@@ -19,7 +19,7 @@ const propTypes = {
 	className: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * HTML id for accordion component. _Tested with snapshot testing._
@@ -37,7 +37,7 @@ const propTypes = {
 	 * </SLDSAccordion>
 	 * ```
 	 */
-	children: PropTypes.node.isRequired
+	children: PropTypes.node.isRequired,
 };
 
 /**

--- a/components/accordion/panel.jsx
+++ b/components/accordion/panel.jsx
@@ -41,7 +41,7 @@ const propTypes = {
 	/**
 	 * HTML title attribute. _Tested with snapshot testing._
 	 */
-	title: PropTypes.string
+	title: PropTypes.string,
 };
 
 const AccordionPanel = ({
@@ -51,12 +51,12 @@ const AccordionPanel = ({
 	panelContentActions,
 	summary,
 	title,
-	onTogglePanel
+	onTogglePanel,
 }) => (
 	<li className="slds-accordion__list-item">
 		<section
 			className={classNames('slds-accordion__section', {
-				'slds-is-open': expanded
+				'slds-is-open': expanded,
 			})}
 		>
 			<div className="slds-accordion__summary">

--- a/components/alert/__docs__/site-stories.js
+++ b/components/alert/__docs__/site-stories.js
@@ -8,7 +8,7 @@ const siteStories = [
 	require('raw-loader!@salesforce/design-system-react/components/alert/__examples__/warning.jsx'),
 	require('raw-loader!@salesforce/design-system-react/components/alert/__examples__/offline.jsx'),
 	require('raw-loader!@salesforce/design-system-react/components/alert/__examples__/error.jsx'),
-	require('raw-loader!@salesforce/design-system-react/components/alert/__examples__/dismissable.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/alert/__examples__/dismissable.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/alert/__examples__/close-alert.jsx
+++ b/components/alert/__examples__/close-alert.jsx
@@ -10,7 +10,7 @@ class Example extends React.Component {
 		super(props);
 
 		this.state = {
-			isOpen: false
+			isOpen: false,
 		};
 	}
 
@@ -31,7 +31,7 @@ class Example extends React.Component {
 								icon={<Icon category="utility" name="user" />}
 								labels={{
 									heading: 'Logged in as John Smith (johnsmith@acme.com).',
-									headingLink: 'Log out'
+									headingLink: 'Log out',
 								}}
 								onClickHeadingLink={() => {
 									console.log('Link clicked.');

--- a/components/alert/__examples__/custom-class-name.jsx
+++ b/components/alert/__examples__/custom-class-name.jsx
@@ -14,7 +14,7 @@ class Example extends React.Component {
 						icon={<Icon category="utility" name="user" />}
 						labels={{
 							heading: 'Logged in as John Smith (johnsmith@acme.com).',
-							headingLink: 'Log out'
+							headingLink: 'Log out',
 						}}
 						onClickHeadingLink={() => {
 							console.log('Link clicked.');

--- a/components/alert/__examples__/dismissable.jsx
+++ b/components/alert/__examples__/dismissable.jsx
@@ -10,7 +10,7 @@ class Example extends React.Component {
 		super(props);
 
 		this.state = {
-			isOpen: false
+			isOpen: false,
 		};
 	}
 
@@ -23,7 +23,7 @@ class Example extends React.Component {
 						icon={<Icon category="utility" name="user" />}
 						labels={{
 							heading: 'Logged in as John Smith (johnsmith@acme.com).',
-							headingLink: 'Log out'
+							headingLink: 'Log out',
 						}}
 						onClickHeadingLink={() => {
 							console.log('Link clicked.');

--- a/components/alert/__examples__/error.jsx
+++ b/components/alert/__examples__/error.jsx
@@ -14,7 +14,7 @@ class Example extends React.Component {
 						labels={{
 							heading:
 								'Your browser is currently not supported. Your Salesforce may be degraded.',
-							headingLink: 'More Information'
+							headingLink: 'More Information',
 						}}
 						onClickHeadingLink={() => {
 							console.log('Link clicked.');

--- a/components/alert/__examples__/info.jsx
+++ b/components/alert/__examples__/info.jsx
@@ -13,7 +13,7 @@ class Example extends React.Component {
 						icon={<Icon category="utility" name="user" />}
 						labels={{
 							heading: 'Logged in as John Smith (johnsmith@acme.com).',
-							headingLink: 'Log out'
+							headingLink: 'Log out',
 						}}
 						onClickHeadingLink={() => {
 							console.log('Link clicked.');

--- a/components/alert/__examples__/offline.jsx
+++ b/components/alert/__examples__/offline.jsx
@@ -12,7 +12,7 @@ class Example extends React.Component {
 					<Alert
 						labels={{
 							heading: 'You are in offline mode.',
-							headingLink: 'More information'
+							headingLink: 'More information',
 						}}
 						onClickHeadingLink={() => {
 							console.log('Link clicked.');

--- a/components/alert/__examples__/warning.jsx
+++ b/components/alert/__examples__/warning.jsx
@@ -13,7 +13,7 @@ class Example extends React.Component {
 						labels={{
 							heading:
 								'Your browser is outdated. Your Salesforce experience may be degraded.',
-							headingLink: 'More Information'
+							headingLink: 'More Information',
 						}}
 						onClickHeadingLink={() => {
 							console.log('Link clicked.');

--- a/components/alert/__tests__/alert.browser-test.jsx
+++ b/components/alert/__tests__/alert.browser-test.jsx
@@ -6,7 +6,7 @@ import chai, { expect } from 'chai';
 import chaiEnzyme from 'chai-enzyme';
 import {
 	mountComponent,
-	unmountComponent
+	unmountComponent,
 } from '../../../tests/enzyme-helpers';
 
 chai.use(chaiEnzyme());
@@ -21,7 +21,7 @@ class DemoComponent extends Component {
 		super(props);
 
 		this.state = {
-			isOpen: true
+			isOpen: true,
 		};
 	}
 
@@ -36,7 +36,7 @@ class DemoComponent extends Component {
 								icon={<Icon category="utility" name="user" />}
 								labels={{
 									heading: 'Logged in as John Smith (johnsmith@acme.com).',
-									headingLink: 'Log out'
+									headingLink: 'Log out',
 								}}
 								onClickHeadingLink={this.props.onClickHeadingLink}
 								onRequestClose={() => {

--- a/components/alert/__tests__/alert.snapshot-test.jsx
+++ b/components/alert/__tests__/alert.snapshot-test.jsx
@@ -11,35 +11,35 @@ import CustomClassNames from '../__examples__/custom-class-name';
 testDOMandHTML({
 	name: 'Alert Info',
 	test,
-	Component: Info
+	Component: Info,
 });
 
 testDOMandHTML({
 	name: 'Alert Warning',
 	test,
-	Component: Warning
+	Component: Warning,
 });
 
 testDOMandHTML({
 	name: 'Alert Error',
 	test,
-	Component: ErrorAlert
+	Component: ErrorAlert,
 });
 
 testDOMandHTML({
 	name: 'Alert Offline',
 	test,
-	Component: Offline
+	Component: Offline,
 });
 
 testDOMandHTML({
 	name: 'Alert Dismissable',
 	test,
-	Component: Dismissable
+	Component: Dismissable,
 });
 
 testDOMandHTML({
 	name: 'Alert Custom Class Name',
 	test,
-	Component: CustomClassNames
+	Component: CustomClassNames,
 });

--- a/components/alert/container.jsx
+++ b/components/alert/container.jsx
@@ -15,12 +15,12 @@ const propTypes = {
 	className: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * Alert components
 	 */
-	children: PropTypes.node
+	children: PropTypes.node,
 };
 
 /**

--- a/components/alert/index.jsx
+++ b/components/alert/index.jsx
@@ -24,7 +24,7 @@ const propTypes = {
 	 * _Tested with snapshot testing._
 	 */
 	assistiveText: shape({
-		closeButton: PropTypes.oneOfType([PropTypes.string, PropTypes.node])
+		closeButton: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
 	}),
 	/**
 	 * CSS classes to be added to tag with `.slds-notify_alert`. Uses `classNames` [API](https://github.com/JedWatson/classnames).
@@ -33,7 +33,7 @@ const propTypes = {
 	className: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * Allows user to click a close button. Banners should be dismissible only if they communicate future impact to the system,
@@ -60,7 +60,7 @@ const propTypes = {
 	 */
 	labels: shape({
 		heading: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-		headingLink: PropTypes.oneOfType([PropTypes.string, PropTypes.node])
+		headingLink: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
 	}),
 	/**
 	 * Triggered by link. _Tested with Mocha testing._
@@ -73,15 +73,15 @@ const propTypes = {
 	/**
 	 * The type of alert. _Tested with snapshot testing._
 	 */
-	variant: PropTypes.oneOf(['error', 'info', 'offline', 'warning']).isRequired
+	variant: PropTypes.oneOf(['error', 'info', 'offline', 'warning']).isRequired,
 };
 
 const defaultProps = {
 	assistiveText: {
-		closeButton: 'Close'
+		closeButton: 'Close',
 	},
 	labels: {},
-	variant: 'info'
+	variant: 'info',
 };
 
 /**
@@ -92,7 +92,7 @@ class Alert extends React.Component {
 	constructor (props) {
 		super(props);
 		this.state = {
-			isInitialRender: true
+			isInitialRender: true,
 		};
 	}
 
@@ -133,14 +133,14 @@ class Alert extends React.Component {
 			info: 'info',
 			warning: 'warning',
 			error: 'error',
-			offline: 'offline'
+			offline: 'offline',
 		};
 
 		const defaultIcons = {
 			info: <Icon category="utility" name="info" />,
 			offline: <Icon category="utility" name="offline" />,
 			warning: <Icon category="utility" name="warning" />,
-			error: <Icon category="utility" name="error" />
+			error: <Icon category="utility" name="error" />,
 		};
 
 		let icon = this.props.icon
@@ -158,7 +158,7 @@ class Alert extends React.Component {
 		const clonedIcon = React.cloneElement(icon, {
 			containerClassName: 'slds-m-right--x-small',
 			inverse: true,
-			size: 'x-small'
+			size: 'x-small',
 		});
 
 		/* eslint-disable no-script-url */
@@ -170,7 +170,7 @@ class Alert extends React.Component {
 						'slds-theme_info': this.props.variant === 'info',
 						'slds-theme_warning': this.props.variant === 'warning',
 						'slds-theme_error': this.props.variant === 'error',
-						'slds-theme_offline': this.props.variant === 'offline'
+						'slds-theme_offline': this.props.variant === 'offline',
 					},
 					this.props.className
 				)}

--- a/components/app-launcher/__docs__/site-stories.js
+++ b/components/app-launcher/__docs__/site-stories.js
@@ -4,7 +4,7 @@
 /* eslint-disable global-require */
 
 const siteStories = [
-	require('raw-loader!@salesforce/design-system-react/components/app-launcher/__examples__/default.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/app-launcher/__examples__/default.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/app-launcher/__docs__/storybook-stories.jsx
+++ b/components/app-launcher/__docs__/storybook-stories.jsx
@@ -23,13 +23,13 @@ SLDSSettings.setAppElement('#root'); // used by Modal component
 const standardTileDemoStyles = {
 	width: '20rem',
 	paddingLeft: '.5rem',
-	paddingRight: '.5rem'
+	paddingRight: '.5rem',
 };
 
 const smallTileDemoStyles = {
 	width: '6rem',
 	paddingLeft: '.5rem',
-	paddingRight: '.5rem'
+	paddingRight: '.5rem',
 };
 
 const DemoAppLauncherTile = createReactClass({
@@ -37,7 +37,7 @@ const DemoAppLauncherTile = createReactClass({
 
 	propTypes: {
 		search: PropTypes.string,
-		size: PropTypes.string
+		size: PropTypes.string,
 	},
 
 	render () {
@@ -52,7 +52,7 @@ const DemoAppLauncherTile = createReactClass({
 				size={this.props.size}
 			/>
 		);
-	}
+	},
 });
 
 const DemoAppLauncherSmallTile = createReactClass({
@@ -67,7 +67,7 @@ const DemoAppLauncherSmallTile = createReactClass({
 				onClick={action('Tiny tile clicked!')}
 			/>
 		);
-	}
+	},
 });
 
 const DemoAppLauncherTileWithIconNode = createReactClass({
@@ -75,7 +75,7 @@ const DemoAppLauncherTileWithIconNode = createReactClass({
 
 	propTypes: {
 		search: PropTypes.string,
-		size: PropTypes.string
+		size: PropTypes.string,
 	},
 
 	render () {
@@ -92,7 +92,7 @@ const DemoAppLauncherTileWithIconNode = createReactClass({
 				size={this.props.size}
 			/>
 		);
-	}
+	},
 });
 
 const DemoAppLauncherTileWithIconText = createReactClass({
@@ -100,7 +100,7 @@ const DemoAppLauncherTileWithIconText = createReactClass({
 
 	propTypes: {
 		search: PropTypes.string,
-		size: PropTypes.string
+		size: PropTypes.string,
 	},
 
 	render () {
@@ -114,7 +114,7 @@ const DemoAppLauncherTileWithIconText = createReactClass({
 				size={this.props.size}
 			/>
 		);
-	}
+	},
 });
 
 const DemoAppLauncherTileWithTruncatedText = createReactClass({
@@ -122,7 +122,7 @@ const DemoAppLauncherTileWithTruncatedText = createReactClass({
 
 	propTypes: {
 		search: PropTypes.string,
-		size: PropTypes.string
+		size: PropTypes.string,
 	},
 
 	render () {
@@ -136,7 +136,7 @@ const DemoAppLauncherTileWithTruncatedText = createReactClass({
 				size={this.props.size}
 			/>
 		);
-	}
+	},
 });
 
 const DemoAppLauncherTileWithDescriptionHeading = createReactClass({
@@ -144,12 +144,12 @@ const DemoAppLauncherTileWithDescriptionHeading = createReactClass({
 
 	propTypes: {
 		search: PropTypes.string,
-		size: PropTypes.string
+		size: PropTypes.string,
 	},
 
 	getDefaultProps () {
 		return {
-			search: 'journey'
+			search: 'journey',
 		};
 	},
 
@@ -165,7 +165,7 @@ const DemoAppLauncherTileWithDescriptionHeading = createReactClass({
 				size={this.props.size}
 			/>
 		);
-	}
+	},
 });
 
 const DemoAppLauncherTileWithSearchText = createReactClass({
@@ -173,12 +173,12 @@ const DemoAppLauncherTileWithSearchText = createReactClass({
 
 	propTypes: {
 		search: PropTypes.string,
-		size: PropTypes.string
+		size: PropTypes.string,
 	},
 
 	getDefaultProps () {
 		return {
-			search: 'Call'
+			search: 'Call',
 		};
 	},
 
@@ -189,7 +189,7 @@ const DemoAppLauncherTileWithSearchText = createReactClass({
 				size={this.props.size}
 			/>
 		);
-	}
+	},
 });
 
 const DemoAppLauncherSection = createReactClass({
@@ -216,7 +216,7 @@ const DemoAppLauncherSection = createReactClass({
 				</AppLauncherSection>
 			</div>
 		);
-	}
+	},
 });
 
 const DemoAppLauncherSectionWithSmallTiles = createReactClass({
@@ -242,7 +242,7 @@ const DemoAppLauncherSectionWithSmallTiles = createReactClass({
 				</AppLauncherSection>
 			</div>
 		);
-	}
+	},
 });
 
 const DemoAppLauncher = createReactClass({
@@ -252,7 +252,7 @@ const DemoAppLauncher = createReactClass({
 		return {
 			search: '',
 			appLauncherOpen: this.props.isOpen || false, // eslint-disable-line react/prop-types
-			allItemsSectionIsOpen: false
+			allItemsSectionIsOpen: false,
 		};
 	},
 
@@ -339,7 +339,7 @@ const DemoAppLauncher = createReactClass({
 				</GlobalNavigationBarRegion>
 			</GlobalNavigationBar>
 		);
-	}
+	},
 });
 
 const DemoAppLauncherNoHeaderButton = createReactClass({
@@ -349,7 +349,7 @@ const DemoAppLauncherNoHeaderButton = createReactClass({
 		return {
 			search: '',
 			appLauncherOpen: false,
-			allItemsSectionIsOpen: false
+			allItemsSectionIsOpen: false,
 		};
 	},
 
@@ -395,7 +395,7 @@ const DemoAppLauncherNoHeaderButton = createReactClass({
 				</GlobalNavigationBarRegion>
 			</GlobalNavigationBar>
 		);
-	}
+	},
 });
 
 const DemoAppLauncherNoSearch = createReactClass({
@@ -404,7 +404,7 @@ const DemoAppLauncherNoSearch = createReactClass({
 	getInitialState () {
 		return {
 			appLauncherOpen: false,
-			allItemsSectionIsOpen: false
+			allItemsSectionIsOpen: false,
 		};
 	},
 
@@ -440,7 +440,7 @@ const DemoAppLauncherNoSearch = createReactClass({
 				</GlobalNavigationBarRegion>
 			</GlobalNavigationBar>
 		);
-	}
+	},
 });
 
 const DemoAppLauncherWithSeveralSections = createReactClass({
@@ -499,7 +499,7 @@ const DemoAppLauncherWithSeveralSections = createReactClass({
 				</GlobalNavigationBarRegion>
 			</GlobalNavigationBar>
 		);
-	}
+	},
 });
 
 storiesOf(APP_LAUNCHER, module)

--- a/components/app-launcher/__examples__/default.jsx
+++ b/components/app-launcher/__examples__/default.jsx
@@ -68,7 +68,7 @@ const Example = createReactClass({
 				</GlobalNavigationBar>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/app-launcher/__tests__/app-launcher.browser-test.jsx
+++ b/components/app-launcher/__tests__/app-launcher.browser-test.jsx
@@ -23,11 +23,11 @@ describe('SLDS APP LAUNCHER *******************************************', () => 
 	const handles = {
 		appLauncher: null,
 		appLauncherIcon: null,
-		modal: null
+		modal: null,
 	};
 
 	const defaultAppLauncherProps = {
-		isOpen: true
+		isOpen: true,
 	};
 
 	const createAppLauncher = (props) =>
@@ -97,7 +97,7 @@ describe('SLDS APP LAUNCHER *******************************************', () => 
 				modalHeaderButton: <Button label="App Exchange" />,
 				onClose,
 				search: <Search assistiveText="Find an app" />,
-				title: 'App Launcher!'
+				title: 'App Launcher!',
 			});
 		});
 
@@ -169,7 +169,7 @@ describe('SLDS APP LAUNCHER *******************************************', () => 
 
 			mountAppLauncher({
 				triggerAssistiveText: 'Custom Icon Assistive Text',
-				triggerOnClick
+				triggerOnClick,
 			});
 		});
 
@@ -194,7 +194,7 @@ describe('SLDS APP LAUNCHER *******************************************', () => 
 						<span className="slds-r6" />,
 						<span className="slds-r7" />,
 						<span className="slds-r8" />,
-						<span className="slds-r9" />
+						<span className="slds-r9" />,
 					])
 			).to.equal(true);
 		});

--- a/components/app-launcher/__tests__/section.browser-test.jsx
+++ b/components/app-launcher/__tests__/section.browser-test.jsx
@@ -15,16 +15,16 @@ const { Simulate } = TestUtils;
 
 describe('SLDS APP LAUNCHER SECTION *******************************************', () => {
 	const handles = {
-		section: null
+		section: null,
 	};
 
 	const defaultSectionProps = {
-		title: 'All Items'
+		title: 'All Items',
 	};
 
 	const defaultChildren = [
 		<AppLauncherTile key="asdf" title="Marketing Cloud" />,
-		<AppLauncherTile key="qwer" title="Support Cloud" />
+		<AppLauncherTile key="qwer" title="Support Cloud" />,
 	];
 
 	const createSection = (props, children) =>
@@ -52,7 +52,7 @@ describe('SLDS APP LAUNCHER SECTION *******************************************'
 				collapseSectionAssistiveText: 'Collapse Section',
 				onToggleClick,
 				title: 'ALL THE ITEMS!',
-				toggleable: true
+				toggleable: true,
 			});
 		});
 
@@ -120,7 +120,7 @@ describe('SLDS APP LAUNCHER SECTION *******************************************'
 		beforeEach(() => {
 			mountSection({
 				toggleable: true,
-				isOpen: false
+				isOpen: false,
 			});
 		});
 

--- a/components/app-launcher/__tests__/tile.browser-test.jsx
+++ b/components/app-launcher/__tests__/tile.browser-test.jsx
@@ -22,11 +22,11 @@ describe('SLDS APP LAUNCHER TILE *******************************************', (
 		icon: null,
 		more: null,
 		tile: null,
-		title: null
+		title: null,
 	};
 
 	const defaultTileProps = {
-		title: 'Marketing Cloud'
+		title: 'Marketing Cloud',
 	};
 
 	const createTile = (props) =>
@@ -69,7 +69,7 @@ describe('SLDS APP LAUNCHER TILE *******************************************', (
 				href: 'https://www.marketingcloud.com/',
 				onClick,
 				search: 'upport',
-				title: 'Support Cloud'
+				title: 'Support Cloud',
 			});
 		});
 
@@ -166,7 +166,7 @@ describe('SLDS APP LAUNCHER TILE *******************************************', (
 				title: 'Call Center',
 				description,
 				moreLabel,
-				search: 'enter'
+				search: 'enter',
 			});
 		});
 
@@ -212,7 +212,7 @@ describe('SLDS APP LAUNCHER TILE *******************************************', (
 			mountTile({
 				title: 'Call Center',
 				iconText: 'CC',
-				description: 'Call center and contact center.'
+				description: 'Call center and contact center.',
 			});
 		});
 
@@ -238,7 +238,7 @@ describe('SLDS APP LAUNCHER TILE *******************************************', (
 			mountTile({
 				description: 'Call center and contact center.',
 				iconNode,
-				title: 'Call Center'
+				title: 'Call Center',
 			});
 		});
 
@@ -264,7 +264,7 @@ describe('SLDS APP LAUNCHER TILE *******************************************', (
 				iconText: 'SC',
 				size: 'small',
 				description: 'This is the app description',
-				search: 'upport'
+				search: 'upport',
 			});
 		});
 

--- a/components/app-launcher/index.jsx
+++ b/components/app-launcher/index.jsx
@@ -82,7 +82,7 @@ const AppLauncher = createReactClass({
 		modalClassName: PropTypes.oneOfType([
 			PropTypes.array,
 			PropTypes.object,
-			PropTypes.string
+			PropTypes.string,
 		]),
 		/**
 		 * Button that exists in the upper right hand corner of the App Launcher modal
@@ -115,19 +115,19 @@ const AppLauncher = createReactClass({
 		/**
 		 * Callback when the App Launcher icon is clicked
 		 */
-		triggerOnClick: PropTypes.func
+		triggerOnClick: PropTypes.func,
 	},
 
 	getDefaultProps () {
 		return {
 			triggerAssistiveText: 'Open App Launcher',
-			title: 'App Launcher'
+			title: 'App Launcher',
 		};
 	},
 
 	getInitialState () {
 		return {
-			isOpen: false
+			isOpen: false,
 		};
 	},
 
@@ -261,7 +261,7 @@ const AppLauncher = createReactClass({
 				) : null}
 			</div>
 		);
-	}
+	},
 });
 
 export default AppLauncher;

--- a/components/app-launcher/section.jsx
+++ b/components/app-launcher/section.jsx
@@ -58,18 +58,18 @@ const AppLauncherSection = createReactClass({
 		/**
 		 * Callback for when section is toggled. Passes "isOpen" bool. Forces `toggleable` to true
 		 */
-		onToggleClick: PropTypes.func
+		onToggleClick: PropTypes.func,
 	},
 
 	getDefaultProps () {
 		return {
-			collapseSectionAssistiveText: 'Toggle visibility of section'
+			collapseSectionAssistiveText: 'Toggle visibility of section',
 		};
 	},
 
 	getInitialState () {
 		return {
-			isOpen: true
+			isOpen: true,
 		};
 	},
 
@@ -126,7 +126,7 @@ const AppLauncherSection = createReactClass({
 				</div>
 			</div>
 		);
-	}
+	},
 });
 
 export default AppLauncherSection;

--- a/components/app-launcher/tile.jsx
+++ b/components/app-launcher/tile.jsx
@@ -54,7 +54,7 @@ const AppLauncherTile = (props) => {
 		>
 			<div
 				className={classNames('slds-app-launcher__tile-figure', {
-					'slds-app-launcher__tile-figure--small': smallTile
+					'slds-app-launcher__tile-figure--small': smallTile,
 				})}
 			>
 				{props.iconNode || (
@@ -130,7 +130,7 @@ AppLauncherTile.displayName = APP_LAUNCHER_TILE;
 AppLauncherTile.defaultProps = {
 	href: 'javascript:void(0);', // eslint-disable-line no-script-url
 	size: 'default',
-	moreLabel: ' More'
+	moreLabel: ' More',
 };
 
 // ### Prop Types
@@ -165,7 +165,7 @@ AppLauncherTile.propTypes = {
 	className: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * Function that will be executed when clicking on a tile
@@ -182,7 +182,7 @@ AppLauncherTile.propTypes = {
 	/**
 	 * Text used to highlight content in app tiles
 	 */
-	search: PropTypes.string
+	search: PropTypes.string,
 	// TODO: allow for passing iconBackgroundColor
 	// TODO: add Highlighter to Truncate text (https://github.com/ShinyChang/React-Text-Truncate/issues/32)
 };

--- a/components/avatar/__docs__/site-stories.js
+++ b/components/avatar/__docs__/site-stories.js
@@ -8,7 +8,7 @@ const siteStories = [
 	require('raw-loader!@salesforce/design-system-react/components/avatar/__examples__/user-initials.jsx'),
 	require('raw-loader!@salesforce/design-system-react/components/avatar/__examples__/user-icon.jsx'),
 	require('raw-loader!@salesforce/design-system-react/components/avatar/__examples__/entity-initials.jsx'),
-	require('raw-loader!@salesforce/design-system-react/components/avatar/__examples__/entity-icon.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/avatar/__examples__/entity-icon.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/avatar/__examples__/base.jsx
+++ b/components/avatar/__examples__/base.jsx
@@ -16,7 +16,7 @@ const Example = createReactClass({
 				/>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/avatar/__examples__/entity-icon.jsx
+++ b/components/avatar/__examples__/entity-icon.jsx
@@ -16,7 +16,7 @@ const Example = createReactClass({
 				/>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/avatar/__examples__/entity-initials.jsx
+++ b/components/avatar/__examples__/entity-initials.jsx
@@ -12,7 +12,7 @@ const Example = createReactClass({
 				<Avatar variant="entity" label="Acme Communications" size="medium" />
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/avatar/__examples__/user-icon.jsx
+++ b/components/avatar/__examples__/user-icon.jsx
@@ -16,7 +16,7 @@ const Example = createReactClass({
 				/>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/avatar/__examples__/user-initials.jsx
+++ b/components/avatar/__examples__/user-initials.jsx
@@ -12,7 +12,7 @@ const Example = createReactClass({
 				<Avatar variant="user" label="Annie Wilson" size="medium" />
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/avatar/__tests__/avatar.browser-test.jsx
+++ b/components/avatar/__tests__/avatar.browser-test.jsx
@@ -7,7 +7,7 @@ import chai, { expect } from 'chai';
 import chaiEnzyme from 'chai-enzyme';
 import {
 	createMountNode,
-	destroyMountNode
+	destroyMountNode,
 } from '../../../tests/enzyme-helpers';
 
 chai.use(chaiEnzyme());
@@ -31,7 +31,7 @@ describe('SLDSAvatar: ', function () {
 		it('avatar renders with image', () => {
 			const expectedSrc = 'success';
 			wrapper = mount(<SLDSAvatar imgSrc={expectedSrc} />, {
-				attachTo: mountNode
+				attachTo: mountNode,
 			});
 
 			const img = wrapper.find('img');

--- a/components/avatar/index.jsx
+++ b/components/avatar/index.jsx
@@ -53,14 +53,14 @@ const propTypes = {
 	/**
 	 * Title attribute for the avatar container.
 	 */
-	title: PropTypes.string
+	title: PropTypes.string,
 };
 
 const defaultProps = {
 	imgAlt: '',
 	size: 'medium',
 	title: 'user avatar',
-	variant: 'user'
+	variant: 'user',
 };
 
 /**
@@ -77,7 +77,7 @@ class Avatar extends React.Component {
 	constructor (props) {
 		super(props);
 		this.state = {
-			imgLoadError: false
+			imgLoadError: false,
 		};
 	}
 
@@ -127,7 +127,7 @@ class Avatar extends React.Component {
 			<abbr
 				className={classNames('slds-avatar__initials', {
 					'slds-icon-standard-account': variant === 'entity',
-					'slds-icon-standard-user': variant === 'user'
+					'slds-icon-standard-user': variant === 'user',
 				})}
 				title={label}
 			>
@@ -158,7 +158,7 @@ class Avatar extends React.Component {
 						'slds-avatar_x-small': size === 'x-small',
 						'slds-avatar_small': size === 'small',
 						'slds-avatar_medium': size === 'medium',
-						'slds-avatar_large': size === 'large'
+						'slds-avatar_large': size === 'large',
 					})}
 				>
 					{renderAvatar()}

--- a/components/breadcrumb/__docs__/site-stories.js
+++ b/components/breadcrumb/__docs__/site-stories.js
@@ -5,7 +5,7 @@
 
 const siteStories = [
 	require('raw-loader!@salesforce/design-system-react/components/breadcrumb/__examples__/base.jsx'),
-	require('raw-loader!@salesforce/design-system-react/components/breadcrumb/__examples__/one-item.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/breadcrumb/__examples__/one-item.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/breadcrumb/__examples__/base.jsx
+++ b/components/breadcrumb/__examples__/base.jsx
@@ -11,7 +11,7 @@ const Example = createReactClass({
 			<a id="parent-entity" href="javascript:void(0);">
 				Parent Entity
 			</a>,
-			<a href="javascript:void(0);">Parent Record Name</a>
+			<a href="javascript:void(0);">Parent Record Name</a>,
 		];
 
 		return (
@@ -19,7 +19,7 @@ const Example = createReactClass({
 				<BreadCrumb trail={trail} />
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/breadcrumb/__examples__/one-item.jsx
+++ b/components/breadcrumb/__examples__/one-item.jsx
@@ -14,7 +14,7 @@ const Example = createReactClass({
 				<BreadCrumb trail={trail} />
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/breadcrumb/index.jsx
+++ b/components/breadcrumb/index.jsx
@@ -50,11 +50,11 @@ Breadcrumb.propTypes = {
 	/**
 	 * An array of react elements presumably anchor elements.
 	 */
-	trail: PropTypes.array
+	trail: PropTypes.array,
 };
 
 Breadcrumb.defaultProps = {
-	assistiveText: 'Breadcrumbs'
+	assistiveText: 'Breadcrumbs',
 };
 
 export default Breadcrumb;

--- a/components/button-group/__docs__/site-stories.js
+++ b/components/button-group/__docs__/site-stories.js
@@ -5,7 +5,7 @@
 
 const siteStories = [
 	require('raw-loader!@salesforce/design-system-react/components/button-group/__examples__/more-icon.jsx'),
-	require('raw-loader!@salesforce/design-system-react/components/button-group/__examples__/icon-group.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/button-group/__examples__/icon-group.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/button-group/__examples__/checkbox-error.jsx
+++ b/components/button-group/__examples__/checkbox-error.jsx
@@ -11,7 +11,7 @@ const Example = createReactClass({
 			<ButtonGroup
 				labels={{
 					error: 'This field is required',
-					label: 'Scheduled Day(s)'
+					label: 'Scheduled Day(s)',
 				}}
 				variant="checkbox"
 			>
@@ -22,7 +22,7 @@ const Example = createReactClass({
 				<Checkbox id="ButtonGroupExampleFri" label="Fri" />
 			</ButtonGroup>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/button-group/__examples__/checkbox.jsx
+++ b/components/button-group/__examples__/checkbox.jsx
@@ -10,7 +10,7 @@ const Example = createReactClass({
 		return (
 			<ButtonGroup
 				labels={{
-					label: 'Scheduled Day(s)'
+					label: 'Scheduled Day(s)',
 				}}
 				variant="checkbox"
 			>
@@ -21,7 +21,7 @@ const Example = createReactClass({
 				<Checkbox id="ButtonGroupExampleFri" label="Fri" />
 			</ButtonGroup>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/button-group/__examples__/icon-group.jsx
+++ b/components/button-group/__examples__/icon-group.jsx
@@ -37,7 +37,7 @@ const Example = createReactClass({
 						openOn="click"
 						options={[
 							{ label: 'Sort ascending', value: 'A0' },
-							{ label: 'Sort descending', value: 'B0' }
+							{ label: 'Sort descending', value: 'B0' },
 						]}
 						value="A0"
 						variant="icon"
@@ -45,7 +45,7 @@ const Example = createReactClass({
 				</ButtonGroup>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/button-group/__examples__/more-icon.jsx
+++ b/components/button-group/__examples__/more-icon.jsx
@@ -28,13 +28,13 @@ const Example = createReactClass({
 						options={[
 							{ label: 'undo', value: 'A0' },
 							{ label: 'redo', value: 'B0' },
-							{ label: 'activate', value: 'C0' }
+							{ label: 'activate', value: 'C0' },
 						]}
 					/>
 				</ButtonGroup>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/button-group/__tests__/button-group.snapshot-test.jsx
+++ b/components/button-group/__tests__/button-group.snapshot-test.jsx
@@ -11,23 +11,23 @@ import CheckboxError from '../__examples__/checkbox-error';
 testDOMandHTML({
 	name: 'Button Group IconGroup',
 	test,
-	Component: IconGroup
+	Component: IconGroup,
 });
 
 testDOMandHTML({
 	name: 'Button Group MoreIcon',
 	test,
-	Component: MoreIcon
+	Component: MoreIcon,
 });
 
 testDOMandHTML({
 	name: 'Button Group Checkbox',
 	test,
-	Component: Checkbox
+	Component: Checkbox,
 });
 
 testDOMandHTML({
 	name: 'Button Group Checkbox Error',
 	test,
-	Component: CheckboxError
+	Component: CheckboxError,
 });

--- a/components/button-group/index.jsx
+++ b/components/button-group/index.jsx
@@ -25,7 +25,7 @@ const propTypes = {
 	className: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * **Text labels for internationalization**
@@ -35,12 +35,12 @@ const propTypes = {
 	 */
 	labels: shape({
 		error: PropTypes.string,
-		label: PropTypes.string
+		label: PropTypes.string,
 	}),
 	/**
 	 * Use checkbox variant for "Checkbox Button Group" styling and add Checkbox components as children _Tested with snapshot testing._
 	 */
-	variant: PropTypes.oneOf(['checkbox'])
+	variant: PropTypes.oneOf(['checkbox']),
 };
 
 const defaultProps = { labels: {} };
@@ -62,7 +62,7 @@ const ButtonGroup = (props) => {
 			let newChild;
 			if (index === zeroIndexLength) {
 				newChild = React.cloneElement(child, {
-					triggerClassName: 'slds-button--last'
+					triggerClassName: 'slds-button--last',
 				});
 			}
 
@@ -73,7 +73,7 @@ const ButtonGroup = (props) => {
 	if (props.variant === 'checkbox') {
 		children = React.Children.map(props.children, (child) =>
 			React.cloneElement(child, {
-				variant: 'button-group'
+				variant: 'button-group',
 			})
 		);
 	}
@@ -82,7 +82,7 @@ const ButtonGroup = (props) => {
 		return (
 			<fieldset
 				className={classNames('slds-form-element', {
-					'slds-has-error': labels.error
+					'slds-has-error': labels.error,
 				})}
 			>
 				<legend className="slds-form-element__legend slds-form-element__label">

--- a/components/button-stateful/__docs__/site-stories.js
+++ b/components/button-stateful/__docs__/site-stories.js
@@ -5,7 +5,7 @@
 
 const siteStories = [
 	require('raw-loader!@salesforce/design-system-react/components/button-stateful/__examples__/icon.jsx'),
-	require('raw-loader!@salesforce/design-system-react/components/button-stateful/__examples__/icon-text.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/button-stateful/__examples__/icon-text.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/button-stateful/__docs__/storybook-stories.jsx
+++ b/components/button-stateful/__docs__/storybook-stories.jsx
@@ -27,6 +27,6 @@ storiesOf(BUTTON_STATEFUL, module)
 			onFocus: action('hover'),
 			onMouseEnter: (e) => {
 				console.log('target is ', e.target);
-			}
+			},
 		})
 	);

--- a/components/button-stateful/__examples__/icon-text.jsx
+++ b/components/button-stateful/__examples__/icon-text.jsx
@@ -16,7 +16,7 @@ const Example = createReactClass({
 						style={{
 							backgroundColor: '#16325c',
 							padding: '10px',
-							display: 'inline-block'
+							display: 'inline-block',
 						}}
 						className="slds-m-horizontal--small"
 					>
@@ -30,7 +30,7 @@ const Example = createReactClass({
 				</div>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/button-stateful/__examples__/icon.jsx
+++ b/components/button-stateful/__examples__/icon.jsx
@@ -17,7 +17,7 @@ const Example = createReactClass({
 				/>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/button-stateful/__tests__/button-stateful.browser-test.jsx
+++ b/components/button-stateful/__tests__/button-stateful.browser-test.jsx
@@ -16,7 +16,7 @@ describe('Button Stateful: ', () => {
 		assistiveText: 'like',
 		iconName: 'like',
 		iconSize: 'large',
-		variant: 'icon'
+		variant: 'icon',
 	};
 
 	// Setup and takedown

--- a/components/button-stateful/index.jsx
+++ b/components/button-stateful/index.jsx
@@ -74,7 +74,7 @@ const propTypes = {
 	 */
 	tabIndex: PropTypes.string,
 	tooltip: PropTypes.node,
-	variant: PropTypes.oneOf(['base', 'neutral', 'brand', 'destructive', 'icon'])
+	variant: PropTypes.oneOf(['base', 'neutral', 'brand', 'destructive', 'icon']),
 };
 
 // i18n
@@ -84,7 +84,7 @@ const defaultProps = {
 	responsive: false,
 	stateOne: { iconName: 'add', label: 'Follow' },
 	stateTwo: { iconName: 'check', label: 'Following' },
-	stateThree: { iconName: 'close', label: 'Unfollow' }
+	stateThree: { iconName: 'close', label: 'Unfollow' },
 };
 
 /**
@@ -104,7 +104,7 @@ class ButtonStateful extends React.Component {
 			'slds-not-selected': !active,
 			'slds-is-selected': active,
 			'slds-max-small-button--stretch': this.props.responsive,
-			'slds-button--icon-border': this.props.variant === 'icon'
+			'slds-button--icon-border': this.props.variant === 'icon',
 		});
 	}
 
@@ -139,7 +139,7 @@ class ButtonStateful extends React.Component {
 			stateTwo,
 			stateThree,
 			tabIndex,
-			variant
+			variant,
 		} = this.props;
 
 		const isActive = isBoolean(active) ? active : this.state.active;

--- a/components/button/__docs__/site-stories.js
+++ b/components/button/__docs__/site-stories.js
@@ -6,7 +6,7 @@
 const siteStories = [
 	require('raw-loader!@salesforce/design-system-react/components/button/__examples__/base-neutral.jsx'),
 	require('raw-loader!@salesforce/design-system-react/components/button/__examples__/brand-disabled-destructive-inverse.jsx'),
-	require('raw-loader!@salesforce/design-system-react/components/button/__examples__/button-icons.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/button/__examples__/button-icons.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/button/__docs__/storybook-stories.jsx
+++ b/components/button/__docs__/storybook-stories.jsx
@@ -28,7 +28,7 @@ storiesOf(BUTTON, module)
 			iconName: 'download',
 			iconPosition: 'left',
 			onFocus: action('focus'),
-			onKeyDown: action('keyDown')
+			onKeyDown: action('keyDown'),
 		})
 	)
 	.add('Disabled', () => getButton({ label: 'Disabled', disabled: true }))
@@ -37,7 +37,7 @@ storiesOf(BUTTON, module)
 			assistiveText: 'Icon',
 			iconSize: 'large',
 			iconName: 'answer',
-			title: 'chat'
+			title: 'chat',
 		})
 	)
 	.add('Icon with external path', () =>
@@ -45,7 +45,7 @@ storiesOf(BUTTON, module)
 			assistiveText: 'Icon',
 			iconSize: 'large',
 			iconPath: '/assets/icons/utility-sprite/svg/symbols.svg#announcement',
-			title: 'announcement'
+			title: 'announcement',
 		})
 	)
 	.addDecorator((getStory) => (
@@ -62,7 +62,7 @@ storiesOf(BUTTON, module)
 			iconName: 'settings',
 			iconSize: 'large',
 			iconVariant: 'border',
-			inverse: true
+			inverse: true,
 		})
 	)
 	.add('Dropdown Icon inverse', () =>
@@ -71,7 +71,7 @@ storiesOf(BUTTON, module)
 			assistiveText: 'Dropdown Icon inverse',
 			iconName: 'settings',
 			iconVariant: 'more',
-			inverse: true
+			inverse: true,
 		})
 	)
 	.addDecorator((getStory) => (
@@ -86,6 +86,6 @@ storiesOf(BUTTON, module)
 			iconVariant: 'border',
 			iconSize: 'small',
 			hint: true,
-			inverse: true
+			inverse: true,
 		})
 	);

--- a/components/button/__examples__/base-neutral.jsx
+++ b/components/button/__examples__/base-neutral.jsx
@@ -30,7 +30,7 @@ const Example = createReactClass({
 				</div>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/button/__examples__/brand-disabled-destructive-inverse.jsx
+++ b/components/button/__examples__/brand-disabled-destructive-inverse.jsx
@@ -27,7 +27,7 @@ const Example = createReactClass({
 						style={{
 							backgroundColor: '#16325c',
 							padding: '10px',
-							display: 'inline-block'
+							display: 'inline-block',
 						}}
 						className="-m-horizontal--small"
 					>
@@ -36,7 +36,7 @@ const Example = createReactClass({
 				</div>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/button/__examples__/button-icons.jsx
+++ b/components/button/__examples__/button-icons.jsx
@@ -33,7 +33,7 @@ const Example = createReactClass({
 						style={{
 							backgroundColor: '#4BC076',
 							padding: '10px',
-							display: 'inline-block'
+							display: 'inline-block',
 						}}
 						className="-m-horizontal--small"
 					>
@@ -64,7 +64,7 @@ const Example = createReactClass({
 						style={{
 							backgroundColor: '#16325c',
 							padding: '10px',
-							display: 'inline-block'
+							display: 'inline-block',
 						}}
 						className="-m-horizontal--small"
 					>
@@ -81,7 +81,7 @@ const Example = createReactClass({
 						style={{
 							backgroundColor: '#FFB75D',
 							padding: '10px 50px',
-							display: 'inline-block'
+							display: 'inline-block',
 						}}
 						className="-hint-parent -m-horizontal--small"
 					>
@@ -96,7 +96,7 @@ const Example = createReactClass({
 				</div>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/button/__tests__/button.browser-test.jsx
+++ b/components/button/__tests__/button.browser-test.jsx
@@ -8,7 +8,7 @@ import assign from 'lodash.assign';
 const {
 	Simulate,
 	findRenderedDOMComponentWithTag,
-	findRenderedDOMComponentWithClass
+	findRenderedDOMComponentWithClass,
 } = TestUtils;
 
 import SLDSButton from '../../button';
@@ -22,7 +22,7 @@ describe('SLDSButton: ', () => {
 	const defaultProps = {
 		label: 'Neutral',
 		onClick: mockCallback,
-		variant: 'neutral'
+		variant: 'neutral',
 	};
 
 	const renderButton = (inst) => {
@@ -51,7 +51,7 @@ describe('SLDSButton: ', () => {
 			cmp = getButton({
 				id: 'custom-id',
 				text: 'Brand',
-				theme: 'brand'
+				theme: 'brand',
 			});
 			btn = findRenderedDOMComponentWithClass(cmp, 'slds-button');
 		});
@@ -84,7 +84,7 @@ describe('SLDSButton: ', () => {
 				iconName: 'download',
 				iconCategory: 'action',
 				iconPosition: 'right',
-				variant: 'neutral'
+				variant: 'neutral',
 			});
 			btn = findRenderedDOMComponentWithClass(cmp, 'slds-button');
 			svg = findRenderedDOMComponentWithClass(cmp, 'slds-button__icon');
@@ -115,7 +115,7 @@ describe('SLDSButton: ', () => {
 				variant: 'icon',
 				iconName: 'settings',
 				iconSize: 'small',
-				iconVariant: 'bare'
+				iconVariant: 'bare',
 			});
 			btn = findRenderedDOMComponentWithClass(cmp, 'slds-button');
 			asstText = findRenderedDOMComponentWithClass(cmp, 'slds-assistive-text');
@@ -146,7 +146,7 @@ describe('SLDSButton: ', () => {
 				variant: 'icon',
 				iconPath: '/assets/icons/utility-sprite/svg/symbols.svg#announcement',
 				iconSize: 'large',
-				iconVariant: 'bare'
+				iconVariant: 'bare',
 			});
 			use = findRenderedDOMComponentWithTag(cmp, 'use');
 			svgHref = use.getAttribute('xlink:href');
@@ -173,7 +173,7 @@ describe('SLDSButton: ', () => {
 			cmp = getButton({
 				label: 'Neutral',
 				variant: 'neutral',
-				onClick: setClick
+				onClick: setClick,
 			});
 			btn = findRenderedDOMComponentWithClass(cmp, 'slds-button');
 		});

--- a/components/button/index.jsx
+++ b/components/button/index.jsx
@@ -53,7 +53,7 @@ const Button = createReactClass({
 		className: PropTypes.oneOfType([
 			PropTypes.array,
 			PropTypes.object,
-			PropTypes.string
+			PropTypes.string,
 		]),
 		/**
 		 * Disables the button and adds disabled styling.
@@ -71,7 +71,7 @@ const Button = createReactClass({
 			'custom',
 			'doctype',
 			'standard',
-			'utility'
+			'utility',
 		]),
 		/**
 		 * Name of the icon. Visit <a href="http://www.lightningdesignsystem.com/resources/icons">Lightning Design System Icons</a> to reference icon names.
@@ -98,7 +98,7 @@ const Button = createReactClass({
 			'border',
 			'border-filled',
 			'more',
-			'global-header'
+			'global-header',
 		]),
 		/**
 		 * Id string applied to button node.
@@ -147,14 +147,14 @@ const Button = createReactClass({
 			'brand',
 			'destructive',
 			'success',
-			'icon'
+			'icon',
 		]),
 		iconClassName: PropTypes.oneOfType([
 			PropTypes.array,
 			PropTypes.object,
-			PropTypes.string
+			PropTypes.string,
 		]),
-		tooltip: PropTypes.node
+		tooltip: PropTypes.node,
 	},
 
 	getDefaultProps () {
@@ -165,7 +165,7 @@ const Button = createReactClass({
 			iconCategory: 'utility',
 			responsive: false,
 			type: 'button',
-			variant: 'neutral'
+			variant: 'neutral',
 		};
 	},
 
@@ -207,7 +207,7 @@ const Button = createReactClass({
 				[`slds-button--icon-${this.props.iconSize}`]:
 					iconVariant && this.props.iconSize !== 'medium',
 				'slds-button--reset': this.props.variant === 'link',
-				'slds-text-link': this.props.variant === 'link'
+				'slds-text-link': this.props.variant === 'link',
 			},
 			this.props.className
 		);
@@ -230,7 +230,7 @@ const Button = createReactClass({
 				className={classNames(
 					{
 						'slds-global-header__icon':
-							this.props.iconVariant === 'global-header'
+							this.props.iconVariant === 'global-header',
 					},
 					this.props.iconClassName
 				)}
@@ -312,7 +312,7 @@ const Button = createReactClass({
 
 	render () {
 		return this.props.tooltip ? this.renderTooltip() : this.renderButton();
-	}
+	},
 });
 
 export default Button;

--- a/components/card/__docs__/site-stories.js
+++ b/components/card/__docs__/site-stories.js
@@ -4,7 +4,7 @@
 /* eslint-disable global-require */
 
 const siteStories = [
-	require('raw-loader!@salesforce/design-system-react/components/card/__examples__/related-list-with-table.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/card/__examples__/related-list-with-table.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/card/__docs__/storybook-stories.jsx
+++ b/components/card/__docs__/storybook-stories.jsx
@@ -21,7 +21,7 @@ import InlineEdit from '../../forms/input/inline';
 const sampleItems = [
 	{ name: 'Cloudhub' },
 	{ name: 'Cloudhub + Anypoint Connectors' },
-	{ name: 'Cloud City' }
+	{ name: 'Cloud City' },
 ];
 
 const DemoCard = createReactClass({
@@ -30,13 +30,13 @@ const DemoCard = createReactClass({
 	propTypes: {
 		items: PropTypes.array,
 		header: PropTypes.node,
-		heading: PropTypes.oneOfType([PropTypes.node, PropTypes.string])
+		heading: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
 	},
 
 	getInitialState () {
 		return {
 			filter: null,
-			items: this.props.items
+			items: this.props.items,
 		};
 	},
 
@@ -47,7 +47,7 @@ const DemoCard = createReactClass({
 			event.target.value !== '' ? RegExp(event.target.value, 'i') : null;
 
 		this.setState({
-			filter
+			filter,
 		});
 	},
 
@@ -56,7 +56,7 @@ const DemoCard = createReactClass({
 
 		this.setState({
 			filter: null,
-			items: []
+			items: [],
 		});
 	},
 
@@ -64,7 +64,7 @@ const DemoCard = createReactClass({
 		action('add')(...rest);
 
 		this.setState({
-			items: [{ name: uniqueId('New item #') }, ...this.state.items]
+			items: [{ name: uniqueId('New item #') }, ...this.state.items],
 		});
 	},
 
@@ -116,7 +116,7 @@ const DemoCard = createReactClass({
 				</Card>
 			</div>
 		);
-	}
+	},
 });
 
 const SetHeightCard = () => (

--- a/components/card/__examples__/related-list-with-table.jsx
+++ b/components/card/__examples__/related-list-with-table.jsx
@@ -12,7 +12,7 @@ import Icon from '~/components/icon';
 const sampleItems = [
 	{ name: 'Cloudhub' },
 	{ name: 'Cloudhub + Anypoint Connectors' },
-	{ name: 'Cloud City' }
+	{ name: 'Cloud City' },
 ];
 
 const Example = createReactClass({
@@ -21,7 +21,7 @@ const Example = createReactClass({
 	getInitialState () {
 		return {
 			items: sampleItems,
-			isFiltering: false
+			isFiltering: false,
 		};
 	},
 
@@ -86,7 +86,7 @@ const Example = createReactClass({
 				</div>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/card/__tests__/card.browser-test.jsx
+++ b/components/card/__tests__/card.browser-test.jsx
@@ -16,33 +16,33 @@ chai.should();
 const headerIdSuffixes = {
 	headerActions: '__header-actions',
 	heading: '__heading',
-	filter: '__filter-input'
+	filter: '__filter-input',
 };
 
 const cardIdSuffixes = {
 	body: '__body',
 	headerActions: '__header-actions',
 	heading: '__heading',
-	filter: '__filter-input'
+	filter: '__filter-input',
 };
 
 const cssClasses = {
-	base: 'slds-card'
+	base: 'slds-card',
 };
 
 const footerCssClasses = {
-	base: 'slds-card__footer'
+	base: 'slds-card__footer',
 };
 
 const headerCssClasses = {
-	base: 'slds-card__header'
+	base: 'slds-card__header',
 };
 
 describe('Card: ', () => {
 	// Base defaults
 	const requiredProps = {
 		id: 'ExampleCard',
-		heading: 'Lots of Related Items'
+		heading: 'Lots of Related Items',
 	};
 
 	const renderCard = (instance) =>
@@ -104,16 +104,16 @@ describe('Card: ', () => {
 
 	// Optional props
 	const renderFooterContents = React.createElement('span', {
-		id: 'sampleFooter'
+		id: 'sampleFooter',
 	});
 	const renderHeaderActions = React.createElement('span', {
-		id: 'sampleHeaderActions'
+		id: 'sampleHeaderActions',
 	});
 	const renderFilter = React.createElement(CardFilter);
 	const renderIcon = React.createElement(Icon, {
 		category: 'standard',
 		name: 'default',
-		size: 'small'
+		size: 'small',
 	});
 
 	const optionalProps = assign(requiredProps, {
@@ -123,7 +123,7 @@ describe('Card: ', () => {
 		headerActions: renderHeaderActions,
 		filter: renderFilter,
 		icon: renderIcon,
-		style: { background: 'rgb(18, 49, 35)' }
+		style: { background: 'rgb(18, 49, 35)' },
 	});
 
 	describe('Optional Structure', () => {
@@ -197,7 +197,7 @@ describe('Card: ', () => {
 				>
 					To Wanda! This is custom!
 				</span>
-			)
+			),
 		};
 
 		beforeEach(renderCard(<Card {...props} />));
@@ -212,7 +212,7 @@ describe('Card: ', () => {
 
 	describe('Empty Structure', () => {
 		const props = assign(optionalProps, {
-			empty: true
+			empty: true,
 		});
 
 		beforeEach(renderCard(<Card {...props} />));

--- a/components/card/empty.jsx
+++ b/components/card/empty.jsx
@@ -35,11 +35,11 @@ CardEmpty.propTypes = {
 	/**
 	 * Primary text for an Empty Card.
 	 */
-	heading: PropTypes.string
+	heading: PropTypes.string,
 };
 
 CardEmpty.defaultProps = {
-	heading: 'No Related Items'
+	heading: 'No Related Items',
 };
 
 export default CardEmpty;

--- a/components/card/filter.jsx
+++ b/components/card/filter.jsx
@@ -45,11 +45,11 @@ Filter.propTypes = {
 	/**
 	 * Text present in input until the user enters text. This text will also be used for a visually hidden label on the filter `input` element for accessibility.
 	 */
-	placeholder: PropTypes.string.isRequired
+	placeholder: PropTypes.string.isRequired,
 };
 
 Filter.defaultProps = {
-	placeholder: 'Find in List'
+	placeholder: 'Find in List',
 };
 
 export default Filter;

--- a/components/card/index.jsx
+++ b/components/card/index.jsx
@@ -28,7 +28,7 @@ const idSuffixes = {
 	body: '__body',
 	headerActions: '__header-actions',
 	heading: '__heading',
-	filter: '__filter-input'
+	filter: '__filter-input',
 };
 
 /**
@@ -81,7 +81,7 @@ const Card = function (props) {
 Card.displayName = CARD;
 
 Card.defaultProps = {
-	heading: 'Related Items'
+	heading: 'Related Items',
 };
 
 // ### Prop Types
@@ -92,7 +92,7 @@ Card.propTypes = {
 	bodyClassName: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * The main section of the card. It often contains a `DataTable` or `Tile`.
@@ -104,7 +104,7 @@ Card.propTypes = {
 	className: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * Replaces the body (that is the children) with the specified empty state, this will also remove header actions, the filter, and the icon. If the default empty state is wanted, set to `true`.
@@ -141,7 +141,7 @@ Card.propTypes = {
 	/**
 	 * Custom styles to be added to the card.
 	 */
-	style: PropTypes.object
+	style: PropTypes.object,
 };
 
 export default Card;

--- a/components/card/private/body.jsx
+++ b/components/card/private/body.jsx
@@ -31,12 +31,12 @@ CardBody.propTypes = {
 	className: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * Set the HTML `id` of the body.
 	 */
-	id: PropTypes.string
+	id: PropTypes.string,
 };
 
 export default CardBody;

--- a/components/card/private/footer.jsx
+++ b/components/card/private/footer.jsx
@@ -17,7 +17,7 @@ CardFooter.propTypes = {
 	/**
 	 * Elements to place in the footer.
 	 */
-	children: PropTypes.node
+	children: PropTypes.node,
 };
 
 export default CardFooter;

--- a/components/card/private/header.jsx
+++ b/components/card/private/header.jsx
@@ -20,13 +20,13 @@ import { CARD_HEADER } from '../../../utilities/constants';
 const idSuffixes = {
 	headerActions: '__header-actions',
 	heading: '__heading',
-	filter: '__filter-input'
+	filter: '__filter-input',
 };
 
 const renderFilter = (filter, id) => {
 	// allow id to be set by custom header component passed in
 	const clonedFilter = React.cloneElement(filter, {
-		id: filter.props.id || id
+		id: filter.props.id || id,
 	});
 
 	return (
@@ -66,7 +66,7 @@ const CardHeader = (props) => {
 			body: heading,
 			verticalCenter: true,
 			canTruncate: true,
-			...props.header.props
+			...props.header.props,
 		});
 	} else {
 		Header = (
@@ -89,7 +89,7 @@ const CardHeader = (props) => {
 				id={props.headerActionsId}
 				className={classnames('slds-no-flex', {
 					'slds-size--1-of-3': hasFilter,
-					'slds-text-align--right': hasFilter
+					'slds-text-align--right': hasFilter,
 				})}
 			>
 				{props.headerActions}
@@ -136,7 +136,7 @@ CardHeader.propTypes = {
 	/**
 	 * Icon associated with grouped items
 	 */
-	icon: PropTypes.node
+	icon: PropTypes.node,
 };
 
 export default CardHeader;

--- a/components/combobox/__docs__/site-stories.js
+++ b/components/combobox/__docs__/site-stories.js
@@ -9,7 +9,7 @@ const siteStories = [
 	require('raw-loader!@salesforce/design-system-react/components/combobox/__examples__/inline-multiple.jsx'),
 	require('raw-loader!@salesforce/design-system-react/components/combobox/__examples__/inline-single.jsx'),
 	require('raw-loader!@salesforce/design-system-react/components/combobox/__examples__/readonly-single.jsx'),
-	require('raw-loader!@salesforce/design-system-react/components/combobox/__examples__/readonly-multiple.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/combobox/__examples__/readonly-multiple.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/combobox/__examples__/base-custom-menu-item.jsx
+++ b/components/combobox/__examples__/base-custom-menu-item.jsx
@@ -10,45 +10,45 @@ const accounts = [
 		id: '1',
 		label: 'Acme',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '2',
 		label: 'Salesforce.com, Inc.',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '3',
 		label: "Paddy's Pub",
 		subTitle: 'Account • Boston, MA',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '4',
 		label: 'Tyrell Corp',
 		subTitle: 'Account • San Francisco, CA',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '5',
 		label: 'Paper St. Soap Company',
 		subTitle: 'Account • Beloit, WI',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '6',
 		label: 'Nakatomi Investments',
 		subTitle: 'Account • Chicago, IL',
-		type: 'account'
+		type: 'account',
 	},
 	{ id: '7', label: 'Acme Landscaping', type: 'account' },
 	{
 		id: '8',
 		label: 'Acme Construction',
 		subTitle: 'Account • Grand Marais, MN',
-		type: 'account'
-	}
+		type: 'account',
+	},
 ];
 
 const accountsWithIcon = accounts.map((elem) =>
@@ -60,7 +60,7 @@ const accountsWithIcon = accounts.map((elem) =>
 				size="x-small"
 				name={elem.type}
 			/>
-		)
+		),
 	})
 );
 
@@ -82,7 +82,7 @@ class Example extends React.Component {
 
 		this.state = {
 			inputValue: '',
-			selection: []
+			selection: [],
 		};
 	}
 
@@ -104,7 +104,7 @@ class Example extends React.Component {
 						onRequestRemoveSelectedOption: (event, data) => {
 							this.setState({
 								inputValue: '',
-								selection: data.selection
+								selection: data.selection,
 							});
 						},
 						onSubmit: (event, { value }) => {
@@ -125,9 +125,9 @@ class Example extends React.Component {
 												category="standard"
 												name="account"
 											/>
-										)
-									}
-								]
+										),
+									},
+								],
 							});
 						},
 						onSelect: (event, data) => {
@@ -141,20 +141,20 @@ class Example extends React.Component {
 							}
 							this.setState({
 								inputValue: '',
-								selection: data.selection
+								selection: data.selection,
 							});
-						}
+						},
 					}}
 					labels={{
 						label: 'Search',
-						placeholder: 'Search Salesforce'
+						placeholder: 'Search Salesforce',
 					}}
 					menuItem={CustomMenuItem}
 					multiple
 					options={comboboxFilterAndLimit({
 						inputValue: this.state.inputValue,
 						options: accountsWithIcon,
-						selection: this.state.selection
+						selection: this.state.selection,
 					})}
 					selection={this.state.selection}
 					value={this.state.inputValue}

--- a/components/combobox/__examples__/base-predefined-options-only.jsx
+++ b/components/combobox/__examples__/base-predefined-options-only.jsx
@@ -11,50 +11,50 @@ const accounts = [
 		id: '1',
 		label: 'Acme',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '2',
 		label: 'Salesforce.com, Inc.',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '3',
 		label: "Paddy's Pub",
 		subTitle: 'Account • Boston, MA',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '4',
 		label: 'Tyrell Corp',
 		subTitle: 'Account • San Francisco, CA',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '5',
 		label: 'Paper St. Soap Company',
 		subTitle: 'Account • Beloit, WI',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '6',
 		label: 'Nakatomi Investments',
 		subTitle: 'Account • Chicago, IL',
-		type: 'account'
+		type: 'account',
 	},
 	{ id: '7', label: 'Acme Landscaping', type: 'account' },
 	{
 		id: '8',
 		label: 'Acme Construction',
 		subTitle: 'Account • Grand Marais, MN',
-		type: 'account'
-	}
+		type: 'account',
+	},
 ];
 
 const accountsWithIcon = accounts.map((elem) =>
 	Object.assign(elem, {
-		icon: <Icon assistiveText="Account" category="standard" name={elem.type} />
+		icon: <Icon assistiveText="Account" category="standard" name={elem.type} />,
 	})
 );
 
@@ -64,7 +64,7 @@ class Example extends React.Component {
 
 		this.state = {
 			inputValue: '',
-			selection: [accountsWithIcon[0], accountsWithIcon[1]]
+			selection: [accountsWithIcon[0], accountsWithIcon[1]],
 		};
 	}
 
@@ -85,7 +85,7 @@ class Example extends React.Component {
 						onRequestRemoveSelectedOption: (event, data) => {
 							this.setState({
 								inputValue: '',
-								selection: data.selection
+								selection: data.selection,
 							});
 						},
 						onSelect: (event, data) => {
@@ -99,19 +99,19 @@ class Example extends React.Component {
 							}
 							this.setState({
 								inputValue: '',
-								selection: data.selection
+								selection: data.selection,
 							});
-						}
+						},
 					}}
 					labels={{
 						label: 'Search',
-						placeholder: 'Search Salesforce'
+						placeholder: 'Search Salesforce',
 					}}
 					multiple
 					options={comboboxFilterAndLimit({
 						inputValue: this.state.inputValue,
 						options: accountsWithIcon,
-						selection: this.state.selection
+						selection: this.state.selection,
 					})}
 					predefinedOptionsOnly
 					selection={this.state.selection}

--- a/components/combobox/__examples__/base.jsx
+++ b/components/combobox/__examples__/base.jsx
@@ -10,50 +10,50 @@ const accounts = [
 		id: '1',
 		label: 'Acme',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '2',
 		label: 'Salesforce.com, Inc.',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '3',
 		label: "Paddy's Pub",
 		subTitle: 'Account • Boston, MA',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '4',
 		label: 'Tyrell Corp',
 		subTitle: 'Account • San Francisco, CA',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '5',
 		label: 'Paper St. Soap Company',
 		subTitle: 'Account • Beloit, WI',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '6',
 		label: 'Nakatomi Investments',
 		subTitle: 'Account • Chicago, IL',
-		type: 'account'
+		type: 'account',
 	},
 	{ id: '7', label: 'Acme Landscaping', subTitle: '\u00A0', type: 'account' },
 	{
 		id: '8',
 		label: 'Acme Construction',
 		subTitle: 'Account • Grand Marais, MN',
-		type: 'account'
-	}
+		type: 'account',
+	},
 ];
 
 const accountsWithIcon = accounts.map((elem) =>
 	Object.assign(elem, {
-		icon: <Icon assistiveText="Account" category="standard" name={elem.type} />
+		icon: <Icon assistiveText="Account" category="standard" name={elem.type} />,
 	})
 );
 
@@ -63,7 +63,7 @@ class Example extends React.Component {
 
 		this.state = {
 			inputValue: '',
-			selection: [accountsWithIcon[0], accountsWithIcon[1]]
+			selection: [accountsWithIcon[0], accountsWithIcon[1]],
 		};
 	}
 
@@ -85,7 +85,7 @@ class Example extends React.Component {
 						onRequestRemoveSelectedOption: (event, data) => {
 							this.setState({
 								inputValue: '',
-								selection: data.selection
+								selection: data.selection,
 							});
 						},
 						onSubmit: (event, { value }) => {
@@ -106,9 +106,9 @@ class Example extends React.Component {
 												category="standard"
 												name="account"
 											/>
-										)
-									}
-								]
+										),
+									},
+								],
 							});
 						},
 						onSelect: (event, data) => {
@@ -122,20 +122,20 @@ class Example extends React.Component {
 							}
 							this.setState({
 								inputValue: '',
-								selection: data.selection
+								selection: data.selection,
 							});
-						}
+						},
 					}}
 					labels={{
 						label: 'Search',
-						placeholder: 'Search Salesforce'
+						placeholder: 'Search Salesforce',
 					}}
 					multiple
 					options={comboboxFilterAndLimit({
 						inputValue: this.state.inputValue,
 						limit: 10,
 						options: accountsWithIcon,
-						selection: this.state.selection
+						selection: this.state.selection,
 					})}
 					selection={this.state.selection}
 					value={this.state.inputValue}

--- a/components/combobox/__examples__/inline-multiple.jsx
+++ b/components/combobox/__examples__/inline-multiple.jsx
@@ -10,50 +10,50 @@ const accounts = [
 		id: '1',
 		label: 'Acme',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '2',
 		label: 'Salesforce.com, Inc.',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '3',
 		label: "Paddy's Pub",
 		subTitle: 'Account • Boston, MA',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '4',
 		label: 'Tyrell Corp',
 		subTitle: 'Account • San Francisco, CA',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '5',
 		label: 'Paper St. Soap Company',
 		subTitle: 'Account • Beloit, WI',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '6',
 		label: 'Nakatomi Investments',
 		subTitle: 'Account • Chicago, IL',
-		type: 'account'
+		type: 'account',
 	},
 	{ id: '7', label: 'Acme Landscaping', type: 'account' },
 	{
 		id: '8',
 		label: 'Acme Construction',
 		subTitle: 'Account • Grand Marais, MN',
-		type: 'account'
-	}
+		type: 'account',
+	},
 ];
 
 const accountsWithIcon = accounts.map((elem) =>
 	Object.assign(elem, {
-		icon: <Icon assistiveText="Account" category="standard" name={elem.type} />
+		icon: <Icon assistiveText="Account" category="standard" name={elem.type} />,
 	})
 );
 
@@ -63,7 +63,7 @@ class Example extends React.Component {
 
 		this.state = {
 			inputValue: '',
-			selection: [accountsWithIcon[0], accountsWithIcon[1]]
+			selection: [accountsWithIcon[0], accountsWithIcon[1]],
 		};
 	}
 
@@ -80,7 +80,7 @@ class Example extends React.Component {
 						onRequestRemoveSelectedOption: (event, data) => {
 							this.setState({
 								inputValue: '',
-								selection: data.selection
+								selection: data.selection,
 							});
 						},
 						onSubmit: (event, { value }) => {
@@ -101,9 +101,9 @@ class Example extends React.Component {
 												category="standard"
 												name="account"
 											/>
-										)
-									}
-								]
+										),
+									},
+								],
 							});
 						},
 						onSelect: (event, data) => {
@@ -117,19 +117,19 @@ class Example extends React.Component {
 							}
 							this.setState({
 								inputValue: '',
-								selection: data.selection
+								selection: data.selection,
 							});
-						}
+						},
 					}}
 					labels={{
 						label: 'Search',
-						placeholder: 'Search Salesforce'
+						placeholder: 'Search Salesforce',
 					}}
 					multiple
 					options={comboboxFilterAndLimit({
 						inputValue: this.state.inputValue,
 						options: accountsWithIcon,
-						selection: this.state.selection
+						selection: this.state.selection,
 					})}
 					selection={this.state.selection}
 					value={this.state.inputValue}

--- a/components/combobox/__examples__/inline-single.jsx
+++ b/components/combobox/__examples__/inline-single.jsx
@@ -10,50 +10,50 @@ const accounts = [
 		id: '1',
 		label: 'Acme',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '2',
 		label: 'Salesforce.com, Inc.',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '3',
 		label: "Paddy's Pub",
 		subTitle: 'Account • Boston, MA',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '4',
 		label: 'Tyrell Corp',
 		subTitle: 'Account • San Francisco, CA',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '5',
 		label: 'Paper St. Soap Company',
 		subTitle: 'Account • Beloit, WI',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '6',
 		label: 'Nakatomi Investments',
 		subTitle: 'Account • Chicago, IL',
-		type: 'account'
+		type: 'account',
 	},
 	{ id: '7', label: 'Acme Landscaping', type: 'account' },
 	{
 		id: '8',
 		label: 'Acme Construction',
 		subTitle: 'Account • Grand Marais, MN',
-		type: 'account'
-	}
+		type: 'account',
+	},
 ];
 
 const accountsWithIcon = accounts.map((elem) =>
 	Object.assign(elem, {
-		icon: <Icon assistiveText="Account" category="standard" name={elem.type} />
+		icon: <Icon assistiveText="Account" category="standard" name={elem.type} />,
 	})
 );
 
@@ -63,7 +63,7 @@ class Example extends React.Component {
 
 		this.state = {
 			inputValue: '',
-			selection: []
+			selection: [],
 		};
 	}
 
@@ -84,7 +84,7 @@ class Example extends React.Component {
 						onRequestRemoveSelectedOption: (event, data) => {
 							this.setState({
 								inputValue: '',
-								selection: data.selection
+								selection: data.selection,
 							});
 						},
 						onSubmit: (event, { value }) => {
@@ -105,9 +105,9 @@ class Example extends React.Component {
 												category="standard"
 												name="account"
 											/>
-										)
-									}
-								]
+										),
+									},
+								],
 							});
 						},
 						onSelect: (event, data) => {
@@ -121,18 +121,18 @@ class Example extends React.Component {
 							}
 							this.setState({
 								inputValue: '',
-								selection: data.selection
+								selection: data.selection,
 							});
-						}
+						},
 					}}
 					labels={{
 						label: 'Search',
-						placeholder: 'Search Salesforce'
+						placeholder: 'Search Salesforce',
 					}}
 					options={comboboxFilterAndLimit({
 						inputValue: this.state.inputValue,
 						options: accountsWithIcon,
-						selection: this.state.selection
+						selection: this.state.selection,
 					})}
 					selection={this.state.selection}
 					value={

--- a/components/combobox/__examples__/readonly-multiple.jsx
+++ b/components/combobox/__examples__/readonly-multiple.jsx
@@ -10,45 +10,45 @@ const accounts = [
 		id: '1',
 		label: 'Acme',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '2',
 		label: 'Salesforce.com, Inc.',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '3',
 		label: "Paddy's Pub",
 		subTitle: 'Account • Boston, MA',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '4',
 		label: 'Tyrell Corp',
 		subTitle: 'Account • San Francisco, CA',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '5',
 		label: 'Paper St. Soap Company',
 		subTitle: 'Account • Beloit, WI',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '6',
 		label: 'Nakatomi Investments',
 		subTitle: 'Account • Chicago, IL',
-		type: 'account'
+		type: 'account',
 	},
 	{ id: '7', label: 'Acme Landscaping', type: 'account' },
 	{
 		id: '8',
 		label: 'Acme Construction',
 		subTitle: 'Account • Grand Marais, MN',
-		type: 'account'
-	}
+		type: 'account',
+	},
 ];
 
 class Example extends React.Component {
@@ -57,7 +57,7 @@ class Example extends React.Component {
 
 		this.state = {
 			inputValue: '',
-			selection: []
+			selection: [],
 		};
 	}
 
@@ -70,7 +70,7 @@ class Example extends React.Component {
 						onRequestRemoveSelectedOption: (event, data) => {
 							this.setState({
 								inputValue: '',
-								selection: data.selection
+								selection: data.selection,
 							});
 						},
 						onSelect: (event, data) => {
@@ -84,13 +84,13 @@ class Example extends React.Component {
 							}
 							this.setState({
 								inputValue: '',
-								selection: data.selection
+								selection: data.selection,
 							});
-						}
+						},
 					}}
 					labels={{
 						label: 'Search',
-						placeholder: 'Search Salesforce'
+						placeholder: 'Search Salesforce',
 					}}
 					multiple
 					options={accounts}

--- a/components/combobox/__examples__/readonly-single-selection-custom-menu-item.jsx
+++ b/components/combobox/__examples__/readonly-single-selection-custom-menu-item.jsx
@@ -10,45 +10,45 @@ const accounts = [
 		id: '1',
 		label: 'Acme',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '2',
 		label: 'Salesforce.com, Inc.',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '3',
 		label: "Paddy's Pub",
 		subTitle: 'Account • Boston, MA',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '4',
 		label: 'Tyrell Corp',
 		subTitle: 'Account • San Francisco, CA',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '5',
 		label: 'Paper St. Soap Company',
 		subTitle: 'Account • Beloit, WI',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '6',
 		label: 'Nakatomi Investments',
 		subTitle: 'Account • Chicago, IL',
-		type: 'account'
+		type: 'account',
 	},
 	{ id: '7', label: 'Acme Landscaping', type: 'account' },
 	{
 		id: '8',
 		label: 'Acme Construction',
 		subTitle: 'Account • Grand Marais, MN',
-		type: 'account'
-	}
+		type: 'account',
+	},
 ];
 
 const accountsWithIcon = accounts.map((elem) =>
@@ -60,7 +60,7 @@ const accountsWithIcon = accounts.map((elem) =>
 				size="x-small"
 				name={elem.type}
 			/>
-		)
+		),
 	})
 );
 
@@ -89,7 +89,7 @@ class Example extends React.Component {
 
 		this.state = {
 			inputValue: '',
-			selection: []
+			selection: [],
 		};
 	}
 
@@ -110,13 +110,13 @@ class Example extends React.Component {
 							}
 							this.setState({
 								inputValue: '',
-								selection: data.selection
+								selection: data.selection,
 							});
-						}
+						},
 					}}
 					labels={{
 						label: 'Search',
-						placeholderReadOnly: 'Select company'
+						placeholderReadOnly: 'Select company',
 					}}
 					menuItem={CustomMenuItem}
 					options={accountsWithIcon}

--- a/components/combobox/__examples__/readonly-single.jsx
+++ b/components/combobox/__examples__/readonly-single.jsx
@@ -10,45 +10,45 @@ const accounts = [
 		id: '1',
 		label: 'Acme',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '2',
 		label: 'Salesforce.com, Inc.',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '3',
 		label: "Paddy's Pub",
 		subTitle: 'Account • Boston, MA',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '4',
 		label: 'Tyrell Corp',
 		subTitle: 'Account • San Francisco, CA',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '5',
 		label: 'Paper St. Soap Company',
 		subTitle: 'Account • Beloit, WI',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '6',
 		label: 'Nakatomi Investments',
 		subTitle: 'Account • Chicago, IL',
-		type: 'account'
+		type: 'account',
 	},
 	{ id: '7', label: 'Acme Landscaping', type: 'account' },
 	{
 		id: '8',
 		label: 'Acme Construction',
 		subTitle: 'Account • Grand Marais, MN',
-		type: 'account'
-	}
+		type: 'account',
+	},
 ];
 
 class Example extends React.Component {
@@ -57,7 +57,7 @@ class Example extends React.Component {
 
 		this.state = {
 			inputValue: '',
-			selection: []
+			selection: [],
 		};
 	}
 
@@ -78,13 +78,13 @@ class Example extends React.Component {
 							}
 							this.setState({
 								inputValue: '',
-								selection: data.selection
+								selection: data.selection,
 							});
-						}
+						},
 					}}
 					labels={{
 						label: 'Search',
-						placeholder: 'Search Salesforce'
+						placeholder: 'Search Salesforce',
 					}}
 					options={accounts}
 					selection={this.state.selection}

--- a/components/combobox/__examples__/snapshot/base-open-class-name.jsx
+++ b/components/combobox/__examples__/snapshot/base-open-class-name.jsx
@@ -10,19 +10,19 @@ const accounts = [
 		id: '1',
 		label: 'Acme',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '2',
 		label: 'Salesforce.com, Inc.',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
-	}
+		type: 'account',
+	},
 ];
 
 const accountsWithIcon = accounts.map((elem) =>
 	Object.assign(elem, {
-		icon: <Icon assistiveText="Account" category="standard" name={elem.type} />
+		icon: <Icon assistiveText="Account" category="standard" name={elem.type} />,
 	})
 );
 
@@ -32,7 +32,7 @@ class Example extends React.Component {
 
 		this.state = {
 			inputValue: '',
-			selection: []
+			selection: [],
 		};
 	}
 
@@ -46,7 +46,7 @@ class Example extends React.Component {
 					id="combobox-unique-id"
 					isOpen
 					labels={{
-						placeholder: 'Search Salesforce'
+						placeholder: 'Search Salesforce',
 					}}
 					menuPosition="relative"
 					onChange={(event, { value }) => {
@@ -56,7 +56,7 @@ class Example extends React.Component {
 					onRequestRemoveSelectedOption={(event, data) => {
 						this.setState({
 							inputValue: '',
-							selection: []
+							selection: [],
 						});
 					}}
 					onSubmit={(event, { value }) => {
@@ -71,9 +71,9 @@ class Example extends React.Component {
 											category="standard"
 											name="account"
 										/>
-									)
-								}
-							]
+									),
+								},
+							],
 						});
 					}}
 					onSelect={(event, data) => {

--- a/components/combobox/__examples__/snapshot/base-open.jsx
+++ b/components/combobox/__examples__/snapshot/base-open.jsx
@@ -10,19 +10,19 @@ const accounts = [
 		id: '1',
 		label: 'Acme',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '2',
 		label: 'Salesforce.com, Inc.',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
-	}
+		type: 'account',
+	},
 ];
 
 const accountsWithIcon = accounts.map((elem) =>
 	Object.assign(elem, {
-		icon: <Icon assistiveText="Account" category="standard" name={elem.type} />
+		icon: <Icon assistiveText="Account" category="standard" name={elem.type} />,
 	})
 );
 
@@ -32,7 +32,7 @@ class Example extends React.Component {
 
 		this.state = {
 			inputValue: '',
-			selection: []
+			selection: [],
 		};
 	}
 
@@ -43,7 +43,7 @@ class Example extends React.Component {
 					id="combobox-unique-id"
 					isOpen
 					labels={{
-						placeholder: 'Search Salesforce'
+						placeholder: 'Search Salesforce',
 					}}
 					menuPosition="relative"
 					onChange={(event, { value }) => {
@@ -53,7 +53,7 @@ class Example extends React.Component {
 					onRequestRemoveSelectedOption={(event, data) => {
 						this.setState({
 							inputValue: '',
-							selection: []
+							selection: [],
 						});
 					}}
 					onSubmit={(event, { value }) => {
@@ -68,9 +68,9 @@ class Example extends React.Component {
 											category="standard"
 											name="account"
 										/>
-									)
-								}
-							]
+									),
+								},
+							],
 						});
 					}}
 					onSelect={(event, data) => {

--- a/components/combobox/__examples__/snapshot/base-selected.jsx
+++ b/components/combobox/__examples__/snapshot/base-selected.jsx
@@ -10,19 +10,19 @@ const accounts = [
 		id: '1',
 		label: 'Acme',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '2',
 		label: 'Salesforce.com, Inc.',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
-	}
+		type: 'account',
+	},
 ];
 
 const accountsWithIcon = accounts.map((elem) =>
 	Object.assign(elem, {
-		icon: <Icon assistiveText="Account" category="standard" name={elem.type} />
+		icon: <Icon assistiveText="Account" category="standard" name={elem.type} />,
 	})
 );
 
@@ -32,7 +32,7 @@ class Example extends React.Component {
 
 		this.state = {
 			inputValue: '',
-			selection: [accounts[1]]
+			selection: [accounts[1]],
 		};
 	}
 
@@ -42,7 +42,7 @@ class Example extends React.Component {
 				<Combobox
 					id="combobox-unique-id"
 					labels={{
-						placeholder: 'Search Salesforce'
+						placeholder: 'Search Salesforce',
 					}}
 					menuPosition="relative"
 					onChange={(event, { value }) => {
@@ -52,7 +52,7 @@ class Example extends React.Component {
 					onRequestRemoveSelectedOption={(event, data) => {
 						this.setState({
 							inputValue: '',
-							selection: []
+							selection: [],
 						});
 					}}
 					onSubmit={(event, { value }) => {
@@ -67,9 +67,9 @@ class Example extends React.Component {
 											category="standard"
 											name="account"
 										/>
-									)
-								}
-							]
+									),
+								},
+							],
 						});
 					}}
 					onSelect={(event, data) => {

--- a/components/combobox/__examples__/snapshot/inline-multiple-selection-selected.jsx
+++ b/components/combobox/__examples__/snapshot/inline-multiple-selection-selected.jsx
@@ -10,50 +10,50 @@ const accounts = [
 		id: '1',
 		label: 'Acme',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '2',
 		label: 'Salesforce.com, Inc.',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '3',
 		label: "Paddy's Pub",
 		subTitle: 'Account • Boston, MA',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '4',
 		label: 'Tyrell Corp',
 		subTitle: 'Account • San Francisco, CA',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '5',
 		label: 'Paper St. Soap Company',
 		subTitle: 'Account • Beloit, WI',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '6',
 		label: 'Nakatomi Investments',
 		subTitle: 'Account • Chicago, IL',
-		type: 'account'
+		type: 'account',
 	},
 	{ id: '7', label: 'Acme Landscaping', type: 'account' },
 	{
 		id: '8',
 		label: 'Acme Construction',
 		subTitle: 'Account • Grand Marais, MN',
-		type: 'account'
-	}
+		type: 'account',
+	},
 ];
 
 const accountsWithIcon = accounts.map((elem) =>
 	Object.assign(elem, {
-		icon: <Icon assistiveText="Account" category="standard" name={elem.type} />
+		icon: <Icon assistiveText="Account" category="standard" name={elem.type} />,
 	})
 );
 
@@ -63,7 +63,7 @@ class Example extends React.Component {
 
 		this.state = {
 			inputValue: '',
-			selection: [accountsWithIcon[0], accountsWithIcon[1]]
+			selection: [accountsWithIcon[0], accountsWithIcon[1]],
 		};
 	}
 
@@ -80,7 +80,7 @@ class Example extends React.Component {
 						onRequestRemoveSelectedOption: (event, data) => {
 							this.setState({
 								inputValue: '',
-								selection: data.selection
+								selection: data.selection,
 							});
 						},
 						onSubmit: (event, { value }) => {
@@ -97,29 +97,29 @@ class Example extends React.Component {
 												category="standard"
 												name="account"
 											/>
-										)
-									}
-								]
+										),
+									},
+								],
 							});
 						},
 						onSelect: (event, data) => {
 							console.log('onSelect', data);
 							this.setState({
 								inputValue: '',
-								selection: data.selection
+								selection: data.selection,
 							});
-						}
+						},
 					}}
 					labels={{
 						label: 'Search',
-						placeholder: 'Search Salesforce'
+						placeholder: 'Search Salesforce',
 					}}
 					menuPosition="relative"
 					multiple
 					options={filter({
 						inputValue: this.state.inputValue,
 						options: accountsWithIcon,
-						selection: this.state.selection
+						selection: this.state.selection,
 					})}
 					selection={this.state.selection}
 					value={this.state.inputValue}

--- a/components/combobox/__examples__/snapshot/inline-multiple-selection.jsx
+++ b/components/combobox/__examples__/snapshot/inline-multiple-selection.jsx
@@ -10,50 +10,50 @@ const accounts = [
 		id: '1',
 		label: 'Acme',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '2',
 		label: 'Salesforce.com, Inc.',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '3',
 		label: "Paddy's Pub",
 		subTitle: 'Account • Boston, MA',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '4',
 		label: 'Tyrell Corp',
 		subTitle: 'Account • San Francisco, CA',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '5',
 		label: 'Paper St. Soap Company',
 		subTitle: 'Account • Beloit, WI',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '6',
 		label: 'Nakatomi Investments',
 		subTitle: 'Account • Chicago, IL',
-		type: 'account'
+		type: 'account',
 	},
 	{ id: '7', label: 'Acme Landscaping', type: 'account' },
 	{
 		id: '8',
 		label: 'Acme Construction',
 		subTitle: 'Account • Grand Marais, MN',
-		type: 'account'
-	}
+		type: 'account',
+	},
 ];
 
 const accountsWithIcon = accounts.map((elem) =>
 	Object.assign(elem, {
-		icon: <Icon assistiveText="Account" category="standard" name={elem.type} />
+		icon: <Icon assistiveText="Account" category="standard" name={elem.type} />,
 	})
 );
 
@@ -63,7 +63,7 @@ class Example extends React.Component {
 
 		this.state = {
 			inputValue: '',
-			selection: []
+			selection: [],
 		};
 	}
 
@@ -80,7 +80,7 @@ class Example extends React.Component {
 						onRequestRemoveSelectedOption: (event, data) => {
 							this.setState({
 								inputValue: '',
-								selection: data.selection
+								selection: data.selection,
 							});
 						},
 						onSubmit: (event, { value }) => {
@@ -97,29 +97,29 @@ class Example extends React.Component {
 												category="standard"
 												name="account"
 											/>
-										)
-									}
-								]
+										),
+									},
+								],
 							});
 						},
 						onSelect: (event, data) => {
 							console.log('onSelect', data);
 							this.setState({
 								inputValue: '',
-								selection: data.selection
+								selection: data.selection,
 							});
-						}
+						},
 					}}
 					labels={{
 						label: 'Search',
-						placeholder: 'Search Salesforce'
+						placeholder: 'Search Salesforce',
 					}}
 					menuPosition="relative"
 					multiple
 					options={filter({
 						inputValue: this.state.inputValue,
 						options: accountsWithIcon,
-						selection: this.state.selection
+						selection: this.state.selection,
 					})}
 					selection={this.state.selection}
 					value={this.state.inputValue}

--- a/components/combobox/__examples__/snapshot/inline-single-selection-selected.jsx
+++ b/components/combobox/__examples__/snapshot/inline-single-selection-selected.jsx
@@ -10,50 +10,50 @@ const accounts = [
 		id: '1',
 		label: 'Acme',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '2',
 		label: 'Salesforce.com, Inc.',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '3',
 		label: "Paddy's Pub",
 		subTitle: 'Account • Boston, MA',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '4',
 		label: 'Tyrell Corp',
 		subTitle: 'Account • San Francisco, CA',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '5',
 		label: 'Paper St. Soap Company',
 		subTitle: 'Account • Beloit, WI',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '6',
 		label: 'Nakatomi Investments',
 		subTitle: 'Account • Chicago, IL',
-		type: 'account'
+		type: 'account',
 	},
 	{ id: '7', label: 'Acme Landscaping', type: 'account' },
 	{
 		id: '8',
 		label: 'Acme Construction',
 		subTitle: 'Account • Grand Marais, MN',
-		type: 'account'
-	}
+		type: 'account',
+	},
 ];
 
 const accountsWithIcon = accounts.map((elem) =>
 	Object.assign(elem, {
-		icon: <Icon assistiveText="Account" category="standard" name={elem.type} />
+		icon: <Icon assistiveText="Account" category="standard" name={elem.type} />,
 	})
 );
 
@@ -63,7 +63,7 @@ class Example extends React.Component {
 
 		this.state = {
 			inputValue: '',
-			selection: [accountsWithIcon[0]]
+			selection: [accountsWithIcon[0]],
 		};
 	}
 
@@ -80,7 +80,7 @@ class Example extends React.Component {
 						onRequestRemoveSelectedOption: (event, data) => {
 							this.setState({
 								inputValue: '',
-								selection: data.selection
+								selection: data.selection,
 							});
 						},
 						onSubmit: (event, { value }) => {
@@ -97,28 +97,28 @@ class Example extends React.Component {
 												category="standard"
 												name="account"
 											/>
-										)
-									}
-								]
+										),
+									},
+								],
 							});
 						},
 						onSelect: (event, data) => {
 							console.log('onSelect', data);
 							this.setState({
 								inputValue: '',
-								selection: data.selection
+								selection: data.selection,
 							});
-						}
+						},
 					}}
 					labels={{
 						label: 'Search',
-						placeholder: 'Search Salesforce'
+						placeholder: 'Search Salesforce',
 					}}
 					menuPosition="relative"
 					options={filter({
 						inputValue: this.state.inputValue,
 						options: accountsWithIcon,
-						selection: this.state.selection
+						selection: this.state.selection,
 					})}
 					selection={this.state.selection}
 					value={

--- a/components/combobox/__examples__/snapshot/inline-single-selection.jsx
+++ b/components/combobox/__examples__/snapshot/inline-single-selection.jsx
@@ -10,50 +10,50 @@ const accounts = [
 		id: '1',
 		label: 'Acme',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '2',
 		label: 'Salesforce.com, Inc.',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '3',
 		label: "Paddy's Pub",
 		subTitle: 'Account • Boston, MA',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '4',
 		label: 'Tyrell Corp',
 		subTitle: 'Account • San Francisco, CA',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '5',
 		label: 'Paper St. Soap Company',
 		subTitle: 'Account • Beloit, WI',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '6',
 		label: 'Nakatomi Investments',
 		subTitle: 'Account • Chicago, IL',
-		type: 'account'
+		type: 'account',
 	},
 	{ id: '7', label: 'Acme Landscaping', type: 'account' },
 	{
 		id: '8',
 		label: 'Acme Construction',
 		subTitle: 'Account • Grand Marais, MN',
-		type: 'account'
-	}
+		type: 'account',
+	},
 ];
 
 const accountsWithIcon = accounts.map((elem) =>
 	Object.assign(elem, {
-		icon: <Icon assistiveText="Account" category="standard" name={elem.type} />
+		icon: <Icon assistiveText="Account" category="standard" name={elem.type} />,
 	})
 );
 
@@ -63,7 +63,7 @@ class Example extends React.Component {
 
 		this.state = {
 			inputValue: '',
-			selection: []
+			selection: [],
 		};
 	}
 
@@ -80,7 +80,7 @@ class Example extends React.Component {
 						onRequestRemoveSelectedOption: (event, data) => {
 							this.setState({
 								inputValue: '',
-								selection: data.selection
+								selection: data.selection,
 							});
 						},
 						onSubmit: (event, { value }) => {
@@ -97,28 +97,28 @@ class Example extends React.Component {
 												category="standard"
 												name="account"
 											/>
-										)
-									}
-								]
+										),
+									},
+								],
 							});
 						},
 						onSelect: (event, data) => {
 							console.log('onSelect', data);
 							this.setState({
 								inputValue: '',
-								selection: data.selection
+								selection: data.selection,
 							});
-						}
+						},
 					}}
 					labels={{
 						label: 'Search',
-						placeholder: 'Search Salesforce'
+						placeholder: 'Search Salesforce',
 					}}
 					menuPosition="relative"
 					options={filter({
 						inputValue: this.state.inputValue,
 						options: accountsWithIcon,
-						selection: this.state.selection
+						selection: this.state.selection,
 					})}
 					selection={this.state.selection}
 					value={

--- a/components/combobox/__examples__/snapshot/readonly-multiple-selection-multiple-items-selected.jsx
+++ b/components/combobox/__examples__/snapshot/readonly-multiple-selection-multiple-items-selected.jsx
@@ -10,45 +10,45 @@ const accounts = [
 		id: '1',
 		label: 'Acme',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '2',
 		label: 'Salesforce.com, Inc.',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '3',
 		label: "Paddy's Pub",
 		subTitle: 'Account • Boston, MA',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '4',
 		label: 'Tyrell Corp',
 		subTitle: 'Account • San Francisco, CA',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '5',
 		label: 'Paper St. Soap Company',
 		subTitle: 'Account • Beloit, WI',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '6',
 		label: 'Nakatomi Investments',
 		subTitle: 'Account • Chicago, IL',
-		type: 'account'
+		type: 'account',
 	},
 	{ id: '7', label: 'Acme Landscaping', type: 'account' },
 	{
 		id: '8',
 		label: 'Acme Construction',
 		subTitle: 'Account • Grand Marais, MN',
-		type: 'account'
-	}
+		type: 'account',
+	},
 ];
 
 class Example extends React.Component {
@@ -57,7 +57,7 @@ class Example extends React.Component {
 
 		this.state = {
 			inputValue: '',
-			selection: [accounts[0], accounts[1]]
+			selection: [accounts[0], accounts[1]],
 		};
 	}
 
@@ -70,20 +70,20 @@ class Example extends React.Component {
 						onRequestRemoveSelectedOption: (event, data) => {
 							this.setState({
 								inputValue: '',
-								selection: data.selection
+								selection: data.selection,
 							});
 						},
 						onSelect: (event, data) => {
 							console.log('onSelect', data);
 							this.setState({
 								inputValue: '',
-								selection: data.selection
+								selection: data.selection,
 							});
-						}
+						},
 					}}
 					labels={{
 						label: 'Search',
-						placeholder: 'Search Salesforce'
+						placeholder: 'Search Salesforce',
 					}}
 					menuPosition="relative"
 					multiple

--- a/components/combobox/__examples__/snapshot/readonly-multiple-selection-single-item-selected.jsx
+++ b/components/combobox/__examples__/snapshot/readonly-multiple-selection-single-item-selected.jsx
@@ -10,45 +10,45 @@ const accounts = [
 		id: '1',
 		label: 'Acme',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '2',
 		label: 'Salesforce.com, Inc.',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '3',
 		label: "Paddy's Pub",
 		subTitle: 'Account • Boston, MA',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '4',
 		label: 'Tyrell Corp',
 		subTitle: 'Account • San Francisco, CA',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '5',
 		label: 'Paper St. Soap Company',
 		subTitle: 'Account • Beloit, WI',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '6',
 		label: 'Nakatomi Investments',
 		subTitle: 'Account • Chicago, IL',
-		type: 'account'
+		type: 'account',
 	},
 	{ id: '7', label: 'Acme Landscaping', type: 'account' },
 	{
 		id: '8',
 		label: 'Acme Construction',
 		subTitle: 'Account • Grand Marais, MN',
-		type: 'account'
-	}
+		type: 'account',
+	},
 ];
 
 class Example extends React.Component {
@@ -57,7 +57,7 @@ class Example extends React.Component {
 
 		this.state = {
 			inputValue: '',
-			selection: [accounts[0]]
+			selection: [accounts[0]],
 		};
 	}
 
@@ -70,20 +70,20 @@ class Example extends React.Component {
 						onRequestRemoveSelectedOption: (event, data) => {
 							this.setState({
 								inputValue: '',
-								selection: data.selection
+								selection: data.selection,
 							});
 						},
 						onSelect: (event, data) => {
 							console.log('onSelect', data);
 							this.setState({
 								inputValue: '',
-								selection: data.selection
+								selection: data.selection,
 							});
-						}
+						},
 					}}
 					labels={{
 						label: 'Search',
-						placeholder: 'Search Salesforce'
+						placeholder: 'Search Salesforce',
 					}}
 					menuPosition="relative"
 					multiple

--- a/components/combobox/__examples__/snapshot/readonly-multiple-selection.jsx
+++ b/components/combobox/__examples__/snapshot/readonly-multiple-selection.jsx
@@ -10,45 +10,45 @@ const accounts = [
 		id: '1',
 		label: 'Acme',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '2',
 		label: 'Salesforce.com, Inc.',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '3',
 		label: "Paddy's Pub",
 		subTitle: 'Account • Boston, MA',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '4',
 		label: 'Tyrell Corp',
 		subTitle: 'Account • San Francisco, CA',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '5',
 		label: 'Paper St. Soap Company',
 		subTitle: 'Account • Beloit, WI',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '6',
 		label: 'Nakatomi Investments',
 		subTitle: 'Account • Chicago, IL',
-		type: 'account'
+		type: 'account',
 	},
 	{ id: '7', label: 'Acme Landscaping', type: 'account' },
 	{
 		id: '8',
 		label: 'Acme Construction',
 		subTitle: 'Account • Grand Marais, MN',
-		type: 'account'
-	}
+		type: 'account',
+	},
 ];
 
 class Example extends React.Component {
@@ -57,7 +57,7 @@ class Example extends React.Component {
 
 		this.state = {
 			inputValue: '',
-			selection: []
+			selection: [],
 		};
 	}
 
@@ -70,20 +70,20 @@ class Example extends React.Component {
 						onRequestRemoveSelectedOption: (event, data) => {
 							this.setState({
 								inputValue: '',
-								selection: data.selection
+								selection: data.selection,
 							});
 						},
 						onSelect: (event, data) => {
 							console.log('onSelect', data);
 							this.setState({
 								inputValue: '',
-								selection: data.selection
+								selection: data.selection,
 							});
-						}
+						},
 					}}
 					labels={{
 						label: 'Search',
-						placeholder: 'Search Salesforce'
+						placeholder: 'Search Salesforce',
 					}}
 					menuPosition="relative"
 					multiple

--- a/components/combobox/__examples__/snapshot/readonly-single-selection-selected-open.jsx
+++ b/components/combobox/__examples__/snapshot/readonly-single-selection-selected-open.jsx
@@ -10,45 +10,45 @@ const accounts = [
 		id: '1',
 		label: 'Acme',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '2',
 		label: 'Salesforce.com, Inc.',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '3',
 		label: "Paddy's Pub",
 		subTitle: 'Account • Boston, MA',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '4',
 		label: 'Tyrell Corp',
 		subTitle: 'Account • San Francisco, CA',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '5',
 		label: 'Paper St. Soap Company',
 		subTitle: 'Account • Beloit, WI',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '6',
 		label: 'Nakatomi Investments',
 		subTitle: 'Account • Chicago, IL',
-		type: 'account'
+		type: 'account',
 	},
 	{ id: '7', label: 'Acme Landscaping', type: 'account' },
 	{
 		id: '8',
 		label: 'Acme Construction',
 		subTitle: 'Account • Grand Marais, MN',
-		type: 'account'
-	}
+		type: 'account',
+	},
 ];
 
 class Example extends React.Component {
@@ -57,7 +57,7 @@ class Example extends React.Component {
 
 		this.state = {
 			inputValue: '',
-			selection: [accounts[0]]
+			selection: [accounts[0]],
 		};
 	}
 
@@ -72,13 +72,13 @@ class Example extends React.Component {
 							console.log('onSelect', data);
 							this.setState({
 								inputValue: '',
-								selection: data.selection
+								selection: data.selection,
 							});
-						}
+						},
 					}}
 					labels={{
 						label: 'Search',
-						placeholder: 'Search Salesforce'
+						placeholder: 'Search Salesforce',
 					}}
 					menuPosition="relative"
 					options={accounts}

--- a/components/combobox/__examples__/snapshot/readonly-single-selection-selected.jsx
+++ b/components/combobox/__examples__/snapshot/readonly-single-selection-selected.jsx
@@ -10,45 +10,45 @@ const accounts = [
 		id: '1',
 		label: 'Acme',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '2',
 		label: 'Salesforce.com, Inc.',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '3',
 		label: "Paddy's Pub",
 		subTitle: 'Account • Boston, MA',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '4',
 		label: 'Tyrell Corp',
 		subTitle: 'Account • San Francisco, CA',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '5',
 		label: 'Paper St. Soap Company',
 		subTitle: 'Account • Beloit, WI',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '6',
 		label: 'Nakatomi Investments',
 		subTitle: 'Account • Chicago, IL',
-		type: 'account'
+		type: 'account',
 	},
 	{ id: '7', label: 'Acme Landscaping', type: 'account' },
 	{
 		id: '8',
 		label: 'Acme Construction',
 		subTitle: 'Account • Grand Marais, MN',
-		type: 'account'
-	}
+		type: 'account',
+	},
 ];
 
 class Example extends React.Component {
@@ -57,7 +57,7 @@ class Example extends React.Component {
 
 		this.state = {
 			inputValue: '',
-			selection: [accounts[0]]
+			selection: [accounts[0]],
 		};
 	}
 
@@ -71,13 +71,13 @@ class Example extends React.Component {
 							console.log('onSelect', data);
 							this.setState({
 								inputValue: '',
-								selection: data.selection
+								selection: data.selection,
 							});
-						}
+						},
 					}}
 					labels={{
 						label: 'Search',
-						placeholder: 'Search Salesforce'
+						placeholder: 'Search Salesforce',
 					}}
 					menuPosition="relative"
 					options={accounts}

--- a/components/combobox/__examples__/snapshot/readonly-single-selection.jsx
+++ b/components/combobox/__examples__/snapshot/readonly-single-selection.jsx
@@ -10,45 +10,45 @@ const accounts = [
 		id: '1',
 		label: 'Acme',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '2',
 		label: 'Salesforce.com, Inc.',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '3',
 		label: "Paddy's Pub",
 		subTitle: 'Account • Boston, MA',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '4',
 		label: 'Tyrell Corp',
 		subTitle: 'Account • San Francisco, CA',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '5',
 		label: 'Paper St. Soap Company',
 		subTitle: 'Account • Beloit, WI',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '6',
 		label: 'Nakatomi Investments',
 		subTitle: 'Account • Chicago, IL',
-		type: 'account'
+		type: 'account',
 	},
 	{ id: '7', label: 'Acme Landscaping', type: 'account' },
 	{
 		id: '8',
 		label: 'Acme Construction',
 		subTitle: 'Account • Grand Marais, MN',
-		type: 'account'
-	}
+		type: 'account',
+	},
 ];
 
 class Example extends React.Component {
@@ -57,7 +57,7 @@ class Example extends React.Component {
 
 		this.state = {
 			inputValue: '',
-			selection: []
+			selection: [],
 		};
 	}
 
@@ -71,13 +71,13 @@ class Example extends React.Component {
 							console.log('onSelect', data);
 							this.setState({
 								inputValue: '',
-								selection: data.selection
+								selection: data.selection,
 							});
-						}
+						},
 					}}
 					labels={{
 						label: 'Search',
-						placeholder: 'Search Salesforce'
+						placeholder: 'Search Salesforce',
 					}}
 					menuPosition="relative"
 					options={accounts}

--- a/components/combobox/__tests__/combobox.browser-test.jsx
+++ b/components/combobox/__tests__/combobox.browser-test.jsx
@@ -13,7 +13,7 @@ import assign from 'lodash.assign';
  */
 import {
 	createMountNode,
-	destroyMountNode
+	destroyMountNode,
 } from '../../../tests/enzyme-helpers';
 
 // Import your internal dependencies (for example):
@@ -22,7 +22,7 @@ import Icon from '../../../components/icon';
 import filter from '~/components/combobox/filter';
 import KEYS, { keyObjects } from '../../../utilities/key-code';
 import LETTERKEYS, {
-	keyObjects as letterKeyObjects
+	keyObjects as letterKeyObjects,
 } from '../../../utilities/letter-key-code';
 import IconSettings from '~/components/icon-settings';
 
@@ -36,50 +36,50 @@ const accounts = [
 		id: '1',
 		label: 'Acme',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '2',
 		label: 'Salesforce.com, Inc.',
 		subTitle: 'Account • San Francisco',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '3',
 		label: "Paddy's Pub",
 		subTitle: 'Account • Boston, MA',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '4',
 		label: 'Tyrell Corp',
 		subTitle: 'Account • San Francisco, CA',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '5',
 		label: 'Paper St. Soap Company',
 		subTitle: 'Account • Beloit, WI',
-		type: 'account'
+		type: 'account',
 	},
 	{
 		id: '6',
 		label: 'Nakatomi Investments',
 		subTitle: 'Account • Chicago, IL',
-		type: 'account'
+		type: 'account',
 	},
 	{ id: '7', label: 'Acme Landscaping', type: 'account' },
 	{
 		id: '8',
 		label: 'Acme Construction',
 		subTitle: 'Account • Grand Marais, MN',
-		type: 'account'
-	}
+		type: 'account',
+	},
 ];
 
 const accountsWithIcon = accounts.map((elem) =>
 	assign(elem, {
-		icon: <Icon assistiveText="Account" category="standard" name={elem.type} />
+		icon: <Icon assistiveText="Account" category="standard" name={elem.type} />,
 	})
 );
 
@@ -87,14 +87,14 @@ const defaultProps = {
 	id: 'combobox-unique-id',
 	labels: {
 		label: 'Search',
-		placeholder: 'Search Salesforce'
+		placeholder: 'Search Salesforce',
 	},
-	menuPosition: 'relative'
+	menuPosition: 'relative',
 };
 
 const propTypes = {
 	componentWillUpdate: PropTypes.func,
-	initialSelection: PropTypes.array
+	initialSelection: PropTypes.array,
 };
 
 /* A re-usable demo component fixture outside of `describe` sections
@@ -108,7 +108,7 @@ class DemoComponent extends React.Component {
 
 		this.state = {
 			inputValue: '',
-			selection: this.props.initialSelection || []
+			selection: this.props.initialSelection || [],
 		};
 	}
 
@@ -130,7 +130,7 @@ class DemoComponent extends React.Component {
 							console.log(data);
 							this.setState({
 								inputValue: '',
-								selection: data.selection
+								selection: data.selection,
 							});
 						},
 						onSubmit: (event, { value }) => {
@@ -146,22 +146,22 @@ class DemoComponent extends React.Component {
 												category="standard"
 												name="account"
 											/>
-										)
-									}
-								]
+										),
+									},
+								],
 							});
 						},
 						onSelect: (event, data) => {
 							this.setState({
 								inputValue: '',
-								selection: data.selection
+								selection: data.selection,
 							});
-						}
+						},
 					}}
 					options={filter({
 						inputValue: this.state.inputValue,
 						options: accountsWithIcon,
-						selection: this.state.selection
+						selection: this.state.selection,
 					})}
 					selection={this.state.selection}
 					value={this.state.inputValue}
@@ -183,7 +183,7 @@ const getNodes = ({ wrapper }) => ({
 	removeSingleItem: wrapper.find('.slds-combobox .slds-input__icon'),
 	selectedListbox: wrapper.find(
 		`#${defaultProps.id}-selected-listbox .slds-listbox`
-	)
+	),
 });
 
 /* All tests for component being tested should be wrapped in a root `describe`,
@@ -230,7 +230,7 @@ describe('SLDSCombobox', function () {
 
 		it('menu filters to second item, menu listbox menu item 2 aria-selected is true, input activedescendent has item 2 id, after pressing down arrow, enter selects item 2', function () {
 			wrapper = mount(<DemoComponent multiple isOpen />, {
-				attachTo: mountNode
+				attachTo: mountNode,
 			});
 			let nodes = getNodes({ wrapper });
 			nodes.input.simulate('focus');
@@ -266,19 +266,19 @@ describe('SLDSCombobox', function () {
 					accountsWithIcon[1],
 					accountsWithIcon[2],
 					accountsWithIcon[3],
-					accountsWithIcon[4]
+					accountsWithIcon[4],
 				],
 				removeThirdInitialItem: [
 					accountsWithIcon[1],
 					accountsWithIcon[3],
-					accountsWithIcon[4]
+					accountsWithIcon[4],
 				],
 				removesLastAndInitialFifthPill: [
 					accountsWithIcon[1],
-					accountsWithIcon[3]
+					accountsWithIcon[3],
 				],
 				removeInitalSecondAndFourthPill: [accountsWithIcon[3]],
-				allPillsRemoved: []
+				allPillsRemoved: [],
 			};
 			const selectionIndexedStates = Object.keys(selectionKeyedStates).map(
 				(key, index) => selectionKeyedStates[key]
@@ -301,7 +301,7 @@ describe('SLDSCombobox', function () {
 						accounts[1],
 						accounts[2],
 						accounts[3],
-						accounts[4]
+						accounts[4],
 					]}
 					multiple
 				/>,
@@ -366,7 +366,7 @@ describe('SLDSCombobox', function () {
 
 		it('Limit to pre-defined choices', function () {
 			wrapper = mount(<DemoComponent multiple predefinedOptionsOnly />, {
-				attachTo: mountNode
+				attachTo: mountNode,
 			});
 			let nodes = getNodes({ wrapper });
 			nodes.input.simulate('focus');
@@ -378,7 +378,7 @@ describe('SLDSCombobox', function () {
 
 		it('Inline Single Selection Remove selection', function () {
 			wrapper = mount(<DemoComponent variant="inline-listbox" />, {
-				attachTo: mountNode
+				attachTo: mountNode,
 			});
 			let nodes = getNodes({ wrapper });
 

--- a/components/combobox/__tests__/combobox.snapshot-test.jsx
+++ b/components/combobox/__tests__/combobox.snapshot-test.jsx
@@ -23,89 +23,89 @@ import SnapshotReadonlySingleSelectionCustomMenuItemOpen from '../__examples__/s
 testDOMandHTML({
 	name: 'Base Open',
 	test,
-	Component: SnapshotBaseOpen
+	Component: SnapshotBaseOpen,
 });
 
 testDOMandHTML({
 	name: 'Base Selected',
 	test,
-	Component: SnapshotBaseSelected
+	Component: SnapshotBaseSelected,
 });
 
 testDOMandHTML({
 	name: 'Base Open Custom Class Name',
 	test,
-	Component: SnapshotBaseOpenClassName
+	Component: SnapshotBaseOpenClassName,
 });
 
 testDOMandHTML({
 	name: 'Inline Single Selection',
 	test,
-	Component: SnapshotInlineSingleSelection
+	Component: SnapshotInlineSingleSelection,
 });
 
 testDOMandHTML({
 	name: 'Inline Single Selection Selected',
 	test,
-	Component: SnapshotInlineSingleSelectionSelected
+	Component: SnapshotInlineSingleSelectionSelected,
 });
 
 testDOMandHTML({
 	name: 'Inline Multiple Selection',
 	test,
-	Component: SnapshotInlineMultipleSelection
+	Component: SnapshotInlineMultipleSelection,
 });
 
 testDOMandHTML({
 	name: 'Inline Multiple Selection Selected',
 	test,
-	Component: SnapshotInlineMultipleSelectionSelected
+	Component: SnapshotInlineMultipleSelectionSelected,
 });
 
 testDOMandHTML({
 	name: 'Base Custom Menu Item Open',
 	test,
-	Component: SnapshotBaseCustomMenuItemOpen
+	Component: SnapshotBaseCustomMenuItemOpen,
 });
 
 testDOMandHTML({
 	name: 'Readonly Single Selection',
 	test,
-	Component: SnapshotReadonlySingleSelection
+	Component: SnapshotReadonlySingleSelection,
 });
 
 testDOMandHTML({
 	name: 'Readonly Single Selection Selected',
 	test,
-	Component: SnapshotReadonlySingleSelectionSelected
+	Component: SnapshotReadonlySingleSelectionSelected,
 });
 
 testDOMandHTML({
 	name: 'Readonly Single Selection Selected Open',
 	test,
-	Component: SnapshotReadonlySingleSelectionSelectedOpen
+	Component: SnapshotReadonlySingleSelectionSelectedOpen,
 });
 
 testDOMandHTML({
 	name: 'Readonly Multiple Selection',
 	test,
-	Component: SnapshotReadonlyMultipleSelection
+	Component: SnapshotReadonlyMultipleSelection,
 });
 
 testDOMandHTML({
 	name: 'Readonly Multiple Selection Single Item Selected',
 	test,
-	Component: SnapshotReadonlyMultipleSelectionSingleItemSelected
+	Component: SnapshotReadonlyMultipleSelectionSingleItemSelected,
 });
 
 testDOMandHTML({
 	name: 'Readonly Multiple Selection Multiple Items Selected',
 	test,
-	Component: SnapshotReadonlyMultipleSelectionMultipleItemsSelected
+	Component: SnapshotReadonlyMultipleSelectionMultipleItemsSelected,
 });
 
 testDOMandHTML({
 	name: 'Readonly Single Selection Custom Menu Item Open',
 	test,
-	Component: SnapshotReadonlySingleSelectionCustomMenuItemOpen
+	Component: SnapshotReadonlySingleSelectionCustomMenuItemOpen,
 });

--- a/components/combobox/combobox.jsx
+++ b/components/combobox/combobox.jsx
@@ -53,7 +53,7 @@ const propTypes = {
 		optionSelectedInMenu: PropTypes.string,
 		removeSingleSelectedOption: PropTypes.string,
 		removePill: PropTypes.string,
-		selectedListboxLabel: PropTypes.string
+		selectedListboxLabel: PropTypes.string,
 	}),
 	/**
 	 * CSS classes to be added to tag with `.slds-combobox`. Uses `classNames` [API](https://github.com/JedWatson/classnames). _Tested with snapshot testing._
@@ -61,7 +61,7 @@ const propTypes = {
 	className: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * CSS classes to be added to top level tag with `.slds-form-element` and not on `.slds-combobox_container`. Uses `classNames` [API](https://github.com/JedWatson/classnames). _Tested with snapshot testing._
@@ -69,7 +69,7 @@ const propTypes = {
 	classNameContainer: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * CSS classes to be added to tag with `.slds-dropdown`. Uses `classNames` [API](https://github.com/JedWatson/classnames). Autocomplete/bass variant menu height should not scroll and should be determined by number items which should be no more than 10. _Tested with snapshot testing._
@@ -77,7 +77,7 @@ const propTypes = {
 	classNameMenu: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * Event Callbacks
@@ -103,7 +103,7 @@ const propTypes = {
 		onRequestOpen: PropTypes.func,
 		onRequestRemoveSelectedOption: PropTypes.func,
 		onSelect: PropTypes.func,
-		onSubmit: PropTypes.func
+		onSubmit: PropTypes.func,
 	}),
 	/**
 	 * By default, dialogs will flip their alignment (such as bottom to top) if they extend beyond a boundary element such as a scrolling parent or a window/viewpoint. This is the opposite of "flippable."
@@ -130,7 +130,7 @@ const propTypes = {
 		noOptionsFound: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
 		placeholder: PropTypes.string,
 		placeholderReadOnly: PropTypes.string,
-		removePillTitle: PropTypes.string
+		removePillTitle: PropTypes.string,
 	}),
 	/**
 	 * Forces the dropdown to be open or closed. See controlled/uncontrolled callback/prop pattern for more on suggested use view [Concepts and Best Practices](https://github.com/salesforce-ux/design-system-react/blob/master/CONTRIBUTING.md#concepts-and-best-practices) _Tested with snapshot testing._
@@ -154,7 +154,7 @@ const propTypes = {
 	menuPosition: PropTypes.oneOf([
 		'absolute',
 		'overflowBoundaryElement',
-		'relative'
+		'relative',
 	]),
 	/**
 	 * Allows multiple selections _Tested with mocha testing._
@@ -183,7 +183,7 @@ const propTypes = {
 	/**
 	 * Changes styles of the input. Currently `entity` is not supported. _Tested with snapshot testing._
 	 */
-	variant: PropTypes.oneOf(['base', 'inline-listbox', 'readonly'])
+	variant: PropTypes.oneOf(['base', 'inline-listbox', 'readonly']),
 };
 
 const defaultProps = {
@@ -191,18 +191,18 @@ const defaultProps = {
 		optionSelectedInMenu: 'Current Selection:',
 		removeSingleSelectedOption: 'Remove selected option',
 		removePill: ', Press delete or backspace to remove',
-		selectedListboxLabel: 'Selected Options:'
+		selectedListboxLabel: 'Selected Options:',
 	},
 	events: {},
 	labels: {
 		noOptionsFound: 'No matches found.',
 		placeholderReadOnly: 'Select an Option',
-		removePillTitle: 'Remove'
+		removePillTitle: 'Remove',
 	},
 	menuPosition: 'absolute',
 	readOnlyMenuItemVisibleLength: 5,
 	selection: [],
-	variant: 'base'
+	variant: 'base',
 };
 
 /**
@@ -219,7 +219,7 @@ class Combobox extends React.Component {
 			// seeding initial state with this.props.selection[0]
 			activeSelectedOption:
 				(this.props.selection && this.props.selection[0]) || undefined,
-			activeSelectedOptionIndex: 0
+			activeSelectedOptionIndex: 0,
 		};
 	}
 
@@ -261,7 +261,7 @@ class Combobox extends React.Component {
 		if (selectedOptionsRenderIsInitialRender) {
 			this.setState({
 				activeSelectedOption: nextProps.selection[0],
-				activeSelectedOptionIndex: 0
+				activeSelectedOptionIndex: 0,
 			});
 		}
 	}
@@ -290,7 +290,7 @@ class Combobox extends React.Component {
 				position={menuPosition}
 				containerProps={{
 					id: `${this.getId()}-listbox`,
-					role: 'listbox'
+					role: 'listbox',
 				}}
 			>
 				{menuRenderer}
@@ -354,7 +354,7 @@ class Combobox extends React.Component {
 			this.setState({
 				activeOption: undefined,
 				activeOptionIndex: -1,
-				isOpen: false
+				isOpen: false,
 			});
 
 			if (this.props.events.onClose) {
@@ -390,7 +390,7 @@ class Combobox extends React.Component {
 		if (this.getIsActiveOption()) {
 			this.handleSelect(event, {
 				option: this.state.activeOption,
-				selection: this.props.selection
+				selection: this.props.selection,
 			});
 			// use input value, if not limited to predefined options (in the menu)
 		} else if (
@@ -399,7 +399,7 @@ class Combobox extends React.Component {
 			this.props.events.onSubmit
 		) {
 			this.props.events.onSubmit(event, {
-				value: event.target.value
+				value: event.target.value,
 			});
 		}
 	};
@@ -415,8 +415,8 @@ class Combobox extends React.Component {
 				[KEYS.DOWN]: { callback: this.handleKeyDownDown },
 				[KEYS.ENTER]: { callback: this.handleInputSubmit },
 				[KEYS.ESCAPE]: { callback: this.handleClose },
-				[KEYS.UP]: { callback: this.handleKeyDownUp }
-			}
+				[KEYS.UP]: { callback: this.handleKeyDownUp },
+			},
 		});
 	};
 
@@ -443,12 +443,12 @@ class Combobox extends React.Component {
 			const newIndex = this.getNewActiveOptionIndex({
 				activeOptionIndex: prevState.activeOptionIndex,
 				offset: offsets[direction],
-				options: this.props.options
+				options: this.props.options,
 			});
 
 			return {
 				activeOption: this.props.options[newIndex],
-				activeOptionIndex: newIndex
+				activeOptionIndex: newIndex,
 			};
 		});
 	};
@@ -467,7 +467,7 @@ class Combobox extends React.Component {
 				newState = {
 					activeSelectedOption: this.props.selection[0],
 					activeSelectedOptionIndex: 0,
-					listboxHasFocus: true
+					listboxHasFocus: true,
 				};
 			} else if (isFirstOptionAndLeftIsPressed) {
 				newState = {
@@ -475,18 +475,18 @@ class Combobox extends React.Component {
 						this.props.selection.length - 1
 					],
 					activeSelectedOptionIndex: this.props.selection.length - 1,
-					listboxHasFocus: true
+					listboxHasFocus: true,
 				};
 			} else {
 				const newIndex = this.getNewActiveOptionIndex({
 					activeOptionIndex: prevState.activeSelectedOptionIndex,
 					offset: offsets[direction],
-					options: this.props.selection
+					options: this.props.selection,
 				});
 				newState = {
 					activeSelectedOption: this.props.selection[newIndex],
 					activeSelectedOptionIndex: newIndex,
-					listboxHasFocus: true
+					listboxHasFocus: true,
 				};
 			}
 
@@ -505,7 +505,7 @@ class Combobox extends React.Component {
 			currentOpenDropdown = this;
 
 			this.setState({
-				isOpen: true
+				isOpen: true,
 			});
 
 			if (this.props.events.onOpen) {
@@ -519,7 +519,7 @@ class Combobox extends React.Component {
 		this.setState({
 			activeSelectedOption: option,
 			activeSelectedOptionIndex: index,
-			listboxHasFocus: true
+			listboxHasFocus: true,
 		});
 	};
 
@@ -546,20 +546,20 @@ class Combobox extends React.Component {
 			this.setState({
 				activeSelectedOption: this.props.selection[index - 1],
 				activeSelectedOptionIndex: index - 1,
-				listboxHasFocus: true
+				listboxHasFocus: true,
 			});
 		} else {
 			// set focus to next option, but same index
 			this.setState({
 				activeSelectedOption: this.props.selection[index + 1],
 				activeSelectedOptionIndex: index,
-				listboxHasFocus: true
+				listboxHasFocus: true,
 			});
 		}
 
 		if (this.props.events.onRequestRemoveSelectedOption) {
 			this.props.events.onRequestRemoveSelectedOption(event, {
-				selection: reject(this.props.selection, option)
+				selection: reject(this.props.selection, option),
 			});
 		}
 	};
@@ -615,7 +615,7 @@ class Combobox extends React.Component {
 			this.props.events.onRequestOpen();
 		} else {
 			this.setState({
-				isOpen: true
+				isOpen: true,
 			});
 		}
 	};
@@ -651,7 +651,7 @@ class Combobox extends React.Component {
 						'slds-dropdown-trigger_click',
 						'ignore-react-onclickoutside',
 						{
-							'slds-is-open': this.getIsOpen()
+							'slds-is-open': this.getIsOpen(),
 						},
 						props.className
 					)}
@@ -673,7 +673,7 @@ class Combobox extends React.Component {
 						className="slds-combobox__input"
 						containerProps={{
 							className: 'slds-combobox__form-element',
-							role: 'none'
+							role: 'none',
 						}}
 						iconRight={
 							<InputIcon
@@ -704,7 +704,7 @@ class Combobox extends React.Component {
 						}
 					/>
 					{this.getDialog({
-						menuRenderer: this.renderMenu({ assistiveText, labels })
+						menuRenderer: this.renderMenu({ assistiveText, labels }),
 					})}
 				</div>
 			</div>
@@ -718,7 +718,7 @@ class Combobox extends React.Component {
 					onRequestFocus: this.handleRequestFocusListboxOfPills,
 					onRequestFocusOnNextPill: this.handleNavigateListboxOfPills,
 					onRequestFocusOnPreviousPill: this.handleNavigateListboxOfPills,
-					onRequestRemove: this.handleRemoveSelectedOption
+					onRequestRemove: this.handleRemoveSelectedOption,
 				}}
 				id={this.getId()}
 				labels={labels}
@@ -732,7 +732,7 @@ class Combobox extends React.Component {
 		<div className="slds-form-element__control">
 			<div
 				className={classNames('slds-combobox_container', {
-					'slds-has-inline-listbox': props.selection.length
+					'slds-has-inline-listbox': props.selection.length,
 				})}
 			>
 				{props.selection.length ? (
@@ -746,7 +746,7 @@ class Combobox extends React.Component {
 							onRequestFocus: this.handleRequestFocusListboxOfPills,
 							onRequestFocusOnNextPill: this.handleNavigateListboxOfPills,
 							onRequestFocusOnPreviousPill: this.handleNavigateListboxOfPills,
-							onRequestRemove: this.handleRemoveSelectedOption
+							onRequestRemove: this.handleRemoveSelectedOption,
 						}}
 						id={this.getId()}
 						labels={labels}
@@ -761,7 +761,7 @@ class Combobox extends React.Component {
 						'slds-dropdown-trigger_click',
 						'ignore-react-onclickoutside',
 						{
-							'slds-is-open': this.getIsOpen()
+							'slds-is-open': this.getIsOpen(),
 						},
 						props.className
 					)}
@@ -783,7 +783,7 @@ class Combobox extends React.Component {
 							'aria-expanded': this.getIsOpen(),
 							'aria-haspopup': 'listbox',
 							className: 'slds-combobox__form-element',
-							role: 'none'
+							role: 'none',
 						}}
 						iconRight={
 							<InputIcon
@@ -814,7 +814,7 @@ class Combobox extends React.Component {
 						}
 					/>
 					{this.getDialog({
-						menuRenderer: this.renderMenu({ assistiveText, labels })
+						menuRenderer: this.renderMenu({ assistiveText, labels }),
 					})}
 				</div>
 			</div>
@@ -825,7 +825,7 @@ class Combobox extends React.Component {
 		const iconLeft =
 			props.selection[0] && props.selection[0].icon
 				? React.cloneElement(props.selection[0].icon, {
-					containerClassName: 'slds-combobox__input-entity-icon'
+					containerClassName: 'slds-combobox__input-entity-icon',
 				})
 				: null;
 
@@ -839,7 +839,7 @@ class Combobox extends React.Component {
 			<div className="slds-form-element__control">
 				<div
 					className={classNames('slds-combobox_container', {
-						'slds-has-inline-listbox': props.selection.length
+						'slds-has-inline-listbox': props.selection.length,
 					})}
 				>
 					<div
@@ -849,7 +849,7 @@ class Combobox extends React.Component {
 							'slds-dropdown-trigger_click',
 							'ignore-react-onclickoutside',
 							{
-								'slds-is-open': this.getIsOpen()
+								'slds-is-open': this.getIsOpen(),
 							},
 							props.className
 						)}
@@ -871,7 +871,7 @@ class Combobox extends React.Component {
 							className="slds-combobox__input"
 							containerProps={{
 								className: 'slds-combobox__form-element',
-								role: 'none'
+								role: 'none',
 							}}
 							iconRight={
 								props.selection.length ? (
@@ -885,7 +885,7 @@ class Combobox extends React.Component {
 										name="close"
 										onClick={(event) => {
 											this.handleRemoveSelectedOption(event, {
-												option: props.selection[0]
+												option: props.selection[0],
 											});
 										}}
 									/>
@@ -922,7 +922,7 @@ class Combobox extends React.Component {
 							}
 						/>
 						{this.getDialog({
-							menuRenderer: this.renderMenu({ assistiveText, labels })
+							menuRenderer: this.renderMenu({ assistiveText, labels }),
 						})}
 					</div>
 				</div>
@@ -934,7 +934,7 @@ class Combobox extends React.Component {
 		const menuVariant = {
 			base: 'icon-title-subtitle',
 			'inline-listbox': 'icon-title-subtitle',
-			readonly: 'checkbox'
+			readonly: 'checkbox',
 		};
 
 		return (
@@ -980,7 +980,7 @@ class Combobox extends React.Component {
 							'slds-dropdown-trigger_click',
 							'ignore-react-onclickoutside',
 							{
-								'slds-is-open': this.getIsOpen()
+								'slds-is-open': this.getIsOpen(),
 							},
 							props.className
 						)}
@@ -1004,7 +1004,7 @@ class Combobox extends React.Component {
 								'aria-expanded': this.getIsOpen(),
 								'aria-haspopup': 'listbox',
 								className: 'slds-combobox__form-element',
-								role: 'none'
+								role: 'none',
 							}}
 							iconRight={
 								<InputIcon category="utility" name="down" variant="combobox" />
@@ -1028,7 +1028,7 @@ class Combobox extends React.Component {
 							value={value}
 						/>
 						{this.getDialog({
-							menuRenderer: this.renderMenu({ assistiveText, labels })
+							menuRenderer: this.renderMenu({ assistiveText, labels }),
 						})}
 					</div>
 				</div>
@@ -1042,7 +1042,7 @@ class Combobox extends React.Component {
 						onRequestFocus: this.handleRequestFocusListboxOfPills,
 						onRequestFocusOnNextPill: this.handleNavigateListboxOfPills,
 						onRequestFocusOnPreviousPill: this.handleNavigateListboxOfPills,
-						onRequestRemove: this.handleRemoveSelectedOption
+						onRequestRemove: this.handleRemoveSelectedOption,
 					}}
 					id={this.getId()}
 					labels={labels}
@@ -1069,7 +1069,7 @@ class Combobox extends React.Component {
 							'slds-dropdown-trigger_click',
 							'ignore-react-onclickoutside',
 							{
-								'slds-is-open': this.getIsOpen()
+								'slds-is-open': this.getIsOpen(),
 							},
 							props.className
 						)}
@@ -1093,7 +1093,7 @@ class Combobox extends React.Component {
 								'aria-expanded': this.getIsOpen(),
 								'aria-haspopup': 'listbox',
 								className: 'slds-combobox__form-element',
-								role: 'none'
+								role: 'none',
 							}}
 							iconRight={
 								<InputIcon category="utility" name="down" variant="combobox" />
@@ -1120,7 +1120,7 @@ class Combobox extends React.Component {
 							}
 						/>
 						{this.getDialog({
-							menuRenderer: this.renderMenu({ assistiveText, labels })
+							menuRenderer: this.renderMenu({ assistiveText, labels }),
 						})}
 					</div>
 				</div>
@@ -1143,16 +1143,16 @@ class Combobox extends React.Component {
 		const subRenders = {
 			base: {
 				multiple: this.renderBase, // same
-				single: this.renderBase
+				single: this.renderBase,
 			},
 			'inline-listbox': {
 				multiple: this.renderInlineMultiple,
-				single: this.renderInlineSingle
+				single: this.renderInlineSingle,
 			},
 			readonly: {
 				multiple: this.renderReadOnlyMultiple,
-				single: this.renderReadOnlySingle
-			}
+				single: this.renderReadOnlySingle,
+			},
 		};
 		const variantExists = subRenders[this.props.variant][multipleOrSingle];
 
@@ -1177,7 +1177,7 @@ class Combobox extends React.Component {
 /* eslint-enable jsx-a11y/role-supports-aria-props */
 
 Combobox.contextTypes = {
-	iconPath: PropTypes.string
+	iconPath: PropTypes.string,
 };
 
 Combobox.displayName = COMBOBOX;

--- a/components/combobox/private/menu.jsx
+++ b/components/combobox/private/menu.jsx
@@ -27,7 +27,7 @@ const propTypes = {
 	className: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * CSS classes to be added to tag with `.slds-dropdown`. Uses `classNames` [API](https://github.com/JedWatson/classnames).
@@ -35,7 +35,7 @@ const propTypes = {
 	classNameMenu: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/*
 	 * Id used for assistive technology
@@ -51,7 +51,7 @@ const propTypes = {
 	 * * `noOptionsFound`: Custom message that renders when no matches found. The default empty state is just text that says, 'No matches found.'.
 	 */
 	labels: shape({
-		noOptionsFound: PropTypes.string.isRequired
+		noOptionsFound: PropTypes.string.isRequired,
 	}),
 	/**
 	 * Accepts a custom menu item rendering function that becomes a custom component and is passed in the following props:
@@ -83,7 +83,7 @@ const propTypes = {
 	 */
 	variant: PropTypes.oneOf(['icon-title-subtitle', 'checkbox']),
 	isSelected: PropTypes.func,
-	assistiveText: PropTypes.object
+	assistiveText: PropTypes.object,
 };
 
 const defaultProps = {};
@@ -95,7 +95,7 @@ const Menu = (props) => {
 			isEqual(optionData, props.activeOption);
 		const selected = props.isSelected({
 			selection: props.selection,
-			option: optionData
+			option: optionData,
 		});
 		const MenuItem = props.menuItem;
 
@@ -151,13 +151,13 @@ const Menu = (props) => {
 									' slds-listbox__option_plain slds-media_small slds-media_center',
 									{
 										'slds-has-focus': active,
-										'slds-is-selected': selected
+										'slds-is-selected': selected,
 									}
 								)}
 								onClick={(event) => {
 									props.onSelect(event, {
 										selection: props.selection,
-										option: optionData
+										option: optionData,
 									});
 								}}
 								role="option"
@@ -189,7 +189,7 @@ const Menu = (props) => {
 									)}
 								</span>
 							</span>
-						)
+						),
 					}[props.variant]
 				}
 			</li>
@@ -203,7 +203,7 @@ const Menu = (props) => {
 				{
 					'slds-dropdown_length-with-icon-5': props.itemVisibleLength === 5,
 					'slds-dropdown_length-with-icon-7': props.itemVisibleLength === 7,
-					'slds-dropdown_length-with-icon-10': props.itemVisibleLength === 10
+					'slds-dropdown_length-with-icon-10': props.itemVisibleLength === 10,
 				},
 				props.classNameMenu
 			)}

--- a/components/combobox/private/selected-listbox.jsx
+++ b/components/combobox/private/selected-listbox.jsx
@@ -28,7 +28,7 @@ const propTypes = {
 	 */
 	assistiveText: shape({
 		label: PropTypes.string,
-		removePill: PropTypes.string
+		removePill: PropTypes.string,
 	}),
 	/*
 	 * Callback called when pill is clicked, delete is pressed, or backspace is pressed.
@@ -38,7 +38,7 @@ const propTypes = {
 		onRequestFocus: PropTypes.func.isRequired,
 		onRequestFocusOnNextPill: PropTypes.func.isRequired,
 		onRequestFocusOnPreviousPill: PropTypes.func.isRequired,
-		onRequestRemove: PropTypes.func.isRequired
+		onRequestRemove: PropTypes.func.isRequired,
 	}),
 	/**
 	 * HTML id for Combobox
@@ -54,7 +54,7 @@ const propTypes = {
 	labels: shape({
 		label: PropTypes.string,
 		remove: PropTypes.string,
-		title: PropTypes.string
+		title: PropTypes.string,
 	}),
 	/**
 	 * Changes styles of the input. Currently `entity` is not supported.
@@ -71,11 +71,11 @@ const propTypes = {
 	/**
 	 * Changes styles of the input. Currently `entity` is not supported.
 	 */
-	variant: PropTypes.oneOf(['base', 'inline-listbox', 'readonly'])
+	variant: PropTypes.oneOf(['base', 'inline-listbox', 'readonly']),
 };
 
 const defaultProps = {
-	renderAtSelectionLength: 1
+	renderAtSelectionLength: 1,
 };
 
 const SelectedListBox = (props) =>
@@ -89,7 +89,7 @@ const SelectedListBox = (props) =>
 				className={classNames('slds-listbox', {
 					'slds-listbox--inline': props.isInline,
 					'slds-listbox_horizontal': !props.isInline,
-					'slds-p-top_xxx-small': !props.isInline
+					'slds-p-top_xxx-small': !props.isInline,
 				})}
 				role="group"
 				aria-label={props.assistiveText.selectedListboxLabel}
@@ -107,7 +107,7 @@ const SelectedListBox = (props) =>
 						setActiveBasedOnstateFromParent || listboxRenderedForFirstTime;
 					const icon = option.icon
 						? React.cloneElement(option.icon, {
-							containerClassName: 'slds-pill__icon_container'
+							containerClassName: 'slds-pill__icon_container',
 						})
 						: null;
 
@@ -120,14 +120,14 @@ const SelectedListBox = (props) =>
 							<Pill
 								active={active}
 								assistiveText={{
-									remove: props.assistiveText.removePill
+									remove: props.assistiveText.removePill,
 								}}
 								events={{
 									onBlur: props.events.onBlurPill,
 									onClick: (event, data) => {
 										props.events.onClickPill(event, {
 											...data,
-											index: renderIndex
+											index: renderIndex,
 										});
 									},
 									onRequestFocusOnNextPill:
@@ -137,16 +137,16 @@ const SelectedListBox = (props) =>
 									onRequestRemove: (event, data) => {
 										props.events.onRequestRemove(event, {
 											...data,
-											index: renderIndex
+											index: renderIndex,
 										});
 									},
-									onRequestFocus: props.events.onRequestFocus
+									onRequestFocus: props.events.onRequestFocus,
 								}}
 								eventData={{ option }}
 								icon={icon}
 								labels={{
 									label: option.label,
-									removeTitle: props.labels.removePillTitle
+									removeTitle: props.labels.removePillTitle,
 								}}
 								requestFocus={props.listboxHasFocus}
 								tabIndex={active ? 0 : -1}

--- a/components/data-table/__docs__/site-stories.js
+++ b/components/data-table/__docs__/site-stories.js
@@ -5,7 +5,7 @@
 
 const siteStories = [
 	require('raw-loader!@salesforce/design-system-react/components/data-table/__examples__/basic.jsx'),
-	require('raw-loader!@salesforce/design-system-react/components/data-table/__examples__/advanced.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/data-table/__examples__/advanced.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/data-table/__examples__/advanced.jsx
+++ b/components/data-table/__examples__/advanced.jsx
@@ -27,7 +27,7 @@ const Example = createReactClass({
 		return {
 			sortColumn: 'opportunityName',
 			sortColumnDirection: {
-				opportunityName: 'asc'
+				opportunityName: 'asc',
 			},
 			items: [
 				{
@@ -38,7 +38,7 @@ const Example = createReactClass({
 					stage: 'Value Proposition',
 					confidence: '70%',
 					amount: '$25,000,000',
-					contact: 'jrogers@acme.com'
+					contact: 'jrogers@acme.com',
 				},
 				{
 					id: '5GJOOOPWU7',
@@ -48,7 +48,7 @@ const Example = createReactClass({
 					stage: 'Prospecting',
 					confidence: '30%',
 					amount: '$5,000,000',
-					contact: 'bob@acme.com'
+					contact: 'bob@acme.com',
 				},
 				{
 					id: '8IKZHZZV81',
@@ -58,8 +58,8 @@ const Example = createReactClass({
 					stage: 'Id. Decision Makers',
 					confidence: '60%',
 					amount: '$25,000',
-					contact: 'nathan@salesforce.com'
-				}
+					contact: 'nathan@salesforce.com',
+				},
 			],
 			selection: [
 				{
@@ -70,9 +70,9 @@ const Example = createReactClass({
 					stage: 'Id. Decision Makers',
 					confidence: '60%',
 					amount: '$25,000',
-					contact: 'nathan@salesforce.com'
-				}
-			]
+					contact: 'nathan@salesforce.com',
+				},
+			],
 		};
 	},
 
@@ -94,9 +94,9 @@ const Example = createReactClass({
 		const newState = {
 			sortColumn: sortProperty,
 			sortColumnDirection: {
-				[sortProperty]: sortDirection
+				[sortProperty]: sortDirection,
 			},
-			items: [...this.state.items]
+			items: [...this.state.items],
 		};
 
 		// needs to work in both directions
@@ -167,13 +167,13 @@ const Example = createReactClass({
 								{
 									id: 0,
 									label: 'Add to Group',
-									value: '1'
+									value: '1',
 								},
 								{
 									id: 1,
 									label: 'Publish',
-									value: '2'
-								}
+									value: '2',
+								},
 							]}
 							onAction={this.handleRowAction}
 						/>
@@ -181,7 +181,7 @@ const Example = createReactClass({
 				</IconSettings>
 			</div>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/data-table/__examples__/basic.jsx
+++ b/components/data-table/__examples__/basic.jsx
@@ -44,7 +44,7 @@ const columns = [
 
 	<DataTableColumn key="contact" label="Contact" property="contact">
 		<CustomDataTableCell />
-	</DataTableColumn>
+	</DataTableColumn>,
 ];
 
 const Example = createReactClass({
@@ -61,7 +61,7 @@ const Example = createReactClass({
 					stage: 'Prospecting',
 					confidence: '20%',
 					amount: '$25k',
-					contact: 'jrogers@cloudhub.com'
+					contact: 'jrogers@cloudhub.com',
 				},
 				{
 					id: '5GJOOOPWU7',
@@ -71,7 +71,7 @@ const Example = createReactClass({
 					stage: 'Prospecting',
 					confidence: '20%',
 					amount: '$25k',
-					contact: 'jrogers@cloudhub.com'
+					contact: 'jrogers@cloudhub.com',
 				},
 				{
 					id: '8IKZHZZV81',
@@ -81,9 +81,9 @@ const Example = createReactClass({
 					stage: 'Prospecting',
 					confidence: '20%',
 					amount: '$25k',
-					contact: 'jrogers@cloudhub.com'
-				}
-			]
+					contact: 'jrogers@cloudhub.com',
+				},
+			],
 		};
 	},
 
@@ -148,7 +148,7 @@ const Example = createReactClass({
 				</div>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/data-table/__tests__/data-table.browser-test.jsx
+++ b/components/data-table/__tests__/data-table.browser-test.jsx
@@ -15,7 +15,7 @@ chai.should();
 const {
 	Simulate,
 	scryRenderedComponentsWithType,
-	findRenderedDOMComponentWithClass
+	findRenderedDOMComponentWithClass,
 } = TestUtils;
 
 describe('DataTable: ', function () {
@@ -24,57 +24,57 @@ describe('DataTable: ', function () {
 			id: '8IKZHZZV80',
 			name: 'Cloudhub',
 			count: 100976,
-			lastModified: 'Yesterday'
+			lastModified: 'Yesterday',
 		},
 		{
 			id: '5GJOOOPWU7',
 			name: 'Cloudhub + Anypoint Connectors',
 			count: 54976,
-			lastModified: 'Today'
+			lastModified: 'Today',
 		},
 		{
 			id: 'Q8Z71ZUCEZ',
 			name: 'Cloud City',
 			count: 101280,
-			lastModified: 'Today'
+			lastModified: 'Today',
 		},
 		{
 			id: '2FSH2DP0LY',
 			name: 'IoT',
 			count: 976,
-			lastModified: 'Yesterday'
+			lastModified: 'Yesterday',
 		},
 		{
 			id: '8NE888QKV1',
 			name: 'IoT + Anypoint Connectors',
 			count: 54976,
-			lastModified: 'Today'
+			lastModified: 'Today',
 		},
 		{
 			id: 'M4D37GW83H',
 			name: 'Salesforce Tower',
 			count: 101280,
-			lastModified: 'Today'
-		}
+			lastModified: 'Today',
+		},
 	];
 
 	const columns = [
 		{
 			label: 'Name',
 			property: 'name',
-			truncate: true
+			truncate: true,
 		},
 		{
 			label: 'Count',
 			property: 'count',
-			sortable: true
-		}
+			sortable: true,
+		},
 	];
 
 	const defaultProps = {
 		id: 'DataTableExample-default',
 		items,
-		selectRows: true
+		selectRows: true,
 	};
 
 	const renderTable = (instance) =>
@@ -165,8 +165,8 @@ describe('DataTable: ', function () {
 				id: '8IKZHZZV80',
 				name: 'Cloudhub',
 				count: 100976,
-				lastModified: 'Yesterday'
-			}
+				lastModified: 'Yesterday',
+			},
 		];
 
 		afterEach(removeTable);
@@ -339,13 +339,13 @@ describe('DataTable: ', function () {
 							{
 								id: 0,
 								label: 'Add to Group',
-								value: '1'
+								value: '1',
 							},
 							{
 								id: 1,
 								label: 'Publish',
-								value: '2'
-							}
+								value: '2',
+							},
 						]}
 					/>
 				</DataTable>
@@ -375,13 +375,13 @@ describe('DataTable: ', function () {
 							{
 								id: 0,
 								label: 'Add to Group',
-								value: '1'
+								value: '1',
 							},
 							{
 								id: 1,
 								label: 'Publish',
-								value: '2'
-							}
+								value: '2',
+							},
 						]}
 						onAction={this.onAction}
 					/>

--- a/components/data-table/cell.jsx
+++ b/components/data-table/cell.jsx
@@ -21,7 +21,7 @@ const DataTableCell = (props) => {
 	const contents = (
 		<div
 			className={classNames({
-				'slds-truncate': props.fixedLayout
+				'slds-truncate': props.fixedLayout,
 			})}
 			title={props.title || childText}
 		>
@@ -70,7 +70,7 @@ DataTableCell.propTypes = {
 	className: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * Use this if you are creating an advanced table (selectable, sortable, or resizable rows)
@@ -95,7 +95,7 @@ DataTableCell.propTypes = {
 	/**
 	 * Width of column. This is required for advanced/fixed layout tables. Please provide units. (`rems` are recommended)
 	 */
-	width: PropTypes.string
+	width: PropTypes.string,
 };
 
 export default DataTableCell;

--- a/components/data-table/column-check-props.js
+++ b/components/data-table/column-check-props.js
@@ -12,7 +12,7 @@ if (process.env.NODE_ENV !== 'production') {
 		// Deprecated and changed to another property
 		ifOneThenBothRequiredProperty(COMPONENT, props, {
 			isSorted: props.isSorted,
-			sortDirection: props.sortDirection
+			sortDirection: props.sortDirection,
 		});
 		/* eslint-enable max-len */
 	};

--- a/components/data-table/column.jsx
+++ b/components/data-table/column.jsx
@@ -77,7 +77,7 @@ DataTableColumn.propTypes = {
 	/**
 	 * Width of column. This is required for advanced/fixed layout tables. Please provide units. (`rems` are recommended)
 	 */
-	width: PropTypes.string
+	width: PropTypes.string,
 };
 
 export default DataTableColumn;

--- a/components/data-table/highlight-cell.jsx
+++ b/components/data-table/highlight-cell.jsx
@@ -33,12 +33,12 @@ DataTableHighlightCell.propTypes = {
 	children: PropTypes.oneOfType([
 		PropTypes.string,
 		PropTypes.number,
-		PropTypes.bool
+		PropTypes.bool,
 	]),
 	/**
 	 * The string of text (or Regular Expression) to highlight.
 	 */
-	search: PropTypes.any
+	search: PropTypes.any,
 };
 
 export default DataTableHighlightCell;

--- a/components/data-table/index.jsx
+++ b/components/data-table/index.jsx
@@ -44,7 +44,7 @@ import {
 	DATA_TABLE,
 	DATA_TABLE_CELL,
 	DATA_TABLE_HEAD,
-	DATA_TABLE_ROW
+	DATA_TABLE_ROW,
 } from '../../utilities/constants';
 
 // Safely get the length of an array, returning 0 for invalid input.
@@ -112,7 +112,7 @@ const DataTable = createReactClass({
 		className: PropTypes.oneOfType([
 			PropTypes.array,
 			PropTypes.object,
-			PropTypes.string
+			PropTypes.string,
 		]),
 		/**
 		 * A variant which adds border to the vertical columns.
@@ -173,7 +173,7 @@ const DataTable = createReactClass({
 		/**
 		 * A variant which removes horizontal padding. CSS class will be removed if `fixedLayout==true`.
 		 */
-		unbufferedCell: PropTypes.bool
+		unbufferedCell: PropTypes.bool,
 	},
 
 	getDefaultProps () {
@@ -185,7 +185,7 @@ const DataTable = createReactClass({
 			assistiveTextForSelectAllRows: 'Select all rows',
 			assistiveTextForSelectRow: 'Select row',
 			id: shortid.generate(),
-			selection: []
+			selection: [],
 		};
 	},
 
@@ -246,7 +246,7 @@ const DataTable = createReactClass({
 				columns.push({
 					Cell,
 					props,
-					dataTableProps: this.props
+					dataTableProps: this.props,
 				});
 			} else if (
 				child &&
@@ -271,7 +271,7 @@ const DataTable = createReactClass({
 							.stackedHorizontal,
 						'slds-table--striped': this.props.striped,
 						'slds-table--col-bordered': this.props.columnBordered,
-						'slds-no-row-hover': this.props.noRowHover
+						'slds-no-row-hover': this.props.noRowHover,
 					},
 					this.props.className
 				)}
@@ -329,7 +329,7 @@ const DataTable = createReactClass({
 				</tbody>
 			</table>
 		);
-	}
+	},
 });
 
 export default DataTable;

--- a/components/data-table/private/head.jsx
+++ b/components/data-table/private/head.jsx
@@ -41,13 +41,13 @@ const DataTableHead = createReactClass({
 		columns: PropTypes.arrayOf(
 			PropTypes.shape({
 				Cell: PropTypes.func,
-				props: PropTypes.object
+				props: PropTypes.object,
 			})
 		),
 		id: PropTypes.string,
 		onToggleAll: PropTypes.func,
 		onSort: PropTypes.func,
-		showRowActions: PropTypes.bool
+		showRowActions: PropTypes.bool,
 	},
 
 	componentWillMount () {},
@@ -96,7 +96,7 @@ const DataTableHead = createReactClass({
 				</tr>
 			</thead>
 		);
-	}
+	},
 });
 
 export default DataTableHead;

--- a/components/data-table/private/header-cell.jsx
+++ b/components/data-table/private/header-cell.jsx
@@ -21,7 +21,7 @@ import checkProps from '../column-check-props';
 // ## Constants
 import {
 	DATA_TABLE_HEADER_CELL,
-	DATA_TABLE_COLUMN
+	DATA_TABLE_COLUMN,
 } from '../../../utilities/constants';
 
 /**
@@ -75,12 +75,12 @@ const DataTableHeaderCell = createReactClass({
 		/**
 		 * Width of column. This is required for advanced/fixed layout tables. Please provide units. (`rems` are recommended)
 		 */
-		width: PropTypes.string
+		width: PropTypes.string,
 	},
 
 	getInitialState () {
 		return {
-			sortDirection: null
+			sortDirection: null,
 		};
 	},
 
@@ -101,11 +101,11 @@ const DataTableHeaderCell = createReactClass({
 		const sortDirection = oldSortDirection === 'asc' ? 'desc' : 'asc';
 		const data = {
 			property: this.props.property,
-			sortDirection
+			sortDirection,
 		};
 
 		this.setState({
-			sortDirection
+			sortDirection,
 		});
 
 		if (isFunction(this.props.onSort)) {
@@ -131,7 +131,7 @@ const DataTableHeaderCell = createReactClass({
 					'slds-is-sortable': sortable,
 					'slds-is-sorted': isSorted,
 					[`slds-is-sorted--${sortDirection}`]: sortDirection,
-					'slds-is-sorted--asc': isSorted && !sortDirection // default for hover, up arrow is ascending which means A is at the top of the table, and Z is at the bottom. You have to think about row numbers abstracting, and not the visual order on the table.
+					'slds-is-sorted--asc': isSorted && !sortDirection, // default for hover, up arrow is ascending which means A is at the top of the table, and Z is at the bottom. You have to think about row numbers abstracting, and not the visual order on the table.
 				})}
 				focusable={sortable ? true : null}
 				scope="col"
@@ -176,7 +176,7 @@ const DataTableHeaderCell = createReactClass({
 				)}
 			</th>
 		);
-	}
+	},
 });
 
 export default DataTableHeaderCell;

--- a/components/data-table/private/row.jsx
+++ b/components/data-table/private/row.jsx
@@ -19,7 +19,7 @@ import Checkbox from '../../forms/checkbox';
 import {
 	DATA_TABLE_ROW,
 	DATA_TABLE_ROW_ACTIONS,
-	DATA_TABLE_CELL
+	DATA_TABLE_CELL,
 } from '../../../utilities/constants';
 
 /**
@@ -40,7 +40,7 @@ const DataTableRow = createReactClass({
 		columns: PropTypes.arrayOf(
 			PropTypes.shape({
 				Cell: PropTypes.func,
-				props: PropTypes.object
+				props: PropTypes.object,
 			})
 		),
 		/**
@@ -51,7 +51,7 @@ const DataTableRow = createReactClass({
 		item: PropTypes.object.isRequired,
 		onToggle: PropTypes.func,
 		rowActions: PropTypes.element,
-		selection: PropTypes.array
+		selection: PropTypes.array,
 	},
 
 	isSelected () {
@@ -71,7 +71,7 @@ const DataTableRow = createReactClass({
 			<tr
 				className={classNames({
 					'slds-hint-parent': this.props.rowActions,
-					'slds-is-selected': this.props.canSelectRows && isSelected
+					'slds-is-selected': this.props.canSelectRows && isSelected,
 				})}
 			>
 				{this.props.canSelectRows ? (
@@ -114,12 +114,12 @@ const DataTableRow = createReactClass({
 				{this.props.rowActions
 					? React.cloneElement(this.props.rowActions, {
 						id: `${this.props.id}-${DATA_TABLE_ROW_ACTIONS}`,
-						item: this.props.item
+						item: this.props.item,
 					})
 					: null}
 			</tr>
 		);
-	}
+	},
 });
 
 export default DataTableRow;

--- a/components/data-table/row-actions.jsx
+++ b/components/data-table/row-actions.jsx
@@ -41,12 +41,12 @@ const DataTableRowActions = createReactClass({
 		id: PropTypes.string,
 		item: PropTypes.object,
 		onAction: PropTypes.func,
-		options: PropTypes.array.isRequired
+		options: PropTypes.array.isRequired,
 	},
 
 	getDefaultProps () {
 		return {
-			assistiveText: 'Actions'
+			assistiveText: 'Actions',
 		};
 	},
 
@@ -88,7 +88,7 @@ const DataTableRowActions = createReactClass({
 				/>
 			</td>
 		);
-	}
+	},
 });
 
 export default DataTableRowActions;

--- a/components/date-picker/__docs__/site-stories.js
+++ b/components/date-picker/__docs__/site-stories.js
@@ -4,7 +4,7 @@
 /* eslint-disable global-require */
 
 const siteStories = [
-	require('raw-loader!@salesforce/design-system-react/components/date-picker/__examples__/default.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/date-picker/__examples__/default.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/date-picker/__examples__/custom-input.jsx
+++ b/components/date-picker/__examples__/custom-input.jsx
@@ -9,7 +9,7 @@ const Example = createReactClass({
 
 	getInitialState () {
 		return {
-			isOpen: false
+			isOpen: false,
 		};
 	},
 
@@ -35,7 +35,7 @@ const Example = createReactClass({
 				<Input placeholder="With custom Input" value="" />
 			</Datepicker>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/date-picker/__examples__/default.jsx
+++ b/components/date-picker/__examples__/default.jsx
@@ -30,7 +30,7 @@ const Example = createReactClass({
 				/>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/date-picker/__examples__/iso-weekday.jsx
+++ b/components/date-picker/__examples__/iso-weekday.jsx
@@ -20,7 +20,7 @@ const Example = createReactClass({
 				}}
 			/>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/date-picker/__examples__/snapshot-default.jsx
+++ b/components/date-picker/__examples__/snapshot-default.jsx
@@ -21,7 +21,7 @@ const Example = createReactClass({
 				/>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example;

--- a/components/date-picker/__examples__/weekday-picker.jsx
+++ b/components/date-picker/__examples__/weekday-picker.jsx
@@ -12,7 +12,7 @@ const Example = createReactClass({
 				dateDisabled={({ date }) => date.getDay() > 5 || date.getDay() < 1}
 			/>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/date-picker/__tests__/date-picker.browser-test.jsx
+++ b/components/date-picker/__tests__/date-picker.browser-test.jsx
@@ -14,7 +14,7 @@ import IconSettings from '../../icon-settings';
  */
 import {
 	createMountNode,
-	destroyMountNode
+	destroyMountNode,
 } from '../../../tests/enzyme-helpers';
 
 // Import your internal dependencies (for example):
@@ -29,7 +29,7 @@ chai.use(chaiEnzyme());
 
 const defaultProps = {
 	id: 'sample-datepicker',
-	value: new Date(2007, 0, 6)
+	value: new Date(2007, 0, 6),
 };
 
 /* A re-usable demo component fixture outside of `describe` sections
@@ -40,7 +40,7 @@ const defaultProps = {
 const DemoComponent = createReactClass({
 	displayName: 'DatepickerDemoComponent',
 	propTypes: {
-		isOpen: PropTypes.bool
+		isOpen: PropTypes.bool,
 	},
 
 	getDefaultProps () {
@@ -59,7 +59,7 @@ const DemoComponent = createReactClass({
 				<Datepicker {...this.props} />
 			</IconSettings>
 		);
-	}
+	},
 });
 
 /* All tests for component being tested should be wrapped in a root `describe`,
@@ -107,7 +107,7 @@ describe('SLDSDatepicker', function () {
 	describe('Optional props', () => {
 		const customPlaceholder = 'With custom Input';
 		const optionalProps = {
-			children: <Input placeholder={customPlaceholder} value="" />
+			children: <Input placeholder={customPlaceholder} value="" />,
 		};
 
 		beforeEach(() => {
@@ -120,7 +120,7 @@ describe('SLDSDatepicker', function () {
 
 		it('has custom input with custom placeholder', function () {
 			wrapper = mount(<DemoComponent {...optionalProps} />, {
-				attachTo: mountNode
+				attachTo: mountNode,
 			});
 
 			expect(wrapper.find('input').node.getAttribute('placeholder')).to.equal(
@@ -233,7 +233,7 @@ describe('SLDSDatepicker', function () {
 							firstDayOfMonth.simulate('keyDown', {
 								key: 'Esc',
 								keyCode: KEYS.ESCAPE,
-								which: KEYS.ESCAPE
+								which: KEYS.ESCAPE,
 							});
 						}}
 					/>,
@@ -264,7 +264,7 @@ describe('SLDSDatepicker', function () {
 				selectedDay.simulate('keyDown', {
 					key: 'Down',
 					keyCode: KEYS.DOWN,
-					which: KEYS.DOWN
+					which: KEYS.DOWN,
 				});
 			});
 
@@ -288,7 +288,7 @@ describe('SLDSDatepicker', function () {
 				selectedDay.simulate('keyDown', {
 					key: 'Right',
 					keyCode: KEYS.RIGHT,
-					which: KEYS.RIGHT
+					which: KEYS.RIGHT,
 				});
 			});
 
@@ -312,7 +312,7 @@ describe('SLDSDatepicker', function () {
 				selectedDay.simulate('keyDown', {
 					key: 'Up',
 					keyCode: KEYS.UP,
-					which: KEYS.UP
+					which: KEYS.UP,
 				});
 			});
 
@@ -336,7 +336,7 @@ describe('SLDSDatepicker', function () {
 				selectedDay.simulate('keyDown', {
 					key: 'Left',
 					keyCode: KEYS.LEFT,
-					which: KEYS.LEFT
+					which: KEYS.LEFT,
 				});
 			});
 
@@ -358,7 +358,7 @@ describe('SLDSDatepicker', function () {
 				selectedDay.simulate('keyDown', {
 					key: 'Tab',
 					keyCode: KEYS.TAB,
-					which: KEYS.TAB
+					which: KEYS.TAB,
 				});
 			});
 
@@ -381,7 +381,7 @@ describe('SLDSDatepicker', function () {
 					key: 'Tab',
 					keyCode: KEYS.TAB,
 					shiftKey: true,
-					which: KEYS.TAB
+					which: KEYS.TAB,
 				});
 			});
 		});

--- a/components/date-picker/__tests__/datepicker.snapshot-test.jsx
+++ b/components/date-picker/__tests__/datepicker.snapshot-test.jsx
@@ -19,7 +19,7 @@ const customProps = {
 	assistiveText: {
 		openCalendar: 'CUSTOM open Calendar',
 		nextMonth: 'CUSTOM next month',
-		previousMonth: 'CUSTOM previous month'
+		previousMonth: 'CUSTOM previous month',
 	},
 	className: 'CUSTOM-CLASSNAME',
 	formatter () {
@@ -40,18 +40,18 @@ const customProps = {
 			'MONTH 9',
 			'MONTH 10',
 			'MONTH 11',
-			'MONTH 12'
+			'MONTH 12',
 		],
 		placeholder: 'SWIPE RIGHT :-)',
 		today: 'TODAY YOU ARE YOU!',
-		weekDays: ['Day 1', 'Day 2', 'Day 3', 'Day 4', 'Day 5', 'Day 6', 'Day 7']
+		weekDays: ['Day 1', 'Day 2', 'Day 3', 'Day 4', 'Day 5', 'Day 6', 'Day 7'],
 	},
 	parser () {
 		return new Date(2007, 0, 6);
 	},
 	relativeYearFrom: -20,
 	relativeYearTo: 20,
-	triggerClassName: 'CUSTOM-TRIGGER-CLASSNAME'
+	triggerClassName: 'CUSTOM-TRIGGER-CLASSNAME',
 };
 
 test(`Datepicker

--- a/components/date-picker/date-picker.jsx
+++ b/components/date-picker/date-picker.jsx
@@ -47,7 +47,7 @@ const propTypes = {
 	assistiveText: shape({
 		nextMonth: PropTypes.string,
 		openCalendar: PropTypes.string,
-		previousMonth: PropTypes.string
+		previousMonth: PropTypes.string,
 	}),
 	/**
 	 * Aligns the right or left side of the menu with the respective side of the trigger. _Tested with snapshot testing._
@@ -63,7 +63,7 @@ const propTypes = {
 	className: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * Disable input and calendar. _Tested with Mocha framework._
@@ -104,7 +104,7 @@ const propTypes = {
 		months: PropTypes.array,
 		placeholder: PropTypes.string,
 		today: PropTypes.string,
-		weekDays: PropTypes.array
+		weekDays: PropTypes.array,
 	}),
 	/**
 	 * Forces the dropdown to be open or closed. See controlled/uncontrolled callback/prop pattern for more on suggested use view [Concepts and Best Practices](https://github.com/salesforce-ux/design-system-react/blob/master/CONTRIBUTING.md#concepts-and-best-practices)
@@ -123,7 +123,7 @@ const propTypes = {
 	menuPosition: PropTypes.oneOf([
 		'absolute',
 		'overflowBoundaryElement',
-		'relative'
+		'relative',
 	]),
 	/**
 	 * Triggered when the user wants to focus on a new day with the keyboard. If the target node is a day it will return the keyboard event a data object with the shape: `{date: [Date object]}`. Event will be `null` when new month is re-rendered.  _Tested with Mocha framework._
@@ -167,12 +167,12 @@ const propTypes = {
 	triggerClassName: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * Sets date with a `Date` ECMAScript object. _Tested with snapshot testing._
 	 */
-	value: PropTypes.instanceOf(Date)
+	value: PropTypes.instanceOf(Date),
 };
 
 const defaultProps = {
@@ -180,7 +180,7 @@ const defaultProps = {
 	assistiveText: {
 		nextMonth: 'Next month',
 		openCalendar: 'Open Calendar',
-		previousMonth: 'Previous month'
+		previousMonth: 'Previous month',
 	},
 	formatter (date) {
 		return date
@@ -201,7 +201,7 @@ const defaultProps = {
 			'September',
 			'October',
 			'November',
-			'December'
+			'December',
 		],
 		placeholder: 'Pick a Date',
 		today: 'Today',
@@ -212,8 +212,8 @@ const defaultProps = {
 			'Wednesday',
 			'Thursday',
 			'Friday',
-			'Saturday'
-		]
+			'Saturday',
+		],
 	},
 	menuPosition: 'absolute',
 	parser (str) {
@@ -221,7 +221,7 @@ const defaultProps = {
 	},
 	relativeYearFrom: -5,
 	relativeYearTo: 5,
-	dateDisabled: () => false
+	dateDisabled: () => false,
 };
 
 /**
@@ -257,7 +257,7 @@ class Datepicker extends React.Component {
 			isOpen: false,
 			value: props.value,
 			formattedValue: initDate || '',
-			inputValue: initDate || ''
+			inputValue: initDate || '',
 		};
 	}
 
@@ -277,7 +277,7 @@ class Datepicker extends React.Component {
 				this.setState({
 					value: nextProps.value,
 					formattedValue: this.props.formatter(nextProps.value),
-					inputValue: this.props.formatter(nextProps.value)
+					inputValue: this.props.formatter(nextProps.value),
 				});
 			}
 		}
@@ -349,7 +349,7 @@ class Datepicker extends React.Component {
 							this.props.align === 'right',
 						'slds-dropdown--left':
 							this.props.menuPosition === 'relative' &&
-							this.props.align === 'left'
+							this.props.align === 'left',
 					},
 					this.props.className
 				)}
@@ -393,7 +393,7 @@ class Datepicker extends React.Component {
 		this.setState({
 			value: date,
 			formattedValue: this.props.formatter(date),
-			inputValue: this.props.formatter(date)
+			inputValue: this.props.formatter(date),
 		});
 
 		this.handleRequestClose();
@@ -402,7 +402,7 @@ class Datepicker extends React.Component {
 			this.props.onChange(event, {
 				date,
 				formattedDate: this.props.formatter(date),
-				timezoneOffset: date.getTimezoneOffset()
+				timezoneOffset: date.getTimezoneOffset(),
 			});
 		}
 
@@ -427,7 +427,7 @@ class Datepicker extends React.Component {
 	handleInputChange (event) {
 		this.setState({
 			formattedValue: event.target.value,
-			inputValue: event.target.value
+			inputValue: event.target.value,
 		});
 
 		const date = this.props.parser(event.target.value);
@@ -436,7 +436,7 @@ class Datepicker extends React.Component {
 			this.props.onChange(event, {
 				date,
 				formattedDate: event.target.value,
-				timezoneOffset: date.getTimezoneOffset()
+				timezoneOffset: date.getTimezoneOffset(),
 			});
 		}
 	}
@@ -564,12 +564,12 @@ class Datepicker extends React.Component {
 				this.props.required, // eslint-disable-line react/prop-types
 			value:
 				(this.props.children && this.props.children.props.value) ||
-				this.state.inputValue
+				this.state.inputValue,
 		};
 
 		const clonedInput = this.props.children ? (
 			React.cloneElement(this.props.children, {
-				...clonedInputProps
+				...clonedInputProps,
 			})
 		) : (
 			<Input {...clonedInputProps} />
@@ -582,7 +582,7 @@ class Datepicker extends React.Component {
 					'slds-dropdown-trigger--click',
 					'ignore-react-onclickoutside',
 					{
-						'slds-is-open': this.getIsOpen()
+						'slds-is-open': this.getIsOpen(),
 					},
 					this.props.triggerClassName
 				)}
@@ -595,7 +595,7 @@ class Datepicker extends React.Component {
 }
 
 Datepicker.contextTypes = {
-	iconPath: PropTypes.string
+	iconPath: PropTypes.string,
 };
 
 Datepicker.displayName = DATE_PICKER;

--- a/components/date-picker/private/calendar-wrapper.jsx
+++ b/components/date-picker/private/calendar-wrapper.jsx
@@ -19,7 +19,7 @@ import classNames from 'classnames';
 class DatepickerCalendarWrapper extends React.Component {
 	static defaultProps = {
 		selectedDate: new Date(),
-		value: new Date()
+		value: new Date(),
 	};
 
 	static displayName = 'DatepickerCalendarWrapper';
@@ -43,7 +43,7 @@ class DatepickerCalendarWrapper extends React.Component {
 		className: PropTypes.oneOfType([
 			PropTypes.array,
 			PropTypes.object,
-			PropTypes.string
+			PropTypes.string,
 		]),
 		/**
 		 * dateDisabled() takes a date as input argument, returns true if given date should be disabled, otherwise returns false.
@@ -100,12 +100,12 @@ class DatepickerCalendarWrapper extends React.Component {
 		/**
 		 * Names of the seven days of the week, starting on Sunday.
 		 */
-		weekDayLabels: PropTypes.array.isRequired
+		weekDayLabels: PropTypes.array.isRequired,
 	};
 
 	state = {
 		initialDateForCalendarRender: this.props.selectedDate,
-		isCalendarFocused: true
+		isCalendarFocused: true,
 	};
 
 	handleCalendarBlur = (event, { direction }) => {
@@ -115,7 +115,7 @@ class DatepickerCalendarWrapper extends React.Component {
 				this.props.onCalendarFocus(event, {
 					direction,
 					isCalendarFocused: false,
-					ref: this.previousMonthRef
+					ref: this.previousMonthRef,
 				});
 			}
 			this.previousMonthRef.focus();
@@ -125,7 +125,7 @@ class DatepickerCalendarWrapper extends React.Component {
 				this.props.onCalendarFocus(event, {
 					direction,
 					isCalendarFocused: false,
-					ref: this.todayRef
+					ref: this.todayRef,
 				});
 			}
 			this.todayRef.focus();
@@ -184,7 +184,7 @@ class DatepickerCalendarWrapper extends React.Component {
 			<div // eslint-disable-line jsx-a11y/no-static-element-interactions
 				className={classNames(
 					{
-						'slds-datepicker': this.props.isolated
+						'slds-datepicker': this.props.isolated,
 					},
 					this.props.className
 				)}

--- a/components/date-picker/private/calendar.jsx
+++ b/components/date-picker/private/calendar.jsx
@@ -74,14 +74,14 @@ const DatepickerCalendar = createReactClass({
 		/**
 		 * Names of the seven days of the week, starting on Sunday.
 		 */
-		weekDayLabels: PropTypes.array.isRequired
+		weekDayLabels: PropTypes.array.isRequired,
 	},
 
 	getInitialState () {
 		return {
 			focusedDate: this.props.initialDateForCalendarRender,
 			calendarHasFocus: true,
-			todayFocus: false
+			todayFocus: false,
 		};
 	},
 
@@ -100,7 +100,7 @@ const DatepickerCalendar = createReactClass({
 			this.setState({ focusedDate: this.props.initialDateForCalendarRender });
 			this.props.onRequestInternalFocusDate(undefined, {
 				date: this.props.initialDateForCalendarRender,
-				triggerCallback: true
+				triggerCallback: true,
 			});
 		}
 	},
@@ -126,7 +126,7 @@ const DatepickerCalendar = createReactClass({
 			this.setState({ focusedDate: prevDate });
 			this.props.onRequestInternalFocusDate(event, {
 				date: prevDate,
-				triggerCallback: true
+				triggerCallback: true,
 			});
 		}
 	},
@@ -139,7 +139,7 @@ const DatepickerCalendar = createReactClass({
 			this.setState({ focusedDate: nextDate });
 			this.props.onRequestInternalFocusDate(event, {
 				date: nextDate,
-				triggerCallback: true
+				triggerCallback: true,
 			});
 		}
 	},
@@ -152,7 +152,7 @@ const DatepickerCalendar = createReactClass({
 			this.setState({ focusedDate: prevDate });
 			this.props.onRequestInternalFocusDate(event, {
 				date: prevDate,
-				triggerCallback: true
+				triggerCallback: true,
 			});
 		}
 	},
@@ -165,7 +165,7 @@ const DatepickerCalendar = createReactClass({
 			this.setState({ focusedDate: nextDate });
 			this.props.onRequestInternalFocusDate(event, {
 				date: nextDate,
-				triggerCallback: true
+				triggerCallback: true,
 			});
 		}
 	},
@@ -317,7 +317,7 @@ const DatepickerCalendar = createReactClass({
 				</table>
 			</div>
 		);
-	}
+	},
 });
 
 export default DatepickerCalendar;

--- a/components/date-picker/private/day.jsx
+++ b/components/date-picker/private/day.jsx
@@ -27,7 +27,7 @@ const handleKeyDown = (
 		onKeyboardNavigateToPreviousDay,
 		onKeyboardNavigateToNextDay,
 		onKeyboardNavigateToPreviousWeek,
-		onKeyboardNavigateToNextWeek
+		onKeyboardNavigateToNextWeek,
 	}
 ) => {
 	const keyDownCallbacks = {
@@ -51,13 +51,13 @@ const handleKeyDown = (
 		},
 		[KEYS.DOWN]: () => {
 			onKeyboardNavigateToNextWeek(event, { date });
-		}
+		},
 	};
 
 	const shiftKeyDownCallbacks = {
 		[KEYS.TAB]: () => {
 			onCalendarBlur(event, { direction: 'previous' });
-		}
+		},
 	};
 
 	if (event.keyCode) {
@@ -89,17 +89,17 @@ const DatepickerCalendarDay = (props) => {
 			className={classNames({
 				'slds-is-today': isToday,
 				'slds-disabled-text': isDisabled,
-				'slds-is-selected': isSelectedDay
+				'slds-is-selected': isSelectedDay,
 			})}
 			onClick={(event) => {
 				handleClick(event, {
 					date: props.date,
-					onSelectDate: props.onSelectDate
+					onSelectDate: props.onSelectDate,
 				});
 			}}
 			onKeyDown={(event) => {
 				handleKeyDown(event, {
-					...props
+					...props,
 				});
 			}}
 			ref={(component) => {
@@ -114,7 +114,7 @@ const DatepickerCalendarDay = (props) => {
 				) {
 					props.onRequestInternalFocusDate(undefined, {
 						date: props.date,
-						ref: component
+						ref: component,
 					});
 				}
 			}}
@@ -194,7 +194,7 @@ DatepickerCalendarDay.propTypes = {
 	 */
 	todayLabel: PropTypes.string.isRequired,
 	focusedDate: PropTypes.instanceOf(Date),
-	onRequestInternalFocusDate: PropTypes.func
+	onRequestInternalFocusDate: PropTypes.func,
 };
 
 export default DatepickerCalendarDay;

--- a/components/date-picker/private/navigation.jsx
+++ b/components/date-picker/private/navigation.jsx
@@ -52,7 +52,7 @@ const DatepickerMonthNavigation = createReactClass({
 		/**
 		 * Offset of year from current year that can be selected in the year selection dropdown. (2017 + 5 = 2012).
 		 */
-		relativeYearTo: PropTypes.number
+		relativeYearTo: PropTypes.number,
 	},
 
 	getMonthLabel () {
@@ -137,7 +137,7 @@ const DatepickerMonthNavigation = createReactClass({
 				/>
 			</div>
 		);
-	}
+	},
 });
 
 export default DatepickerMonthNavigation;

--- a/components/date-picker/private/week.jsx
+++ b/components/date-picker/private/week.jsx
@@ -110,7 +110,7 @@ DatepickerWeek.propTypes = {
 	/**
 	 * Label of shortcut to jump to today within the calendar. Also used for assistive text for the current day.
 	 */
-	todayLabel: PropTypes.string.isRequired
+	todayLabel: PropTypes.string.isRequired,
 };
 
 DatepickerWeek.displayName = 'SLDSDatepickerWeek';

--- a/components/date-picker/private/year-picklist.jsx
+++ b/components/date-picker/private/year-picklist.jsx
@@ -33,7 +33,7 @@ const DatepickerYearSelector = createReactClass({
 		/**
 		 * Callback that passes in the DOM reference of the `<button>` DOM node within this component. Primary use is to allow `focus` to be called. You should still test if the node exists, since rendering is asynchronous. `buttonRef={(component) => { if(component) console.log(component); }}`
 		 */
-		yearPicklistButtonRef: PropTypes.func
+		yearPicklistButtonRef: PropTypes.func,
 	},
 
 	getOptions () {
@@ -77,7 +77,7 @@ const DatepickerYearSelector = createReactClass({
 				/>
 			</div>
 		);
-	}
+	},
 });
 
 export default DatepickerYearSelector;

--- a/components/filter/__docs__/site-stories.js
+++ b/components/filter/__docs__/site-stories.js
@@ -7,7 +7,7 @@ const siteStories = [
 	require('raw-loader!@salesforce/design-system-react/components/filter/__examples__/default.jsx'),
 	require('raw-loader!@salesforce/design-system-react/components/filter/__examples__/new.jsx'),
 	require('raw-loader!@salesforce/design-system-react/components/filter/__examples__/error.jsx'),
-	require('raw-loader!@salesforce/design-system-react/components/filter/__examples__/locked.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/filter/__examples__/locked.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/filter/__examples__/assistive-text.jsx
+++ b/components/filter/__examples__/assistive-text.jsx
@@ -14,8 +14,8 @@ import Combobox from '~/components/combobox';
 const options = {
 	'show-me': [
 		{ id: 1, label: 'All Products', value: 'all-products' },
-		{ id: 2, label: 'All Wackamoles', value: 'all-Wackamoles' }
-	]
+		{ id: 2, label: 'All Wackamoles', value: 'all-Wackamoles' },
+	],
 };
 
 const Example = createReactClass({
@@ -23,7 +23,7 @@ const Example = createReactClass({
 
 	propTypes () {
 		return {
-			align: PropTypes.string
+			align: PropTypes.string,
 		};
 	},
 
@@ -32,8 +32,8 @@ const Example = createReactClass({
 			'show-me': {
 				selectedItem: options['show-me'][0],
 				isActive: true,
-				comboboxSelection: [options['show-me'][0]]
-			}
+				comboboxSelection: [options['show-me'][0]],
+			},
 		};
 	},
 
@@ -42,8 +42,8 @@ const Example = createReactClass({
 		this.setState({
 			[idSuffix]: {
 				...this.state[idSuffix],
-				selectedItem: this.state[idSuffix].comboboxSelection[0]
-			}
+				selectedItem: this.state[idSuffix].comboboxSelection[0],
+			},
 		});
 	},
 
@@ -52,8 +52,8 @@ const Example = createReactClass({
 		this.setState({
 			[idSuffix]: {
 				...this.state[idSuffix],
-				isActive: false
-			}
+				isActive: false,
+			},
 		});
 	},
 
@@ -65,7 +65,7 @@ const Example = createReactClass({
 						assistiveText={{
 							editFilter: 'editFilter-TEST',
 							editFilterHeading: 'editFilterHeading-TEST',
-							removeFilter: 'removeFilter-TEST'
+							removeFilter: 'removeFilter-TEST',
 						}}
 						align={this.props.align}
 						id="sample-panel-filtering-show-me"
@@ -81,14 +81,14 @@ const Example = createReactClass({
 									this.setState({
 										'show-me': {
 											...this.state['show-me'],
-											comboboxSelection: data.selection
-										}
+											comboboxSelection: data.selection,
+										},
 									});
-								}
+								},
 							}}
 							labels={{
 								label: 'Show Me',
-								placeholder: 'Select record type'
+								placeholder: 'Select record type',
 							}}
 							menuPosition="relative"
 							options={options['show-me']}
@@ -99,7 +99,7 @@ const Example = createReactClass({
 				</IconSettings>
 			)
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/filter/__examples__/default.jsx
+++ b/components/filter/__examples__/default.jsx
@@ -14,8 +14,8 @@ import Combobox from '~/components/combobox';
 const options = {
 	'show-me': [
 		{ id: 1, label: 'All Products', value: 'all-products' },
-		{ id: 2, label: 'All Wackamoles', value: 'all-Wackamoles' }
-	]
+		{ id: 2, label: 'All Wackamoles', value: 'all-Wackamoles' },
+	],
 };
 
 const Example = createReactClass({
@@ -23,7 +23,7 @@ const Example = createReactClass({
 
 	propTypes () {
 		return {
-			align: PropTypes.string
+			align: PropTypes.string,
 		};
 	},
 
@@ -32,8 +32,8 @@ const Example = createReactClass({
 			'show-me': {
 				selectedItem: options['show-me'][0],
 				isActive: true,
-				comboboxSelection: [options['show-me'][0]]
-			}
+				comboboxSelection: [options['show-me'][0]],
+			},
 		};
 	},
 
@@ -42,8 +42,8 @@ const Example = createReactClass({
 		this.setState({
 			[idSuffix]: {
 				...this.state[idSuffix],
-				selectedItem: this.state[idSuffix].comboboxSelection[0]
-			}
+				selectedItem: this.state[idSuffix].comboboxSelection[0],
+			},
 		});
 	},
 
@@ -52,8 +52,8 @@ const Example = createReactClass({
 		this.setState({
 			[idSuffix]: {
 				...this.state[idSuffix],
-				isActive: false
-			}
+				isActive: false,
+			},
 		});
 	},
 
@@ -76,14 +76,14 @@ const Example = createReactClass({
 									this.setState({
 										'show-me': {
 											...this.state['show-me'],
-											comboboxSelection: data.selection
-										}
+											comboboxSelection: data.selection,
+										},
 									});
-								}
+								},
 							}}
 							labels={{
 								label: 'Show Me',
-								placeholder: 'Select record type'
+								placeholder: 'Select record type',
 							}}
 							menuPosition="relative"
 							options={options['show-me']}
@@ -94,7 +94,7 @@ const Example = createReactClass({
 				</IconSettings>
 			)
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/filter/__examples__/error.jsx
+++ b/components/filter/__examples__/error.jsx
@@ -14,8 +14,8 @@ import Picklist from '~/components/menu-picklist';
 const options = {
 	'show-me': [
 		{ label: 'All Products', value: 'all-products' },
-		{ label: 'All Wackamoles', value: 'all-Wackamoles' }
-	]
+		{ label: 'All Wackamoles', value: 'all-Wackamoles' },
+	],
 };
 
 const Example = createReactClass({
@@ -23,7 +23,7 @@ const Example = createReactClass({
 
 	propTypes () {
 		return {
-			align: PropTypes.string
+			align: PropTypes.string,
 		};
 	},
 
@@ -32,8 +32,8 @@ const Example = createReactClass({
 			'show-me': {
 				selectedPicklistItem: options['show-me'][0],
 				selectedItem: options['show-me'][0],
-				isActive: true
-			}
+				isActive: true,
+			},
 		};
 	},
 
@@ -42,8 +42,8 @@ const Example = createReactClass({
 		this.setState({
 			[idSuffix]: {
 				...this.state[idSuffix],
-				selectedItem: this.state[idSuffix].selectedPicklistItem
-			}
+				selectedItem: this.state[idSuffix].selectedPicklistItem,
+			},
 		});
 	},
 
@@ -51,8 +51,8 @@ const Example = createReactClass({
 		this.setState({
 			[id]: {
 				...this.state[id],
-				selectedPicklistItem: selectedItem
-			}
+				selectedPicklistItem: selectedItem,
+			},
 		});
 	},
 
@@ -61,8 +61,8 @@ const Example = createReactClass({
 		this.setState({
 			[idSuffix]: {
 				...this.state[idSuffix],
-				isActive: false
-			}
+				isActive: false,
+			},
 		});
 	},
 
@@ -93,7 +93,7 @@ const Example = createReactClass({
 				</IconSettings>
 			)
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/filter/__examples__/locked.jsx
+++ b/components/filter/__examples__/locked.jsx
@@ -14,8 +14,8 @@ import Picklist from '~/components/menu-picklist';
 const options = {
 	'show-me': [
 		{ label: 'All Products', value: 'all-products' },
-		{ label: 'All Wackamoles', value: 'all-Wackamoles' }
-	]
+		{ label: 'All Wackamoles', value: 'all-Wackamoles' },
+	],
 };
 
 const Example = createReactClass({
@@ -23,7 +23,7 @@ const Example = createReactClass({
 
 	propTypes () {
 		return {
-			align: PropTypes.string
+			align: PropTypes.string,
 		};
 	},
 
@@ -32,8 +32,8 @@ const Example = createReactClass({
 			'show-me': {
 				selectedPicklistItem: options['show-me'][0],
 				selectedItem: options['show-me'][0],
-				isActive: true
-			}
+				isActive: true,
+			},
 		};
 	},
 
@@ -42,8 +42,8 @@ const Example = createReactClass({
 		this.setState({
 			[idSuffix]: {
 				...this.state[idSuffix],
-				selectedItem: this.state[idSuffix].selectedPicklistItem
-			}
+				selectedItem: this.state[idSuffix].selectedPicklistItem,
+			},
 		});
 	},
 
@@ -51,8 +51,8 @@ const Example = createReactClass({
 		this.setState({
 			[id]: {
 				...this.state[id],
-				selectedPicklistItem: selectedItem
-			}
+				selectedPicklistItem: selectedItem,
+			},
 		});
 	},
 
@@ -61,8 +61,8 @@ const Example = createReactClass({
 		this.setState({
 			[idSuffix]: {
 				...this.state[idSuffix],
-				isActive: false
-			}
+				isActive: false,
+			},
 		});
 	},
 
@@ -93,7 +93,7 @@ const Example = createReactClass({
 				</IconSettings>
 			)
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/filter/__examples__/new.jsx
+++ b/components/filter/__examples__/new.jsx
@@ -14,8 +14,8 @@ import Picklist from '~/components/menu-picklist';
 const options = {
 	'show-me': [
 		{ label: 'All Products', value: 'all-products' },
-		{ label: 'All Wackamoles', value: 'all-Wackamoles' }
-	]
+		{ label: 'All Wackamoles', value: 'all-Wackamoles' },
+	],
 };
 
 const Example = createReactClass({
@@ -23,7 +23,7 @@ const Example = createReactClass({
 
 	propTypes () {
 		return {
-			align: PropTypes.string
+			align: PropTypes.string,
 		};
 	},
 
@@ -32,8 +32,8 @@ const Example = createReactClass({
 			'show-me': {
 				selectedPicklistItem: options['show-me'][0],
 				selectedItem: options['show-me'][0],
-				isActive: true
-			}
+				isActive: true,
+			},
 		};
 	},
 
@@ -42,8 +42,8 @@ const Example = createReactClass({
 		this.setState({
 			[idSuffix]: {
 				...this.state[idSuffix],
-				selectedItem: this.state[idSuffix].selectedPicklistItem
-			}
+				selectedItem: this.state[idSuffix].selectedPicklistItem,
+			},
 		});
 	},
 
@@ -51,8 +51,8 @@ const Example = createReactClass({
 		this.setState({
 			[id]: {
 				...this.state[id],
-				selectedPicklistItem: selectedItem
-			}
+				selectedPicklistItem: selectedItem,
+			},
 		});
 	},
 
@@ -61,8 +61,8 @@ const Example = createReactClass({
 		this.setState({
 			[idSuffix]: {
 				...this.state[idSuffix],
-				isActive: false
-			}
+				isActive: false,
+			},
 		});
 	},
 
@@ -93,7 +93,7 @@ const Example = createReactClass({
 				</IconSettings>
 			)
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/filter/__examples__/permanant.jsx
+++ b/components/filter/__examples__/permanant.jsx
@@ -14,8 +14,8 @@ import Picklist from '~/components/menu-picklist';
 const options = {
 	'show-me': [
 		{ label: 'All Products', value: 'all-products' },
-		{ label: 'All Wackamoles', value: 'all-Wackamoles' }
-	]
+		{ label: 'All Wackamoles', value: 'all-Wackamoles' },
+	],
 };
 
 const Example = createReactClass({
@@ -23,7 +23,7 @@ const Example = createReactClass({
 
 	propTypes () {
 		return {
-			align: PropTypes.string
+			align: PropTypes.string,
 		};
 	},
 
@@ -32,8 +32,8 @@ const Example = createReactClass({
 			'show-me': {
 				selectedPicklistItem: options['show-me'][0],
 				selectedItem: options['show-me'][0],
-				isActive: true
-			}
+				isActive: true,
+			},
 		};
 	},
 
@@ -42,8 +42,8 @@ const Example = createReactClass({
 		this.setState({
 			[idSuffix]: {
 				...this.state[idSuffix],
-				selectedItem: this.state[idSuffix].selectedPicklistItem
-			}
+				selectedItem: this.state[idSuffix].selectedPicklistItem,
+			},
 		});
 	},
 
@@ -51,8 +51,8 @@ const Example = createReactClass({
 		this.setState({
 			[id]: {
 				...this.state[id],
-				selectedPicklistItem: selectedItem
-			}
+				selectedPicklistItem: selectedItem,
+			},
 		});
 	},
 
@@ -61,8 +61,8 @@ const Example = createReactClass({
 		this.setState({
 			[idSuffix]: {
 				...this.state[idSuffix],
-				isActive: false
-			}
+				isActive: false,
+			},
 		});
 	},
 
@@ -93,7 +93,7 @@ const Example = createReactClass({
 				</IconSettings>
 			)
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/filter/__tests__/filter.browser-test.jsx
+++ b/components/filter/__tests__/filter.browser-test.jsx
@@ -12,7 +12,7 @@ import { mount } from 'enzyme';
  */
 import {
 	createMountNode,
-	destroyMountNode
+	destroyMountNode,
 } from '../../../tests/enzyme-helpers';
 
 // Import your internal dependencies (for example):
@@ -29,14 +29,14 @@ chai.use(chaiEnzyme());
 const defaultProps = {
 	id: 'sample-popover',
 	body: <span id="sample-body">This is the body</span>,
-	heading: <span id="sample-heading">This is the heading</span>
+	heading: <span id="sample-heading">This is the heading</span>,
 };
 
 const defaultIds = {
 	trigger: defaultProps.id,
 	popover: `${defaultProps.id}-popover`,
 	body: `${defaultProps.id}-dialog-body`,
-	heading: `${defaultProps.id}-dialog-heading`
+	heading: `${defaultProps.id}-dialog-heading`,
 };
 
 /* A re-usable demo component fixture outside of `describe` sections
@@ -47,7 +47,7 @@ const defaultIds = {
 const DemoComponent = createReactClass({
 	displayName: 'PopoverDemoComponent',
 	propTypes: {
-		isOpen: PropTypes.bool
+		isOpen: PropTypes.bool,
 	},
 
 	getDefaultProps () {
@@ -64,7 +64,7 @@ const DemoComponent = createReactClass({
 				<Button label="Trigger Popover" />
 			</Popover>
 		);
-	}
+	},
 });
 
 /* All tests for component being tested should be wrapped in a root `describe`,

--- a/components/filter/index.jsx
+++ b/components/filter/index.jsx
@@ -55,7 +55,7 @@ const Filter = createReactClass({
 		assistiveText: PropTypes.shape({
 			editFilter: PropTypes.string,
 			editFilterHeading: PropTypes.string,
-			removeFilter: PropTypes.string
+			removeFilter: PropTypes.string,
 		}),
 		/**
 		 * Contents of popover. That is the dropdowns and inputs that set the filter criteria.
@@ -67,7 +67,7 @@ const Filter = createReactClass({
 		className: PropTypes.oneOfType([
 			PropTypes.array,
 			PropTypes.object,
-			PropTypes.string
+			PropTypes.string,
 		]),
 		/**
 		 * Applies error state styling. Per filter error messages are outside this components.
@@ -112,7 +112,7 @@ const Filter = createReactClass({
 		/**
 		 * The property you are filtering. For instance, if "Hair Color is PURPLE" is your filter, "Hair Color" is your filter property.
 		 */
-		property: PropTypes.node
+		property: PropTypes.node,
 	},
 
 	getDefaultProps () {
@@ -120,9 +120,9 @@ const Filter = createReactClass({
 			align: 'left',
 			assistiveText: {
 				editFilter: 'Edit filter:',
-				editFilterHeading: 'Choose filter criteria'
+				editFilterHeading: 'Choose filter criteria',
 			},
-			predicate: 'New Filter'
+			predicate: 'New Filter',
 		};
 	},
 
@@ -130,7 +130,7 @@ const Filter = createReactClass({
 		return {
 			popoverIsOpen: this.props.popover
 				? this.props.popover.props.isOpen
-				: false
+				: false,
 		};
 	},
 
@@ -178,7 +178,7 @@ const Filter = createReactClass({
 			onClose: this.handleClose,
 			onRequestClose: this.handleClose,
 			position: 'overflowBoundaryElement',
-			triggerClassName: 'slds-grow'
+			triggerClassName: 'slds-grow',
 		};
 
 		/* Mixin passed popover's props if there is any to override the default popover props */
@@ -228,7 +228,7 @@ const Filter = createReactClass({
 			removeFilter:
 				this.props.assistiveTextRemoveFilter || // eslint-disable-line react/prop-types
 				this.props.assistiveText.removeFilter ||
-				`Remove Filter: ${this.props.property} ${this.props.predicate}`
+				`Remove Filter: ${this.props.property} ${this.props.predicate}`,
 		};
 
 		/* TODO: Button wrapper for property and predictate should be transitioned to `Button` component. `Button` needs to take custom children first though. */
@@ -242,7 +242,7 @@ const Filter = createReactClass({
 					{
 						'slds-is-locked': this.props.isLocked,
 						'slds-is-new': this.props.isNew,
-						'slds-has-error': this.props.isError
+						'slds-has-error': this.props.isError,
 					},
 					this.props.className
 				)}
@@ -293,7 +293,7 @@ const Filter = createReactClass({
 					) : null}
 			</div>
 		);
-	}
+	},
 });
 
 export default Filter;

--- a/components/forms/checkbox/__docs__/site-stories.js
+++ b/components/forms/checkbox/__docs__/site-stories.js
@@ -6,7 +6,7 @@
 const siteStories = [
 	require('raw-loader!@salesforce/design-system-react/components/forms/checkbox/__examples__/default.jsx'),
 	require('raw-loader!@salesforce/design-system-react/components/forms/checkbox/__examples__/error.jsx'),
-	require('raw-loader!@salesforce/design-system-react/components/forms/checkbox/__examples__/toggle.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/forms/checkbox/__examples__/toggle.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/forms/checkbox/__docs__/storybook-stories.jsx
+++ b/components/forms/checkbox/__docs__/storybook-stories.jsx
@@ -14,7 +14,7 @@ const CheckboxIndeterminate = createReactClass({
 		return {
 			indeterminate: true,
 			checked: true,
-			currentStateHelper: 'Indeterminate'
+			currentStateHelper: 'Indeterminate',
 		};
 	},
 
@@ -23,7 +23,7 @@ const CheckboxIndeterminate = createReactClass({
 		this.setState({
 			checked: data.checked,
 			currentStateHelper: data.indeterminate ? 'Indeterminate' : checkedLabel,
-			indeterminate: data.indeterminate
+			indeterminate: data.indeterminate,
 		});
 
 		action('handleChange')(
@@ -38,7 +38,7 @@ const CheckboxIndeterminate = createReactClass({
 		this.setState({
 			currentStateHelper: 'Indeterminate',
 			checked: true,
-			indeterminate: true
+			indeterminate: true,
 		});
 		action('changeToIndeterminate')(
 			event,
@@ -50,7 +50,7 @@ const CheckboxIndeterminate = createReactClass({
 		this.setState({
 			currentStateHelper: 'Checked',
 			checked: true,
-			indeterminate: false
+			indeterminate: false,
 		});
 		action('changeToCheck')(event, 'checked: true, indeterminate: false');
 	},
@@ -59,7 +59,7 @@ const CheckboxIndeterminate = createReactClass({
 		this.setState({
 			currentStateHelper: 'Unchecked',
 			checked: false,
-			indeterminate: false
+			indeterminate: false,
 		});
 		action('changeToUnChecked')(event, 'checked: false, indeterminate: false');
 	},
@@ -101,7 +101,7 @@ const CheckboxIndeterminate = createReactClass({
 				</div>
 			</div>
 		);
-	}
+	},
 });
 
 storiesOf(FORMS_CHECKBOX, module)

--- a/components/forms/checkbox/__docs__/storybook-stories.jsx
+++ b/components/forms/checkbox/__docs__/storybook-stories.jsx
@@ -150,14 +150,14 @@ storiesOf(FORMS_CHECKBOX, module)
 	.add('Checkbox (assistive text)', () => (
 		<div>
 			<Checkbox
-				assistiveText={`This is my checkbox.
+				assistiveText="This is my checkbox.
 							There are many like it, but this one is mine.
 							My checkbox is my best friend.
 							It is my life.
 							I must master it as I must master my life.
 							Without me, my checkbox is useless. Without my checkbox, I am useless.
 							I must make my checkbox true.
-							I must make it truer than my radio button who is trying to... `}
+							I must make it truer than my radio button who is trying to... "
 				label="Checkbox Label"
 				name="checkbox-example-base-assistiveText"
 				onChange={action('change')}
@@ -236,14 +236,14 @@ storiesOf(FORMS_CHECKBOX, module)
 	.add('Checkbox Toggle (assistive text)', () => (
 		<div>
 			<Checkbox
-				assistiveText={`This is my checkbox.
+				assistiveText="This is my checkbox.
 							There are many like it, but this one is mine.
 							My checkbox is my best friend.
 							It is my life.
 							I must master it as I must master my life.
 							Without me, my checkbox is useless. Without my checkbox, I am useless.
 							I must make my checkbox true.
-							I must make it truer than my radio button who is trying to... `}
+							I must make it truer than my radio button who is trying to... "
 				label="Checkbox Label"
 				name="checkbox-example-base-assistiveText"
 				onChange={action('change')}

--- a/components/forms/checkbox/__examples__/default.jsx
+++ b/components/forms/checkbox/__examples__/default.jsx
@@ -29,7 +29,7 @@ const Example = createReactClass({
 				</div>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/forms/checkbox/__examples__/error.jsx
+++ b/components/forms/checkbox/__examples__/error.jsx
@@ -33,7 +33,7 @@ const Example = createReactClass({
 				</div>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/forms/checkbox/__examples__/snapshot-base.jsx
+++ b/components/forms/checkbox/__examples__/snapshot-base.jsx
@@ -64,7 +64,7 @@ const Example = createReactClass({
 				</div>
 			</div>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/forms/checkbox/__examples__/snapshot-toggle.jsx
+++ b/components/forms/checkbox/__examples__/snapshot-toggle.jsx
@@ -67,7 +67,7 @@ const Example = createReactClass({
 				</div>
 			</div>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/forms/checkbox/__examples__/toggle.jsx
+++ b/components/forms/checkbox/__examples__/toggle.jsx
@@ -74,7 +74,7 @@ const Example = createReactClass({
 				</div>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/forms/checkbox/check-props.js
+++ b/components/forms/checkbox/check-props.js
@@ -14,7 +14,7 @@ if (process.env.NODE_ENV !== 'production') {
 				COMPONENT,
 				{
 					variant: props.variant,
-					indeterminate: props.indeterminate
+					indeterminate: props.indeterminate,
 				},
 				'Currently SLDS does not support the `indeterminate` state in Checkbox Toggle. See SLDS documentation about [Checkbox Toggle](https://lightningdesignsystem.com/components/forms/#flavor-checkbox-toggle-checkbox-toggle) for more information.'
 			);

--- a/components/forms/checkbox/index.jsx
+++ b/components/forms/checkbox/index.jsx
@@ -59,7 +59,7 @@ const Checkbox = createReactClass({
 		className: PropTypes.oneOfType([
 			PropTypes.array,
 			PropTypes.object,
-			PropTypes.string
+			PropTypes.string,
 		]),
 		/**
 		 * Disables the Checkbox and prevents clicking it.
@@ -132,14 +132,14 @@ const Checkbox = createReactClass({
 		/**
 		 * Which flavor of checkbox? Default is `base` while other option is `toggle`. (**Note:** `toggle` variant does not support the `indeterminate` feature, because [SLDS does not support it](https://lightningdesignsystem.com/components/forms/#flavor-checkbox-toggle-checkbox-toggle).)
 		 */
-		variant: PropTypes.oneOf(['base', 'toggle', 'button-group'])
+		variant: PropTypes.oneOf(['base', 'toggle', 'button-group']),
 	},
 
 	getDefaultProps () {
 		return {
 			variant: 'base',
 			labelToggleEnabled: 'Enabled',
-			labelToggleDisabled: 'Disabled'
+			labelToggleDisabled: 'Disabled',
 		};
 	},
 
@@ -160,7 +160,7 @@ const Checkbox = createReactClass({
 			// `checked` is present twice to maintain backwards compatibility. Please remove first parameter `value` on the next breaking change.
 			onChange(value, event, {
 				checked: indeterminate ? true : !checked,
-				indeterminate: false
+				indeterminate: false,
 			});
 		}
 	},
@@ -216,7 +216,7 @@ const Checkbox = createReactClass({
 					'slds-form-element',
 					{
 						'is-required': props.required,
-						'slds-has-error': props.errorText
+						'slds-has-error': props.errorText,
 					},
 					props.className
 				)}
@@ -280,7 +280,7 @@ const Checkbox = createReactClass({
 					'slds-form-element',
 					{
 						'is-required': props.required,
-						'slds-has-error': props.errorText
+						'slds-has-error': props.errorText,
 					},
 					props.className
 				)}
@@ -359,7 +359,7 @@ const Checkbox = createReactClass({
 				renderer = this.renderBaseVariant(this.props);
 		}
 		return renderer;
-	}
+	},
 });
 
 export default Checkbox;

--- a/components/forms/input/__docs__/inline/site-stories.js
+++ b/components/forms/input/__docs__/inline/site-stories.js
@@ -4,7 +4,7 @@
 /* eslint-disable global-require */
 
 const siteStories = [
-	require('raw-loader!@salesforce/design-system-react/components/forms/input/__examples__/inline-default.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/forms/input/__examples__/inline-default.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/forms/input/__docs__/inline/storybook-stories.jsx
+++ b/components/forms/input/__docs__/inline/storybook-stories.jsx
@@ -13,7 +13,7 @@ const DemoInlineEdit = createReactClass({
 
 	getInitialState () {
 		return {
-			value: 'Edit me inline'
+			value: 'Edit me inline',
 		};
 	},
 
@@ -35,7 +35,7 @@ const DemoInlineEdit = createReactClass({
 				onChange={this.handleChange}
 			/>
 		);
-	}
+	},
 });
 
 storiesOf(FORMS_INLINE_EDIT, module)

--- a/components/forms/input/__docs__/site-stories.js
+++ b/components/forms/input/__docs__/site-stories.js
@@ -7,7 +7,7 @@ const siteStories = [
 	require('raw-loader!@salesforce/design-system-react/components/forms/input/__examples__/default.jsx'),
 	require('raw-loader!@salesforce/design-system-react/components/forms/input/__examples__/icons.jsx'),
 	require('raw-loader!@salesforce/design-system-react/components/forms/input/__examples__/error.jsx'),
-	require('raw-loader!@salesforce/design-system-react/components/forms/input/__examples__/inactiveInputs.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/forms/input/__examples__/inactiveInputs.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/forms/input/__examples__/default.jsx
+++ b/components/forms/input/__examples__/default.jsx
@@ -40,7 +40,7 @@ const Example = createReactClass({
 				</section>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/forms/input/__examples__/error.jsx
+++ b/components/forms/input/__examples__/error.jsx
@@ -43,7 +43,7 @@ const Example = createReactClass({
 				</div>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/forms/input/__examples__/icons.jsx
+++ b/components/forms/input/__examples__/icons.jsx
@@ -94,7 +94,7 @@ const Example = createReactClass({
 				</div>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/forms/input/__examples__/icons.jsx
+++ b/components/forms/input/__examples__/icons.jsx
@@ -52,7 +52,7 @@ const Example = createReactClass({
 							}
 							id="unique-id-2"
 							label="Input Label"
-							placeholder={'Clickable Icons (Left and Right)'}
+							placeholder="Clickable Icons (Left and Right)"
 						/>
 					</div>
 					<div className="slds-col--padded">

--- a/components/forms/input/__examples__/inactiveInputs.jsx
+++ b/components/forms/input/__examples__/inactiveInputs.jsx
@@ -46,7 +46,7 @@ const Example = createReactClass({
 				</section>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/forms/input/__examples__/inline-default.jsx
+++ b/components/forms/input/__examples__/inline-default.jsx
@@ -8,7 +8,7 @@ const Example = createReactClass({
 
 	getInitialState () {
 		return {
-			value: 'Edit me inline'
+			value: 'Edit me inline',
 		};
 	},
 
@@ -44,7 +44,7 @@ const Example = createReactClass({
 				</section>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/forms/input/__tests__/input.browser-test.jsx
+++ b/components/forms/input/__tests__/input.browser-test.jsx
@@ -13,12 +13,12 @@ import IconSettings from '../../../icon-settings';
 const {
 	findRenderedDOMComponentWithTag,
 	scryRenderedDOMComponentsWithTag,
-	findRenderedDOMComponentWithClass
+	findRenderedDOMComponentWithClass,
 } = TestUtils;
 
 describe('SLDSInput', () => {
 	const defaultProps = {
-		placeholder: 'Placeholder Text'
+		placeholder: 'Placeholder Text',
 	};
 
 	let body;
@@ -226,7 +226,7 @@ describe('SLDSInput', () => {
 			component = getInput({
 				label: 'Input Label',
 				required: true,
-				errorText: 'Error Message'
+				errorText: 'Error Message',
 			});
 			wrapper = findRenderedDOMComponentWithClass(
 				component,
@@ -281,7 +281,7 @@ describe('SLDSInput', () => {
 						category="utility"
 						onClick={clickCallback}
 					/>
-				)
+				),
 			});
 			leftButton = findRenderedDOMComponentWithTag(component, 'button');
 			iconAssistiveText = findRenderedDOMComponentWithClass(
@@ -335,7 +335,7 @@ describe('SLDSInput', () => {
 						category="utility"
 						onClick={clickCallback}
 					/>
-				)
+				),
 			});
 			leftButton = findRenderedDOMComponentWithTag(component, 'button');
 			elementControl = findRenderedDOMComponentWithClass(
@@ -370,7 +370,7 @@ describe('SLDSInput', () => {
 
 		beforeEach(() => {
 			component = getInput({
-				iconRight: <Icon name="search" category="utility" />
+				iconRight: <Icon name="search" category="utility" />,
 			});
 			elementControl = findRenderedDOMComponentWithClass(
 				component,
@@ -404,7 +404,7 @@ describe('SLDSInput', () => {
 					/>
 				),
 				id: 'unique-id-4',
-				label: 'Input Label'
+				label: 'Input Label',
 			});
 			spinner = findRenderedDOMComponentWithClass(component, 'slds-spinner');
 			input = findRenderedDOMComponentWithTag(component, 'input');
@@ -451,7 +451,7 @@ describe('SLDSInput', () => {
 					/>
 				),
 				id: 'unique-id-4',
-				label: 'Input Label'
+				label: 'Input Label',
 			});
 			spinner = findRenderedDOMComponentWithClass(component, 'slds-spinner');
 			input = findRenderedDOMComponentWithTag(component, 'input');
@@ -481,7 +481,7 @@ describe('SLDSInput', () => {
 			component = getInput({
 				fixedTextLeft: '$',
 				id: 'unique-id-5',
-				label: 'Input Label'
+				label: 'Input Label',
 			});
 			fixedTextLeft = findRenderedDOMComponentWithClass(
 				component,

--- a/components/forms/input/check-props.js
+++ b/components/forms/input/check-props.js
@@ -60,12 +60,12 @@ if (process.env.NODE_ENV !== 'production') {
 
 		onlyOneOfProperties(COMPONENT, {
 			assistiveText: props.assistiveText,
-			label: props.label
+			label: props.label,
 		});
 
 		onlyOneOfProperties(COMPONENT, {
 			fixedTextLeft: props.fixedTextLeft,
-			fixedTextRight: props.fixedTextRight
+			fixedTextRight: props.fixedTextRight,
 		});
 
 		/*

--- a/components/forms/input/index.jsx
+++ b/components/forms/input/index.jsx
@@ -69,7 +69,7 @@ const Input = createReactClass({
 		 */
 		assistiveText: shape({
 			label: PropTypes.string,
-			spinner: PropTypes.string
+			spinner: PropTypes.string,
 		}),
 		children: PropTypes.node,
 		/**
@@ -78,7 +78,7 @@ const Input = createReactClass({
 		className: PropTypes.oneOfType([
 			PropTypes.array,
 			PropTypes.object,
-			PropTypes.string
+			PropTypes.string,
 		]),
 		/**
 		 * Disables the input and prevents editing the contents.
@@ -176,7 +176,7 @@ const Input = createReactClass({
 			'url',
 			'search',
 			'tel',
-			'color'
+			'color',
 		]),
 		/**
 		 * The input is a controlled component, and will always display this value.
@@ -184,12 +184,12 @@ const Input = createReactClass({
 		value: PropTypes.string,
 		iconPosition: PropTypes.string,
 		inlineEditTrigger: PropTypes.node,
-		role: PropTypes.string
+		role: PropTypes.string,
 	},
 
 	getDefaultProps () {
 		return {
-			type: 'text'
+			type: 'text',
 		};
 	},
 
@@ -232,7 +232,7 @@ const Input = createReactClass({
 			onClick:
 				(this.props[iconPositionProp] &&
 					this.props[iconPositionProp].props.onClick) ||
-				this.props.onIconClick
+				this.props.onIconClick,
 		};
 		/* eslint-enable react/prop-types */
 
@@ -242,7 +242,7 @@ const Input = createReactClass({
 			this.props[iconPositionProp]
 		) {
 			icon = React.cloneElement(this.props[iconPositionProp], {
-				iconPosition: `${position}`
+				iconPosition: `${position}`,
 			});
 		} else if (deprecatedProps.name) {
 			icon = <InputIcon iconPosition={position} {...deprecatedProps} />;
@@ -268,7 +268,7 @@ const Input = createReactClass({
 				className={classNames(
 					'slds-form-element',
 					{
-						'slds-has-error': this.props.errorText
+						'slds-has-error': this.props.errorText,
 					},
 					this.props.className
 				)}
@@ -290,7 +290,7 @@ const Input = createReactClass({
 					aria-owns={this.props['aria-owns']}
 					aria-required={this.props['aria-required']}
 					containerProps={{
-						className: 'slds-form-element__control'
+						className: 'slds-form-element__control',
 					}}
 					disabled={this.props.disabled}
 					fixedTextLeft={this.props.fixedTextLeft}
@@ -336,7 +336,7 @@ const Input = createReactClass({
 				{this.props.children}
 			</div>
 		);
-	}
+	},
 });
 
 export default Input;

--- a/components/forms/input/inline.jsx
+++ b/components/forms/input/inline.jsx
@@ -33,7 +33,7 @@ const propTypes = {
 	className: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * Name of the submitted form parameter.
@@ -80,17 +80,17 @@ const propTypes = {
 		'url',
 		'search',
 		'tel',
-		'color'
+		'color',
 	]),
 	/**
 	 * Inline Edit is a controlled component, and will always display this value.
 	 */
-	value: PropTypes.string.isRequired
+	value: PropTypes.string.isRequired,
 };
 
 const defaultProps = {
 	assistiveText: 'Edit text',
-	type: 'text'
+	type: 'text',
 };
 
 /**
@@ -101,7 +101,7 @@ class InlineEdit extends React.Component {
 		super(props);
 		this.state = {
 			isEditing: false,
-			value: null
+			value: null,
 		};
 	}
 
@@ -123,7 +123,7 @@ class InlineEdit extends React.Component {
 
 		this.setState({
 			isEditing: false,
-			value: null
+			value: null,
 		});
 
 		if (this.props.onLeaveEditMode && isFunction(this.props.onLeaveEditMode)) {
@@ -142,7 +142,7 @@ class InlineEdit extends React.Component {
 
 	handleChange = (event) => {
 		this.setState({
-			value: event.target.value
+			value: event.target.value,
 		});
 	};
 
@@ -160,7 +160,7 @@ class InlineEdit extends React.Component {
 		if (event.keyCode) {
 			if (this.props.onKeyUp && isFunction(this.props.onKeyUp)) {
 				this.props.onKeyUp(event, {
-					value: this.state.value
+					value: this.state.value,
 				});
 			}
 		}
@@ -170,7 +170,7 @@ class InlineEdit extends React.Component {
 		if (!(option && option.cancel === true)) {
 			if (isFunction(this.props.onChange)) {
 				this.props.onChange({
-					value: this.state.value
+					value: this.state.value,
 				});
 			}
 		}
@@ -182,7 +182,7 @@ class InlineEdit extends React.Component {
 			this.autoFocus = true;
 			this.setState({
 				isEditing: true,
-				value: this.props.value
+				value: this.props.value,
 			});
 			if (isFunction(this.props.onEnterEditMode)) {
 				this.props.onEnterEditMode();

--- a/components/forms/input/private/inner-input.jsx
+++ b/components/forms/input/private/inner-input.jsx
@@ -42,7 +42,7 @@ const propTypes = {
 	className: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * Class names to be added to the outer container `div` of the input.
@@ -50,7 +50,7 @@ const propTypes = {
 	containerClassName: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * Props to be added to the outer container `div` of the input (excluding `containerClassName`).
@@ -164,17 +164,17 @@ const propTypes = {
 		'url',
 		'search',
 		'tel',
-		'color'
+		'color',
 	]),
 	/**
 	 * The input is a controlled component, and will always display this value.
 	 */
-	value: PropTypes.string
+	value: PropTypes.string,
 };
 
 const defaultProps = {
 	spinnerAssistiveText: 'Loading ...',
-	type: 'text'
+	type: 'text',
 };
 
 /*
@@ -195,7 +195,7 @@ const InnerInput = (props) => {
 				'slds-input-has-icon_left-right': props.iconLeft && props.iconRight,
 				'slds-input-has-fixed-addon':
 					props.fixedTextLeft || props.fixedTextRight,
-				'slds-has-divider--bottom': props.isStatic
+				'slds-has-divider--bottom': props.isStatic,
 			})}
 			{...containerProps}
 		>

--- a/components/forms/input/search.jsx
+++ b/components/forms/input/search.jsx
@@ -88,7 +88,7 @@ Search.propTypes = {
 	/**
 	 * Placeholder for the input
 	 */
-	placeholder: PropTypes.string
+	placeholder: PropTypes.string,
 };
 
 export default Search;

--- a/components/forms/private/label.jsx
+++ b/components/forms/private/label.jsx
@@ -25,11 +25,11 @@ const propTypes = {
 	/**
 	 * Changes markup of label.
 	 */
-	variant: PropTypes.oneOf(['base', 'static'])
+	variant: PropTypes.oneOf(['base', 'static']),
 };
 
 const defaultProps = {
-	variant: 'base'
+	variant: 'base',
 };
 
 /*
@@ -43,7 +43,7 @@ const Label = (props) => {
 		base: (
 			<label
 				className={classNames('slds-form-element__label', {
-					'slds-assistive-text': props.assistiveText && !props.label
+					'slds-assistive-text': props.assistiveText && !props.label,
 				})}
 				htmlFor={props.htmlFor}
 			>
@@ -55,7 +55,7 @@ const Label = (props) => {
 				{labelText}
 			</label>
 		),
-		static: <span className="slds-form-element__label">{labelText}</span>
+		static: <span className="slds-form-element__label">{labelText}</span>,
 	};
 
 	return labelText ? subRenders[props.variant] : null;

--- a/components/forms/radio/__examples__/default.jsx
+++ b/components/forms/radio/__examples__/default.jsx
@@ -7,7 +7,7 @@ const Example = createReactClass({
 
 	render () {
 		return <Radio id="radioId1" label="Radio Label" />;
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/forms/radio/__examples__/disabled.jsx
+++ b/components/forms/radio/__examples__/disabled.jsx
@@ -7,7 +7,7 @@ const Example = createReactClass({
 
 	render () {
 		return <Radio id="radioId1" label="Radio Label" disabled />;
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/forms/radio/index.jsx
+++ b/components/forms/radio/index.jsx
@@ -44,11 +44,11 @@ const propTypes = {
 	/**
 	 * Variant of the Radio button. Base is the default and button-group makes the radio button look like a normal button (should be a child of <RadioButtonGroup>).
 	 */
-	variant: PropTypes.oneOf(['base', 'button-group'])
+	variant: PropTypes.oneOf(['base', 'button-group']),
 };
 
 const defaultProps = {
-	variant: 'base'
+	variant: 'base',
 };
 
 /**
@@ -70,7 +70,8 @@ class Radio extends React.Component {
 			<span
 				className={classNames({
 					'slds-radio': this.props.variant === 'base',
-					'slds-button slds-radio_button': this.props.variant === 'button-group'
+					'slds-button slds-radio_button':
+						this.props.variant === 'button-group',
 				})}
 			>
 				<input

--- a/components/forms/textarea/__docs__/site-stories.js
+++ b/components/forms/textarea/__docs__/site-stories.js
@@ -6,7 +6,7 @@
 const siteStories = [
 	require('raw-loader!@salesforce/design-system-react/components/forms/textarea/__examples__/default.jsx'),
 	require('raw-loader!@salesforce/design-system-react/components/forms/textarea/__examples__/error.jsx'),
-	require('raw-loader!@salesforce/design-system-react/components/forms/textarea/__examples__/disabled.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/forms/textarea/__examples__/disabled.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/forms/textarea/__examples__/default.jsx
+++ b/components/forms/textarea/__examples__/default.jsx
@@ -12,7 +12,7 @@ const Example = createReactClass({
 				<Textarea id="unique-id-1" label="Textarea Label" />
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/forms/textarea/__examples__/disabled.jsx
+++ b/components/forms/textarea/__examples__/disabled.jsx
@@ -17,7 +17,7 @@ const Example = createReactClass({
 				/>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/forms/textarea/__examples__/error.jsx
+++ b/components/forms/textarea/__examples__/error.jsx
@@ -19,7 +19,7 @@ const Example = createReactClass({
 				/>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/forms/textarea/__tests__/textarea.browser-test.jsx
+++ b/components/forms/textarea/__tests__/textarea.browser-test.jsx
@@ -10,12 +10,12 @@ import Textarea from '../';
 const {
 	findRenderedDOMComponentWithTag,
 	scryRenderedDOMComponentsWithTag,
-	findRenderedDOMComponentWithClass
+	findRenderedDOMComponentWithClass,
 } = TestUtils;
 
 describe('SLDS TEXTAREA **************************************************', () => {
 	const defaultProps = {
-		placeholder: 'Placeholder Text'
+		placeholder: 'Placeholder Text',
 	};
 
 	let body;
@@ -141,7 +141,7 @@ describe('SLDS TEXTAREA **************************************************', () 
 			component = getTextarea({
 				label: 'Textarea Label',
 				required: true,
-				errorText: 'Error Message'
+				errorText: 'Error Message',
 			});
 			wrapper = findRenderedDOMComponentWithClass(
 				component,

--- a/components/forms/textarea/check-props.js
+++ b/components/forms/textarea/check-props.js
@@ -11,7 +11,7 @@ if (process.env.NODE_ENV !== 'production') {
 	checkProps = function (COMPONENT, props) {
 		onlyOneOfProperties(COMPONENT, {
 			assistiveText: props.assistiveText,
-			label: props.label
+			label: props.label,
 		});
 	};
 }

--- a/components/forms/textarea/index.jsx
+++ b/components/forms/textarea/index.jsx
@@ -74,14 +74,14 @@ const Textarea = createReactClass({
 		className: PropTypes.oneOfType([
 			PropTypes.array,
 			PropTypes.object,
-			PropTypes.string
+			PropTypes.string,
 		]),
 		/** Allows for ability to apply classNames to outer textarea div.
 		 */
 		classNameContainer: PropTypes.oneOfType([
 			PropTypes.array,
 			PropTypes.object,
-			PropTypes.string
+			PropTypes.string,
 		]),
 		/**
 		 * Message to display when the textarea is in an error state. When this is present, also visually highlights the component as in error.
@@ -144,7 +144,7 @@ const Textarea = createReactClass({
 		/**
 		 * Specifies how the text in a text area is to be wrapped when submitted in a form.
 		 */
-		wrap: PropTypes.oneOf(['soft', 'hard'])
+		wrap: PropTypes.oneOf(['soft', 'hard']),
 	},
 
 	componentWillMount () {
@@ -194,7 +194,7 @@ const Textarea = createReactClass({
 			required,
 			role,
 			value,
-			wrap
+			wrap,
 
 			// ### Additional properties
 			// Using [object destructuring](https://facebook.github.io/react/docs/transferring-props.html#transferring-with-...-in-jsx) to pass on any properties which are not explicitly defined.
@@ -208,7 +208,7 @@ const Textarea = createReactClass({
 				className={classNames(
 					'slds-form-element',
 					{
-						'slds-has-error': errorText
+						'slds-has-error': errorText,
 					},
 					classNameContainer
 				)}
@@ -216,7 +216,7 @@ const Textarea = createReactClass({
 				{labelText && (
 					<label
 						className={classNames('slds-form-element__label', {
-							'slds-assistive-text': assistiveText && !label
+							'slds-assistive-text': assistiveText && !label,
 						})}
 						htmlFor={this.getId()}
 					>
@@ -270,7 +270,7 @@ const Textarea = createReactClass({
 				{children}
 			</div>
 		);
-	}
+	},
 });
 
 export default Textarea;

--- a/components/global-header/__docs__/site-stories.js
+++ b/components/global-header/__docs__/site-stories.js
@@ -4,7 +4,7 @@
 /* eslint-disable global-require */
 
 const siteStories = [
-	require('raw-loader!@salesforce/design-system-react/components/global-header/__examples__/default.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/global-header/__examples__/default.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/global-header/__docs__/storybook-stories.jsx
+++ b/components/global-header/__docs__/storybook-stories.jsx
@@ -72,12 +72,16 @@ const GlobalHeaderDemo = (props) => (
 			options={[
 				{
 					label: 'New Note',
-					rightIcon: { category: 'standard', name: 'note', size: 'small' }
+					rightIcon: { category: 'standard', name: 'note', size: 'small' },
 				},
 				{
 					label: 'Log a Call',
-					rightIcon: { category: 'standard', name: 'log_a_call', size: 'small' }
-				}
+					rightIcon: {
+						category: 'standard',
+						name: 'log_a_call',
+						size: 'small',
+					},
+				},
 			]}
 		/>
 		<GlobalHeaderButton

--- a/components/global-header/__examples__/default.jsx
+++ b/components/global-header/__examples__/default.jsx
@@ -74,7 +74,7 @@ const Example = createReactClass({
 				</GlobalHeader>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/global-header/dropdown.jsx
+++ b/components/global-header/dropdown.jsx
@@ -59,7 +59,7 @@ GlobalHeaderDropdown.propTypes = {
 	buttonClassName: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * Name of the icon. Visit <a href="http://www.lightningdesignsystem.com/resources/icons">Lightning Design System Icons</a> to reference icon names.
@@ -74,7 +74,7 @@ GlobalHeaderDropdown.propTypes = {
 		'border',
 		'border-filled',
 		'more',
-		'global-header'
+		'global-header',
 	]),
 	/**
 	 * A unique ID is needed in order to support keyboard navigation, ARIA support, and connect the dropdown to the triggering button.
@@ -93,7 +93,7 @@ GlobalHeaderDropdown.propTypes = {
 		'top right',
 		'bottom left',
 		'bottom',
-		'bottom right'
+		'bottom right',
 	]),
 	/**
 	 *  Offset adds pixels to the absolutely positioned dropdown menu in the format: ([vertical]px [horizontal]px).
@@ -106,7 +106,7 @@ GlobalHeaderDropdown.propTypes = {
 	/**
 	 * An array of menu item.
 	 */
-	options: PropTypes.array.isRequired
+	options: PropTypes.array.isRequired,
 };
 
 // ### Default Props
@@ -116,7 +116,7 @@ GlobalHeaderDropdown.defaultProps = {
 	iconVariant: 'global-header',
 	nubbinPosition: 'top right',
 	// TODO: Use design tokens to remove "magic numbers" that center nubbin under button
-	offset: '12px 16px'
+	offset: '12px 16px',
 };
 
 export default GlobalHeaderDropdown;

--- a/components/global-header/index.jsx
+++ b/components/global-header/index.jsx
@@ -21,7 +21,7 @@ import {
 	GLOBAL_HEADER,
 	GLOBAL_HEADER_PROFILE,
 	GLOBAL_HEADER_SEARCH,
-	GLOBAL_HEADER_TOOL
+	GLOBAL_HEADER_TOOL,
 } from '../../utilities/constants';
 
 /**
@@ -69,14 +69,14 @@ const GlobalHeader = createReactClass({
 		/**
 		 * The localized text that will be read back for the "Skip to Navigation" accessibility link.
 		 */
-		skipToNavAssistiveText: PropTypes.string
+		skipToNavAssistiveText: PropTypes.string,
 	},
 
 	getDefaultProps () {
 		return {
 			logoSrc: '/assets/images/logo.svg',
 			skipToNavAssistiveText: 'Skip to Navigation',
-			skipToContentAssistiveText: 'Skip to Main Content'
+			skipToContentAssistiveText: 'Skip to Main Content',
 		};
 	},
 
@@ -143,7 +143,7 @@ const GlobalHeader = createReactClass({
 			</header>
 		);
 		/* eslint-enable max-len, no-script-url */
-	}
+	},
 });
 
 export default GlobalHeader;

--- a/components/global-header/private/dropdown-trigger.jsx
+++ b/components/global-header/private/dropdown-trigger.jsx
@@ -47,7 +47,7 @@ const GlobalHeaderDropdownTrigger = createReactClass({
 		className: PropTypes.oneOfType([
 			PropTypes.array,
 			PropTypes.object,
-			PropTypes.string
+			PropTypes.string,
 		]),
 		/**
 		 * A unique ID is needed in order to support keyboard navigation, ARIA support, and connect the dropdown to the triggering button.
@@ -104,7 +104,7 @@ const GlobalHeaderDropdownTrigger = createReactClass({
 		/**
 		 * The ref of the actual triggering button.
 		 */
-		triggerRef: PropTypes.func
+		triggerRef: PropTypes.func,
 	},
 
 	// ### Render
@@ -137,7 +137,7 @@ const GlobalHeaderDropdownTrigger = createReactClass({
 					'slds-dropdown-trigger slds-dropdown-trigger--click',
 					{
 						'slds-is-open': isOpen,
-						'slds-p-around--xx-small': globalAction
+						'slds-p-around--xx-small': globalAction,
 					},
 					className
 				)}
@@ -154,10 +154,10 @@ const GlobalHeaderDropdownTrigger = createReactClass({
 				{/* eslint-enable jsx-a11y/no-static-element-interactions */}
 				<Button
 					className={classnames({
-						'slds-global-header__button--icon-actions': globalAction
+						'slds-global-header__button--icon-actions': globalAction,
 					})}
 					iconClassName={classnames({
-						'slds-global-header__icon-actions': globalAction
+						'slds-global-header__icon-actions': globalAction,
 					})}
 					aria-haspopup="true"
 					{...rest}
@@ -171,7 +171,7 @@ const GlobalHeaderDropdownTrigger = createReactClass({
 				{menu}
 			</li>
 		);
-	}
+	},
 });
 
 export default GlobalHeaderDropdownTrigger;

--- a/components/global-header/profile.jsx
+++ b/components/global-header/profile.jsx
@@ -79,7 +79,7 @@ GlobalHeaderProfile.propTypes = {
 	buttonClassName: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * A unique ID is needed in order to support keyboard navigation, ARIA support, and connect the dropdown to the triggering button.
@@ -94,7 +94,7 @@ GlobalHeaderProfile.propTypes = {
 		'top right',
 		'bottom left',
 		'bottom',
-		'bottom right'
+		'bottom right',
 	]),
 	/**
 	 *  Offset adds pixels to the absolutely positioned dropdown menu in the format: ([vertical]px [horizontal]px).
@@ -107,7 +107,7 @@ GlobalHeaderProfile.propTypes = {
 	/**
 	 * An array of menu item.
 	 */
-	options: PropTypes.array
+	options: PropTypes.array,
 };
 
 // ### Default Props
@@ -117,7 +117,7 @@ GlobalHeaderProfile.defaultProps = {
 	iconVariant: 'container',
 	nubbinPosition: 'top right',
 	// TODO: Use design tokens to remove "magic numbers" that center nubbin under button
-	offset: '-12px -18px'
+	offset: '-12px -18px',
 };
 
 export default GlobalHeaderProfile;

--- a/components/global-navigation-bar/__docs__/site-stories.js
+++ b/components/global-navigation-bar/__docs__/site-stories.js
@@ -4,7 +4,7 @@
 /* eslint-disable global-require */
 
 const siteStories = [
-	require('raw-loader!@salesforce/design-system-react/components/global-navigation-bar/__examples__/default.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/global-navigation-bar/__examples__/default.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/global-navigation-bar/__docs__/storybook-stories.jsx
+++ b/components/global-navigation-bar/__docs__/storybook-stories.jsx
@@ -29,51 +29,51 @@ const dropdownCollection = [
 		value: '0',
 		iconCategory: 'utility',
 		iconName: 'table',
-		href: 'http://www.google.com'
+		href: 'http://www.google.com',
 	},
 	{
 		label: 'Menu Header',
 		type: 'header',
-		divider: 'top'
+		divider: 'top',
 	},
 	{
 		label: 'Menu Item One',
 		value: '1',
 		iconCategory: 'utility',
 		iconName: 'kanban',
-		href: 'http://www.google.com'
+		href: 'http://www.google.com',
 	},
 	{
 		label: 'Menu Item Two',
 		value: '2',
 		iconCategory: 'utility',
 		iconName: 'kanban',
-		href: 'http://www.google.com'
+		href: 'http://www.google.com',
 	},
 	{
 		label: 'Menu Item Three',
 		value: '3',
 		iconCategory: 'utility',
 		iconName: 'side_list',
-		href: 'http://www.google.com'
+		href: 'http://www.google.com',
 	},
 	{
 		label: 'Menu Item Four',
 		value: '4',
 		iconCategory: 'utility',
 		iconName: 'side_list',
-		href: 'http://www.google.com'
+		href: 'http://www.google.com',
 	},
 	{
-		type: 'divider'
+		type: 'divider',
 	},
 	{
 		label: 'Menu Item Five',
 		value: '5',
 		iconCategory: 'utility',
 		iconName: 'side_list',
-		href: 'http://www.google.com'
-	}
+		href: 'http://www.google.com',
+	},
 ];
 
 /* eslint-disable react/display-name */

--- a/components/global-navigation-bar/__examples__/default.jsx
+++ b/components/global-navigation-bar/__examples__/default.jsx
@@ -23,22 +23,22 @@ const Example = createReactClass({
 				value: '1',
 				iconCategory: 'utility',
 				iconName: 'table',
-				href: 'http://www.google.com'
+				href: 'http://www.google.com',
 			},
 			{
 				label: 'Menu Item Two',
 				value: '2',
 				iconCategory: 'utility',
 				iconName: 'kanban',
-				href: 'http://www.google.com'
+				href: 'http://www.google.com',
 			},
 			{
 				label: 'Menu Item Three',
 				value: '3',
 				iconCategory: 'utility',
 				iconName: 'side_list',
-				href: 'http://www.google.com'
-			}
+				href: 'http://www.google.com',
+			},
 		];
 
 		return (
@@ -108,7 +108,7 @@ const Example = createReactClass({
 				</GlobalNavigationBar>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/global-navigation-bar/__tests__/global-navigation-bar.browser-test.jsx
+++ b/components/global-navigation-bar/__tests__/global-navigation-bar.browser-test.jsx
@@ -6,13 +6,13 @@ import chaiEnzyme from 'chai-enzyme';
 // `this.wrapper` and `this.dom` is set in the helpers file
 import {
 	mountComponent,
-	unmountComponent
+	unmountComponent,
 } from '../../../tests/enzyme-helpers';
 
 // sample props and children
 import {
 	dropdownCollection,
-	propSets
+	propSets,
 } from '../../../utilities/sample-data/global-navigation-bar';
 
 import IconSettings from '../../icon-settings';
@@ -27,14 +27,14 @@ chai.use(chaiEnzyme());
 
 const COMPONENT_CSS_CLASSES = {
 	base: 'slds-context-bar',
-	themePrefix: 'slds-context-bar--theme-'
+	themePrefix: 'slds-context-bar--theme-',
 };
 
 const REGION_CSS_CLASSES = {
 	primary: 'slds-context-bar__primary',
 	secondary: 'slds-context-bar__secondary',
 	tertiary: 'slds-context-bar__tertiary',
-	appName: 'slds-context-bar__app-name'
+	appName: 'slds-context-bar__app-name',
 };
 
 describe('Global Navigation Bar: ', () => {
@@ -235,7 +235,7 @@ describe('Global Navigation Bar: ', () => {
 				/>
 			);
 			this.wrapper = mount(instance, {
-				attachTo: document.body.appendChild(document.createElement('div'))
+				attachTo: document.body.appendChild(document.createElement('div')),
 			});
 			link = this.wrapper.find('#home-link');
 		});
@@ -266,7 +266,7 @@ describe('Global Navigation Bar: ', () => {
 				/>
 			);
 			this.wrapper = mount(instance, {
-				attachTo: document.body.appendChild(document.createElement('div'))
+				attachTo: document.body.appendChild(document.createElement('div')),
 			});
 			const link = this.wrapper.find('#global-nav__button');
 			expect(link.text()).to.equal('Button');
@@ -281,7 +281,7 @@ describe('Global Navigation Bar: ', () => {
 		it('GlobalNavigationBarLabel has attributes', function () {
 			const instance = <GlobalNavigationBarLabel label="Text" id="test-text" />;
 			this.wrapper = mount(instance, {
-				attachTo: document.body.appendChild(document.createElement('div'))
+				attachTo: document.body.appendChild(document.createElement('div')),
 			});
 			const item = this.wrapper.find('#test-text');
 			expect(item.text()).to.equal('Text');

--- a/components/global-navigation-bar/button.jsx
+++ b/components/global-navigation-bar/button.jsx
@@ -25,7 +25,7 @@ const GlobalNavigationButton = ({ active, dividerPosition, ...props }) => (
 	<li
 		className={classNames('slds-context-bar__item', {
 			'slds-is-active': active,
-			[`slds-context-bar__item--divider-${dividerPosition}`]: dividerPosition
+			[`slds-context-bar__item--divider-${dividerPosition}`]: dividerPosition,
 		})}
 	>
 		<Button {...props} />
@@ -43,7 +43,7 @@ GlobalNavigationButton.propTypes = {
 	/**
 	 * Determines position of separating bar.
 	 */
-	dividerPosition: PropTypes.oneOf(['left', 'right'])
+	dividerPosition: PropTypes.oneOf(['left', 'right']),
 };
 
 // ### Default Props
@@ -53,7 +53,7 @@ GlobalNavigationButton.defaultProps = {
 	// Bar and have different `font-size` and `line-height` than links or
 	// dropdowns.
 	style: { lineHeight: 'inherit' },
-	variant: 'base'
+	variant: 'base',
 };
 
 export default GlobalNavigationButton;

--- a/components/global-navigation-bar/dropdown-trigger.jsx
+++ b/components/global-navigation-bar/dropdown-trigger.jsx
@@ -50,7 +50,7 @@ const GlobalNavigationDropdownTrigger = createReactClass({
 		className: PropTypes.oneOfType([
 			PropTypes.array,
 			PropTypes.object,
-			PropTypes.string
+			PropTypes.string,
 		]),
 		/**
 		 * Determines position of separating bar.
@@ -103,7 +103,7 @@ const GlobalNavigationDropdownTrigger = createReactClass({
 		/**
 		 * The ref of the actual triggering button.
 		 */
-		triggerRef: PropTypes.func
+		triggerRef: PropTypes.func,
 	},
 
 	// ### Render
@@ -151,7 +151,7 @@ const GlobalNavigationDropdownTrigger = createReactClass({
 					{
 						'slds-is-open': isOpen,
 						'slds-is-active': active,
-						[`slds-context-bar__item--divider-${dividerPosition}`]: dividerPosition
+						[`slds-context-bar__item--divider-${dividerPosition}`]: dividerPosition,
 					},
 					className
 				)}
@@ -184,7 +184,7 @@ const GlobalNavigationDropdownTrigger = createReactClass({
 				{menu}
 			</li>
 		);
-	}
+	},
 });
 
 export default GlobalNavigationDropdownTrigger;

--- a/components/global-navigation-bar/dropdown.jsx
+++ b/components/global-navigation-bar/dropdown.jsx
@@ -86,7 +86,7 @@ GlobalNavigationBarDropdown.propTypes = {
 	buttonClassName: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * A unique ID is needed in order to support keyboard navigation, ARIA support, and connect the dropdown to the triggering button.
@@ -107,13 +107,13 @@ GlobalNavigationBarDropdown.propTypes = {
 	/**
 	 * An array of menu item.
 	 */
-	options: PropTypes.array.isRequired
+	options: PropTypes.array.isRequired,
 };
 
 // ### Default Props
 GlobalNavigationBarDropdown.defaultProps = {
 	align: 'right',
-	length: null
+	length: null,
 };
 
 export default GlobalNavigationBarDropdown;

--- a/components/global-navigation-bar/index.jsx
+++ b/components/global-navigation-bar/index.jsx
@@ -18,7 +18,7 @@ import classNames from 'classnames';
 // ## Constants
 import {
 	GLOBAL_NAVIGATION_BAR,
-	GLOBAL_NAVIGATION_BAR_REGION
+	GLOBAL_NAVIGATION_BAR_REGION,
 } from '../../utilities/constants';
 
 const auditChildren = (children) => {
@@ -47,7 +47,7 @@ const auditChildren = (children) => {
 
 		primaryRegion = React.cloneElement(primaryRegion, {
 			dividerPosition,
-			key: 'primary-region'
+			key: 'primary-region',
 		});
 	}
 
@@ -63,7 +63,7 @@ const GlobalNavigationBar = (props) => (
 			'slds-context-bar',
 			{
 				[`slds-context-bar--theme-${props.cloud}`]: props.cloud,
-				[`slds-context-bar--theme-${props.theme}`]: props.theme
+				[`slds-context-bar--theme-${props.theme}`]: props.theme,
 			},
 			props.className
 		)}
@@ -84,7 +84,7 @@ GlobalNavigationBar.propTypes = {
 	className: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * Typically the cloud name (e.g.- "sales" or "marketing"). This primarily changes the background color.
@@ -93,12 +93,12 @@ GlobalNavigationBar.propTypes = {
 	/**
 	 * Transforms text and interactions (such as hover) to be more visually accessible.
 	 */
-	theme: PropTypes.oneOf(['light', 'dark'])
+	theme: PropTypes.oneOf(['light', 'dark']),
 };
 
 GlobalNavigationBar.defaultProps = {
 	cloud: 'default',
-	theme: 'dark'
+	theme: 'dark',
 };
 
 GlobalNavigationBar.displayName = GLOBAL_NAVIGATION_BAR;

--- a/components/global-navigation-bar/label.jsx
+++ b/components/global-navigation-bar/label.jsx
@@ -31,7 +31,7 @@ const GlobalNavigationBarLabel = (props) => {
 				className={classNames(
 					'slds-context-bar__label-action',
 					{
-						[`slds-context-bar__item--divider-${dividerPosition}`]: dividerPosition
+						[`slds-context-bar__item--divider-${dividerPosition}`]: dividerPosition,
 					},
 					className
 				)}
@@ -52,7 +52,7 @@ GlobalNavigationBarLabel.propTypes = {
 	className: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * Determines position of separating bar.
@@ -65,7 +65,7 @@ GlobalNavigationBarLabel.propTypes = {
 	/**
 	 * Text to show
 	 */
-	label: PropTypes.string
+	label: PropTypes.string,
 };
 
 export default GlobalNavigationBarLabel;

--- a/components/global-navigation-bar/link.jsx
+++ b/components/global-navigation-bar/link.jsx
@@ -42,13 +42,13 @@ const GlobalNavigationBarLink = (props) => {
 		onFocus,
 		onKeyDown,
 		onKeyPress,
-		tabIndex
+		tabIndex,
 	} = props;
 
 	const listItemstyle = active
 		? {
 			backgroundColor: activeBackgroundColor,
-			borderBottomColor: activeBackgroundColor
+			borderBottomColor: activeBackgroundColor,
 		}
 		: null;
 
@@ -56,7 +56,7 @@ const GlobalNavigationBarLink = (props) => {
 		<li
 			className={classNames('slds-context-bar__item', {
 				'slds-is-active': active,
-				[`slds-context-bar__item--divider-${dividerPosition}`]: dividerPosition
+				[`slds-context-bar__item--divider-${dividerPosition}`]: dividerPosition,
 			})}
 			id={id}
 			style={listItemstyle}
@@ -99,7 +99,7 @@ GlobalNavigationBarLink.propTypes = {
 	className: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * Determines position of separating bar.
@@ -131,11 +131,11 @@ GlobalNavigationBarLink.propTypes = {
 	/**
 	 * Write "-1" if you don't want the user to tab to the button.
 	 */
-	tabIndex: PropTypes.string
+	tabIndex: PropTypes.string,
 };
 
 GlobalNavigationBarLink.defaultProps = {
-	href: 'javascript:void(0);' // eslint-disable-line no-script-url
+	href: 'javascript:void(0);', // eslint-disable-line no-script-url
 };
 
 export default GlobalNavigationBarLink;

--- a/components/global-navigation-bar/region.jsx
+++ b/components/global-navigation-bar/region.jsx
@@ -97,7 +97,7 @@ const Region = createReactClass({
 		className: PropTypes.oneOfType([
 			PropTypes.array,
 			PropTypes.object,
-			PropTypes.string
+			PropTypes.string,
 		]),
 		/**
 		 * Wraps the `secondary` region in a `nav` and adds a role attribute
@@ -106,7 +106,7 @@ const Region = createReactClass({
 		/**
 		 * Region wrap children in styling specific to that region.
 		 */
-		region: PropTypes.oneOf(['primary', 'secondary', 'tertiary']).isRequired
+		region: PropTypes.oneOf(['primary', 'secondary', 'tertiary']).isRequired,
 	},
 
 	render () {
@@ -143,7 +143,7 @@ const Region = createReactClass({
 		}
 
 		return region;
-	}
+	},
 });
 
 export default Region;

--- a/components/grid/index.jsx
+++ b/components/grid/index.jsx
@@ -18,7 +18,7 @@ class Grid extends React.Component {
 	getClassName () {
 		const flavor = this.props.flavor;
 		return classNames(this.props.className, 'slds-grid', {
-			[`slds-grid--${flavor}`]: flavor
+			[`slds-grid--${flavor}`]: flavor,
 		});
 	}
 

--- a/components/icon-settings/__docs__/site-stories.js
+++ b/components/icon-settings/__docs__/site-stories.js
@@ -5,7 +5,7 @@
 
 const siteStories = [
 	require('raw-loader!@salesforce/design-system-react/components/icon-settings/__examples__/icon-path.jsx'),
-	require('raw-loader!@salesforce/design-system-react/components/icon-settings/__examples__/sprite.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/icon-settings/__examples__/sprite.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/icon-settings/__examples__/icon-path.jsx
+++ b/components/icon-settings/__examples__/icon-path.jsx
@@ -53,7 +53,7 @@ const Example = createReactClass({
 				</div>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/icon-settings/__examples__/sprite.jsx
+++ b/components/icon-settings/__examples__/sprite.jsx
@@ -65,7 +65,7 @@ const Example = createReactClass({
 				</div>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/icon-settings/index.jsx
+++ b/components/icon-settings/index.jsx
@@ -31,7 +31,7 @@ class IconSettings extends React.Component {
 			customSprite: this.props.customSprite,
 			doctypeSprite: this.props.doctypeSprite,
 			standardSprite: this.props.standardSprite,
-			utilitySprite: this.props.utilitySprite
+			utilitySprite: this.props.utilitySprite,
 		};
 	}
 
@@ -48,7 +48,7 @@ IconSettings.childContextTypes = {
 	customSprite: PropTypes.string,
 	doctypeSprite: PropTypes.string,
 	standardSprite: PropTypes.string,
-	utilitySprite: PropTypes.string
+	utilitySprite: PropTypes.string,
 };
 
 IconSettings.propTypes = {
@@ -81,7 +81,7 @@ IconSettings.propTypes = {
 	 * Path to the utility sprite
 	 * example: '@salesforce-ux/design-system/assets/icons/utility-sprite/svg/symbols.svg';
 	 */
-	utilitySprite: PropTypes.string
+	utilitySprite: PropTypes.string,
 };
 
 export default IconSettings;

--- a/components/lookup/__docs__/site-stories.js
+++ b/components/lookup/__docs__/site-stories.js
@@ -6,7 +6,7 @@
 const siteStories = [
 	require('raw-loader!@salesforce/design-system-react/components/lookup/__examples__/default.jsx'),
 	require('raw-loader!@salesforce/design-system-react/components/lookup/__examples__/files.jsx'),
-	require('raw-loader!@salesforce/design-system-react/components/lookup/__examples__/with-selection.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/lookup/__examples__/with-selection.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/lookup/__docs__/storybook-stories.jsx
+++ b/components/lookup/__docs__/storybook-stories.jsx
@@ -19,8 +19,8 @@ const DemoLookup = createReactClass({
 				{ label: 'File 1' },
 				{ label: 'File 2' },
 				{ label: 'File 3' },
-				{ label: 'File 4' }
-			]
+				{ label: 'File 4' },
+			],
 		};
 	},
 
@@ -31,7 +31,7 @@ const DemoLookup = createReactClass({
 	handleSelect (selectedItem, ...rest) {
 		action('select')(selectedItem, ...rest);
 		this.setState({
-			currentSelected: this.state.options.indexOf(selectedItem)
+			currentSelected: this.state.options.indexOf(selectedItem),
 		});
 	},
 
@@ -50,7 +50,7 @@ const DemoLookup = createReactClass({
 				/>
 			</div>
 		);
-	}
+	},
 });
 
 const DemoLookupAccounts = createReactClass({
@@ -64,8 +64,8 @@ const DemoLookupAccounts = createReactClass({
 				{ label: 'Paper St. Soap Company', subTitle: 'Beloit, WI' },
 				{ label: 'Nakatomi Investments', subTitle: 'Chicago, IL' },
 				{ label: 'Acme Landscaping' },
-				{ label: 'Acme Construction', subTitle: 'Grand Marais, MN' }
-			]
+				{ label: 'Acme Construction', subTitle: 'Grand Marais, MN' },
+			],
 		};
 	},
 
@@ -85,7 +85,7 @@ const DemoLookupAccounts = createReactClass({
 				options={this.state.options}
 			/>
 		);
-	}
+	},
 });
 
 storiesOf(LOOKUP, module)

--- a/components/lookup/__examples__/default.jsx
+++ b/components/lookup/__examples__/default.jsx
@@ -28,13 +28,13 @@ const Example = createReactClass({
 						{ label: 'Nakatomi Investments' },
 						{ label: 'Acme Landscaping' },
 						{ type: 'section', label: 'SECTION 3' },
-						{ label: 'Acme Construction' }
+						{ label: 'Acme Construction' },
 					]}
 					sectionDividerRenderer={Lookup.DefaultSectionDivider}
 				/>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/lookup/__examples__/files.jsx
+++ b/components/lookup/__examples__/files.jsx
@@ -23,12 +23,12 @@ const Example = createReactClass({
 						{ label: 'File 1' },
 						{ label: 'File 2' },
 						{ label: 'File 3' },
-						{ label: 'File 4' }
+						{ label: 'File 4' },
 					]}
 				/>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/lookup/__examples__/with-selection.jsx
+++ b/components/lookup/__examples__/with-selection.jsx
@@ -29,13 +29,13 @@ const Example = createReactClass({
 						{ label: 'Paper St. Soap Company' },
 						{ label: 'Nakatomi Investments' },
 						{ label: 'Acme Landscaping' },
-						{ label: 'Acme Construction' }
+						{ label: 'Acme Construction' },
 					]}
 					selectedItem={1}
 				/>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/lookup/__tests__/lookup.browser-test.jsx
+++ b/components/lookup/__tests__/lookup.browser-test.jsx
@@ -17,7 +17,7 @@ import Footer from '../../lookup/footer';
 const {
 	Simulate,
 	scryRenderedDOMComponentsWithClass,
-	scryRenderedDOMComponentsWithTag
+	scryRenderedDOMComponentsWithTag,
 } = TestUtils;
 
 describe('SLDSLookup: ', () => {
@@ -47,8 +47,8 @@ describe('SLDSLookup: ', () => {
 			{ label: 'Paper St. Soap Company' },
 			{ label: 'Nakatomi Investments' },
 			{ label: 'Acme Landscaping' },
-			{ label: 'Acme Construction' }
-		]
+			{ label: 'Acme Construction' },
+		],
 	};
 
 	const getLookup = (props = {}) =>
@@ -127,7 +127,7 @@ describe('SLDSLookup: ', () => {
 			TestUtils.Simulate.keyDown(deleteBtn, {
 				key: 'Down',
 				keyCode: 46,
-				which: 46
+				which: 46,
 			});
 			const ariaExpanded = lookup
 				.getElementsByTagName('input')[0]
@@ -144,12 +144,12 @@ describe('SLDSLookup: ', () => {
 			TestUtils.Simulate.keyDown(input, {
 				key: 'Down',
 				keyCode: 40,
-				which: 40
+				which: 40,
 			});
 			TestUtils.Simulate.keyDown(input, {
 				key: 'Down',
 				keyCode: 40,
-				which: 40
+				which: 40,
 			});
 			const ariaActiveDescendant = lookup
 				.getElementsByTagName('input')[0]
@@ -164,12 +164,12 @@ describe('SLDSLookup: ', () => {
 			TestUtils.Simulate.keyDown(input, {
 				key: 'Down',
 				keyCode: 40,
-				which: 40
+				which: 40,
 			});
 			TestUtils.Simulate.keyDown(input, {
 				key: 'Down',
 				keyCode: 40,
-				which: 40
+				which: 40,
 			});
 			const ariaActiveDescendant = lookup
 				.getElementsByTagName('input')[0]
@@ -184,22 +184,22 @@ describe('SLDSLookup: ', () => {
 			TestUtils.Simulate.keyDown(input, {
 				key: 'Down',
 				keyCode: 40,
-				which: 40
+				which: 40,
 			});
 			TestUtils.Simulate.keyDown(input, {
 				key: 'Down',
 				keyCode: 40,
-				which: 40
+				which: 40,
 			});
 			TestUtils.Simulate.keyDown(input, {
 				key: 'Down',
 				keyCode: 40,
-				which: 40
+				which: 40,
 			});
 			TestUtils.Simulate.keyDown(input, {
 				key: 'Enter',
 				keyCode: 13,
-				which: 13
+				which: 13,
 			});
 			const selected = lookup
 				.getElementsByTagName('a')[0]
@@ -214,22 +214,22 @@ describe('SLDSLookup: ', () => {
 			TestUtils.Simulate.keyDown(input, {
 				key: 'Down',
 				keyCode: 40,
-				which: 40
+				which: 40,
 			});
 			TestUtils.Simulate.keyDown(input, {
 				key: 'Down',
 				keyCode: 40,
-				which: 40
+				which: 40,
 			});
 			TestUtils.Simulate.keyDown(input, {
 				key: 'Down',
 				keyCode: 40,
-				which: 40
+				which: 40,
 			});
 			TestUtils.Simulate.keyDown(input, {
 				key: 'Enter',
 				keyCode: 13,
-				which: 13
+				which: 13,
 			});
 			const selected = lookup
 				.getElementsByTagName('a')[0]
@@ -244,7 +244,7 @@ describe('SLDSLookup: ', () => {
 			TestUtils.Simulate.keyDown(input, {
 				key: 'Down',
 				keyCode: 40,
-				which: 40
+				which: 40,
 			});
 			TestUtils.Simulate.keyDown(input, { key: 'Esc', keyCode: 27, which: 27 });
 			const ariaExpanded = input.getAttribute('aria-expanded');
@@ -258,12 +258,12 @@ describe('SLDSLookup: ', () => {
 			TestUtils.Simulate.keyDown(input, {
 				key: 'Down',
 				keyCode: 40,
-				which: 40
+				which: 40,
 			});
 			TestUtils.Simulate.keyDown(input, {
 				key: 'Enter',
 				keyCode: 13,
-				which: 13
+				which: 13,
 			});
 			const menu = lookup.getElementsByTagName('ul');
 			expect(menu.length).to.equal(0);
@@ -276,7 +276,7 @@ describe('SLDSLookup: ', () => {
 			TestUtils.Simulate.keyDown(input, {
 				key: 'Down',
 				keyCode: 40,
-				which: 40
+				which: 40,
 			});
 			const focusedItem = lookup
 				.getElementsByTagName('ul')[0]

--- a/components/lookup/index.jsx
+++ b/components/lookup/index.jsx
@@ -10,7 +10,7 @@ import DefaultSectionDivider from './menu/default-section-divider';
 import Lookup from './lookup';
 
 export default onClickOutside(Lookup, {
-	excludeScrollbar: true
+	excludeScrollbar: true,
 });
 
 export { DefaultHeader };

--- a/components/lookup/lookup.jsx
+++ b/components/lookup/lookup.jsx
@@ -71,7 +71,7 @@ const Lookup = createReactClass({
 		className: PropTypes.oneOfType([
 			PropTypes.array,
 			PropTypes.object,
-			PropTypes.string
+			PropTypes.string,
 		]),
 		/**
 		 * If true, constrains the menu to the scroll parent. Has no effect if `isInline` is `true`.
@@ -199,7 +199,7 @@ const Lookup = createReactClass({
 		/**
 		 * Index of current selected item. To clear the selection, pass in -1.
 		 */
-		selectedItem: PropTypes.number
+		selectedItem: PropTypes.number,
 	},
 
 	getDefaultProps () {
@@ -208,7 +208,7 @@ const Lookup = createReactClass({
 			filterWith: defaultFilter,
 			iconPosition: 'right',
 			searchTerm: '',
-			menuPosition: 'absolute'
+			menuPosition: 'absolute',
 		};
 	},
 
@@ -219,7 +219,7 @@ const Lookup = createReactClass({
 			items: [],
 			listLength: this.props.options.length,
 			searchTerm: this.normalizeSearchTerm(this.props.searchTerm),
-			selectedIndex: this.props.selectedItem
+			selectedIndex: this.props.selectedItem,
 		};
 	},
 
@@ -268,7 +268,7 @@ const Lookup = createReactClass({
 	getClassName () {
 		return classNames(this.props.className, 'slds-form-element slds-lookup', {
 			'slds-has-selection': this.isSelected(),
-			'slds-is-open': this.getIsOpen()
+			'slds-is-open': this.getIsOpen(),
 		});
 	},
 
@@ -405,7 +405,7 @@ const Lookup = createReactClass({
 			this.setState({
 				isOpen: false,
 				selectedIndex: index,
-				searchTerm: ''
+				searchTerm: '',
 			});
 			const data = this.state.items[index].data;
 			if (this.props.onSelect) {
@@ -420,7 +420,7 @@ const Lookup = createReactClass({
 		}
 		this.setState({
 			selectedIndex: null,
-			isOpen: true
+			isOpen: true,
 		});
 
 		this.focusInput();
@@ -439,7 +439,7 @@ const Lookup = createReactClass({
 		this.setState({
 			isOpen: false,
 			focusIndex: null,
-			currentFocus: null
+			currentFocus: null,
 		});
 	},
 
@@ -578,7 +578,7 @@ const Lookup = createReactClass({
 		const items = itemsToModify.map((item, index) => ({
 			id: `item-${index}`,
 			label: item.label,
-			data: item
+			data: item,
 		}));
 
 		this.setState({ items });
@@ -768,7 +768,7 @@ const Lookup = createReactClass({
 			'slds-form-element__control': true,
 			[`slds-input-has-icon slds-input-has-icon--${
 				this.props.iconPosition
-			}`]: !this.isSelected()
+			}`]: !this.isSelected(),
 		};
 
 		return (
@@ -786,11 +786,11 @@ const Lookup = createReactClass({
 				{isInline ? this.renderInlineMenu() : this.renderSeparateMenu()}
 			</div>
 		);
-	}
+	},
 });
 
 Lookup.contextTypes = {
-	iconPath: PropTypes.string
+	iconPath: PropTypes.string,
 };
 
 export default Lookup;

--- a/components/lookup/private/item.jsx
+++ b/components/lookup/private/item.jsx
@@ -22,7 +22,7 @@ const propTypes = {
 	listItemLabelRenderer: PropTypes.func,
 	onSelect: PropTypes.func,
 	searchTerm: PropTypes.string,
-	setFocus: PropTypes.func
+	setFocus: PropTypes.func,
 };
 
 class Item extends React.Component {
@@ -73,7 +73,7 @@ class Item extends React.Component {
 			);
 		} else {
 			const labelClassName = cx('slds-lookup__result-text', {
-				'slds-m-left--x-small': !this.props.iconName
+				'slds-m-left--x-small': !this.props.iconName,
 			});
 
 			label = (

--- a/components/lookup/private/menu.jsx
+++ b/components/lookup/private/menu.jsx
@@ -19,10 +19,10 @@ const propTypes = {
 	label: PropTypes.string,
 	listLength: PropTypes.number,
 	searchTerm: PropTypes.string,
-	setFocus: PropTypes.func
+	setFocus: PropTypes.func,
 };
 const defaultProps = {
-	emptyMessage: 'No matches found.'
+	emptyMessage: 'No matches found.',
 };
 class Menu extends React.Component {
 	constructor (props) {
@@ -46,7 +46,7 @@ class Menu extends React.Component {
 		) {
 			// eslint-disable-next-line class-methods-use-this
 			this.setState({
-				filteredItems: this.filteredItems()
+				filteredItems: this.filteredItems(),
 			});
 		}
 	}

--- a/components/lookup/section-divider.jsx
+++ b/components/lookup/section-divider.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 
 const displayName = 'LookupDefaultSectionDivider';
 const propTypes = {
-	data: PropTypes.object
+	data: PropTypes.object,
 };
 
 const DefaultSectionDivider = (props) => (

--- a/components/media-object/__docs__/site-stories.js
+++ b/components/media-object/__docs__/site-stories.js
@@ -5,7 +5,7 @@
 
 const siteStories = [
 	require('raw-loader!@salesforce/design-system-react/components/media-object/__examples__/default.jsx'),
-	require('raw-loader!@salesforce/design-system-react/components/media-object/__examples__/vertically-centered.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/media-object/__examples__/vertically-centered.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/media-object/__examples__/default.jsx
+++ b/components/media-object/__examples__/default.jsx
@@ -16,7 +16,7 @@ const Example = createReactClass({
 				/>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/media-object/__examples__/vertically-centered.jsx
+++ b/components/media-object/__examples__/vertically-centered.jsx
@@ -17,7 +17,7 @@ const Example = createReactClass({
 				/>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/media-object/__tests__/media-object.browser-test.jsx
+++ b/components/media-object/__tests__/media-object.browser-test.jsx
@@ -4,7 +4,7 @@ import chaiEnzyme from 'chai-enzyme';
 // `this.wrapper` and `this.dom` is set in the helpers file
 import {
 	mountComponent,
-	unmountComponent
+	unmountComponent,
 } from '../../../tests/enzyme-helpers';
 
 import MediaObject from '../../media-object';
@@ -18,7 +18,7 @@ chai.use(chaiEnzyme());
 const COMPONENT_CSS_CLASSES = {
 	base: 'slds-media',
 	figure: 'slds-media__figure',
-	body: 'slds-media__body'
+	body: 'slds-media__body',
 };
 
 const DemoComponent = (props) => (

--- a/components/media-object/index.jsx
+++ b/components/media-object/index.jsx
@@ -18,7 +18,7 @@ import { MEDIA_OBJECT } from '../../utilities/constants';
 export const cssClasses = {
 	base: 'slds-media',
 	figure: 'slds-media__figure',
-	body: 'slds-media__body'
+	body: 'slds-media__body',
 };
 
 /**
@@ -40,7 +40,7 @@ const MediaObject = createReactClass({
 		className: PropTypes.oneOfType([
 			PropTypes.array,
 			PropTypes.object,
-			PropTypes.string
+			PropTypes.string,
 		]),
 		/**
 		 * The body is often text such as a heading or paragraph.
@@ -53,7 +53,7 @@ const MediaObject = createReactClass({
 		/**
 		 * Vertically centers the body with the middle of the figure.
 		 */
-		verticalCenter: PropTypes.bool
+		verticalCenter: PropTypes.bool,
 	},
 
 	render () {
@@ -63,7 +63,7 @@ const MediaObject = createReactClass({
 					cssClasses.base,
 					{
 						'slds-media--center': this.props.verticalCenter,
-						'slds-has-flexi-truncate': this.props.canTruncate
+						'slds-has-flexi-truncate': this.props.canTruncate,
 					},
 					this.props.className
 				)}
@@ -74,7 +74,7 @@ const MediaObject = createReactClass({
 				<div className={cssClasses.body}>{this.props.body}</div>
 			</div>
 		);
-	}
+	},
 });
 
 export default MediaObject;

--- a/components/menu-dropdown/__docs__/site-stories.js
+++ b/components/menu-dropdown/__docs__/site-stories.js
@@ -7,7 +7,7 @@ const siteStories = [
 	require('raw-loader!@salesforce/design-system-react/components/menu-dropdown/__examples__/default.jsx'),
 	require('raw-loader!@salesforce/design-system-react/components/menu-dropdown/__examples__/sub-heading.jsx'),
 	require('raw-loader!@salesforce/design-system-react/components/menu-dropdown/__examples__/custom-trigger.jsx'),
-	require('raw-loader!@salesforce/design-system-react/components/menu-dropdown/__examples__/checkmark.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/menu-dropdown/__examples__/checkmark.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/menu-dropdown/__docs__/storybook-stories.jsx
+++ b/components/menu-dropdown/__docs__/storybook-stories.jsx
@@ -18,7 +18,7 @@ const options = [
 		className: 'custom-li-class',
 		divider: 'bottom',
 		label: 'A Header',
-		type: 'header'
+		type: 'header',
 	},
 	{ disabled: true, label: 'An option that is Super Super Long', value: 'A0' },
 	{ label: 'Custom Class', className: 'custom-item-class', value: 'classssss' },
@@ -28,17 +28,17 @@ const options = [
 		label: 'Has a value',
 		leftIcon: {
 			name: 'settings',
-			category: 'utility'
+			category: 'utility',
 		},
 		rightIcon: {
 			name: 'settings',
-			category: 'utility'
+			category: 'utility',
 		},
 		type: 'item',
-		value: 'B0'
+		value: 'B0',
 	},
 	{
-		type: 'divider'
+		type: 'divider',
 	},
 	{ label: 'C Option', value: 'C0' },
 	{ label: 'D Option', value: 'D0' },
@@ -47,7 +47,7 @@ const options = [
 	{ label: 'B2 Option', value: 'B1' },
 	{ label: 'C2 Option', value: 'C1' },
 	{ label: 'D2 Option', value: 'D1' },
-	{ label: 'E2 Option Super Super Long', value: 'E1' }
+	{ label: 'E2 Option Super Super Long', value: 'E1' },
 ];
 
 const getDropdown = (props) => (
@@ -60,7 +60,7 @@ const DropdownControlled = createReactClass({
 	getInitialState () {
 		return {
 			forcedState: undefined,
-			menuOptions: options
+			menuOptions: options,
 		};
 	},
 
@@ -83,7 +83,7 @@ const DropdownControlled = createReactClass({
 			prevState.menuOptions.splice(1, 1, {
 				disabled: false,
 				label: 'An option that is Super Super Long',
-				value: 'A0'
+				value: 'A0',
 			});
 			return { options: prevState.menuOptions };
 		});
@@ -116,7 +116,7 @@ const DropdownControlled = createReactClass({
 				</div>
 			</div>
 		);
-	}
+	},
 });
 
 const getDropdownPositioned = (props) => {
@@ -226,7 +226,7 @@ storiesOf(MENU_DROPDOWN, module)
 			onSelect: (...rest) => {
 				action('Selected')(...rest);
 			},
-			options
+			options,
 		})
 	)
 	.add('Base with icon', () =>
@@ -241,7 +241,7 @@ storiesOf(MENU_DROPDOWN, module)
 			onSelect: (...rest) => {
 				action('Selected')(...rest);
 			},
-			options
+			options,
 		})
 	)
 	.add('Render inline', () =>
@@ -255,7 +255,7 @@ storiesOf(MENU_DROPDOWN, module)
 			onSelect: (...rest) => {
 				action('Selected')(...rest);
 			},
-			options
+			options,
 		})
 	)
 	.add('Render inline w/ Nubbins', () =>
@@ -264,7 +264,7 @@ storiesOf(MENU_DROPDOWN, module)
 			onSelect: (...rest) => {
 				action('Selected')(...rest);
 			},
-			options
+			options,
 		})
 	)
 	.add('Custom Trigger', () =>
@@ -273,7 +273,7 @@ storiesOf(MENU_DROPDOWN, module)
 			onSelect: (...rest) => {
 				action('Selected')(...rest);
 			},
-			options
+			options,
 		})
 	)
 	.add('Custom Content', () =>
@@ -282,7 +282,7 @@ storiesOf(MENU_DROPDOWN, module)
 			onSelect: (...rest) => {
 				action('Selected')(...rest);
 			},
-			options
+			options,
 		})
 	)
 	.add('Hover', () =>
@@ -295,7 +295,7 @@ storiesOf(MENU_DROPDOWN, module)
 				action('Selected')(...rest);
 			},
 			openOn: 'hover',
-			options
+			options,
 		})
 	)
 	.add('Two Hovers', () => (
@@ -309,7 +309,7 @@ storiesOf(MENU_DROPDOWN, module)
 					action('Selected')(...rest);
 				},
 				openOn: 'hover',
-				options
+				options,
 			})}{' '}
 			{getDropdown({
 				assistiveText: 'Icon More large',
@@ -320,7 +320,7 @@ storiesOf(MENU_DROPDOWN, module)
 					action('Selected')(...rest);
 				},
 				openOn: 'hover',
-				options
+				options,
 			})}
 		</div>
 	))
@@ -338,7 +338,7 @@ storiesOf(MENU_DROPDOWN, module)
 			},
 			openOn: 'hover',
 			options,
-			value: 'C0'
+			value: 'C0',
 		})
 	)
 	.add('Controled w/ isOpen', () => (

--- a/components/menu-dropdown/__examples__/checkmark.jsx
+++ b/components/menu-dropdown/__examples__/checkmark.jsx
@@ -23,7 +23,7 @@ const Example = createReactClass({
 							options={[
 								{ label: 'Menu Item One', value: 'A0' },
 								{ label: 'Menu Item Two', value: 'B0' },
-								{ label: 'Menu Item Three', value: 'C0' }
+								{ label: 'Menu Item Three', value: 'C0' },
 							]}
 							value="A0"
 						/>
@@ -46,25 +46,25 @@ const Example = createReactClass({
 									value: 'A0',
 									rightIcon: {
 										category: 'utility',
-										name: 'table'
-									}
+										name: 'table',
+									},
 								},
 								{
 									label: 'Kanban Board',
 									value: 'A0',
 									rightIcon: {
 										category: 'utility',
-										name: 'kanban'
-									}
+										name: 'kanban',
+									},
 								},
 								{
 									label: 'List View',
 									value: 'A0',
 									rightIcon: {
 										category: 'utility',
-										name: 'side_list'
-									}
-								}
+										name: 'side_list',
+									},
+								},
 							]}
 							value="A0"
 						/>
@@ -72,7 +72,7 @@ const Example = createReactClass({
 				</div>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/menu-dropdown/__examples__/custom-trigger.jsx
+++ b/components/menu-dropdown/__examples__/custom-trigger.jsx
@@ -18,7 +18,7 @@ const Example = createReactClass({
 						{ label: 'Menu Item Two', value: 'B0' },
 						{ label: 'Menu Item Three', value: 'C0' },
 						{ type: 'divider' },
-						{ label: 'Menu Item Four', value: 'D0' }
+						{ label: 'Menu Item Four', value: 'D0' },
 					]}
 				>
 					<DropdownTrigger>
@@ -27,7 +27,7 @@ const Example = createReactClass({
 				</Dropdown>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/menu-dropdown/__examples__/default-icon-label.jsx
+++ b/components/menu-dropdown/__examples__/default-icon-label.jsx
@@ -19,11 +19,11 @@ const Example = createReactClass({
 					{ label: 'Menu Item Two', value: 'B0' },
 					{ label: 'Menu Item Three', value: 'C0' },
 					{ type: 'divider' },
-					{ label: 'Menu Item Four', value: 'D0' }
+					{ label: 'Menu Item Four', value: 'D0' },
 				]}
 			/>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/menu-dropdown/__examples__/default.jsx
+++ b/components/menu-dropdown/__examples__/default.jsx
@@ -21,12 +21,12 @@ const Example = createReactClass({
 						{ label: 'Menu Item Two', value: 'B0' },
 						{ label: 'Menu Item Three', value: 'C0' },
 						{ type: 'divider' },
-						{ label: 'Menu Item Four', value: 'D0' }
+						{ label: 'Menu Item Four', value: 'D0' },
 					]}
 				/>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/menu-dropdown/__examples__/sub-heading.jsx
+++ b/components/menu-dropdown/__examples__/sub-heading.jsx
@@ -22,12 +22,12 @@ const Example = createReactClass({
 						{ label: 'Menu Item Two', value: 'B0' },
 						{ label: 'Menu Sub Heading', type: 'header' },
 						{ label: 'Menu Item One', value: 'A0' },
-						{ label: 'Menu Item Two', value: 'B0' }
+						{ label: 'Menu Item Two', value: 'B0' },
 					]}
 				/>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/menu-dropdown/__tests__/dropdown.browser-test.jsx
+++ b/components/menu-dropdown/__tests__/dropdown.browser-test.jsx
@@ -8,7 +8,7 @@ import { mount } from 'enzyme';
 import assign from 'lodash.assign';
 import {
 	Simulate,
-	findRenderedDOMComponentWithClass
+	findRenderedDOMComponentWithClass,
 } from 'react-addons-test-utils';
 
 /* Enzyme Helpers that can mount and unmount React component instances to
@@ -18,7 +18,7 @@ import {
  */
 import {
 	mountComponent,
-	unmountComponent
+	unmountComponent,
 } from '../../../tests/enzyme-helpers';
 
 // Import your internal dependencies (for example):
@@ -36,7 +36,7 @@ const menuOptions = [
 	{ label: 'A super short', value: 'A0' },
 	{ label: 'B Option Super Super Long', value: 'B0' },
 	{ label: 'C Option', value: 'C0' },
-	{ disabled: true, label: 'D Option', value: 'D0' }
+	{ disabled: true, label: 'D Option', value: 'D0' },
 ];
 
 const defaultProps = {
@@ -46,7 +46,7 @@ const defaultProps = {
 	openOn: 'click',
 	options: menuOptions,
 	placeholder: 'Select a contact',
-	value: 'B0'
+	value: 'B0',
 };
 
 /* eslint-disable react/prop-types */
@@ -103,7 +103,7 @@ const getNodes = ({ wrapper }) => ({
 	customContent: wrapper.find('#custom-dropdown-menu-content'),
 	customContentLink: wrapper.find(
 		'#custom-dropdown-menu-content #custom-dropdown-menu-content-link'
-	)
+	),
 });
 
 /* All tests for component being tested should be wrapped in a root `describe`,

--- a/components/menu-dropdown/button-trigger.jsx
+++ b/components/menu-dropdown/button-trigger.jsx
@@ -47,7 +47,7 @@ const Trigger = createReactClass({
 		className: PropTypes.oneOfType([
 			PropTypes.array,
 			PropTypes.object,
-			PropTypes.string
+			PropTypes.string,
 		]),
 		/**
 		 * A unique ID is needed in order to support keyboard navigation, ARIA support, and connect the dropdown to the triggering button. This is provided by the `MenuDropdown`. Please use `MenuDropdown` to set.
@@ -103,8 +103,8 @@ const Trigger = createReactClass({
 		triggerClassName: PropTypes.oneOfType([
 			PropTypes.array,
 			PropTypes.object,
-			PropTypes.string
-		])
+			PropTypes.string,
+		]),
 	},
 
 	// ### Render
@@ -149,7 +149,7 @@ const Trigger = createReactClass({
 				className={classnames(
 					`slds-dropdown-trigger slds-dropdown-trigger--${openOn}`,
 					{
-						'slds-is-open': isOpen
+						'slds-is-open': isOpen,
 					},
 					triggerClassName
 				)}
@@ -175,7 +175,7 @@ const Trigger = createReactClass({
 				{menu}
 			</div>
 		);
-	}
+	},
 });
 
 export default Trigger;

--- a/components/menu-dropdown/check-props.js
+++ b/components/menu-dropdown/check-props.js
@@ -22,7 +22,7 @@ if (process.env.NODE_ENV !== 'production') {
 
 		oneOfRequiredProperty(COMPONENT, {
 			options: props.options,
-			children: props.children
+			children: props.children,
 		});
 
 		if (!props.options) {

--- a/components/menu-dropdown/menu-dropdown.jsx
+++ b/components/menu-dropdown/menu-dropdown.jsx
@@ -54,7 +54,7 @@ import KEYS from '../../utilities/key-code';
 import {
 	MENU_DROPDOWN,
 	MENU_DROPDOWN_TRIGGER,
-	LIST
+	LIST,
 } from '../../utilities/constants';
 
 const documentDefined = typeof document !== 'undefined';
@@ -80,7 +80,7 @@ const DropdownNubbinPositions = [
 	'top right',
 	'bottom left',
 	'bottom',
-	'bottom right'
+	'bottom right',
 ];
 
 /**
@@ -112,7 +112,7 @@ const MenuDropdown = createReactClass({
 		buttonClassName: PropTypes.oneOfType([
 			PropTypes.array,
 			PropTypes.object,
-			PropTypes.string
+			PropTypes.string,
 		]),
 		/**
 		 * If true, button/icon is white. Meant for buttons or utility icons on dark backgrounds.
@@ -126,7 +126,7 @@ const MenuDropdown = createReactClass({
 			'neutral',
 			'brand',
 			'destructive',
-			'icon'
+			'icon',
 		]),
 		/**
 		 * If true, renders checkmark icon on the selected Menu Item.
@@ -153,7 +153,7 @@ const MenuDropdown = createReactClass({
 		className: PropTypes.oneOfType([
 			PropTypes.array,
 			PropTypes.object,
-			PropTypes.string
+			PropTypes.string,
 		]),
 		/**
 		 * By default, these class names will be added to the absolutely-positioned `Dialog` component.
@@ -161,7 +161,7 @@ const MenuDropdown = createReactClass({
 		containerClassName: PropTypes.oneOfType([
 			PropTypes.array,
 			PropTypes.object,
-			PropTypes.string
+			PropTypes.string,
 		]),
 		/**
 		 * This prop is passed onto the triggering `Button`. Prevent dropdown menu from opening. Also applies disabled styling to trigger button.
@@ -186,7 +186,7 @@ const MenuDropdown = createReactClass({
 			'custom',
 			'doctype',
 			'standard',
-			'utility'
+			'utility',
 		]),
 		/**
 		 * Name of the icon. Visit <a href="http://www.lightningdesignsystem.com/resources/icons">Lightning Design System Icons</a> to reference icon names.
@@ -205,7 +205,7 @@ const MenuDropdown = createReactClass({
 			'border',
 			'border-filled',
 			'small',
-			'more'
+			'more',
 		]),
 		/**
 		 * Determines the size of the icon.
@@ -240,7 +240,7 @@ const MenuDropdown = createReactClass({
 		menuPosition: PropTypes.oneOf([
 			'absolute',
 			'overflowBoundaryElement',
-			'relative'
+			'relative',
 		]),
 		/**
 		 * Style applied to menu element (that is the `.slds-dropdown` element)
@@ -255,7 +255,7 @@ const MenuDropdown = createReactClass({
 			'top right',
 			'bottom left',
 			'bottom',
-			'bottom right'
+			'bottom right',
 		]),
 		/**
 		 *  Offset adds pixels to the absolutely positioned dropdown menu in the format: ([vertical]px [horizontal]px).
@@ -347,7 +347,7 @@ const MenuDropdown = createReactClass({
 		value: PropTypes.oneOfType([
 			PropTypes.number,
 			PropTypes.string,
-			PropTypes.array
+			PropTypes.array,
 		]),
 		/**
 		 * This prop is passed onto the triggering `Button`. It creates a tooltip with the content of the `node` provided.
@@ -359,12 +359,12 @@ const MenuDropdown = createReactClass({
 		triggerClassName: PropTypes.oneOfType([
 			PropTypes.array,
 			PropTypes.object,
-			PropTypes.string
+			PropTypes.string,
 		]),
 		/**
 		 * Whether this dropdown supports multi select.
 		 */
-		multiple: PropTypes.bool
+		multiple: PropTypes.bool,
 	},
 
 	mixins: [KeyboardNavigable],
@@ -374,7 +374,7 @@ const MenuDropdown = createReactClass({
 			align: 'left',
 			hoverCloseDelay: 300,
 			menuPosition: 'absolute',
-			openOn: 'click'
+			openOn: 'click',
 		};
 	},
 
@@ -382,7 +382,7 @@ const MenuDropdown = createReactClass({
 		return {
 			focusedIndex: -1,
 			selectedIndex: -1,
-			selectedIndices: []
+			selectedIndices: [],
 		};
 	},
 
@@ -471,7 +471,7 @@ const MenuDropdown = createReactClass({
 	setCurrentSelectedIndices (nextProps) {
 		if (this.props.multiple !== true) {
 			this.setState({
-				selectedIndex: this.getIndexByValue(nextProps.value)
+				selectedIndex: this.getIndexByValue(nextProps.value),
 			});
 		} else {
 			let values = [];
@@ -485,7 +485,7 @@ const MenuDropdown = createReactClass({
 			currentIndices = values.map((value) => this.getIndexByValue(value));
 
 			this.setState({
-				selectedIndices: currentIndices
+				selectedIndices: currentIndices,
 			});
 		}
 	},
@@ -530,7 +530,7 @@ const MenuDropdown = createReactClass({
 			}
 
 			this.setState({
-				isOpen: false
+				isOpen: false,
 			});
 
 			this.isHover = false;
@@ -552,7 +552,7 @@ const MenuDropdown = createReactClass({
 			currentOpenDropdown = this;
 
 			this.setState({
-				isOpen: true
+				isOpen: true,
 			});
 
 			if (this.props.onOpen) {
@@ -639,14 +639,14 @@ const MenuDropdown = createReactClass({
 		) {
 			const currentIndices = this.state.selectedIndices.concat(index);
 			this.setState({
-				selectedIndices: currentIndices
+				selectedIndices: currentIndices,
 			});
 		} else if (this.props.multiple) {
 			const deselectIndex = this.state.selectedIndices.indexOf(index);
 			const currentSelected = this.state.selectedIndices;
 			currentSelected.splice(deselectIndex, 1);
 			this.setState({
-				selectedIndices: currentSelected
+				selectedIndices: currentSelected,
 			});
 		}
 
@@ -677,7 +677,7 @@ const MenuDropdown = createReactClass({
 					keyCode: event.keyCode,
 					onSelect: this.handleSelect,
 					target: event.target,
-					toggleOpen: this.toggleOpen
+					toggleOpen: this.toggleOpen,
 				});
 			} else {
 				this.handleCancel();
@@ -745,7 +745,7 @@ const MenuDropdown = createReactClass({
 			} else if (child) {
 				const clonedCustomContent = React.cloneElement(child, {
 					onClick: this.handleClickCustomContent,
-					key: shortid.generate()
+					key: shortid.generate(),
 				});
 				customContentWithListPropInjection.push(clonedCustomContent);
 			}
@@ -960,11 +960,11 @@ const MenuDropdown = createReactClass({
 				{...CustomTriggerChildProps}
 			/>
 		);
-	}
+	},
 });
 
 MenuDropdown.contextTypes = {
-	iconPath: PropTypes.string
+	iconPath: PropTypes.string,
 };
 
 export default MenuDropdown;

--- a/components/menu-picklist/__docs__/site-stories.js
+++ b/components/menu-picklist/__docs__/site-stories.js
@@ -5,7 +5,7 @@
 
 const siteStories = [
 	require('raw-loader!@salesforce/design-system-react/components/menu-picklist/__examples__/base.jsx'),
-	require('raw-loader!@salesforce/design-system-react/components/menu-picklist/__examples__/tooltip-list-item.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/menu-picklist/__examples__/tooltip-list-item.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/menu-picklist/__docs__/storybook-stories.jsx
+++ b/components/menu-picklist/__docs__/storybook-stories.jsx
@@ -19,7 +19,7 @@ const options = [
 	{ label: 'B2 Option', value: 'B1' },
 	{ label: 'C2 Option', value: 'C1' },
 	{ label: 'D2 Option', value: 'D1' },
-	{ label: 'E2 Option Super Super Long', value: 'E1' }
+	{ label: 'E2 Option Super Super Long', value: 'E1' },
 ];
 
 const getPicklist = (props) => (
@@ -34,7 +34,7 @@ const MultipleExample = createReactClass({
 
 	getInitialState () {
 		return {
-			selectedIndexes: new Set()
+			selectedIndexes: new Set(),
 		};
 	},
 
@@ -42,7 +42,7 @@ const MultipleExample = createReactClass({
 		this.setState((prevState, props) => ({
 			selectedItems: prevState.selectedIndexes.has(data.optionIndex)
 				? Array.from(prevState.selectedIndexes.delete(data.optionIndex))
-				: Array.from(prevState.selectedIndexes.add(data.optionIndex))
+				: Array.from(prevState.selectedIndexes.add(data.optionIndex)),
 		}));
 	},
 
@@ -55,7 +55,7 @@ const MultipleExample = createReactClass({
 				labels={{
 					multipleOptionsSelected: `${
 						this.state.selectedIndexes.size
-					} Contacts Selected`
+					} Contacts Selected`,
 				}}
 				multiple
 				onSelect={this.handleSelect}
@@ -70,7 +70,7 @@ const MultipleExample = createReactClass({
 				}}
 			/>
 		);
-	}
+	},
 });
 
 storiesOf(MENU_PICKLIST, module)
@@ -86,7 +86,7 @@ storiesOf(MENU_PICKLIST, module)
 			onSelect: (...rest) => {
 				action('Selected')(...rest);
 			},
-			options
+			options,
 		})
 	)
 	.add('Non-modal', () =>
@@ -100,7 +100,7 @@ storiesOf(MENU_PICKLIST, module)
 			onSelect: (...rest) => {
 				action('Selected')(...rest);
 			},
-			options
+			options,
 		})
 	)
 	.add('Error state', () =>
@@ -112,7 +112,7 @@ storiesOf(MENU_PICKLIST, module)
 				action('Selected')(...rest);
 			},
 			options,
-			required: true
+			required: true,
 		})
 	)
 	.add('Multiselect', () => <MultipleExample />);

--- a/components/menu-picklist/__examples__/base.jsx
+++ b/components/menu-picklist/__examples__/base.jsx
@@ -22,7 +22,7 @@ const Example = createReactClass({
 								{ label: 'Option C', value: 'C0' },
 								{ label: 'Option D', value: 'D0' },
 								{ label: 'Option E', value: 'E0' },
-								{ label: 'Option FGHIJKLMNOPQRSTUVWXYZ', value: 'F0' }
+								{ label: 'Option FGHIJKLMNOPQRSTUVWXYZ', value: 'F0' },
 							]}
 							placeholder="Select a contact"
 						/>
@@ -39,7 +39,7 @@ const Example = createReactClass({
 								{ label: 'Option C', value: 'C0' },
 								{ label: 'Option D', value: 'D0' },
 								{ label: 'Option E', value: 'E0' },
-								{ label: 'Option FGHIJKLMNOPQRSTUVWXYZ', value: 'F0' }
+								{ label: 'Option FGHIJKLMNOPQRSTUVWXYZ', value: 'F0' },
 							]}
 							placeholder="Select a contact"
 							value="C0"
@@ -58,7 +58,7 @@ const Example = createReactClass({
 								{ label: 'Option C', value: 'C0' },
 								{ label: 'Option D', value: 'D0' },
 								{ label: 'Option E', value: 'E0' },
-								{ label: 'Option FGHIJKLMNOPQRSTUVWXYZ', value: 'F0' }
+								{ label: 'Option FGHIJKLMNOPQRSTUVWXYZ', value: 'F0' },
 							]}
 							placeholder="Select a contact"
 							value="C0"
@@ -67,7 +67,7 @@ const Example = createReactClass({
 				</div>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/menu-picklist/__examples__/snapshot-default.jsx
+++ b/components/menu-picklist/__examples__/snapshot-default.jsx
@@ -25,14 +25,14 @@ const Example = createReactClass({
 						{ label: 'Option C', value: 'C0' },
 						{ label: 'Option D', value: 'D0' },
 						{ label: 'Option E', value: 'E0' },
-						{ label: 'Option FGHIJKLMNOPQRSTUVWXYZ', value: 'F0' }
+						{ label: 'Option FGHIJKLMNOPQRSTUVWXYZ', value: 'F0' },
 					]}
 					placeholder="Select a contact"
 					value="C0"
 				/>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example;

--- a/components/menu-picklist/__examples__/tooltip-list-item.jsx
+++ b/components/menu-picklist/__examples__/tooltip-list-item.jsx
@@ -32,14 +32,14 @@ const Example = createReactClass({
 						{ label: 'Option C', value: 'C0' },
 						{ label: 'Option D', value: 'D0' },
 						{ label: 'Option E', value: 'E0' },
-						{ label: 'Option FGHIJKLMNOPQRSTUVWXYZ', value: 'F0' }
+						{ label: 'Option FGHIJKLMNOPQRSTUVWXYZ', value: 'F0' },
 					]}
 					placeholder="Select a contact"
 					value="C0"
 				/>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/menu-picklist/__tests__/picklist-base.browser-test.jsx
+++ b/components/menu-picklist/__tests__/picklist-base.browser-test.jsx
@@ -12,7 +12,7 @@ import IconSettings from '../../icon-settings';
 const {
 	Simulate,
 	scryRenderedDOMComponentsWithTag,
-	findRenderedDOMComponentWithClass
+	findRenderedDOMComponentWithClass,
 } = TestUtils;
 
 describe('SLDSMenuPicklist: ', function () {
@@ -22,12 +22,12 @@ describe('SLDSMenuPicklist: ', function () {
 		{
 			label: 'A Option Option Super Super Long',
 			value: 'A0',
-			title: 'Greg'
+			title: 'Greg',
 		},
 		{
 			label: 'B Option',
-			value: 'B0'
-		}
+			value: 'B0',
+		},
 	];
 
 	const renderPicklist = (inst) => {
@@ -48,7 +48,7 @@ describe('SLDSMenuPicklist: ', function () {
 		modal: false,
 		options,
 		placeholder: 'Select a contact',
-		value: 'C0'
+		value: 'C0',
 	};
 
 	const createPicklist = (props) =>
@@ -99,7 +99,7 @@ describe('SLDSMenuPicklist: ', function () {
 			cmp = getPicklist({
 				onClick: () => {
 					clicked = true;
-				}
+				},
 			});
 			btn = findRenderedDOMComponentWithClass(cmp, 'slds-button');
 		});
@@ -142,7 +142,7 @@ describe('SLDSMenuPicklist: ', function () {
 			cmp = getPicklist({
 				onSelect: (i) => {
 					selected = i;
-				}
+				},
 			});
 			btn = findRenderedDOMComponentWithClass(cmp, 'slds-button');
 			Simulate.click(btn, {});
@@ -171,7 +171,7 @@ describe('SLDSMenuPicklist: ', function () {
 				disabled: true,
 				onClick: () => {
 					clicked = true;
-				}
+				},
 			});
 			btn = findRenderedDOMComponentWithClass(cmp, 'slds-button');
 		});
@@ -203,7 +203,7 @@ describe('SLDSMenuPicklist: ', function () {
 			cmp = getPicklist({
 				onSelect: (i) => {
 					selected = i;
-				}
+				},
 			});
 			btn = findRenderedDOMComponentWithClass(cmp, 'slds-button');
 		});
@@ -246,7 +246,7 @@ describe('SLDSMenuPicklist: ', function () {
 			cmp = getPicklist({
 				onSelect: (i) => {
 					selected = i;
-				}
+				},
 			});
 			btn = findRenderedDOMComponentWithClass(cmp, 'slds-button');
 		});
@@ -286,7 +286,7 @@ describe('SLDSMenuPicklist: ', function () {
 			Simulate.keyDown(menuItems[1].querySelector('a'), {
 				key: 'Esc',
 				keyCode: 27,
-				which: 27
+				which: 27,
 			});
 			expect(getMenu(body)).to.equal(null);
 		});
@@ -298,7 +298,7 @@ describe('SLDSMenuPicklist: ', function () {
 
 		beforeEach(() => {
 			cmp = getPicklist({
-				multiple: true
+				multiple: true,
 			});
 			btn = findRenderedDOMComponentWithClass(cmp, 'slds-button');
 			Simulate.click(btn, {});

--- a/components/menu-picklist/index.jsx
+++ b/components/menu-picklist/index.jsx
@@ -88,7 +88,7 @@ const MenuPicklist = createReactClass({
 		 * * `multipleOptionsSelected`: Text to be used when multiple items are selected. "2 Options Selected" is a good pattern to use.
 		 */
 		labels: shape({
-			multipleOptionsSelected: PropTypes.string
+			multipleOptionsSelected: PropTypes.string,
 		}),
 		/**
 		 * Custom element that overrides the default Menu Item component.
@@ -125,7 +125,7 @@ const MenuPicklist = createReactClass({
 		/**
 		 * Current selected item.
 		 */
-		value: PropTypes.node
+		value: PropTypes.node,
 	},
 
 	mixins: [KeyboardNavigable],
@@ -136,9 +136,9 @@ const MenuPicklist = createReactClass({
 			placeholder: 'Select an Option',
 			checkmark: true,
 			labels: {
-				multipleOptionsSelected: 'Multiple Options Selected'
+				multipleOptionsSelected: 'Multiple Options Selected',
 			},
-			menuPosition: 'absolute'
+			menuPosition: 'absolute',
 		};
 	},
 
@@ -147,7 +147,7 @@ const MenuPicklist = createReactClass({
 			focusedIndex: -1,
 			selectedIndex: -1,
 			selectedIndices: [],
-			currentPillLabel: ''
+			currentPillLabel: '',
 		};
 	},
 
@@ -166,7 +166,7 @@ const MenuPicklist = createReactClass({
 
 		if (!this.props.multiple) {
 			this.setState({
-				selectedIndex: this.getIndexByValue(this.props)
+				selectedIndex: this.getIndexByValue(this.props),
 			});
 		} else {
 			const currentSelectedIndex = this.getIndexByValue(this.props);
@@ -175,7 +175,7 @@ const MenuPicklist = createReactClass({
 				currentIndices.push(currentSelectedIndex);
 			}
 			this.setState({
-				selectedIndices: currentIndices
+				selectedIndices: currentIndices,
 			});
 		}
 	},
@@ -187,7 +187,7 @@ const MenuPicklist = createReactClass({
 		) {
 			if (this.props.multiple !== true) {
 				this.setState({
-					selectedIndex: this.getIndexByValue(nextProps)
+					selectedIndex: this.getIndexByValue(nextProps),
 				});
 			} else {
 				const currentSelectedIndex = this.getIndexByValue(nextProps);
@@ -196,7 +196,7 @@ const MenuPicklist = createReactClass({
 						currentSelectedIndex
 					);
 					this.setState({
-						selectedIndices: currentIndices
+						selectedIndices: currentIndices,
 					});
 				}
 			}
@@ -270,7 +270,7 @@ const MenuPicklist = createReactClass({
 			}
 
 			this.setState({
-				selectedIndices: currentIndices
+				selectedIndices: currentIndices,
 			});
 		}
 
@@ -334,7 +334,7 @@ const MenuPicklist = createReactClass({
 					isOpen: this.state.isOpen || false,
 					keyCode: event.keyCode,
 					onSelect: this.handleSelect,
-					toggleOpen: this.toggleOpen
+					toggleOpen: this.toggleOpen,
 				});
 			} else {
 				this.handleCancel();
@@ -415,7 +415,7 @@ const MenuPicklist = createReactClass({
 				style={{
 					maxHeight: '20em',
 					overflowX: 'hidden',
-					minWidth: '100%'
+					minWidth: '100%',
 				}}
 			>
 				{this.renderMenuContent()}
@@ -510,7 +510,7 @@ const MenuPicklist = createReactClass({
 					<Pill
 						eventData={{
 							item: this.props.options[selectedPill],
-							index: selectedPill
+							index: selectedPill,
 						}}
 						events={{
 							onRequestRemove: (event, data) => {
@@ -523,13 +523,13 @@ const MenuPicklist = createReactClass({
 									const option = this.getValueByIndex(index);
 									this.props.onPillRemove(option, {
 										option,
-										optionIndex: index
+										optionIndex: index,
 									});
 								}
-							}
+							},
 						}}
 						labels={{
-							label: pillLabel
+							label: pillLabel,
 						}}
 					/>
 				</li>
@@ -564,7 +564,7 @@ const MenuPicklist = createReactClass({
 				className={classNames(
 					'slds-form-element',
 					{
-						'slds-has-error': errorText
+						'slds-has-error': errorText,
 					},
 					className
 				)}
@@ -589,11 +589,11 @@ const MenuPicklist = createReactClass({
 				)}
 			</div>
 		);
-	}
+	},
 });
 
 MenuPicklist.contextTypes = {
-	iconPath: PropTypes.string
+	iconPath: PropTypes.string,
 };
 
 export default MenuPicklist;

--- a/components/modal/__docs__/site-stories.js
+++ b/components/modal/__docs__/site-stories.js
@@ -8,7 +8,7 @@ const siteStories = [
 	require('raw-loader!@salesforce/design-system-react/components/modal/__examples__/header-footer.jsx'),
 	require('raw-loader!@salesforce/design-system-react/components/modal/__examples__/taglines.jsx'),
 	require('raw-loader!@salesforce/design-system-react/components/modal/__examples__/prompt.jsx'),
-	require('raw-loader!@salesforce/design-system-react/components/modal/__examples__/sizes.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/modal/__examples__/sizes.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/modal/__docs__/storybook-stories.jsx
+++ b/components/modal/__docs__/storybook-stories.jsx
@@ -23,7 +23,7 @@ const getModal = (props) => <Modal {...props} />;
 
 const modalFooter = [
 	<Button key="modalBCancel" label="Cancel" />,
-	<Button key="modalBSave" label="Save" variant="brand" />
+	<Button key="modalBSave" label="Save" variant="brand" />,
 ];
 
 const modalContent = (
@@ -103,7 +103,7 @@ const modalContent = (
 				{ label: 'Cold Call', value: 'B0' },
 				{ label: 'LinkedIn', value: 'C0' },
 				{ label: 'Direct Mail', value: 'D0' },
-				{ label: 'Other', value: 'E0' }
+				{ label: 'Other', value: 'E0' },
 			]}
 			placeholder="Select Lead Source"
 			value="B0"
@@ -201,7 +201,7 @@ storiesOf(MODAL, module)
 			title: 'New Opportunity',
 			children: modalContent,
 			onRequestClose: action('modal closed'),
-			portalClassName: 'portal-class-name-test'
+			portalClassName: 'portal-class-name-test',
 		})
 	)
 	.add('Small with footer, not dismissible', () =>
@@ -212,7 +212,7 @@ storiesOf(MODAL, module)
 			title: 'New Opportunity',
 			children: modalContent,
 			onRequestClose: action('modal closed'),
-			footer: modalFooter
+			footer: modalFooter,
 		})
 	)
 	.add('Small with custom footer', () =>
@@ -229,7 +229,7 @@ storiesOf(MODAL, module)
 					<Button label="update" />
 					<Button label="run" />
 				</div>
-			)
+			),
 		})
 	)
 	.add('Small no header', () =>
@@ -237,7 +237,7 @@ storiesOf(MODAL, module)
 			isOpen: true,
 			children: modalContent,
 			onRequestClose: action('modal closed'),
-			portalClassName: 'portal-class-name-test'
+			portalClassName: 'portal-class-name-test',
 		})
 	)
 	.add('Large with directional footer', () =>
@@ -249,7 +249,7 @@ storiesOf(MODAL, module)
 			children: modalContent,
 			onRequestClose: action('modal closed'),
 			footer: modalFooter,
-			size: 'large'
+			size: 'large',
 		})
 	)
 	.add('Prompt', () =>
@@ -266,6 +266,6 @@ storiesOf(MODAL, module)
 				</div>
 			), // eslint-disable-line max-len
 			prompt: 'error',
-			onRequestClose: action('modal closed')
+			onRequestClose: action('modal closed'),
 		})
 	);

--- a/components/modal/__examples__/header-footer.jsx
+++ b/components/modal/__examples__/header-footer.jsx
@@ -10,7 +10,7 @@ const Example = createReactClass({
 	getInitialState () {
 		return {
 			noHeaderIsOpen: false,
-			noFooterIsOpen: false
+			noFooterIsOpen: false,
 		};
 	},
 
@@ -78,7 +78,7 @@ const Example = createReactClass({
 				</div>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/modal/__examples__/menu-contents.jsx
+++ b/components/modal/__examples__/menu-contents.jsx
@@ -11,7 +11,7 @@ const Example = createReactClass({
 
 	getInitialState () {
 		return {
-			isOpen: false
+			isOpen: false,
 		};
 	},
 
@@ -31,7 +31,7 @@ const Example = createReactClass({
 						isOpen={this.state.isOpen}
 						footer={[
 							<Button label="Cancel" onClick={this.toggleOpen} />,
-							<Button label="Save" variant="brand" onClick={this.toggleOpen} />
+							<Button label="Save" variant="brand" onClick={this.toggleOpen} />,
 						]}
 						onRequestClose={this.toggleOpen}
 						title="New Opportunity"
@@ -85,7 +85,7 @@ const Example = createReactClass({
 										{ label: 'Nakatomi Investments' },
 										{ label: 'Acme Landscaping' },
 										{ type: 'section', label: 'SECTION 3' },
-										{ label: 'Acme Construction' }
+										{ label: 'Acme Construction' },
 									]}
 									sectionDividerRenderer={Lookup.DefaultSectionDivider}
 								/>
@@ -101,7 +101,7 @@ const Example = createReactClass({
 									{ label: 'Cold Call', value: 'B0' },
 									{ label: 'LinkedIn', value: 'C0' },
 									{ label: 'Direct Mail', value: 'D0' },
-									{ label: 'Other', value: 'E0' }
+									{ label: 'Other', value: 'E0' },
 								]}
 								placeholder="Select Lead Source"
 								value="B0"
@@ -117,7 +117,7 @@ const Example = createReactClass({
 									{ label: 'Courtesy', value: 'B0' },
 									{ label: 'New Business', value: 'C0' },
 									{ label: 'Renewal', value: 'D0' },
-									{ label: 'Upgrade', value: 'E0' }
+									{ label: 'Upgrade', value: 'E0' },
 								]}
 								placeholder="Select Opportunity Type"
 								value="C0"
@@ -140,7 +140,7 @@ const Example = createReactClass({
 				</div>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/modal/__examples__/modal-custom-parent-node.jsx
+++ b/components/modal/__examples__/modal-custom-parent-node.jsx
@@ -8,7 +8,7 @@ const Example = createReactClass({
 
 	getInitialState () {
 		return {
-			isOpen: false
+			isOpen: false,
 		};
 	},
 
@@ -51,7 +51,7 @@ const Example = createReactClass({
 				</Modal>
 			</div>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/modal/__examples__/prompt.jsx
+++ b/components/modal/__examples__/prompt.jsx
@@ -9,7 +9,7 @@ const Example = createReactClass({
 
 	getInitialState () {
 		return {
-			isOpen: false
+			isOpen: false,
 		};
 	},
 
@@ -29,7 +29,7 @@ const Example = createReactClass({
 								key="promptBtn"
 								label="Got it"
 								onClick={this.toggleOpen}
-							/>
+							/>,
 						]}
 						isOpen={this.state.isOpen}
 						onRequestClose={this.toggleOpen}
@@ -46,7 +46,7 @@ const Example = createReactClass({
 				</div>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/modal/__examples__/sizes.jsx
+++ b/components/modal/__examples__/sizes.jsx
@@ -9,7 +9,7 @@ const Example = createReactClass({
 
 	getInitialState () {
 		return {
-			isOpen: false
+			isOpen: false,
 		};
 	},
 
@@ -50,7 +50,7 @@ const Example = createReactClass({
 				</div>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/modal/__examples__/taglines.jsx
+++ b/components/modal/__examples__/taglines.jsx
@@ -9,7 +9,7 @@ const Example = createReactClass({
 
 	getInitialState () {
 		return {
-			isOpen: false
+			isOpen: false,
 		};
 	},
 
@@ -57,7 +57,7 @@ const Example = createReactClass({
 				</div>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/modal/__tests__/modal.browser-test.jsx
+++ b/components/modal/__tests__/modal.browser-test.jsx
@@ -23,7 +23,7 @@ describe('SLDSModal: ', function () {
 
 	const defaultProps = {
 		align: 'top',
-		children: <div>hello</div>
+		children: <div>hello</div>,
 	};
 
 	const renderModal = (modalInstance) => {
@@ -52,7 +52,7 @@ describe('SLDSModal: ', function () {
 				contentClassName: 'content-class-name-test',
 				contentStyle: { height: '500px' },
 				isOpen: true,
-				portalClassName: 'portal-class-name-test'
+				portalClassName: 'portal-class-name-test',
 			});
 		});
 
@@ -101,7 +101,7 @@ describe('SLDSModal: ', function () {
 				containerClassName: 'my-custom-class',
 				onRequestClose: () => {
 					closed = true;
-				}
+				},
 			});
 			modal = getModalNode(document.body);
 		});
@@ -139,7 +139,7 @@ describe('SLDSModal: ', function () {
 			getModal({
 				header: <div id="art-vandelay">Art vandelay</div>,
 				headerClassName: 'art-vandelay',
-				isOpen: true
+				isOpen: true,
 			});
 			modal = getModalNode(document.body);
 		});
@@ -165,7 +165,7 @@ describe('SLDSModal: ', function () {
 				isOpen: true,
 				prompt: 'warning',
 				title: 'are you sure?',
-				footer: feet
+				footer: feet,
 			});
 			modal = getModalNode(document.body);
 		});
@@ -196,12 +196,12 @@ describe('SLDSModal: ', function () {
 		beforeEach(() => {
 			const feet = [
 				<div className="toes">Toe 1</div>,
-				<div className="toes">Toe 2</div>
+				<div className="toes">Toe 2</div>,
 			];
 			getModal({
 				isOpen: true,
 				directional: true,
-				footer: feet
+				footer: feet,
 			});
 			modal = getModalNode(document.body);
 		});
@@ -218,12 +218,12 @@ describe('SLDSModal: ', function () {
 		beforeEach(() => {
 			const feet = [
 				<button className="cancel">Cancel</button>,
-				<button className="save">Save</button>
+				<button className="save">Save</button>,
 			];
 			getModal({
 				isOpen: true,
 				directional: true,
-				footer: feet
+				footer: feet,
 			});
 			modal = getModalNode(document.body);
 		});
@@ -233,7 +233,7 @@ describe('SLDSModal: ', function () {
 				Simulate.keyDown(modal, {
 					key: 'Tab',
 					keyCode: 9,
-					which: 9
+					which: 9,
 				});
 				setTimeout(() => {
 					expect(document.activeElement.className).to.include(

--- a/components/modal/index.jsx
+++ b/components/modal/index.jsx
@@ -42,7 +42,7 @@ const propTypes = {
 	containerClassName: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * Custom CSS classes for the modal's body. This is the element that has overflow rules and should be used to set a static height if desired. Use `classNames` [API](https://github.com/JedWatson/classnames).
@@ -50,7 +50,7 @@ const propTypes = {
 	contentClassName: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * Custom styles for the modal's body. This is the element that has overflow rules and should be used to set a static height if desired.
@@ -86,7 +86,7 @@ const propTypes = {
 	headerClassName: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * Forces the modal to be open or closed.
@@ -102,7 +102,7 @@ const propTypes = {
 	portalClassName: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * Styles the modal as a prompt.
@@ -113,7 +113,7 @@ const propTypes = {
 		'error',
 		'wrench',
 		'offline',
-		'info'
+		'info',
 	]),
 	/**
 	 * Specifiies the modal's width. May be deprecated in favor of `width` in the future.
@@ -130,12 +130,12 @@ const propTypes = {
 	/**
 	 * Allows adding additional notifications within the modal.
 	 */
-	toast: PropTypes.node
+	toast: PropTypes.node,
 };
 
 const defaultProps = {
 	align: 'center',
-	dismissible: true
+	dismissible: true,
 };
 
 /**
@@ -152,7 +152,7 @@ class Modal extends React.Component {
 	constructor (props) {
 		super(props);
 		this.state = {
-			isClosing: false
+			isClosing: false,
 		};
 
 		// Bind
@@ -207,7 +207,7 @@ class Modal extends React.Component {
 		const contentStyleFromProps = this.props.contentStyle || {};
 		const contentStyle = {
 			...borderRadius,
-			...contentStyleFromProps
+			...contentStyleFromProps,
 		};
 		return (
 			// temporarily disabling eslint for the onClicks on the div tags
@@ -218,7 +218,7 @@ class Modal extends React.Component {
 					'slds-modal': true,
 					'slds-fade-in-open': this.state.revealed,
 					'slds-modal--large': this.props.size === 'large',
-					'slds-modal--prompt': this.isPrompt()
+					'slds-modal--prompt': this.isPrompt(),
 				})}
 				onClick={this.dismissModalOnClickOutside}
 				role="dialog"
@@ -250,7 +250,7 @@ class Modal extends React.Component {
 
 	setReturnFocus () {
 		this.setState({
-			returnFocusTo: document.activeElement
+			returnFocusTo: document.activeElement,
 		});
 	}
 
@@ -294,7 +294,7 @@ class Modal extends React.Component {
 		const footerClass = {
 			'slds-modal__footer': true,
 			'slds-modal__footer--directional': this.props.directional,
-			'slds-theme--default': this.isPrompt()
+			'slds-theme--default': this.isPrompt(),
 		};
 
 		if (hasFooter) {
@@ -347,7 +347,7 @@ class Modal extends React.Component {
 					<h2
 						className={classNames({
 							'slds-text-heading--small': this.isPrompt(),
-							'slds-text-heading--medium': !this.isPrompt()
+							'slds-text-heading--medium': !this.isPrompt(),
 						})}
 						id={this.getId()}
 					>
@@ -368,7 +368,7 @@ class Modal extends React.Component {
 					{
 						'slds-modal__header--empty': headerEmpty,
 						[`slds-theme--${this.props.prompt}`]: this.isPrompt(),
-						'slds-theme--alert-texture': this.isPrompt()
+						'slds-theme--alert-texture': this.isPrompt(),
 					},
 					this.props.headerClassName
 				)}
@@ -408,12 +408,12 @@ class Modal extends React.Component {
 				WebkitOverflowScrolling: 'default',
 				borderRadius: 'default',
 				outline: 'default',
-				padding: 'default'
+				padding: 'default',
 			},
 			overlay: {
 				position: 'static',
-				backgroundColor: 'default'
-			}
+				backgroundColor: 'default',
+			},
 		};
 
 		return (

--- a/components/modal/private/manager.jsx
+++ b/components/modal/private/manager.jsx
@@ -24,25 +24,25 @@ const customStyles = {
 		WebkitOverflowScrolling: 'default',
 		borderRadius: 'default',
 		outline: 'default',
-		padding: 'default'
+		padding: 'default',
 	},
 	overlay: {
-		backgroundColor: 'default'
-	}
+		backgroundColor: 'default',
+	},
 };
 
 const Manager = createReactClass({
 	getDefaultProps () {
 		return {
 			title: '',
-			isOpen: false
+			isOpen: false,
 		};
 	},
 
 	getInitialState () {
 		return {
 			isOpen: this.props.isOpen,
-			revealed: false
+			revealed: false,
 		};
 	},
 
@@ -144,7 +144,7 @@ const Manager = createReactClass({
 				{this.getModal()}
 			</Modal>
 		);
-	}
+	},
 });
 
 export default Manager;

--- a/components/modal/trigger.jsx
+++ b/components/modal/trigger.jsx
@@ -17,7 +17,7 @@ const ModalTrigger = {
 			</Modal>
 		);
 		ReactDOM.render(comp, el);
-	}
+	},
 };
 
 export default ModalTrigger;

--- a/components/navigation/__docs__/site-stories.js
+++ b/components/navigation/__docs__/site-stories.js
@@ -5,7 +5,7 @@
 
 const siteStories = [
 	require('raw-loader!@salesforce/design-system-react/components/navigation/__examples__/default.jsx'),
-	require('raw-loader!@salesforce/design-system-react/components/navigation/__examples__/shade.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/navigation/__examples__/shade.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/navigation/__examples__/default.jsx
+++ b/components/navigation/__examples__/default.jsx
@@ -13,8 +13,8 @@ const sampleReportCategories = [
 			{ id: 'my_reports', label: 'Created by Me' },
 			{ id: 'private_reports', label: 'Private Reports' },
 			{ id: 'public_reports', label: 'Public Reports' },
-			{ id: 'all_reports', label: 'All Reports' }
-		]
+			{ id: 'all_reports', label: 'All Reports' },
+		],
 	},
 	{
 		id: 'folders',
@@ -22,9 +22,9 @@ const sampleReportCategories = [
 		items: [
 			{ id: 'my_folders', label: 'Created by Me' },
 			{ id: 'shared_folders', label: 'Shared with Me' },
-			{ id: 'all_folders', label: 'All Folders' }
-		]
-	}
+			{ id: 'all_folders', label: 'All Folders' },
+		],
+	},
 ];
 
 const Example = createReactClass({
@@ -32,7 +32,7 @@ const Example = createReactClass({
 
 	getInitialState () {
 		return {
-			selectedId: 'recent_reports'
+			selectedId: 'recent_reports',
 		};
 	},
 
@@ -57,7 +57,7 @@ const Example = createReactClass({
 				</div>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/navigation/__examples__/shade.jsx
+++ b/components/navigation/__examples__/shade.jsx
@@ -18,8 +18,8 @@ const sampleSearchCategories = [
 			{ id: 'files', label: 'Files' },
 			{ id: 'dashboards', label: 'Dashboards' },
 			{ id: 'reports', label: 'Reports' },
-			{ id: 'feeds', label: 'Feeds' }
-		]
+			{ id: 'feeds', label: 'Feeds' },
+		],
 	},
 	{
 		id: 'external_results',
@@ -27,9 +27,9 @@ const sampleSearchCategories = [
 		items: [
 			{ id: 'app_one', label: 'App One' },
 			{ id: 'app_two', label: 'App Two' },
-			{ id: 'app_three', label: 'App Three' }
-		]
-	}
+			{ id: 'app_three', label: 'App Three' },
+		],
+	},
 ];
 
 const Example = createReactClass({
@@ -37,7 +37,7 @@ const Example = createReactClass({
 
 	getInitialState () {
 		return {
-			selectedId: 'top'
+			selectedId: 'top',
 		};
 	},
 
@@ -63,7 +63,7 @@ const Example = createReactClass({
 				</div>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/navigation/__examples__/snapshot-default.jsx
+++ b/components/navigation/__examples__/snapshot-default.jsx
@@ -21,7 +21,7 @@ const Example = createReactClass({
 				/>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example;

--- a/components/navigation/__tests__/navigation.browser-test.jsx
+++ b/components/navigation/__tests__/navigation.browser-test.jsx
@@ -32,7 +32,7 @@ if (!Object.entries) {
  */
 import {
 	mountComponent,
-	unmountComponent
+	unmountComponent,
 } from '../../../tests/enzyme-helpers';
 
 import { sampleReportCategories } from '../../../utilities/sample-data/navigation';
@@ -46,7 +46,7 @@ chai.use(chaiEnzyme());
 const defaultProps = {
 	id: 'sample-navigation',
 	className: 'sample-navigation',
-	categories: sampleReportCategories
+	categories: sampleReportCategories,
 };
 
 /* A re-usable demo component fixture outside of `describe` sections
@@ -56,7 +56,7 @@ const DemoComponent = createReactClass({
 	displayName: 'NavigationDemoComponent',
 	propTypes: {
 		selectedId: PropTypes.string,
-		onSelect: PropTypes.func
+		onSelect: PropTypes.func,
 	},
 
 	getDefaultProps () {
@@ -71,7 +71,7 @@ const DemoComponent = createReactClass({
 
 	render () {
 		return <Navigation {...this.props} />;
-	}
+	},
 });
 
 describe('SLDSNavigation', () => {

--- a/components/navigation/__tests__/navigation.snapshot-test.jsx
+++ b/components/navigation/__tests__/navigation.snapshot-test.jsx
@@ -17,7 +17,7 @@ const customProps = {
 	className: 'CUSTOM-CLASSNAME',
 	id: 'CUSTOM-ID',
 	variant: 'shade',
-	selectedId: 'all_reports'
+	selectedId: 'all_reports',
 };
 
 test(`Navigation

--- a/components/navigation/index.jsx
+++ b/components/navigation/index.jsx
@@ -41,7 +41,7 @@ const Navigation = createReactClass({
 		className: PropTypes.oneOfType([
 			PropTypes.array,
 			PropTypes.object,
-			PropTypes.string
+			PropTypes.string,
 		]),
 		/**
 		 * Array of categories. The required shape is: `{id: string, label: string, items: array}`. The required shape of an item is `{id: string, label: string, url: string}`. All item ids are expected to be unique. _Tested with snapshot testing._
@@ -58,12 +58,12 @@ const Navigation = createReactClass({
 		/**
 		 * Determines component style. _Tested with snapshot testing._
 		 */
-		variant: PropTypes.oneOf(['default', 'shade'])
+		variant: PropTypes.oneOf(['default', 'shade']),
 	},
 
 	getDefaultProps () {
 		return {
-			variant: 'default'
+			variant: 'default',
 		};
 	},
 
@@ -105,7 +105,7 @@ const Navigation = createReactClass({
 					'slds-grid--vertical',
 					'slds-navigation-list--vertical',
 					{
-						'slds-navigation-list--vertical-inverse': variant === 'shade'
+						'slds-navigation-list--vertical-inverse': variant === 'shade',
 					},
 					this.props.className
 				)}
@@ -131,12 +131,12 @@ const Navigation = createReactClass({
 									onSelect={this.props.onSelect}
 								/>
 							))}
-						</ul>
+						</ul>,
 					];
 				})}
 			</div>
 		);
-	}
+	},
 });
 
 export default Navigation;

--- a/components/navigation/private/item.jsx
+++ b/components/navigation/private/item.jsx
@@ -18,7 +18,7 @@ import { NAVIGATION_ITEM } from '../../../utilities/constants';
 const handleClick = (event, props) => {
 	if (isFunction(props.onSelect)) {
 		props.onSelect(event, {
-			item: props.item
+			item: props.item,
 		});
 	}
 };
@@ -51,7 +51,7 @@ Item.propTypes = {
 	item: PropTypes.shape({
 		id: PropTypes.string.isRequired,
 		label: PropTypes.string.isRequired,
-		url: PropTypes.string
+		url: PropTypes.string,
 	}),
 	/**
 	 * Whether item is selected or not.
@@ -64,11 +64,11 @@ Item.propTypes = {
 	/**
 	 * Function that will run whenever an item is selected.
 	 */
-	onSelect: PropTypes.func
+	onSelect: PropTypes.func,
 };
 
 Item.defaultProps = {
-	isSelected: false
+	isSelected: false,
 };
 
 export default Item;

--- a/components/notification/__docs__/site-stories.js
+++ b/components/notification/__docs__/site-stories.js
@@ -6,7 +6,7 @@
 const siteStories = [
 	require('raw-loader!@salesforce/design-system-react/components/notification/__examples__/alerts.jsx'),
 	require('raw-loader!@salesforce/design-system-react/components/notification/__examples__/toasts.jsx'),
-	require('raw-loader!@salesforce/design-system-react/components/notification/__examples__/within-modal.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/notification/__examples__/within-modal.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/notification/__docs__/storybook-stories.jsx
+++ b/components/notification/__docs__/storybook-stories.jsx
@@ -18,7 +18,7 @@ storiesOf(NOTIFICATION, module)
 				<a href="javascript:void(0);" key="0123">
 					Sara Smith
 				</a>,
-				' was successfully created.'
+				' was successfully created.',
 			]}
 			iconName="notification"
 			isOpen

--- a/components/notification/__examples__/alerts.jsx
+++ b/components/notification/__examples__/alerts.jsx
@@ -12,7 +12,7 @@ const Example = createReactClass({
 			baseIsOpen: false,
 			successIsOpen: false,
 			errorIsOpen: false,
-			offlineIsOpen: false
+			offlineIsOpen: false,
 		};
 	},
 
@@ -51,7 +51,7 @@ const Example = createReactClass({
 							<span key="maintenance">
 								Scheduled Maintenance Notification: Sunday March 15, 8:00
 								AM–10:00 PST <a href="javascript:void(0);">More Information</a>
-							</span>
+							</span>,
 						]}
 						iconName="notification"
 						isOpen={this.state.successIsOpen}
@@ -74,7 +74,7 @@ const Example = createReactClass({
 							<span key="browser">
 								Your browser is currently not supported. Your Salesforce may be
 								degraded. <a href="javascript:void(0);">More Information</a>
-							</span>
+							</span>,
 						]}
 						iconName="ban"
 						isOpen={this.state.errorIsOpen}
@@ -97,7 +97,7 @@ const Example = createReactClass({
 							<span key="offline">
 								You are in offline mode{' '}
 								<a href="javascript:void(0);">More Information</a>
-							</span>
+							</span>,
 						]}
 						iconName="offline"
 						isOpen={this.state.offlineIsOpen}
@@ -111,7 +111,7 @@ const Example = createReactClass({
 				</div>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/notification/__examples__/toasts.jsx
+++ b/components/notification/__examples__/toasts.jsx
@@ -12,7 +12,7 @@ const Example = createReactClass({
 			baseIsOpen: false,
 			successIsOpen: false,
 			warningIsOpen: false,
-			errorIsOpen: false
+			errorIsOpen: false,
 		};
 	},
 
@@ -50,7 +50,7 @@ const Example = createReactClass({
 							<span key="new-contact">
 								Your new contact <a href="javascript:void(0);">Sara Smith</a>{' '}
 								was successfully created.
-							</span>
+							</span>,
 						]}
 						iconName="notification"
 						isOpen={this.state.successIsOpen}
@@ -71,7 +71,7 @@ const Example = createReactClass({
 						content={[
 							<span key="required-fields">
 								Oops, you&quot;ve missed some required form inputs.
-							</span>
+							</span>,
 						]}
 						isOpen={this.state.warningIsOpen}
 						onDismiss={(event) => {
@@ -92,7 +92,7 @@ const Example = createReactClass({
 							<span key="required-fields">
 								You encountered some errors when trying to save edits to Samuel
 								Smith.
-							</span>
+							</span>,
 						]}
 						iconName="warning"
 						isOpen={this.state.errorIsOpen}
@@ -105,7 +105,7 @@ const Example = createReactClass({
 				</div>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/notification/__examples__/within-modal.jsx
+++ b/components/notification/__examples__/within-modal.jsx
@@ -12,7 +12,7 @@ const Example = createReactClass({
 		return {
 			isOpen: false,
 			modalOpen: false,
-			toastOpen: true
+			toastOpen: true,
 		};
 	},
 
@@ -39,7 +39,7 @@ const Example = createReactClass({
 								label="Toggle Toast"
 								onClick={this.toggleToast}
 								variant="brand"
-							/>
+							/>,
 						]}
 						isOpen={this.state.modalOpen}
 						onRequestClose={this.toggleModal}
@@ -77,7 +77,7 @@ const Example = createReactClass({
 				</div>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/notification/__tests__/notification.browser-test.jsx
+++ b/components/notification/__tests__/notification.browser-test.jsx
@@ -62,7 +62,7 @@ describe('SLDSNotification: ', () => {
 					iconName="notification"
 					isOpen
 					texture
-					content={'hi'}
+					content="hi"
 				/>
 			);
 			setTimeout(() => {

--- a/components/notification/index.jsx
+++ b/components/notification/index.jsx
@@ -42,14 +42,14 @@ const propTypes = {
 	 * Styling for Notification background color. Please reference <a href='http://www.lightningdesignsystem.com/components/utilities/themes/#color'>Lighning Design System Themes > Color</a>.
 	 */
 	theme: PropTypes.oneOf(['success', 'warning', 'error', 'offline']),
-	variant: PropTypes.oneOf(['alert', 'toast']).isRequired
+	variant: PropTypes.oneOf(['alert', 'toast']).isRequired,
 };
 
 const defaultProps = {
 	iconCategory: 'utility',
 	dismissible: true,
 	isOpen: false,
-	texture: false
+	texture: false,
 };
 
 /**
@@ -112,7 +112,7 @@ class Notification extends React.Component {
 		return classNames(this.props.className, 'slds-notify', {
 			[`slds-notify--${this.props.variant}`]: this.props.variant,
 			[`slds-theme--${this.props.theme}`]: this.props.theme,
-			'slds-theme--alert-texture': this.props.texture
+			'slds-theme--alert-texture': this.props.texture,
 		});
 	}
 

--- a/components/page-header/__docs__/site-stories.js
+++ b/components/page-header/__docs__/site-stories.js
@@ -6,7 +6,7 @@
 const siteStories = [
 	require('raw-loader!@salesforce/design-system-react/components/page-header/__examples__/record-home.jsx'),
 	require('raw-loader!@salesforce/design-system-react/components/page-header/__examples__/object-home.jsx'),
-	require('raw-loader!@salesforce/design-system-react/components/page-header/__examples__/related-list.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/page-header/__examples__/related-list.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/page-header/__docs__/storybook-stories.jsx
+++ b/components/page-header/__docs__/storybook-stories.jsx
@@ -21,16 +21,16 @@ const recordHomeDetails1 = [
 		content:
 			'Description that demonstrates truncation with content. Description that demonstrates truncation with content.',
 		flavor: '1-of-4',
-		truncate: true
+		truncate: true,
 	},
 	{ label: 'Field 2', content: 'Multiple Values' },
-	{ label: 'Field 3', content: 'Description (2-line truncation)' }
+	{ label: 'Field 3', content: 'Description (2-line truncation)' },
 ];
 
 const recordHomeDetails2 = [
 	{ label: 'Field 1', content: 'hi', flavor: '1-of-4', truncate: true },
 	{ label: 'Field 2', content: 'Multiple Values' },
-	{ label: 'Field 3', content: 'Description (2-line truncation)' }
+	{ label: 'Field 3', content: 'Description (2-line truncation)' },
 ];
 
 const DemoPageHeader = createReactClass({
@@ -38,7 +38,7 @@ const DemoPageHeader = createReactClass({
 
 	getInitialState () {
 		return {
-			recordHomeDetails: recordHomeDetails2
+			recordHomeDetails: recordHomeDetails2,
 		};
 	},
 
@@ -53,7 +53,7 @@ const DemoPageHeader = createReactClass({
 	handleSelect (selectedItem, ...rest) {
 		action('select')(selectedItem, ...rest);
 		this.setState({
-			currentSelected: this.state.options.indexOf(selectedItem)
+			currentSelected: this.state.options.indexOf(selectedItem),
 		});
 	},
 
@@ -65,7 +65,7 @@ const DemoPageHeader = createReactClass({
 			label: 'Record Type',
 			title: 'Record Title',
 			variant: 'recordHome',
-			details: this.state.recordHomeDetails
+			details: this.state.recordHomeDetails,
 		};
 
 		return (
@@ -76,7 +76,7 @@ const DemoPageHeader = createReactClass({
 				<SLDSPageHeader {...defaultProps} />
 			</div>
 		);
-	}
+	},
 });
 const getPageHeader = (props) => <SLDSPageHeader {...props} />;
 
@@ -105,7 +105,7 @@ const recordHomeContentRight = (
 				align="right"
 				options={[
 					{ label: 'Disable', value: 'A0' },
-					{ label: 'Promote', value: 'C0' }
+					{ label: 'Promote', value: 'C0' },
 				]}
 			/>
 		</SLDSButtonGroup>
@@ -130,11 +130,11 @@ const recordHomeDetails = [
 		content:
 			'Description that demonstrates truncation with content. Description that demonstrates truncation with content.',
 		flavor: '1-of-4',
-		truncate: true
+		truncate: true,
 	},
 	{ label: 'Field 2', content: 'Multiple Values' },
 	{ label: 'Field 3', content: customTooltip(), flavor: '1-of-4' },
-	{ label: 'Field 4', content: 'Description (2-line truncation)' }
+	{ label: 'Field 4', content: 'Description (2-line truncation)' },
 ];
 
 const objectHomeContentRight = (
@@ -179,7 +179,7 @@ const objectHomeContentRight = (
 					{ label: 'Last Name (ascending)', value: 'LNA' },
 					{ label: 'Last Name (descending)', value: 'LND' },
 					{ label: 'Last Contacted (descending)', value: 'LCD' },
-					{ label: 'Last Contacted (ascending)', value: 'LCA' }
+					{ label: 'Last Contacted (ascending)', value: 'LCA' },
 				]}
 			/>
 		</SLDSButtonGroup>
@@ -198,7 +198,7 @@ const objectHomeNavRight = (
 			options={[
 				{ label: 'Refresh List', value: 'A0' },
 				{ label: 'Duplicate Selected Leads', value: 'B0' },
-				{ label: 'Disabled Selected Leads', value: 'C0' }
+				{ label: 'Disabled Selected Leads', value: 'C0' },
 			]}
 		/>
 	</SLDSButtonGroup>
@@ -240,7 +240,7 @@ const relatedListContentRight = (
 					{ label: 'Last Name (ascending)', value: 'LNA' },
 					{ label: 'Last Name (descending)', value: 'LND' },
 					{ label: 'Last Contacted (descending)', value: 'LCD' },
-					{ label: 'Last Contacted (ascending)', value: 'LCA' }
+					{ label: 'Last Contacted (ascending)', value: 'LCA' },
 				]}
 			/>
 		</SLDSButtonGroup>
@@ -261,7 +261,7 @@ const relatedListNavRight = (
 			options={[
 				{ label: 'Refresh List', value: 'A0' },
 				{ label: 'Duplicate Selected Leads', value: 'B0' },
-				{ label: 'Disabled Selected Leads', value: 'C0' }
+				{ label: 'Disabled Selected Leads', value: 'C0' },
 			]}
 		/>
 	</SLDSButtonGroup>
@@ -269,7 +269,7 @@ const relatedListNavRight = (
 
 const relatedListTrail = [
 	<a href="javascript:void(0);">Accounts</a>,
-	<a href="javascript:void(0);">Company One</a>
+	<a href="javascript:void(0);">Company One</a>,
 ];
 
 storiesOf(PAGE_HEADER, module)
@@ -284,7 +284,7 @@ storiesOf(PAGE_HEADER, module)
 			iconCategory: 'standard',
 			iconName: 'opportunity',
 			title: 'Rohde Corp - 80,000 Widgets',
-			info: 'Mark Jaeckal • Unlimited Customer • 11/13/15'
+			info: 'Mark Jaeckal • Unlimited Customer • 11/13/15',
 		})
 	)
 	.add('Record Home (truncates)', () =>
@@ -296,7 +296,7 @@ storiesOf(PAGE_HEADER, module)
 			title: 'Record Title',
 			variant: 'recordHome',
 			contentRight: recordHomeContentRight,
-			details: recordHomeDetails
+			details: recordHomeDetails,
 		})
 	)
 	.add('Object Home', () => <ObjectHome />)
@@ -307,7 +307,7 @@ storiesOf(PAGE_HEADER, module)
 			info: '10 items • sorted by name',
 			contentRight: relatedListContentRight,
 			navRight: relatedListNavRight,
-			trail: relatedListTrail
+			trail: relatedListTrail,
 		})
 	)
 	.add('Record Home (field updates)', () => <DemoPageHeader />);

--- a/components/page-header/__examples__/object-home.jsx
+++ b/components/page-header/__examples__/object-home.jsx
@@ -26,7 +26,7 @@ const Example = createReactClass({
 							{ label: 'Menu Item Two', value: 'B0' },
 							{ label: 'Menu Item Three', value: 'C0' },
 							{ type: 'divider' },
-							{ label: 'Menu Item Four', value: 'D0' }
+							{ label: 'Menu Item Four', value: 'D0' },
 						]}
 					/>
 				</ButtonGroup>
@@ -42,7 +42,7 @@ const Example = createReactClass({
 						{ label: 'Menu Item Two', value: 'B0' },
 						{ label: 'Menu Item Three', value: 'C0' },
 						{ type: 'divider' },
-						{ label: 'Menu Item Four', value: 'D0' }
+						{ label: 'Menu Item Four', value: 'D0' },
 					]}
 				>
 					<DropdownTrigger>
@@ -64,7 +64,7 @@ const Example = createReactClass({
 						{ label: 'Menu Item Two', value: 'B0' },
 						{ label: 'Menu Item Three', value: 'C0' },
 						{ type: 'divider' },
-						{ label: 'Menu Item Four', value: 'D0' }
+						{ label: 'Menu Item Four', value: 'D0' },
 					]}
 				>
 					<DropdownTrigger>
@@ -126,7 +126,7 @@ const Example = createReactClass({
 									{ label: 'Menu Item Two', value: 'B0' },
 									{ label: 'Menu Item Three', value: 'C0' },
 									{ type: 'divider' },
-									{ label: 'Menu Item Four', value: 'D0' }
+									{ label: 'Menu Item Four', value: 'D0' },
 								]}
 							>
 								<DropdownTrigger>
@@ -147,7 +147,7 @@ const Example = createReactClass({
 				/>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/page-header/__examples__/record-home.jsx
+++ b/components/page-header/__examples__/record-home.jsx
@@ -34,7 +34,7 @@ const Example = createReactClass({
 							{ label: 'Menu Item Two', value: 'B0' },
 							{ label: 'Menu Item Three', value: 'C0' },
 							{ type: 'divider' },
-							{ label: 'Menu Item Four', value: 'D0' }
+							{ label: 'Menu Item Four', value: 'D0' },
 						]}
 					/>
 				</ButtonGroup>
@@ -46,18 +46,18 @@ const Example = createReactClass({
 				label: 'Field 1',
 				content:
 					'Description that demonstrates truncation with content. Description that demonstrates truncation with content.',
-				truncate: true
+				truncate: true,
 			},
 			{ label: 'Field 2', content: 'Multiple Values' },
 			{
 				label: 'Field 3',
-				content: <a href="javascript:void(0);">Hyperlink</a>
+				content: <a href="javascript:void(0);">Hyperlink</a>,
 			},
 			{
 				label: 'Field 4',
 				content: 'Description (2-line truncation)',
-				truncate: true
-			}
+				truncate: true,
+			},
 		];
 
 		return (
@@ -74,7 +74,7 @@ const Example = createReactClass({
 				/>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/page-header/__examples__/related-list.jsx
+++ b/components/page-header/__examples__/related-list.jsx
@@ -39,7 +39,7 @@ const Example = createReactClass({
 						{ label: 'Menu Item Two', value: 'B0' },
 						{ label: 'Menu Item Three', value: 'C0' },
 						{ type: 'divider' },
-						{ label: 'Menu Item Four', value: 'D0' }
+						{ label: 'Menu Item Four', value: 'D0' },
 					]}
 				>
 					<DropdownTrigger>
@@ -78,7 +78,7 @@ const Example = createReactClass({
 							{ label: 'Menu Item Two', value: 'B0' },
 							{ label: 'Menu Item Three', value: 'C0' },
 							{ type: 'divider' },
-							{ label: 'Menu Item Four', value: 'D0' }
+							{ label: 'Menu Item Four', value: 'D0' },
 						]}
 					/>
 				</ButtonGroup>
@@ -87,7 +87,7 @@ const Example = createReactClass({
 
 		const trail = [
 			<a href="javascript:void(0);">Accounts</a>,
-			<a href="javascript:void(0);">Company One</a>
+			<a href="javascript:void(0);">Company One</a>,
 		];
 
 		return (
@@ -103,7 +103,7 @@ const Example = createReactClass({
 				/>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/page-header/__tests__/page-header.browser-test.jsx
+++ b/components/page-header/__tests__/page-header.browser-test.jsx
@@ -39,7 +39,7 @@ const recordHomeContentRight = (
 				align="right"
 				options={[
 					{ label: 'Disable', value: 'A0' },
-					{ label: 'Promote', value: 'C0' }
+					{ label: 'Promote', value: 'C0' },
 				]}
 			/>
 		</SLDSButtonGroup>
@@ -52,10 +52,10 @@ const recordHomeDetails = [
 		content:
 			'Description that demonstrates truncation with content. Description that demonstrates truncation with content.',
 		flavor: '1-of-4',
-		truncate: true
+		truncate: true,
 	},
 	{ label: 'Last Modified', content: 'August 31, 2016 2:01PM PST' },
-	{ label: 'Status', content: 'Status of thing you wanna know' }
+	{ label: 'Status', content: 'Status of thing you wanna know' },
 ];
 
 describe('PageHeader: ', function () {
@@ -67,7 +67,7 @@ describe('PageHeader: ', function () {
 		title: 'Record Title',
 		variant: 'recordHome',
 		contentRight: recordHomeContentRight,
-		details: recordHomeDetails
+		details: recordHomeDetails,
 	};
 
 	describe('Renders basic props', function () {

--- a/components/page-header/index.jsx
+++ b/components/page-header/index.jsx
@@ -65,7 +65,7 @@ const propTypes = {
 		'custom',
 		'doctype',
 		'standard',
-		'utility'
+		'utility',
 	]),
 	/**
 	 * If omitted, icon position is centered.
@@ -80,7 +80,7 @@ const propTypes = {
 		'border',
 		'border-filled',
 		'small',
-		'more'
+		'more',
 	]),
 	/**
 	 * Content to appear on the right hand side of the page header
@@ -97,7 +97,7 @@ const propTypes = {
 	/**
 	 * An array of react elements presumably anchor <a> elements.
 	 */
-	trail: PropTypes.array
+	trail: PropTypes.array,
 };
 
 const defaultProps = {
@@ -106,7 +106,7 @@ const defaultProps = {
 	navRight: '',
 	contentRight: '',
 	details: [],
-	trail: []
+	trail: [],
 };
 
 /**
@@ -117,7 +117,7 @@ class PageHeader extends Component {
 		return classnames(
 			'slds-page-header',
 			{
-				'slds-page-header--object-home': this.props.variant === 'objectHome'
+				'slds-page-header--object-home': this.props.variant === 'objectHome',
 			},
 			className
 		);
@@ -143,7 +143,7 @@ class PageHeader extends Component {
 			navRight,
 			title,
 			trail,
-			variant
+			variant,
 		} = this.props;
 
 		const classes = this._getClassNames(className);

--- a/components/page-header/private/base/index.jsx
+++ b/components/page-header/private/base/index.jsx
@@ -18,7 +18,7 @@ const propTypes = {
 	/**
 	 * Info node passed by PageHeader
 	 */
-	info: PropTypes.node
+	info: PropTypes.node,
 };
 
 const Base = (props) => (

--- a/components/page-header/private/detail-block.jsx
+++ b/components/page-header/private/detail-block.jsx
@@ -26,12 +26,12 @@ const propTypes = {
 	 * Sets whether the fields truncate
 	 */
 	truncate: PropTypes.bool,
-	flavor: PropTypes.string
+	flavor: PropTypes.string,
 };
 
 const defaultProps = {
 	label: '',
-	content: ''
+	content: '',
 };
 
 class DetailBlock extends Component {
@@ -53,7 +53,7 @@ class DetailBlock extends Component {
 	// eslint-disable-next-line class-methods-use-this
 	_getClassNames (className, flavor) {
 		return classnames('slds-page-header__detail-block', className, {
-			[`slds-size--${flavor}`]: flavor
+			[`slds-size--${flavor}`]: flavor,
 		});
 	}
 
@@ -81,7 +81,7 @@ class DetailBlock extends Component {
 
 			if (type === 'string') {
 				const labelClasses = classnames('slds-text-title', {
-					'slds-truncate': truncate
+					'slds-truncate': truncate,
 				});
 				return (
 					<p className={labelClasses} title={label}>
@@ -99,7 +99,7 @@ class DetailBlock extends Component {
 			const type = typeof content;
 			if (type === 'string') {
 				const labelClasses = classnames('slds-text-body--regular', {
-					'slds-truncate': truncate
+					'slds-truncate': truncate,
 				});
 				return (
 					<p
@@ -121,7 +121,7 @@ class DetailBlock extends Component {
 		 */
 		const renderContentWithTooltip = () => {
 			const labelClasses = classnames('slds-text-body--regular', {
-				'slds-truncate': truncate
+				'slds-truncate': truncate,
 			});
 			return (
 				<PopoverTooltip align="top" content={content}>

--- a/components/page-header/private/detail-row.jsx
+++ b/components/page-header/private/detail-row.jsx
@@ -16,7 +16,7 @@ const propTypes = {
 	/**
 	 * An array of detail blocks
 	 */
-	details: PropTypes.array
+	details: PropTypes.array,
 };
 const defaultProps = {};
 

--- a/components/page-header/private/info.jsx
+++ b/components/page-header/private/info.jsx
@@ -14,7 +14,7 @@ const propTypes = {
 	/**
 	 * Optional class name
 	 */
-	className: PropTypes.string
+	className: PropTypes.string,
 };
 
 const Info = (props) => (

--- a/components/page-header/private/object-home/index.jsx
+++ b/components/page-header/private/object-home/index.jsx
@@ -30,7 +30,7 @@ const propTypes = {
 	/**
 	 * Title node passed by PageHeader
 	 */
-	title: PropTypes.node
+	title: PropTypes.node,
 };
 
 const ObjectHome = (props) => (

--- a/components/page-header/private/record-home/index.jsx
+++ b/components/page-header/private/record-home/index.jsx
@@ -31,7 +31,7 @@ const propTypes = {
 	/**
 	 * Title node passed by PageHeader
 	 */
-	title: PropTypes.node
+	title: PropTypes.node,
 };
 
 const RecordHome = (props) => (

--- a/components/page-header/private/related-list/index.jsx
+++ b/components/page-header/private/related-list/index.jsx
@@ -25,7 +25,7 @@ const propTypes = {
 	/**
 	 * Nav content which appears in the upper right hand corner.
 	 */
-	navRight: PropTypes.oneOfType([PropTypes.string, PropTypes.element])
+	navRight: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
 };
 const defaultProps = {};
 

--- a/components/page-header/private/title.jsx
+++ b/components/page-header/private/title.jsx
@@ -22,13 +22,13 @@ const propTypes = {
 	/**
 	 * Optional class name
 	 */
-	className: PropTypes.string
+	className: PropTypes.string,
 };
 const defaultProps = {
 	truncate: true,
 	align: 'middle',
 	title: 'Page Header Title',
-	className: ''
+	className: '',
 };
 
 class Title extends Component {
@@ -39,7 +39,7 @@ class Title extends Component {
 			className,
 			{
 				'slds-truncate': truncate,
-				[`slds-align-${align}`]: align
+				[`slds-align-${align}`]: align,
 			}
 		);
 	}

--- a/components/panel/__docs__/site-stories.js
+++ b/components/panel/__docs__/site-stories.js
@@ -6,7 +6,7 @@
 const siteStories = [
 	require('raw-loader!@salesforce/design-system-react/components/panel/__examples__/filtering.jsx'),
 	require('raw-loader!@salesforce/design-system-react/components/panel/__examples__/filtering-locked.jsx'),
-	require('raw-loader!@salesforce/design-system-react/components/panel/__examples__/filtering-error.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/panel/__examples__/filtering-error.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/panel/__examples__/filtering-error.jsx
+++ b/components/panel/__examples__/filtering-error.jsx
@@ -13,16 +13,16 @@ import Picklist from '~/components/menu-picklist';
 const options = {
 	'show-me': [
 		{ label: 'All Products', value: 'all-products' },
-		{ label: 'All Wackamoles', value: 'all-Wackamoles' }
+		{ label: 'All Wackamoles', value: 'all-Wackamoles' },
 	],
 	'created-date': [
 		{ label: 'equals THIS WEEK', value: 'this-week' },
-		{ label: 'equals LAST WEEK', value: 'last-week' }
+		{ label: 'equals LAST WEEK', value: 'last-week' },
 	],
 	'list-price': [
 		{ label: 'greater than "500"', value: 'greater-than-500' },
-		{ label: 'greater than "100"', value: 'greater-than-100' }
-	]
+		{ label: 'greater than "100"', value: 'greater-than-100' },
+	],
 };
 
 const Example = createReactClass({
@@ -33,18 +33,18 @@ const Example = createReactClass({
 			modifiedPanel: false,
 			'show-me': {
 				selectedPicklistItem: options['show-me'][0],
-				selectedItem: options['show-me'][0]
+				selectedItem: options['show-me'][0],
 			},
 			'created-date': {
 				selectedPicklistItem: options['created-date'][0],
 				selectedItem: options['created-date'][0],
-				isActive: true
+				isActive: true,
 			},
 			'list-price': {
 				selectedPicklistItem: options['list-price'][0],
 				selectedItem: options['list-price'][0],
-				isActive: true
-			}
+				isActive: true,
+			},
 		};
 	},
 
@@ -56,8 +56,8 @@ const Example = createReactClass({
 				this.state[idSuffix].selectedPicklistItem,
 			[idSuffix]: {
 				...this.state[idSuffix],
-				selectedItem: this.state[idSuffix].selectedPicklistItem
-			}
+				selectedItem: this.state[idSuffix].selectedPicklistItem,
+			},
 		});
 	},
 
@@ -65,8 +65,8 @@ const Example = createReactClass({
 		this.setState({
 			[id]: {
 				...this.state[id],
-				selectedPicklistItem: selectedItem
-			}
+				selectedPicklistItem: selectedItem,
+			},
 		});
 	},
 
@@ -75,8 +75,8 @@ const Example = createReactClass({
 		this.setState({
 			[idSuffix]: {
 				...this.state[idSuffix],
-				isActive: false
-			}
+				isActive: false,
+			},
 		});
 	},
 
@@ -94,12 +94,12 @@ const Example = createReactClass({
 						onClickAdd={() => {
 							this.setState({
 								modifiedPanel: true,
-								new: { isActive: true, new: true }
+								new: { isActive: true, new: true },
 							});
 						}}
 						onClickRemoveAll={() => {
 							this.onRemove(null, {
-								id: 'sample-panel-filtering-created-date'
+								id: 'sample-panel-filtering-created-date',
 							});
 							this.onRemove(null, { id: 'sample-panel-filtering-list-price' });
 							this.onRemove(null, { id: 'sample-panel-filtering-new' });
@@ -198,7 +198,7 @@ const Example = createReactClass({
 				</Panel>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/panel/__examples__/filtering-locked.jsx
+++ b/components/panel/__examples__/filtering-locked.jsx
@@ -13,16 +13,16 @@ import Picklist from '~/components/menu-picklist';
 const options = {
 	'show-me': [
 		{ label: 'All Products', value: 'all-products' },
-		{ label: 'All Wackamoles', value: 'all-Wackamoles' }
+		{ label: 'All Wackamoles', value: 'all-Wackamoles' },
 	],
 	'created-date': [
 		{ label: 'equals THIS WEEK', value: 'this-week' },
-		{ label: 'equals LAST WEEK', value: 'last-week' }
+		{ label: 'equals LAST WEEK', value: 'last-week' },
 	],
 	'list-price': [
 		{ label: 'greater than "500"', value: 'greater-than-500' },
-		{ label: 'greater than "100"', value: 'greater-than-100' }
-	]
+		{ label: 'greater than "100"', value: 'greater-than-100' },
+	],
 };
 
 const Example = createReactClass({
@@ -33,18 +33,18 @@ const Example = createReactClass({
 			modifiedPanel: false,
 			'show-me': {
 				selectedPicklistItem: options['show-me'][0],
-				selectedItem: options['show-me'][0]
+				selectedItem: options['show-me'][0],
 			},
 			'created-date': {
 				selectedPicklistItem: options['created-date'][0],
 				selectedItem: options['created-date'][0],
-				isActive: true
+				isActive: true,
 			},
 			'list-price': {
 				selectedPicklistItem: options['list-price'][0],
 				selectedItem: options['list-price'][0],
-				isActive: true
-			}
+				isActive: true,
+			},
 		};
 	},
 
@@ -56,8 +56,8 @@ const Example = createReactClass({
 				this.state[idSuffix].selectedPicklistItem,
 			[idSuffix]: {
 				...this.state[idSuffix],
-				selectedItem: this.state[idSuffix].selectedPicklistItem
-			}
+				selectedItem: this.state[idSuffix].selectedPicklistItem,
+			},
 		});
 	},
 
@@ -65,8 +65,8 @@ const Example = createReactClass({
 		this.setState({
 			[id]: {
 				...this.state[id],
-				selectedPicklistItem: selectedItem
-			}
+				selectedPicklistItem: selectedItem,
+			},
 		});
 	},
 
@@ -75,8 +75,8 @@ const Example = createReactClass({
 		this.setState({
 			[idSuffix]: {
 				...this.state[idSuffix],
-				isActive: false
-			}
+				isActive: false,
+			},
 		});
 	},
 
@@ -93,12 +93,12 @@ const Example = createReactClass({
 						onClickAdd={() => {
 							this.setState({
 								modifiedPanel: true,
-								new: { isActive: true, new: true }
+								new: { isActive: true, new: true },
 							});
 						}}
 						onClickRemoveAll={() => {
 							this.onRemove(null, {
-								id: 'sample-panel-filtering-created-date'
+								id: 'sample-panel-filtering-created-date',
 							});
 							this.onRemove(null, { id: 'sample-panel-filtering-list-price' });
 							this.onRemove(null, { id: 'sample-panel-filtering-new' });
@@ -201,7 +201,7 @@ const Example = createReactClass({
 				</Panel>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/panel/__examples__/filtering.jsx
+++ b/components/panel/__examples__/filtering.jsx
@@ -13,20 +13,20 @@ import Picklist from '~/components/menu-picklist';
 const options = {
 	'show-me': [
 		{ label: 'All Products', value: 'all-products' },
-		{ label: 'All Wackamoles', value: 'all-Wackamoles' }
+		{ label: 'All Wackamoles', value: 'all-Wackamoles' },
 	],
 	'created-date': [
 		{ label: 'equals THIS WEEK', value: 'this-week' },
-		{ label: 'equals LAST WEEK', value: 'last-week' }
+		{ label: 'equals LAST WEEK', value: 'last-week' },
 	],
 	'list-price': [
 		{ label: 'greater than "500"', value: 'greater-than-500' },
-		{ label: 'greater than "100"', value: 'greater-than-100' }
+		{ label: 'greater than "100"', value: 'greater-than-100' },
 	],
 	new: [
 		{ label: 'less than "1000"', value: 'less-than-1000' },
-		{ label: 'less than "800"', value: 'less-than-800' }
-	]
+		{ label: 'less than "800"', value: 'less-than-800' },
+	],
 };
 
 const Example = createReactClass({
@@ -37,19 +37,19 @@ const Example = createReactClass({
 			modifiedPanel: false,
 			'show-me': {
 				selectedPicklistItem: options['show-me'][0],
-				selectedItem: options['show-me'][0]
+				selectedItem: options['show-me'][0],
 			},
 			'created-date': {
 				selectedPicklistItem: options['created-date'][0],
 				selectedItem: options['created-date'][0],
-				isActive: true
+				isActive: true,
 			},
 			'list-price': {
 				selectedPicklistItem: options['list-price'][0],
 				selectedItem: options['list-price'][0],
-				isActive: true
+				isActive: true,
 			},
-			new: {}
+			new: {},
 		};
 	},
 
@@ -61,8 +61,8 @@ const Example = createReactClass({
 				this.state[idSuffix].selectedPicklistItem,
 			[idSuffix]: {
 				...this.state[idSuffix],
-				selectedItem: this.state[idSuffix].selectedPicklistItem
-			}
+				selectedItem: this.state[idSuffix].selectedPicklistItem,
+			},
 		});
 	},
 
@@ -70,8 +70,8 @@ const Example = createReactClass({
 		this.setState({
 			[id]: {
 				...this.state[id],
-				selectedPicklistItem: selectedItem
-			}
+				selectedPicklistItem: selectedItem,
+			},
 		});
 	},
 
@@ -80,8 +80,8 @@ const Example = createReactClass({
 		this.setState({
 			[idSuffix]: {
 				...this.state[idSuffix],
-				isActive: false
-			}
+				isActive: false,
+			},
 		});
 	},
 
@@ -98,12 +98,12 @@ const Example = createReactClass({
 						onClickAdd={() => {
 							this.setState({
 								modifiedPanel: true,
-								new: { isActive: true, new: true }
+								new: { isActive: true, new: true },
 							});
 						}}
 						onClickRemoveAll={() => {
 							this.onRemove(null, {
-								id: 'sample-panel-filtering-created-date'
+								id: 'sample-panel-filtering-created-date',
 							});
 							this.onRemove(null, { id: 'sample-panel-filtering-list-price' });
 							this.onRemove(null, { id: 'sample-panel-filtering-new' });
@@ -228,7 +228,7 @@ const Example = createReactClass({
 				</Panel>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/panel/__tests__/filtering.snapshot-test.jsx
+++ b/components/panel/__tests__/filtering.snapshot-test.jsx
@@ -16,7 +16,7 @@ test('Panel Filtering Default Snapshot', () => {
 test('Panel Filtering Default HTML Snapshot', () => {
 	const domTree = String(
 		jsBeautify.html(ReactDOMServer.renderToStaticMarkup(<PanelFiltering />), {
-			indent_size: 2
+			indent_size: 2,
 		}),
 		'utf-8'
 	);

--- a/components/panel/filtering/group.jsx
+++ b/components/panel/filtering/group.jsx
@@ -42,7 +42,7 @@ const PanelFilterGroup = ({
 	onRequestCancel,
 	onRequestClose,
 	onRequestSave,
-	saveLabel
+	saveLabel,
 }) => (
 	<div className="slds-filters">
 		{variant === 'panel' ? (
@@ -168,7 +168,7 @@ PanelFilterGroup.propTypes = {
 	/**
 	 * Adds in default Panel header and footer
 	 */
-	variant: PropTypes.oneOf(['panel'])
+	variant: PropTypes.oneOf(['panel']),
 };
 
 PanelFilterGroup.defaultProps = {
@@ -177,7 +177,7 @@ PanelFilterGroup.defaultProps = {
 	assistiveTextCloseFilterPanel: 'Close Filter Panel',
 	heading: 'Filter',
 	saveLabel: 'Save',
-	removeAllLabel: 'Remove All'
+	removeAllLabel: 'Remove All',
 };
 
 export default PanelFilterGroup;

--- a/components/panel/filtering/list-heading.jsx
+++ b/components/panel/filtering/list-heading.jsx
@@ -26,7 +26,7 @@ import { PANEL_FILTER_LIST_HEADING } from '../../../utilities/constants';
 const PanelFilterListHeading = ({ heading, isLocked, lockedHeading }) => (
 	<h3
 		className={classNames('slds-text-body--small', 'slds-m-vertical--x-small', {
-			'slds-grid': isLocked
+			'slds-grid': isLocked,
 		})}
 	>
 		{isLocked ? lockedHeading : heading}
@@ -56,12 +56,12 @@ PanelFilterListHeading.propTypes = {
 	/**
 	 * Heading for a group of filters that are locked
 	 */
-	lockedHeading: PropTypes.string
+	lockedHeading: PropTypes.string,
 };
 
 PanelFilterListHeading.defaultProps = {
 	heading: 'Matching all these filters',
-	lockedLabel: 'Locked filters'
+	lockedLabel: 'Locked filters',
 };
 
 export default PanelFilterListHeading;

--- a/components/panel/filtering/list.jsx
+++ b/components/panel/filtering/list.jsx
@@ -32,7 +32,7 @@ const PanelFilterList = createReactClass({
 			/**
 			 * Pass in `Filter` components
 			 */
-			children: PropTypes.node
+			children: PropTypes.node,
 		};
 	},
 
@@ -51,7 +51,7 @@ const PanelFilterList = createReactClass({
 
 			if (child && child.props.errorLabel) {
 				clonedChild = React.cloneElement(child, {
-					isError: true
+					isError: true,
 				});
 			}
 
@@ -75,7 +75,7 @@ const PanelFilterList = createReactClass({
 				{children}
 			</ol>
 		);
-	}
+	},
 });
 
 export default PanelFilterList;

--- a/components/panel/filtering/private/panel-footer.jsx
+++ b/components/panel/filtering/private/panel-footer.jsx
@@ -21,7 +21,7 @@ const PanelFilterFooter = ({
 	addFilterLabel,
 	onClickAdd,
 	onClickRemoveAll,
-	removeAllLabel
+	removeAllLabel,
 }) => (
 	<div className="slds-filters__footer slds-grid slds-shrink-none">
 		<Button label={addFilterLabel} onClick={onClickAdd} variant="link" />
@@ -52,7 +52,7 @@ PanelFilterFooter.propTypes = {
 	/**
 	 * Localized description of the "Remove All" button in the footer
 	 */
-	removeAllLabel: PropTypes.node.isRequired
+	removeAllLabel: PropTypes.node.isRequired,
 };
 
 export default PanelFilterFooter;

--- a/components/panel/filtering/private/panel-header.jsx
+++ b/components/panel/filtering/private/panel-header.jsx
@@ -25,7 +25,7 @@ const PanelFilterHeader = ({
 	onRequestCancel,
 	onRequestClose,
 	onRequestSave,
-	saveLabel
+	saveLabel,
 }) =>
 	(modified ? (
 		<div className="slds-filters__header slds-grid slds-has-divider--bottom-space slds-grid--align-spread">
@@ -83,7 +83,7 @@ PanelFilterHeader.propTypes = {
 	/**
 	 * Label for button that saves modified filters
 	 */
-	saveLabel: PropTypes.string
+	saveLabel: PropTypes.string,
 };
 
 export default PanelFilterHeader;

--- a/components/panel/index.jsx
+++ b/components/panel/index.jsx
@@ -37,7 +37,7 @@ class Panel extends React.Component {
 					'slds-grid--vertical',
 					'slds-nowrap',
 					{
-						'slds-panel--filters': this.props.variant === 'filters'
+						'slds-panel--filters': this.props.variant === 'filters',
 					}
 				)}
 			>
@@ -59,7 +59,7 @@ Panel.propTypes = {
 	/**
 	 * The type of panel
 	 */
-	variant: PropTypes.oneOf(['filters'])
+	variant: PropTypes.oneOf(['filters']),
 };
 
 export default Panel;

--- a/components/pill/__docs__/site-stories.js
+++ b/components/pill/__docs__/site-stories.js
@@ -10,7 +10,7 @@ const siteStories = [
 	require('raw-loader!@salesforce/design-system-react/components/pill/__examples__/container.jsx'),
 	require('raw-loader!@salesforce/design-system-react/components/pill/__examples__/listbox-bare.jsx'),
 	require('raw-loader!@salesforce/design-system-react/components/pill/__examples__/listbox.jsx'),
-	require('raw-loader!@salesforce/design-system-react/components/pill/__examples__/listbox-avatar.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/pill/__examples__/listbox-avatar.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/pill/__examples__/base.jsx
+++ b/components/pill/__examples__/base.jsx
@@ -10,12 +10,12 @@ const Example = createReactClass({
 	displayName: 'BasePillExample',
 
 	propTypes: {
-		action: PropTypes.func
+		action: PropTypes.func,
 	},
 
 	getDefaultProps () {
 		return {
-			action: () => noop
+			action: () => noop,
 		};
 	},
 
@@ -23,7 +23,7 @@ const Example = createReactClass({
 		return {
 			linked: true,
 			unlinked: true,
-			truncated: true
+			truncated: true,
 		};
 	},
 
@@ -34,21 +34,21 @@ const Example = createReactClass({
 	onRemoveLinked (event) {
 		this.props.action('onRemove')(event);
 		this.setState({
-			linked: false
+			linked: false,
 		});
 	},
 
 	onRemoveUnlinked (event) {
 		this.props.action('onRemove')(event);
 		this.setState({
-			unlinked: false
+			unlinked: false,
 		});
 	},
 
 	onRemoveTruncated (event) {
 		this.props.action('onRemove')(event);
 		this.setState({
-			truncated: false
+			truncated: false,
 		});
 	},
 
@@ -59,7 +59,7 @@ const Example = createReactClass({
 					labels={{
 						label: 'Pill Label',
 						title: 'Full pill label verbiage mirrored here',
-						removeTitle: 'Remove'
+						removeTitle: 'Remove',
 					}}
 					onClick={this.onClick}
 					onRemove={this.onRemoveLinked}
@@ -76,7 +76,7 @@ const Example = createReactClass({
 					labels={{
 						label: 'Pill Label',
 						title: 'Full pill label verbiage mirrored here',
-						removeTitle: 'Remove'
+						removeTitle: 'Remove',
 					}}
 					onRemove={this.onRemoveUnlinked}
 				/>
@@ -94,7 +94,7 @@ const Example = createReactClass({
 							labels={{
 								label:
 									'Pill label that is longer than the area that contains it',
-								removeTitle: 'Remove'
+								removeTitle: 'Remove',
 							}}
 							onClick={this.onClick}
 							onRemove={this.onRemoveTruncated}
@@ -120,7 +120,7 @@ const Example = createReactClass({
 				</div>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example;

--- a/components/pill/__examples__/container.jsx
+++ b/components/pill/__examples__/container.jsx
@@ -10,12 +10,12 @@ const Example = createReactClass({
 	displayName: 'PillContainerExample',
 
 	propTypes: {
-		action: PropTypes.func
+		action: PropTypes.func,
 	},
 
 	getDefaultProps () {
 		return {
-			action: () => noop
+			action: () => noop,
 		};
 	},
 
@@ -41,7 +41,7 @@ const Example = createReactClass({
 									labels={{
 										label: 'Pill Label',
 										title: 'Full pill label verbiage mirrored here',
-										removeTitle: 'Remove'
+										removeTitle: 'Remove',
 									}}
 									onClick={this.onClick}
 									onRemove={this.onRemove}
@@ -50,7 +50,7 @@ const Example = createReactClass({
 									labels={{
 										label: 'Pill Label',
 										title: 'Full pill label verbiage mirrored here',
-										removeTitle: 'Remove'
+										removeTitle: 'Remove',
 									}}
 									onClick={this.onClick}
 									onRemove={this.onRemove}
@@ -59,7 +59,7 @@ const Example = createReactClass({
 									labels={{
 										label: 'Pill Label',
 										title: 'Full pill label verbiage mirrored here',
-										removeTitle: 'Remove'
+										removeTitle: 'Remove',
 									}}
 									onClick={this.onClick}
 									onRemove={this.onRemove}
@@ -79,10 +79,10 @@ const Example = createReactClass({
 											labels={{
 												label: 'Pill Label',
 												title: 'Full pill label verbiage mirrored here',
-												removeTitle: 'Remove'
+												removeTitle: 'Remove',
 											}}
 											assistiveText={{
-												remove: 'Press delete or backspace to remove'
+												remove: 'Press delete or backspace to remove',
 											}}
 											variant="option"
 											aria-selected="true"
@@ -93,10 +93,10 @@ const Example = createReactClass({
 											labels={{
 												label: 'Pill Label',
 												title: 'Full pill label verbiage mirrored here',
-												removeTitle: 'Remove'
+												removeTitle: 'Remove',
 											}}
 											assistiveText={{
-												remove: 'Press delete or backspace to remove'
+												remove: 'Press delete or backspace to remove',
 											}}
 											variant="option"
 										/>
@@ -108,7 +108,7 @@ const Example = createReactClass({
 				</div>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example;

--- a/components/pill/__examples__/icon.jsx
+++ b/components/pill/__examples__/icon.jsx
@@ -12,12 +12,12 @@ const Example = createReactClass({
 	displayName: 'PillWithIconExample',
 
 	propTypes: {
-		action: PropTypes.func
+		action: PropTypes.func,
 	},
 
 	getDefaultProps () {
 		return {
-			action: () => noop
+			action: () => noop,
 		};
 	},
 
@@ -25,7 +25,7 @@ const Example = createReactClass({
 		return {
 			pill1: true,
 			pill2: true,
-			pill3: true
+			pill3: true,
 		};
 	},
 
@@ -36,7 +36,7 @@ const Example = createReactClass({
 	onRemove (event, pill) {
 		this.props.action('onRemove')(event);
 		this.setState({
-			[pill]: false
+			[pill]: false,
 		});
 	},
 
@@ -50,7 +50,7 @@ const Example = createReactClass({
 								labels={{
 									label: 'Pill Label',
 									title: 'Full pill label verbiage mirrored here',
-									removeTitle: 'Remove'
+									removeTitle: 'Remove',
 								}}
 								icon={
 									<Icon title="Account" category="standard" name="account" />
@@ -66,7 +66,7 @@ const Example = createReactClass({
 								labels={{
 									label: 'Pill Label',
 									title: 'Full pill label verbiage mirrored here',
-									removeTitle: 'Remove'
+									removeTitle: 'Remove',
 								}}
 								avatar={
 									<Avatar
@@ -86,7 +86,7 @@ const Example = createReactClass({
 								labels={{
 									label: 'Pill Label',
 									title: 'Full pill label verbiage mirrored here',
-									removeTitle: 'Remove'
+									removeTitle: 'Remove',
 								}}
 								hasError
 								icon={
@@ -105,7 +105,7 @@ const Example = createReactClass({
 				</div>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/pill/__examples__/listbox-avatar.jsx
+++ b/components/pill/__examples__/listbox-avatar.jsx
@@ -11,12 +11,12 @@ const Example = createReactClass({
 	displayName: 'PillWithAvatarListboxExample',
 
 	propTypes: {
-		action: PropTypes.func
+		action: PropTypes.func,
 	},
 
 	getDefaultProps () {
 		return {
-			action: () => noop
+			action: () => noop,
 		};
 	},
 
@@ -48,10 +48,10 @@ const Example = createReactClass({
 										labels={{
 											label: 'Pill Label',
 											title: 'Full pill label verbiage mirrored here',
-											removeTitle: 'Remove'
+											removeTitle: 'Remove',
 										}}
 										assistiveText={{
-											remove: 'Press delete or backspace to remove'
+											remove: 'Press delete or backspace to remove',
 										}}
 										tabIndex="0"
 										variant="option"
@@ -71,10 +71,10 @@ const Example = createReactClass({
 										labels={{
 											label: 'Pill Label',
 											title: 'Full pill label verbiage mirrored here',
-											removeTitle: 'Remove'
+											removeTitle: 'Remove',
 										}}
 										assistiveText={{
-											remove: 'Press delete or backspace to remove'
+											remove: 'Press delete or backspace to remove',
 										}}
 										tabIndex="0"
 										variant="option"
@@ -95,7 +95,7 @@ const Example = createReactClass({
 				</div>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/pill/__examples__/listbox-bare.jsx
+++ b/components/pill/__examples__/listbox-bare.jsx
@@ -10,12 +10,12 @@ const Example = createReactClass({
 	displayName: 'BarePillListboxExample',
 
 	propTypes: {
-		action: PropTypes.func
+		action: PropTypes.func,
 	},
 
 	getDefaultProps () {
 		return {
-			action: () => noop
+			action: () => noop,
 		};
 	},
 
@@ -43,10 +43,10 @@ const Example = createReactClass({
 										labels={{
 											label: 'Pill Label',
 											title: 'Full pill label verbiage mirrored here',
-											removeTitle: 'Remove'
+											removeTitle: 'Remove',
 										}}
 										assistiveText={{
-											remove: 'Press delete or backspace to remove'
+											remove: 'Press delete or backspace to remove',
 										}}
 										bare
 										variant="option"
@@ -60,10 +60,10 @@ const Example = createReactClass({
 										labels={{
 											label: 'Pill Label',
 											title: 'Full pill label verbiage mirrored here',
-											removeTitle: 'Remove'
+											removeTitle: 'Remove',
 										}}
 										assistiveText={{
-											remove: 'Press delete or backspace to remove'
+											remove: 'Press delete or backspace to remove',
 										}}
 										bare
 										variant="option"
@@ -78,7 +78,7 @@ const Example = createReactClass({
 				</div>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/pill/__examples__/listbox-icon.jsx
+++ b/components/pill/__examples__/listbox-icon.jsx
@@ -8,40 +8,40 @@ import IconSettings from '~/components/icon-settings';
 const PILLS = [
 	{
 		category: 'standard',
-		name: 'account'
+		name: 'account',
 	},
 	{
 		category: 'standard',
-		name: 'case'
+		name: 'case',
 	},
 	{
 		category: 'utility',
-		name: 'retweet'
+		name: 'retweet',
 	},
 	{
 		category: 'standard',
-		name: 'solution'
+		name: 'solution',
 	},
 	{
 		category: 'standard',
-		name: 'custom_notification'
+		name: 'custom_notification',
 	},
 	{
 		category: 'standard',
-		name: 'email'
+		name: 'email',
 	},
 	{
 		category: 'standard',
-		name: 'endorsement'
+		name: 'endorsement',
 	},
 	{
 		category: 'standard',
-		name: 'recent'
+		name: 'recent',
 	},
 	{
 		category: 'custom',
-		name: 'custom31'
-	}
+		name: 'custom31',
+	},
 ];
 
 function noop () {}
@@ -50,12 +50,12 @@ const Example = createReactClass({
 	displayName: 'PillWithIconListboxExample',
 
 	propTypes: {
-		action: PropTypes.func
+		action: PropTypes.func,
 	},
 
 	getDefaultProps () {
 		return {
-			action: () => noop
+			action: () => noop,
 		};
 	},
 
@@ -70,7 +70,7 @@ const Example = createReactClass({
 	onRemove (event, pill) {
 		this.props.action('onRemove')(event);
 		this.setState({
-			[pill]: false
+			[pill]: false,
 		});
 	},
 
@@ -89,10 +89,10 @@ const Example = createReactClass({
 						labels={{
 							label: 'Pill Label',
 							title: 'Full pill label verbiage mirrored here',
-							removeTitle: 'Remove'
+							removeTitle: 'Remove',
 						}}
 						assistiveText={{
-							remove: 'Press delete or backspace to remove'
+							remove: 'Press delete or backspace to remove',
 						}}
 						variant="option"
 						icon={
@@ -126,7 +126,7 @@ const Example = createReactClass({
 				</div>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/pill/__examples__/listbox.jsx
+++ b/components/pill/__examples__/listbox.jsx
@@ -10,12 +10,12 @@ const Example = createReactClass({
 	displayName: 'PillListboxExample',
 
 	propTypes: {
-		action: PropTypes.func
+		action: PropTypes.func,
 	},
 
 	getDefaultProps () {
 		return {
-			action: () => noop
+			action: () => noop,
 		};
 	},
 
@@ -47,10 +47,10 @@ const Example = createReactClass({
 										labels={{
 											label: 'Pill Label',
 											title: 'Full pill label verbiage mirrored here',
-											removeTitle: 'Remove'
+											removeTitle: 'Remove',
 										}}
 										assistiveText={{
-											remove: 'Press delete or backspace to remove'
+											remove: 'Press delete or backspace to remove',
 										}}
 										variant="option"
 										tabIndex="0"
@@ -63,10 +63,10 @@ const Example = createReactClass({
 										labels={{
 											label: 'Pill Label',
 											title: 'Full pill label verbiage mirrored here',
-											removeTitle: 'Remove'
+											removeTitle: 'Remove',
 										}}
 										assistiveText={{
-											remove: 'Press delete or backspace to remove'
+											remove: 'Press delete or backspace to remove',
 										}}
 										variant="option"
 										tabIndex="0"
@@ -80,7 +80,7 @@ const Example = createReactClass({
 				</div>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/pill/__examples__/snapshot.jsx
+++ b/components/pill/__examples__/snapshot.jsx
@@ -19,7 +19,7 @@ const Example = createReactClass({
 							labels={{
 								label: 'Pill Label',
 								title: 'Full pill label verbiage mirrored here',
-								removeTitle: 'Remove'
+								removeTitle: 'Remove',
 							}}
 							onClick={noop}
 							onRemove={noop}
@@ -30,7 +30,7 @@ const Example = createReactClass({
 							labels={{
 								label: 'Pill Label',
 								title: 'Full pill label verbiage mirrored here',
-								removeTitle: 'Remove'
+								removeTitle: 'Remove',
 							}}
 							onRemove={noop}
 						/>
@@ -40,7 +40,7 @@ const Example = createReactClass({
 							labels={{
 								label: 'Pill Label',
 								title: 'Full pill label verbiage mirrored here',
-								removeTitle: 'Remove'
+								removeTitle: 'Remove',
 							}}
 							icon={<Icon title="Account" category="standard" name="account" />}
 							onClick={noop}
@@ -52,7 +52,7 @@ const Example = createReactClass({
 							labels={{
 								label: 'Pill Label',
 								title: 'Full pill label verbiage mirrored here',
-								removeTitle: 'Remove'
+								removeTitle: 'Remove',
 							}}
 							avatar={
 								<Avatar
@@ -70,7 +70,7 @@ const Example = createReactClass({
 							labels={{
 								label: 'Pill Label',
 								title: 'Full pill label verbiage mirrored here',
-								removeTitle: 'Remove'
+								removeTitle: 'Remove',
 							}}
 							hasError
 							icon={
@@ -90,10 +90,10 @@ const Example = createReactClass({
 							labels={{
 								label: 'Pill Label',
 								title: 'Full pill label verbiage mirrored here',
-								removeTitle: 'Remove'
+								removeTitle: 'Remove',
 							}}
 							assistiveText={{
-								remove: 'Press delete or backspace to remove'
+								remove: 'Press delete or backspace to remove',
 							}}
 							bare
 							variant="option"
@@ -105,7 +105,7 @@ const Example = createReactClass({
 				</div>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/pill/__tests__/pill.browser-test.jsx
+++ b/components/pill/__tests__/pill.browser-test.jsx
@@ -26,10 +26,10 @@ describe('SLDSPill', () => {
 					labels={{
 						label: LABEL,
 						title: LABEL_TITLE,
-						removeTitle: 'Remove'
+						removeTitle: 'Remove',
 					}}
 					assistiveText={{
-						remove: 'Remove assistive text'
+						remove: 'Remove assistive text',
 					}}
 					className="extra-class"
 					onClick={onClick}
@@ -108,7 +108,7 @@ describe('SLDSPill', () => {
 			mountComponent(
 				<SLDSPill
 					labels={{
-						label: LABEL
+						label: LABEL,
 					}}
 					href={HREF}
 				/>
@@ -130,7 +130,7 @@ describe('SLDSPill', () => {
 			mountComponent(
 				<SLDSPill
 					labels={{
-						label: LABEL
+						label: LABEL,
 					}}
 				/>
 			)
@@ -150,7 +150,7 @@ describe('SLDSPill', () => {
 			mountComponent(
 				<SLDSPill
 					labels={{
-						label: LABEL
+						label: LABEL,
 					}}
 					bare
 				/>
@@ -172,7 +172,7 @@ describe('SLDSPill', () => {
 			mountComponent(
 				<SLDSPill
 					labels={{
-						label: LABEL
+						label: LABEL,
 					}}
 					hasError
 				/>
@@ -193,7 +193,7 @@ describe('SLDSPill', () => {
 			mountComponent(
 				<SLDSPill
 					labels={{
-						label: LABEL
+						label: LABEL,
 					}}
 					onClick={onClick}
 					icon={<SLDSIcon title="Account" category="standard" name="account" />}
@@ -217,7 +217,7 @@ describe('SLDSPill', () => {
 			mountComponent(
 				<SLDSPill
 					labels={{
-						label: LABEL
+						label: LABEL,
 					}}
 					avatar={
 						<SLDSAvatar
@@ -251,7 +251,7 @@ describe('SLDSPill', () => {
 				<SLDSPill
 					labels={{
 						label: LABEL,
-						title: LABEL_TITLE
+						title: LABEL_TITLE,
 					}}
 					variant="option"
 					removeTitle="Remove"

--- a/components/pill/__tests__/pill.snapshot-test.jsx
+++ b/components/pill/__tests__/pill.snapshot-test.jsx
@@ -13,41 +13,41 @@ import AvatarListboxExample from '../__examples__/listbox-avatar';
 testDOMandHTML({
 	name: 'Linked, Unlinked, Truncated',
 	test,
-	Component: BaseExample
+	Component: BaseExample,
 });
 
 testDOMandHTML({
 	name: 'Icon, Avatar, Error',
 	test,
-	Component: IconExample
+	Component: IconExample,
 });
 
 testDOMandHTML({
 	name: 'Bare',
 	test,
-	Component: BarePillListboxExample
+	Component: BarePillListboxExample,
 });
 
 testDOMandHTML({
 	name: 'Pill Container',
 	test,
-	Component: ContainerExample
+	Component: ContainerExample,
 });
 
 testDOMandHTML({
 	name: 'Listbox Of Pill Options',
 	test,
-	Component: ListboxExample
+	Component: ListboxExample,
 });
 
 testDOMandHTML({
 	name: 'Listbox Of Pill Options With Icon',
 	test,
-	Component: IconListboxExample
+	Component: IconListboxExample,
 });
 
 testDOMandHTML({
 	name: 'Listbox Of Pill Options With Avatar',
 	test,
-	Component: AvatarListboxExample
+	Component: AvatarListboxExample,
 });

--- a/components/pill/index.jsx
+++ b/components/pill/index.jsx
@@ -24,7 +24,7 @@ const propTypes = {
 	 * _Tested with snapshot testing._
 	 */
 	assistiveText: shape({
-		remove: PropTypes.string
+		remove: PropTypes.string,
 	}),
 	/**
 	 * SLDSAvatar component to show on the left of the pill.
@@ -48,7 +48,7 @@ const propTypes = {
 	className: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * Applies the error style to the component.
@@ -77,7 +77,7 @@ const propTypes = {
 	labels: shape({
 		label: PropTypes.string,
 		title: PropTypes.string,
-		removeTitle: PropTypes.string
+		removeTitle: PropTypes.string,
 	}),
 	/**
 	 * `onBlur` callback executes when the component loses focus.
@@ -108,7 +108,7 @@ const propTypes = {
 	 * A variant of a pill
 	 * _Tested with Mocha framework._
 	 */
-	variant: PropTypes.oneOf(['link', 'option'])
+	variant: PropTypes.oneOf(['link', 'option']),
 };
 
 class Pill extends React.Component {
@@ -275,7 +275,7 @@ class Pill extends React.Component {
 					{
 						'slds-pill_link': this.props.variant === 'link',
 						'slds-has-error': this.props.hasError,
-						'slds-pill_bare': this.props.bare
+						'slds-pill_bare': this.props.bare,
 					},
 					this.props.className
 				)}
@@ -302,7 +302,7 @@ Pill.displayName = PILL;
 Pill.defaultProps = {
 	variant: 'link',
 	labels: {},
-	assistiveText: {}
+	assistiveText: {},
 };
 
 Pill.propTypes = propTypes;

--- a/components/popover/__docs__/site-stories.js
+++ b/components/popover/__docs__/site-stories.js
@@ -6,7 +6,7 @@
 const siteStories = [
 	require('raw-loader!@salesforce/design-system-react/components/popover/__examples__/header.jsx'),
 	require('raw-loader!@salesforce/design-system-react/components/popover/__examples__/alternative-header.jsx'),
-	require('raw-loader!@salesforce/design-system-react/components/popover/__examples__/controlled-with-footer.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/popover/__examples__/controlled-with-footer.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/popover/__docs__/storybook-stories.jsx
+++ b/components/popover/__docs__/storybook-stories.jsx
@@ -34,7 +34,7 @@ const getPopoverNubbins = (props) => {
 		'bottom',
 		'bottom left',
 		'bottom right',
-		'left'
+		'left',
 	];
 
 	align.forEach((value) => {
@@ -72,7 +72,7 @@ storiesOf(POPOVER, module)
 			style={{
 				margin: '300px auto',
 				textAlign: 'center',
-				width: '500px'
+				width: '500px',
 			}}
 		>
 			<IconSettings iconPath="/assets/icons">{getStory()}</IconSettings>
@@ -83,7 +83,7 @@ storiesOf(POPOVER, module)
 	.add('AlternativeHeader', () => <AlternativeHeader />)
 	.add('Alignment (Button)', () =>
 		getPopoverNubbins({
-			trigger: <Button label="Trigger Popover" tabIndex="0" />
+			trigger: <Button label="Trigger Popover" tabIndex="0" />,
 		})
 	)
 	.add('Alignment (ButtonIcon)', () =>
@@ -102,7 +102,7 @@ storiesOf(POPOVER, module)
 					iconVariant="border"
 					variant="icon"
 				/>
-			)
+			),
 		})
 	)
 	.add('Styling (dev-only)', () =>
@@ -115,6 +115,6 @@ storiesOf(POPOVER, module)
 			closeButtonAssistiveText: 'Shut it now!',
 			containerClassName: 'sample-container-classname',
 			containerStyle: { background: containerBackgroundColor },
-			style: { background: popoverBackgroundColor }
+			style: { background: popoverBackgroundColor },
 		})
 	);

--- a/components/popover/__examples__/alternative-header.jsx
+++ b/components/popover/__examples__/alternative-header.jsx
@@ -80,7 +80,7 @@ const Example = createReactClass({
 				</div>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/popover/__examples__/controlled-with-footer.jsx
+++ b/components/popover/__examples__/controlled-with-footer.jsx
@@ -11,7 +11,7 @@ const Example = createReactClass({
 
 	getInitialState () {
 		return {
-			isOpen: false
+			isOpen: false,
 		};
 	},
 
@@ -66,7 +66,7 @@ const Example = createReactClass({
 				</div>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/popover/__examples__/header.jsx
+++ b/components/popover/__examples__/header.jsx
@@ -20,7 +20,7 @@ const Example = createReactClass({
 				</div>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/popover/__tests__/popover.browser-test.jsx
+++ b/components/popover/__tests__/popover.browser-test.jsx
@@ -12,7 +12,7 @@ import { mount } from 'enzyme';
  */
 import {
 	createMountNode,
-	destroyMountNode
+	destroyMountNode,
 } from '../../../tests/enzyme-helpers';
 
 // Import your internal dependencies (for example):
@@ -28,14 +28,14 @@ chai.use(chaiEnzyme());
 const defaultProps = {
 	id: 'sample-popover',
 	body: <span id="sample-body">This is the body</span>,
-	heading: <span id="sample-heading">This is the heading</span>
+	heading: <span id="sample-heading">This is the heading</span>,
 };
 
 const defaultIds = {
 	trigger: defaultProps.id,
 	popover: `${defaultProps.id}-popover`,
 	body: `${defaultProps.id}-dialog-body`,
-	heading: `${defaultProps.id}-dialog-heading`
+	heading: `${defaultProps.id}-dialog-heading`,
 };
 
 /* A re-usable demo component fixture outside of `describe` sections
@@ -46,7 +46,7 @@ const defaultIds = {
 const DemoComponent = createReactClass({
 	displayName: 'PopoverDemoComponent',
 	propTypes: {
-		isOpen: PropTypes.bool
+		isOpen: PropTypes.bool,
 	},
 
 	getDefaultProps () {
@@ -70,7 +70,7 @@ const DemoComponent = createReactClass({
 				</div>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 /* All tests for component being tested should be wrapped in a root `describe`,
@@ -144,7 +144,7 @@ describe('SLDSPopover', function () {
 			containerClassName: 'sample-container-classname',
 			containerStyle: { background: containerBackgroundColor },
 			footer: <p id="footer">Footer</p>,
-			style: { background: popoverBackgroundColor }
+			style: { background: popoverBackgroundColor },
 		};
 
 		beforeEach(() => {
@@ -157,7 +157,7 @@ describe('SLDSPopover', function () {
 
 		it('has correct className, closeButtonAssistiveText, style, and footer', function () {
 			wrapper = mount(<DemoComponent {...optionalProps} isOpen />, {
-				attachTo: mountNode
+				attachTo: mountNode,
 			});
 
 			const popover = wrapper.find(`#${defaultIds.popover}`);
@@ -231,7 +231,7 @@ describe('SLDSPopover', function () {
 							popover.simulate('keyDown', {
 								key: 'Esc',
 								keyCode: 27,
-								which: 27
+								which: 27,
 							});
 						}}
 					/>,

--- a/components/popover/check-props.js
+++ b/components/popover/check-props.js
@@ -13,14 +13,14 @@ if (process.env.NODE_ENV !== 'production') {
 	checkProps = function (COMPONENT, props) {
 		oneOfRequiredProperty(COMPONENT, {
 			ariaLabelledby: props.ariaLabelledby,
-			heading: props.heading
+			heading: props.heading,
 		});
 
 		if (props.children !== undefined) {
 			oneOfComponent(COMPONENT, props, 'children', [
 				'SLDSButton',
 				'a',
-				'button'
+				'button',
 			]);
 		}
 

--- a/components/popover/popover.jsx
+++ b/components/popover/popover.jsx
@@ -70,7 +70,7 @@ const PopoverNubbinPositions = [
 	'top right',
 	'bottom left',
 	'bottom',
-	'bottom right'
+	'bottom right',
 ];
 
 /**
@@ -94,7 +94,7 @@ const Popover = createReactClass({
 			'bottom',
 			'bottom left',
 			'bottom right',
-			'left'
+			'left',
 		]),
 		/**
 		 * HTML `id` of heading for popover. Only use if your header is within your popover body.
@@ -114,7 +114,7 @@ const Popover = createReactClass({
 		className: PropTypes.oneOfType([
 			PropTypes.array,
 			PropTypes.object,
-			PropTypes.string
+			PropTypes.string,
 		]),
 		/*
 		 * All popovers require a close button.
@@ -180,7 +180,7 @@ const Popover = createReactClass({
 		position: PropTypes.oneOf([
 			'absolute',
 			'overflowBoundaryElement',
-			'relative'
+			'relative',
 		]),
 		/**
 		 * An object of CSS styles that are applied to the `slds-popover` DOM element.
@@ -196,8 +196,8 @@ const Popover = createReactClass({
 		triggerClassName: PropTypes.oneOfType([
 			PropTypes.array,
 			PropTypes.object,
-			PropTypes.string
-		])
+			PropTypes.string,
+		]),
 	},
 
 	getDefaultProps () {
@@ -206,13 +206,13 @@ const Popover = createReactClass({
 			closeButtonAssistiveText: 'Close dialog',
 			hoverCloseDelay: 300,
 			openOn: 'click',
-			position: 'absolute'
+			position: 'absolute',
 		};
 	},
 
 	getInitialState () {
 		return {
-			isOpen: false
+			isOpen: false,
 		};
 	},
 
@@ -273,7 +273,7 @@ const Popover = createReactClass({
 			this.props.onClose(event, {
 				// Breaking change: component object reference has been
 				// removed (`this`), due to endless loop creation.
-				componentWillUnmount
+				componentWillUnmount,
 			});
 		}
 	},
@@ -292,7 +292,7 @@ const Popover = createReactClass({
 			}
 
 			this.setState({
-				isOpen: false
+				isOpen: false,
 			});
 
 			this.isHover = false;
@@ -306,14 +306,14 @@ const Popover = createReactClass({
 			if (currentOpenPopover && isFunction(currentOpenPopover.handleClose)) {
 				currentOpenPopover.handleClose(undefined, {
 					trigger: 'newPopover',
-					id: currentOpenPopover.getId()
+					id: currentOpenPopover.getId(),
 				});
 			}
 
 			currentOpenPopover = this;
 
 			this.setState({
-				isOpen: true
+				isOpen: true,
 			});
 		}
 	},
@@ -396,7 +396,7 @@ const Popover = createReactClass({
 					keyCode: event.keyCode,
 					targetTarget: event.target,
 					toggleOpen: this.toggleOpenFromKeyboard,
-					trigger: this.trigger
+					trigger: this.trigger,
 				});
 			}
 			if (this.props.onKeyDown) {
@@ -450,7 +450,7 @@ const Popover = createReactClass({
 					marginBottom: getMargin.bottom(props.align),
 					marginLeft: getMargin.left(props.align),
 					marginRight: getMargin.right(props.align),
-					marginTop: getMargin.top(props.align)
+					marginTop: getMargin.top(props.align),
 				}}
 				variant="popover"
 			>
@@ -533,7 +533,7 @@ const Popover = createReactClass({
 						this.props.openOn === 'click' || this.props.openOn === 'hybrid'
 							? (event) => {
 								this.handleClick(event, {
-									triggerOnClickCallback: this.props.children.props.onClick
+									triggerOnClickCallback: this.props.children.props.onClick,
 								});
 							}
 							: this.children.props.onClick,
@@ -548,7 +548,7 @@ const Popover = createReactClass({
 							? this.handleMouseLeave
 							: null,
 				tabIndex: this.props.children.props.tabIndex || '0',
-				...this.props.children.props
+				...this.props.children.props,
 			})
 			: null;
 
@@ -565,11 +565,11 @@ const Popover = createReactClass({
 				{this.renderDialog(this.getIsOpen(), outsideClickIgnoreClass)}
 			</div>
 		);
-	}
+	},
 });
 
 Popover.contextTypes = {
-	iconPath: PropTypes.string
+	iconPath: PropTypes.string,
 };
 
 export default Popover;

--- a/components/progress-indicator/__docs__/site-stories.js
+++ b/components/progress-indicator/__docs__/site-stories.js
@@ -4,7 +4,7 @@
 /* eslint-disable global-require */
 
 const siteStories = [
-	require('raw-loader!@salesforce/design-system-react/components/progress-indicator/__examples__/default.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/progress-indicator/__examples__/default.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/progress-indicator/__docs__/storybook-stories.jsx
+++ b/components/progress-indicator/__docs__/storybook-stories.jsx
@@ -13,17 +13,17 @@ const steps = [
 	{
 		id: 0,
 		label: <i>tooltip label #1</i>,
-		assistiveText: 'This is custom text in the assistive text key'
+		assistiveText: 'This is custom text in the assistive text key',
 	},
 	{ id: 1, label: 'tooltip label #2' },
 	{ id: 2, label: <strong>tooltip label #3</strong> },
 	{ id: 3, label: 'tooltip label #4' },
-	{ id: 4, label: 'tooltip label #5' }
+	{ id: 4, label: 'tooltip label #5' },
 ];
 
 const stepsDisabled = [
 	{ id: 3, label: 'tooltip label #4' },
-	{ id: 4, label: 'tooltip label #5' }
+	{ id: 4, label: 'tooltip label #5' },
 ];
 
 const manySteps = [
@@ -35,7 +35,7 @@ const manySteps = [
 	{ id: 'f', label: 'tooltip label #6' },
 	{ id: 'g', label: 'tooltip label #7' },
 	{ id: 'h', label: 'tooltip label #8' },
-	{ id: 'i', label: 'tooltip label #9' }
+	{ id: 'i', label: 'tooltip label #9' },
 ];
 
 const ExampleProgressIndicator = createReactClass({
@@ -53,7 +53,7 @@ const ExampleProgressIndicator = createReactClass({
 				/>
 			</div>
 		);
-	}
+	},
 });
 
 storiesOf(PROGRESS_INDICATOR, module)

--- a/components/progress-indicator/__examples__/default.jsx
+++ b/components/progress-indicator/__examples__/default.jsx
@@ -7,12 +7,12 @@ const steps = [
 	{
 		id: 0,
 		label: <i>tooltip label #1</i>,
-		assistiveText: 'This is custom text in the assistive text key'
+		assistiveText: 'This is custom text in the assistive text key',
 	},
 	{ id: 1, label: 'tooltip label #2' },
 	{ id: 2, label: <strong>tooltip label #3</strong> },
 	{ id: 3, label: 'tooltip label #4' },
-	{ id: 4, label: 'tooltip label #5' }
+	{ id: 4, label: 'tooltip label #5' },
 ];
 
 const handleStepEvent = function (event, data) {
@@ -29,7 +29,7 @@ const Example = createReactClass({
 					style={{
 						padding: '2rem 1rem 0px',
 						background:
-							this.props.variant === 'modal' ? 'rgb(244, 246, 249)' : ''
+							this.props.variant === 'modal' ? 'rgb(244, 246, 249)' : '',
 					}}
 				>
 					<ProgressIndicator
@@ -41,7 +41,7 @@ const Example = createReactClass({
 				</div>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/progress-indicator/__examples__/modal.jsx
+++ b/components/progress-indicator/__examples__/modal.jsx
@@ -11,12 +11,12 @@ const steps = [
 	{
 		id: 0,
 		label: <i>tooltip label #1</i>,
-		assistiveText: 'This is custom text in the assistive text key'
+		assistiveText: 'This is custom text in the assistive text key',
 	},
 	{ id: 1, label: 'tooltip label #2' },
 	{ id: 2, label: <strong>tooltip label #3</strong> },
 	{ id: 3, label: 'tooltip label #4' },
-	{ id: 4, label: 'tooltip label #5' }
+	{ id: 4, label: 'tooltip label #5' },
 ];
 
 const handleStepEvent = function (event, data) {
@@ -36,7 +36,7 @@ const modalFooter = (props) => [
 		errorSteps={steps.slice(2, 3)}
 		onStepClick={handleStepEvent}
 	/>,
-	<Button key="modalBSave" label="Save" variant="brand" />
+	<Button key="modalBSave" label="Save" variant="brand" />,
 ];
 const modalContent = (
 	<div
@@ -59,11 +59,11 @@ const Example = createReactClass({
 					onRequestClose: action('modal closed'),
 					footer: modalFooter(this.props),
 					size: 'large',
-					footerClassNames: 'slds-grid slds-grid_align-spread'
+					footerClassNames: 'slds-grid slds-grid_align-spread',
 				})}
 			</div>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/progress-indicator/__examples__/step-error.jsx
+++ b/components/progress-indicator/__examples__/step-error.jsx
@@ -11,7 +11,7 @@ const Example = createReactClass({
 				<ProgressIndicator {...this.props} />
 			</div>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/progress-indicator/__tests__/progress-indicator.browser-test.jsx
+++ b/components/progress-indicator/__tests__/progress-indicator.browser-test.jsx
@@ -27,20 +27,20 @@ import assign from 'lodash.assign';
  */
 import {
 	mountComponent,
-	unmountComponent
+	unmountComponent,
 } from '../../../tests/enzyme-helpers';
 
 const {
 	Simulate,
 	findRenderedDOMComponentWithTag,
-	findRenderedDOMComponentWithClass
+	findRenderedDOMComponentWithClass,
 } = TestUtils;
 
 import SLDSProgressIndicator from '../../progress-indicator';
 import IconSettings from '../../icon-settings';
 
 const defaultProps = {
-	id: 'sample-progress-indicator'
+	id: 'sample-progress-indicator',
 };
 
 const mockCallback = sinon.spy();
@@ -49,7 +49,7 @@ const DemoComponent = createReactClass({
 	displayName: 'ProgressIndicatorDemoComponent',
 	propTypes: {
 		onStepClick: mockCallback,
-		onStepFocus: mockCallback
+		onStepFocus: mockCallback,
 	},
 
 	getDefaultProps () {
@@ -62,7 +62,7 @@ const DemoComponent = createReactClass({
 				<SLDSProgressIndicator {...this.props} />
 			</IconSettings>
 		);
-	}
+	},
 });
 
 const steps = [
@@ -70,7 +70,7 @@ const steps = [
 	{ id: 1, label: 'tooltip label #2' },
 	{ id: 2, label: 'tooltip label #3' },
 	{ id: 3, label: 'tooltip label #4' },
-	{ id: 4, label: 'tooltip label #5' }
+	{ id: 4, label: 'tooltip label #5' },
 ];
 
 const sixSteps = [
@@ -79,7 +79,7 @@ const sixSteps = [
 	{ id: 2, label: 'tooltip label #3' },
 	{ id: 3, label: 'tooltip label #4' },
 	{ id: 4, label: 'tooltip label #5' },
-	{ id: 5, label: 'tooltip label #6' }
+	{ id: 5, label: 'tooltip label #6' },
 ];
 
 describe('SLDSProgressIndicator: ', () => {

--- a/components/progress-indicator/index.jsx
+++ b/components/progress-indicator/index.jsx
@@ -31,7 +31,7 @@ const propTypes = {
 	 * * `percentage`: Label for Progress Bar. The default is `Progress: [this.props.value]%`
 	 */
 	assistiveText: shape({
-		percentage: PropTypes.string
+		percentage: PropTypes.string,
 	}),
 	/**
 	 * CSS class names to be added to the container element. `array`, `object`, or `string` are accepted.
@@ -39,7 +39,7 @@ const propTypes = {
 	className: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * Stores all completed steps. It is an array of step objects.
@@ -96,7 +96,7 @@ const propTypes = {
 	/**
 	 * Determines component style.
 	 */
-	variant: PropTypes.oneOf(['base', 'modal'])
+	variant: PropTypes.oneOf(['base', 'modal']),
 };
 
 const defaultSteps = [
@@ -104,7 +104,7 @@ const defaultSteps = [
 	{ id: 1, label: 'tooltip label #2' },
 	{ id: 2, label: 'tooltip label #3' },
 	{ id: 3, label: 'tooltip label #4' },
-	{ id: 4, label: 'tooltip label #5' }
+	{ id: 4, label: 'tooltip label #5' },
 ];
 
 const defaultProps = {
@@ -116,7 +116,7 @@ const defaultProps = {
 	variant: 'base',
 	// click/focus callbacks by default do nothing
 	onStepClick: () => {},
-	onStepFocus: () => {}
+	onStepFocus: () => {},
 };
 
 /**

--- a/components/progress-indicator/private/progress-bar.jsx
+++ b/components/progress-indicator/private/progress-bar.jsx
@@ -10,12 +10,12 @@ const propTypes = {
 	 * Assistive text for percentage
 	 */
 	assistiveText: shape({
-		percentage: PropTypes.string
+		percentage: PropTypes.string,
 	}),
 	/**
 	 * Percentage of progress completion, with range of [0, 100]
 	 */
-	value: PropTypes.string.isRequired
+	value: PropTypes.string.isRequired,
 };
 /**
  * ProgressBar renders the blue/gray progress bar and dynamically updates its completion percentage

--- a/components/progress-indicator/private/progress.jsx
+++ b/components/progress-indicator/private/progress.jsx
@@ -21,7 +21,7 @@ const propTypes = {
 	 * Assistive text for percentage
 	 */
 	assistiveText: shape({
-		percentage: PropTypes.string
+		percentage: PropTypes.string,
 	}),
 	/**
 	 * Steps in the component
@@ -33,7 +33,7 @@ const propTypes = {
 	className: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * HTML id for component.
@@ -46,7 +46,7 @@ const propTypes = {
 	/**
 	 * Determines component style
 	 */
-	variant: PropTypes.oneOf(['base', 'modal'])
+	variant: PropTypes.oneOf(['base', 'modal']),
 };
 
 /**

--- a/components/progress-indicator/private/step.jsx
+++ b/components/progress-indicator/private/step.jsx
@@ -66,7 +66,7 @@ const propTypes = {
 	 * This is mainly for dev test purpose.
 	 * Usually the tooltip should only show when hover.
 	 */
-	tooltipIsOpen: PropTypes.bool
+	tooltipIsOpen: PropTypes.bool,
 };
 
 /**
@@ -85,7 +85,7 @@ class Step extends React.Component {
 			isError: props.isError,
 			isCompleted: props.isCompleted,
 			isDisabled: props.isDisabled,
-			step: props.step
+			step: props.step,
 		};
 
 		const icon = renderIcon ? (
@@ -157,7 +157,7 @@ class Step extends React.Component {
 				this.props.index}`,
 			content: this.props.step.label,
 			variant: this.props.isError ? 'error' : 'info',
-			triggerStyle: { display: !renderIcon ? 'flex' : '' }
+			triggerStyle: { display: !renderIcon ? 'flex' : '' },
 		};
 
 		// This is mainly for dev test purpose.
@@ -173,7 +173,7 @@ class Step extends React.Component {
 				className={classNames('slds-progress__item', {
 					'slds-is-completed': this.props.isCompleted,
 					'slds-is-active': this.props.isSelected && !this.props.isError,
-					'slds-has-error': this.props.isError
+					'slds-has-error': this.props.isError,
 				})}
 			>
 				<PopoverTooltip {...tooltipProps}>

--- a/components/progress-ring/__docs__/site-stories.js
+++ b/components/progress-ring/__docs__/site-stories.js
@@ -8,7 +8,7 @@ const siteStories = [
 	require('raw-loader!@salesforce/design-system-react/components/progress-ring/__examples__/complete.jsx'),
 	require('raw-loader!@salesforce/design-system-react/components/progress-ring/__examples__/warning.jsx'),
 	require('raw-loader!@salesforce/design-system-react/components/progress-ring/__examples__/expired.jsx'),
-	require('raw-loader!@salesforce/design-system-react/components/progress-ring/__examples__/customIcon.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/progress-ring/__examples__/customIcon.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/progress-ring/__examples__/examples.jsx
+++ b/components/progress-ring/__examples__/examples.jsx
@@ -31,7 +31,7 @@ export const EXPIRED_WITH_CUSTOM_ICON = () => (
 		value={20}
 		theme={THEME_OPTIONS.EXPIRED}
 		hasIcon
-		icon={<Icon category={'utility'} name={'lock'} />}
+		icon={<Icon category="utility" name="lock" />}
 	/>
 );
 export const EXPIRED_100 = () => (

--- a/components/progress-ring/index.jsx
+++ b/components/progress-ring/index.jsx
@@ -77,11 +77,11 @@ class ProgressRing extends React.Component {
 			if (this.props.icon) {
 				icon = this.props.icon;
 			} else if (this.props.theme === THEME_OPTIONS.WARNING) {
-				icon = <Icon category={'utility'} name={'warning'} title={'Warning'} />;
+				icon = <Icon category="utility" name="warning" title="Warning" />;
 			} else if (this.props.theme === THEME_OPTIONS.EXPIRED) {
-				icon = <Icon category={'utility'} name={'error'} title={'Expired'} />;
+				icon = <Icon category="utility" name="error" title="Expired" />;
 			} else if (this.props.theme === THEME_OPTIONS.COMPLETE) {
-				icon = <Icon category={'utility'} name={'check'} title={'complete'} />;
+				icon = <Icon category="utility" name="check" title="complete" />;
 			}
 		}
 

--- a/components/progress-ring/index.jsx
+++ b/components/progress-ring/index.jsx
@@ -17,7 +17,7 @@ import ProgressRingShape from './private/ring-shape';
 export const THEME_OPTIONS = Object.freeze({
 	WARNING: 'warning',
 	EXPIRED: 'expired',
-	COMPLETE: 'complete'
+	COMPLETE: 'complete',
 });
 
 /**
@@ -26,7 +26,7 @@ export const THEME_OPTIONS = Object.freeze({
 const THEME_CLASSES = {
 	[THEME_OPTIONS.COMPLETE]: 'slds-progress-ring_complete',
 	[THEME_OPTIONS.WARNING]: 'slds-progress-ring_warning',
-	[THEME_OPTIONS.EXPIRED]: 'slds-progress-ring_expired'
+	[THEME_OPTIONS.EXPIRED]: 'slds-progress-ring_expired',
 };
 
 const propTypes = {
@@ -40,7 +40,7 @@ const propTypes = {
 	className: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * The theme applied to the ring.
@@ -57,7 +57,7 @@ const propTypes = {
 	/**
 	 * Percentage of progress completion, ranging [0, 100].
 	 */
-	value: PropTypes.number.isRequired
+	value: PropTypes.number.isRequired,
 };
 
 const defaultProps = {};

--- a/components/progress-ring/private/ring-shape.jsx
+++ b/components/progress-ring/private/ring-shape.jsx
@@ -20,16 +20,16 @@ const propTypes = {
 	className: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * Decimal percentage drain of the ring [0.0 - 1.0]
 	 */
-	fillPercentDecimal: PropTypes.number
+	fillPercentDecimal: PropTypes.number,
 };
 
 const defaultProps = {
-	fillPercentDecimal: 0
+	fillPercentDecimal: 0,
 };
 
 /**

--- a/components/radio-button-group/__docs__/site-stories.js
+++ b/components/radio-button-group/__docs__/site-stories.js
@@ -4,7 +4,7 @@
 /* eslint-disable global-require */
 
 const siteStories = [
-	require('raw-loader!@salesforce/design-system-react/components/radio-button-group/__examples__/base.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/radio-button-group/__examples__/base.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/radio-button-group/__docs__/storybook-stories.jsx
+++ b/components/radio-button-group/__docs__/storybook-stories.jsx
@@ -53,15 +53,15 @@ class RadioButtonGroupExample extends React.Component {
 RadioButtonGroupExample.propTypes = {
 	labels: shape({
 		error: PropTypes.string,
-		label: PropTypes.string
+		label: PropTypes.string,
 	}),
 	disabled: PropTypes.bool,
 	required: PropTypes.bool,
-	heading: PropTypes.string
+	heading: PropTypes.string,
 };
 
 RadioButtonGroupExample.defaultProps = {
-	labels: { label: 'Day of week' }
+	labels: { label: 'Day of week' },
 };
 
 storiesOf(RADIO_BUTTON_GROUP, module)

--- a/components/radio-button-group/__examples__/base.jsx
+++ b/components/radio-button-group/__examples__/base.jsx
@@ -49,7 +49,7 @@ Example.propTypes = {
 	required: PropTypes.bool,
 	name: PropTypes.string,
 	errorId: PropTypes.string,
-	errorLabel: PropTypes.string
+	errorLabel: PropTypes.string,
 };
 
 Example.displayName = 'RadioButtonGroupExample';

--- a/components/radio-button-group/__tests__/radio-button-group.browser-test.jsx
+++ b/components/radio-button-group/__tests__/radio-button-group.browser-test.jsx
@@ -12,7 +12,7 @@ import { shape } from 'airbnb-prop-types';
  */
 import {
 	createMountNode,
-	destroyMountNode
+	destroyMountNode,
 } from '../../../tests/enzyme-helpers';
 
 import RadioButtonGroup from '../../radio-button-group';
@@ -54,14 +54,14 @@ class RadioButtonGroupExample extends React.Component {
 RadioButtonGroupExample.propTypes = {
 	labels: shape({
 		error: PropTypes.string,
-		label: PropTypes.string
+		label: PropTypes.string,
 	}),
 	disabled: PropTypes.bool,
-	required: PropTypes.bool
+	required: PropTypes.bool,
 };
 
 RadioButtonGroupExample.defaultProps = {
-	labels: { label: 'Day of week' }
+	labels: { label: 'Day of week' },
 };
 
 /* RadioButtonGroup rendering tests
@@ -95,7 +95,7 @@ describe('RadioButtonGroup', function () {
 
 	it('renders a disabled state', () => {
 		wrapper = mount(<RadioButtonGroupExample disabled />, {
-			attachTo: mountNode
+			attachTo: mountNode,
 		});
 		const radios = wrapper.find(Radio);
 		for (let index = 0; index < radios.length; index++) {
@@ -106,7 +106,7 @@ describe('RadioButtonGroup', function () {
 
 	it('renders a required indicator', () => {
 		wrapper = mount(<RadioButtonGroupExample required />, {
-			attachTo: mountNode
+			attachTo: mountNode,
 		});
 		const abbr = wrapper.find('abbr');
 		expect(abbr.text()).to.equal('*', 'there is a required indicator');

--- a/components/radio-button-group/index.jsx
+++ b/components/radio-button-group/index.jsx
@@ -25,7 +25,7 @@ const propTypes = {
 	className: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * **Text labels for internationalization**
@@ -35,7 +35,7 @@ const propTypes = {
 	 */
 	labels: shape({
 		error: PropTypes.string,
-		label: PropTypes.string
+		label: PropTypes.string,
 	}),
 	/**
 	 * This event fires when the radio selection changes.
@@ -56,7 +56,7 @@ const propTypes = {
 	/**
 	 * The ID of the error message, for linking to radio inputs with aria-describedby.
 	 */
-	errorId: PropTypes.string
+	errorId: PropTypes.string,
 };
 
 const defaultProps = { labels: {} };
@@ -99,14 +99,14 @@ class RadioButtonGroup extends React.Component {
 				name: this.getName(),
 				onChange: this.props.onChange,
 				'aria-describedby': this.getErrorId(),
-				disabled: this.props.disabled
+				disabled: this.props.disabled,
 			})
 		);
 
 		return (
 			<fieldset
 				className={classNames('slds-form-element', {
-					'slds-has-error': this.labels.error
+					'slds-has-error': this.labels.error,
 				})}
 			>
 				<legend className="slds-form-element__legend slds-form-element__label">

--- a/components/radio-group/__docs__/site-stories.js
+++ b/components/radio-group/__docs__/site-stories.js
@@ -4,7 +4,7 @@
 /* eslint-disable global-require */
 
 const siteStories = [
-	require('raw-loader!@salesforce/design-system-react/components/radio-group/__examples__/base.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/radio-group/__examples__/base.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/radio-group/__docs__/storybook-stories.jsx
+++ b/components/radio-group/__docs__/storybook-stories.jsx
@@ -54,15 +54,15 @@ class RadioGroupExample extends React.Component {
 RadioGroupExample.propTypes = {
 	labels: shape({
 		error: PropTypes.string,
-		label: PropTypes.string
+		label: PropTypes.string,
 	}),
 	disabled: PropTypes.bool,
 	required: PropTypes.bool,
-	heading: PropTypes.string
+	heading: PropTypes.string,
 };
 
 RadioGroupExample.defaultProps = {
-	labels: { label: 'Radio Group Label' }
+	labels: { label: 'Radio Group Label' },
 };
 
 storiesOf(RADIO_GROUP, module)

--- a/components/radio-group/__examples__/base.jsx
+++ b/components/radio-group/__examples__/base.jsx
@@ -46,7 +46,7 @@ Example.propTypes = {
 	required: PropTypes.bool,
 	name: PropTypes.string,
 	errorId: PropTypes.string,
-	errorLabel: PropTypes.string
+	errorLabel: PropTypes.string,
 };
 
 Example.displayName = 'RadioGroupExample';

--- a/components/radio-group/__tests__/radio-group.browser-test.jsx
+++ b/components/radio-group/__tests__/radio-group.browser-test.jsx
@@ -12,7 +12,7 @@ import { shape } from 'airbnb-prop-types';
  */
 import {
 	createMountNode,
-	destroyMountNode
+	destroyMountNode,
 } from '../../../tests/enzyme-helpers';
 
 import RadioGroup from '../../radio-group';
@@ -54,14 +54,14 @@ class RadioGroupExample extends React.Component {
 RadioGroupExample.propTypes = {
 	labels: shape({
 		error: PropTypes.string,
-		label: PropTypes.string
+		label: PropTypes.string,
 	}),
 	disabled: PropTypes.bool,
-	required: PropTypes.bool
+	required: PropTypes.bool,
 };
 
 RadioGroupExample.defaultProps = {
-	labels: { label: 'Radio Group Label' }
+	labels: { label: 'Radio Group Label' },
 };
 
 /* RadioGroup rendering tests

--- a/components/radio-group/index.jsx
+++ b/components/radio-group/index.jsx
@@ -25,7 +25,7 @@ const propTypes = {
 	className: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * **Text labels for internationalization**
@@ -35,7 +35,7 @@ const propTypes = {
 	 */
 	labels: shape({
 		error: PropTypes.string,
-		label: PropTypes.string
+		label: PropTypes.string,
 	}),
 	/**
 	 * This event fires when the radio selection changes.
@@ -56,7 +56,7 @@ const propTypes = {
 	/**
 	 * The ID of the error message, for linking to radio inputs with aria-describedby.
 	 */
-	errorId: PropTypes.string
+	errorId: PropTypes.string,
 };
 
 const defaultProps = { labels: {} };
@@ -99,14 +99,14 @@ class RadioGroup extends React.Component {
 				name: this.getName(),
 				onChange: this.props.onChange,
 				'aria-describedby': this.getErrorId(),
-				disabled: this.props.disabled
+				disabled: this.props.disabled,
 			})
 		);
 
 		return (
 			<fieldset
 				className={classNames('slds-form-element', {
-					'slds-has-error': this.labels.error
+					'slds-has-error': this.labels.error,
 				})}
 			>
 				<legend className="slds-form-element__legend slds-form-element__label">

--- a/components/settings.js
+++ b/components/settings.js
@@ -35,7 +35,7 @@ const settings = {
 		}
 	},
 
-	getAppElement: () => appRoot
+	getAppElement: () => appRoot,
 };
 
 export default settings;

--- a/components/site-stories.js
+++ b/components/site-stories.js
@@ -48,7 +48,7 @@ const documentationSiteLiveExamples = {
 	'time-picker': require('@salesforce/design-system-react/components/time-picker/__docs__/site-stories.js'),
 	toast: require('@salesforce/design-system-react/components/toast/__docs__/site-stories.js'),
 	tooltip: require('@salesforce/design-system-react/components/tooltip/__docs__/site-stories.js'),
-	tree: require('@salesforce/design-system-react/components/tree/__docs__/site-stories.js')
+	tree: require('@salesforce/design-system-react/components/tree/__docs__/site-stories.js'),
 };
 
 module.exports = documentationSiteLiveExamples;

--- a/components/spinner/__docs__/site-stories.js
+++ b/components/spinner/__docs__/site-stories.js
@@ -5,7 +5,7 @@
 
 const siteStories = [
 	require('raw-loader!@salesforce/design-system-react/components/forms/radio/__examples__/default.jsx'),
-	require('raw-loader!@salesforce/design-system-react/components/forms/radio/__examples__/disabled.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/forms/radio/__examples__/disabled.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/spinner/__docs__/storybook-stories.jsx
+++ b/components/spinner/__docs__/storybook-stories.jsx
@@ -13,7 +13,7 @@ const inverseContainer = {
 	backgroundColor: '#4bca81',
 	position: 'absolute',
 	width: '100%',
-	height: '100%'
+	height: '100%',
 };
 
 storiesOf(SPINNER, module)
@@ -31,7 +31,7 @@ storiesOf(SPINNER, module)
 		getSpinner({
 			size: 'large',
 			variant: 'brand',
-			containerClassName: 'my-custom-classname'
+			containerClassName: 'my-custom-classname',
 		})
 	)
 

--- a/components/spinner/index.jsx
+++ b/components/spinner/index.jsx
@@ -39,13 +39,13 @@ const PROP_TYPES = {
 	/**
 	 * Determines the color of the spinner: `base` is gray, `brand` is blue, and `inverse` is white.
 	 */
-	variant: PropTypes.oneOf(['base', 'brand', 'inverse'])
+	variant: PropTypes.oneOf(['base', 'brand', 'inverse']),
 };
 
 const DEFAULT_PROPS = {
 	assistiveText: 'Loading...',
 	size: 'medium',
-	variant: 'base'
+	variant: 'base',
 };
 
 // ## Spinner
@@ -56,14 +56,14 @@ const Spinner = (props) => {
 		id,
 		isInput,
 		size,
-		variant
+		variant,
 	} = props;
 
 	const spinnerClassName = classNames('slds-spinner', {
 		'slds-input__spinner': isInput,
 		'slds-spinner_brand': variant === 'brand',
 		'slds-spinner_inverse': variant === 'inverse',
-		[`slds-spinner_${size}`]: size
+		[`slds-spinner_${size}`]: size,
 	});
 
 	return (

--- a/components/split-view/__docs__/site-stories.js
+++ b/components/split-view/__docs__/site-stories.js
@@ -7,7 +7,7 @@ const siteStories = [
 	require('raw-loader!@salesforce/design-system-react/components/split-view/__examples__/base.jsx'),
 	require('raw-loader!@salesforce/design-system-react/components/split-view/__examples__/base-multiple.jsx'),
 	require('raw-loader!@salesforce/design-system-react/components/split-view/__examples__/external-state.jsx'),
-	require('raw-loader!@salesforce/design-system-react/components/split-view/__examples__/custom-item-list.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/split-view/__examples__/custom-item-list.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/split-view/__examples__/base-multiple.jsx
+++ b/components/split-view/__examples__/base-multiple.jsx
@@ -9,7 +9,7 @@ import DropdownTrigger from '~/components/menu-dropdown/button-trigger';
 
 const SORT_OPTIONS = {
 	UP: 'up',
-	DOWN: 'down'
+	DOWN: 'down',
 };
 
 const listOptions = [
@@ -18,64 +18,64 @@ const listOptions = [
 		label: 'Riley Shultz',
 		topRightText: '99',
 		bottomLeftText: 'Biotech, Inc.',
-		bottomRightText: 'Nurturing'
+		bottomRightText: 'Nurturing',
 	},
 	{
 		id: '002',
 		label: 'Jason A. - VP of Sales',
 		topRightText: '92',
 		bottomLeftText: 'Case Management Solutions',
-		bottomRightText: 'Contacted'
+		bottomRightText: 'Contacted',
 	},
 	{
 		id: '003',
 		label: 'Josh Smith',
 		topRightText: '90',
 		bottomLeftText: 'Acme, Inc.',
-		bottomRightText: 'Contacted'
+		bottomRightText: 'Contacted',
 	},
 	{
 		id: '004',
 		label: 'Bobby Tree',
 		topRightText: '89',
 		bottomLeftText: 'Salesforce, Inc.',
-		bottomRightText: 'Closing'
+		bottomRightText: 'Closing',
 	},
 	{
 		id: '005',
 		label: 'Riley Shultz',
 		topRightText: '74',
 		bottomLeftText: 'Tesla',
-		bottomRightText: 'Contacted'
+		bottomRightText: 'Contacted',
 	},
 	{
 		id: '006',
 		label: 'Andy Smith',
 		topRightText: '72',
 		bottomLeftText: 'Universal Technologies',
-		bottomRightText: 'New'
+		bottomRightText: 'New',
 	},
 	{
 		id: '007',
 		label: 'Jim Steele',
 		topRightText: '71',
 		bottomLeftText: 'BigList, Inc.',
-		bottomRightText: 'New'
+		bottomRightText: 'New',
 	},
 	{
 		id: '008',
 		label: 'John Gardner',
 		topRightText: '70',
 		bottomLeftText: '3C Systems',
-		bottomRightText: 'Contacted'
+		bottomRightText: 'Contacted',
 	},
 	{
 		id: '009',
 		label: 'Sarah Loehr',
 		topRightText: '68',
 		bottomLeftText: 'MedLife, Inc.',
-		bottomRightText: 'New'
-	}
+		bottomRightText: 'New',
+	},
 ];
 
 const headerNavRight = (
@@ -88,7 +88,7 @@ const headerNavRight = (
 			iconVariant="border-filled"
 			options={[
 				{ label: 'Menu Item One', value: 'A0' },
-				{ label: 'Menu Item Two', value: 'B0' }
+				{ label: 'Menu Item Two', value: 'B0' },
 			]}
 		/>
 	</div>
@@ -116,17 +116,17 @@ const headerContentRight = (
 					value: 'A0',
 					rightIcon: {
 						category: 'utility',
-						name: 'table'
-					}
+						name: 'table',
+					},
 				},
 				{
 					label: 'List View',
 					value: 'B0',
 					rightIcon: {
 						category: 'utility',
-						name: 'side_list'
-					}
-				}
+						name: 'side_list',
+					},
+				},
 			]}
 			value="B0"
 		/>
@@ -150,7 +150,7 @@ const headerTitle = (
 					{ label: 'Menu Item Two', value: 'B0' },
 					{ label: 'Menu Item Three', value: 'C0' },
 					{ type: 'divider' },
-					{ label: 'Menu Item Four', value: 'D0' }
+					{ label: 'Menu Item Four', value: 'D0' },
 				]}
 			>
 				<DropdownTrigger>
@@ -176,7 +176,7 @@ class Example extends React.Component {
 			options: listOptions,
 			selected: [listOptions[listOptions.length - 2]],
 			unread: [listOptions[0], listOptions[2]],
-			sortDirection: SORT_OPTIONS.DOWN
+			sortDirection: SORT_OPTIONS.DOWN,
 		};
 
 		this.sortList = this.sortList.bind(this);
@@ -195,7 +195,7 @@ class Example extends React.Component {
 						? a.label > b.label
 						: b.label > a.label)
 			),
-			sortDirection
+			sortDirection,
 		});
 	}
 
@@ -218,7 +218,7 @@ class Example extends React.Component {
 			<SplitViewListbox
 				key="2"
 				labels={{
-					header: 'Lead Score'
+					header: 'Lead Score',
 				}}
 				multiple
 				sortDirection={this.state.sortDirection}
@@ -228,13 +228,13 @@ class Example extends React.Component {
 					onSelect: (event, { selectedItems, item }) => {
 						this.setState({
 							unread: this.state.unread.filter((i) => i !== item),
-							selected: selectedItems
+							selected: selectedItems,
 						});
-					}
+					},
 				}}
 				selection={this.state.selected}
 				unread={this.state.unread}
-			/>
+			/>,
 		];
 	}
 

--- a/components/split-view/__examples__/base-multiple.jsx
+++ b/components/split-view/__examples__/base-multiple.jsx
@@ -81,7 +81,7 @@ const listOptions = [
 const headerNavRight = (
 	<div>
 		<Dropdown
-			id={'header-nav-right-more'}
+			id="header-nav-right-more"
 			align="right"
 			assistiveText="More Options"
 			iconName="down"
@@ -97,8 +97,8 @@ const headerNavRight = (
 const headerContentRight = (
 	<div>
 		<Dropdown
-			id={'header-right-refresh'}
-			buttonClassName={'slds-m-right_xx-small'}
+			id="header-right-refresh"
+			buttonClassName="slds-m-right_xx-small"
 			assistiveText="Checkmark with right icon"
 			buttonVariant="icon"
 			checkmark
@@ -141,10 +141,10 @@ const headerContentRight = (
 );
 
 const headerTitle = (
-	<div className={'slds-media__body'}>
+	<div className="slds-media__body">
 		<h1 className="slds-text-heading_small slds-text-color_default slds-p-right_x-small">
 			<Dropdown
-				id={'header-title-leads'}
+				id="header-title-leads"
 				options={[
 					{ label: 'Menu Item One', value: 'A0' },
 					{ label: 'Menu Item Two', value: 'B0' },
@@ -204,7 +204,7 @@ class Example extends React.Component {
 	masterView () {
 		return [
 			<SplitViewHeader
-				key={'1'}
+				key="1"
 				contentRight={headerContentRight}
 				navRight={headerNavRight}
 				iconAssistiveText="User"
@@ -216,7 +216,7 @@ class Example extends React.Component {
 				variant="objectHome"
 			/>,
 			<SplitViewListbox
-				key={'2'}
+				key="2"
 				labels={{
 					header: 'Lead Score'
 				}}
@@ -302,7 +302,7 @@ class Example extends React.Component {
 			<IconSettings iconPath="/assets/icons">
 				<div style={{ height: '90vh' }}>
 					<SplitView
-						id={'base-multiple-example'}
+						id="base-multiple-example"
 						master={this.masterView()}
 						detail={this.detailView()}
 					/>

--- a/components/split-view/__examples__/base.jsx
+++ b/components/split-view/__examples__/base.jsx
@@ -9,7 +9,7 @@ import DropdownTrigger from '~/components/menu-dropdown/button-trigger';
 
 const SORT_OPTIONS = {
 	UP: 'up',
-	DOWN: 'down'
+	DOWN: 'down',
 };
 
 const listOptions = [
@@ -18,64 +18,64 @@ const listOptions = [
 		label: 'Riley Shultz',
 		topRightText: '99',
 		bottomLeftText: 'Biotech, Inc.',
-		bottomRightText: 'Nurturing'
+		bottomRightText: 'Nurturing',
 	},
 	{
 		id: '002',
 		label: 'Jason A. - VP of Sales',
 		topRightText: '92',
 		bottomLeftText: 'Case Management Solutions',
-		bottomRightText: 'Contacted'
+		bottomRightText: 'Contacted',
 	},
 	{
 		id: '003',
 		label: 'Josh Smith',
 		topRightText: '90',
 		bottomLeftText: 'Acme, Inc.',
-		bottomRightText: 'Contacted'
+		bottomRightText: 'Contacted',
 	},
 	{
 		id: '004',
 		label: 'Bobby Tree',
 		topRightText: '89',
 		bottomLeftText: 'Salesforce, Inc.',
-		bottomRightText: 'Closing'
+		bottomRightText: 'Closing',
 	},
 	{
 		id: '005',
 		label: 'Riley Shultz',
 		topRightText: '74',
 		bottomLeftText: 'Tesla',
-		bottomRightText: 'Contacted'
+		bottomRightText: 'Contacted',
 	},
 	{
 		id: '006',
 		label: 'Andy Smith',
 		topRightText: '72',
 		bottomLeftText: 'Universal Technologies',
-		bottomRightText: 'New'
+		bottomRightText: 'New',
 	},
 	{
 		id: '007',
 		label: 'Jim Steele',
 		topRightText: '71',
 		bottomLeftText: 'BigList, Inc.',
-		bottomRightText: 'New'
+		bottomRightText: 'New',
 	},
 	{
 		id: '008',
 		label: 'John Gardner',
 		topRightText: '70',
 		bottomLeftText: '3C Systems',
-		bottomRightText: 'Contacted'
+		bottomRightText: 'Contacted',
 	},
 	{
 		id: '009',
 		label: 'Sarah Loehr',
 		topRightText: '68',
 		bottomLeftText: 'MedLife, Inc.',
-		bottomRightText: 'New'
-	}
+		bottomRightText: 'New',
+	},
 ];
 
 const headerNavRight = (
@@ -88,7 +88,7 @@ const headerNavRight = (
 			iconVariant="border-filled"
 			options={[
 				{ label: 'Menu Item One', value: 'A0' },
-				{ label: 'Menu Item Two', value: 'B0' }
+				{ label: 'Menu Item Two', value: 'B0' },
 			]}
 		/>
 	</div>
@@ -116,17 +116,17 @@ const headerContentRight = (
 					value: 'A0',
 					rightIcon: {
 						category: 'utility',
-						name: 'table'
-					}
+						name: 'table',
+					},
 				},
 				{
 					label: 'List View',
 					value: 'B0',
 					rightIcon: {
 						category: 'utility',
-						name: 'side_list'
-					}
-				}
+						name: 'side_list',
+					},
+				},
 			]}
 			value="B0"
 		/>
@@ -150,7 +150,7 @@ const headerTitle = (
 					{ label: 'Menu Item Two', value: 'B0' },
 					{ label: 'Menu Item Three', value: 'C0' },
 					{ type: 'divider' },
-					{ label: 'Menu Item Four', value: 'D0' }
+					{ label: 'Menu Item Four', value: 'D0' },
 				]}
 			>
 				<DropdownTrigger>
@@ -176,7 +176,7 @@ class Example extends React.Component {
 			options: listOptions,
 			selected: [listOptions[listOptions.length - 2]],
 			unread: [listOptions[0], listOptions[2]],
-			sortDirection: SORT_OPTIONS.DOWN
+			sortDirection: SORT_OPTIONS.DOWN,
 		};
 
 		this.sortList = this.sortList.bind(this);
@@ -195,7 +195,7 @@ class Example extends React.Component {
 						? a.label > b.label
 						: b.label > a.label)
 			),
-			sortDirection
+			sortDirection,
 		});
 	}
 
@@ -218,7 +218,7 @@ class Example extends React.Component {
 			<SplitViewListbox
 				key="2"
 				labels={{
-					header: 'Lead Score'
+					header: 'Lead Score',
 				}}
 				sortDirection={this.state.sortDirection}
 				options={this.state.options}
@@ -227,13 +227,13 @@ class Example extends React.Component {
 					onSelect: (event, { selectedItems, item }) => {
 						this.setState({
 							unread: this.state.unread.filter((i) => i !== item),
-							selected: selectedItems
+							selected: selectedItems,
 						});
-					}
+					},
 				}}
 				selection={this.state.selected}
 				unread={this.state.unread}
-			/>
+			/>,
 		];
 	}
 

--- a/components/split-view/__examples__/base.jsx
+++ b/components/split-view/__examples__/base.jsx
@@ -81,7 +81,7 @@ const listOptions = [
 const headerNavRight = (
 	<div>
 		<Dropdown
-			id={'header-nav-right-more'}
+			id="header-nav-right-more"
 			align="right"
 			assistiveText="More Options"
 			iconName="down"
@@ -97,8 +97,8 @@ const headerNavRight = (
 const headerContentRight = (
 	<div>
 		<Dropdown
-			id={'header-right-refresh'}
-			buttonClassName={'slds-m-right_xx-small'}
+			id="header-right-refresh"
+			buttonClassName="slds-m-right_xx-small"
 			assistiveText="Checkmark with right icon"
 			buttonVariant="icon"
 			checkmark
@@ -141,10 +141,10 @@ const headerContentRight = (
 );
 
 const headerTitle = (
-	<div className={'slds-media__body'}>
+	<div className="slds-media__body">
 		<h1 className="slds-text-heading_small slds-text-color_default slds-p-right_x-small">
 			<Dropdown
-				id={'header-title-leads'}
+				id="header-title-leads"
 				options={[
 					{ label: 'Menu Item One', value: 'A0' },
 					{ label: 'Menu Item Two', value: 'B0' },
@@ -204,7 +204,7 @@ class Example extends React.Component {
 	masterView () {
 		return [
 			<SplitViewHeader
-				key={'1'}
+				key="1"
 				contentRight={headerContentRight}
 				navRight={headerNavRight}
 				iconAssistiveText="User"
@@ -216,7 +216,7 @@ class Example extends React.Component {
 				variant="objectHome"
 			/>,
 			<SplitViewListbox
-				key={'2'}
+				key="2"
 				labels={{
 					header: 'Lead Score'
 				}}
@@ -301,7 +301,7 @@ class Example extends React.Component {
 			<IconSettings iconPath="/assets/icons">
 				<div style={{ height: '90vh' }}>
 					<SplitView
-						id={'base-example'}
+						id="base-example"
 						isOpen={this.props.isOpen}
 						master={this.masterView()}
 						detail={this.detailView()}

--- a/components/split-view/__examples__/custom-Item-list.jsx
+++ b/components/split-view/__examples__/custom-Item-list.jsx
@@ -55,7 +55,7 @@ const listOptions = [
 const headerNavRight = (
 	<div>
 		<Dropdown
-			id={'header-nav-right-more'}
+			id="header-nav-right-more"
 			align="right"
 			assistiveText="More Options"
 			iconName="down"
@@ -71,8 +71,8 @@ const headerNavRight = (
 const headerContentRight = (
 	<div>
 		<Dropdown
-			id={'header-right-refresh'}
-			buttonClassName={'slds-m-right_xx-small'}
+			id="header-right-refresh"
+			buttonClassName="slds-m-right_xx-small"
 			assistiveText="Checkmark with right icon"
 			buttonVariant="icon"
 			checkmark
@@ -115,10 +115,10 @@ const headerContentRight = (
 );
 
 const headerTitle = (
-	<div className={'slds-media__body'}>
+	<div className="slds-media__body">
 		<h1 className="slds-text-heading_small slds-text-color_default slds-p-right_x-small">
 			<Dropdown
-				id={'header-title-leads'}
+				id="header-title-leads"
 				options={[
 					{ label: 'Menu Item One', value: 'A0' },
 					{ label: 'Menu Item Two', value: 'B0' },
@@ -149,9 +149,9 @@ const headerTitle = (
 const CustomListItem = (props) => (
 	<div>
 		<Icon
-			category={'action'}
+			category="action"
 			name={props.item.status === 'Contacted' ? 'check' : 'call'}
-			size={'x-small'}
+			size="x-small"
 		/>
 		<span className="slds-text-heading_small slds-m-left_medium">
 			{props.item.name}
@@ -204,7 +204,7 @@ class Example extends React.Component {
 	masterView () {
 		return [
 			<SplitViewHeader
-				key={'1'}
+				key="1"
 				contentRight={headerContentRight}
 				navRight={headerNavRight}
 				iconAssistiveText="User"
@@ -216,7 +216,7 @@ class Example extends React.Component {
 				variant="objectHome"
 			/>,
 			<SplitViewListbox
-				key={'2'}
+				key="2"
 				labels={{
 					header: 'Lead Score'
 				}}
@@ -293,7 +293,7 @@ class Example extends React.Component {
 			<IconSettings iconPath="/assets/icons">
 				<div style={{ height: '90vh' }}>
 					<SplitView
-						id={'custom-example'}
+						id="custom-example"
 						master={this.masterView()}
 						detail={this.detailView()}
 					/>

--- a/components/split-view/__examples__/custom-Item-list.jsx
+++ b/components/split-view/__examples__/custom-Item-list.jsx
@@ -11,7 +11,7 @@ import DropdownTrigger from '~/components/menu-dropdown/button-trigger';
 
 const SORT_OPTIONS = {
 	UP: 'up',
-	DOWN: 'down'
+	DOWN: 'down',
 };
 
 const listOptions = [
@@ -20,36 +20,36 @@ const listOptions = [
 		name: 'Riley Shultz',
 		ranking: '99',
 		company: 'Biotech, Inc.',
-		status: 'Nurturing'
+		status: 'Nurturing',
 	},
 	{
 		id: '002',
 		name: 'Jason A. - VP of Sales',
 		ranking: '92',
 		company: 'Case Management Solutions',
-		status: 'Contacted'
+		status: 'Contacted',
 	},
 	{
 		id: '003',
 		name: 'Josh Smith',
 		ranking: '90',
 		company: 'Acme, Inc.',
-		status: 'Contacted'
+		status: 'Contacted',
 	},
 	{
 		id: '004',
 		name: 'Bobby Tree',
 		ranking: '89',
 		company: 'Salesforce, Inc.',
-		status: 'Closing'
+		status: 'Closing',
 	},
 	{
 		id: '005',
 		name: 'Riley Shultz',
 		ranking: '74',
 		company: 'Tesla',
-		status: 'Contacted'
-	}
+		status: 'Contacted',
+	},
 ];
 
 const headerNavRight = (
@@ -62,7 +62,7 @@ const headerNavRight = (
 			iconVariant="border-filled"
 			options={[
 				{ label: 'Menu Item One', value: 'A0' },
-				{ label: 'Menu Item Two', value: 'B0' }
+				{ label: 'Menu Item Two', value: 'B0' },
 			]}
 		/>
 	</div>
@@ -90,17 +90,17 @@ const headerContentRight = (
 					value: 'A0',
 					rightIcon: {
 						category: 'utility',
-						name: 'table'
-					}
+						name: 'table',
+					},
 				},
 				{
 					label: 'List View',
 					value: 'B0',
 					rightIcon: {
 						category: 'utility',
-						name: 'side_list'
-					}
-				}
+						name: 'side_list',
+					},
+				},
 			]}
 			value="B0"
 		/>
@@ -124,7 +124,7 @@ const headerTitle = (
 					{ label: 'Menu Item Two', value: 'B0' },
 					{ label: 'Menu Item Three', value: 'C0' },
 					{ type: 'divider' },
-					{ label: 'Menu Item Four', value: 'D0' }
+					{ label: 'Menu Item Four', value: 'D0' },
 				]}
 			>
 				<DropdownTrigger>
@@ -162,8 +162,8 @@ const CustomListItem = (props) => (
 CustomListItem.propsTypes = {
 	item: PropTypes.shape({
 		status: PropTypes.string,
-		name: PropTypes.string
-	})
+		name: PropTypes.string,
+	}),
 };
 
 CustomListItem.displayName = 'CustomListItem';
@@ -176,7 +176,7 @@ class Example extends React.Component {
 			options: listOptions,
 			selected: [listOptions[listOptions.length - 2]],
 			unread: [listOptions[0], listOptions[2]],
-			sortDirection: SORT_OPTIONS.DOWN
+			sortDirection: SORT_OPTIONS.DOWN,
 		};
 
 		this.sortList = this.sortList.bind(this);
@@ -195,7 +195,7 @@ class Example extends React.Component {
 						? a.name > b.name
 						: b.name > a.name)
 			),
-			sortDirection
+			sortDirection,
 		});
 	}
 
@@ -218,7 +218,7 @@ class Example extends React.Component {
 			<SplitViewListbox
 				key="2"
 				labels={{
-					header: 'Lead Score'
+					header: 'Lead Score',
 				}}
 				sortDirection={this.state.sortDirection}
 				options={this.state.options}
@@ -227,14 +227,14 @@ class Example extends React.Component {
 					onSelect: (event, { selectedItems, item }) => {
 						this.setState({
 							unread: this.state.unread.filter((i) => i !== item),
-							selected: selectedItems
+							selected: selectedItems,
 						});
-					}
+					},
 				}}
 				selection={this.state.selected}
 				unread={this.state.unread}
 				listItem={CustomListItem}
-			/>
+			/>,
 		];
 	}
 

--- a/components/split-view/__examples__/external-state.jsx
+++ b/components/split-view/__examples__/external-state.jsx
@@ -9,7 +9,7 @@ import DropdownTrigger from '~/components/menu-dropdown/button-trigger';
 
 const SORT_OPTIONS = {
 	UP: 'up',
-	DOWN: 'down'
+	DOWN: 'down',
 };
 
 const listOptions = [
@@ -18,64 +18,64 @@ const listOptions = [
 		label: 'Riley Shultz',
 		topRightText: '99',
 		bottomLeftText: 'Biotech, Inc.',
-		bottomRightText: 'Nurturing'
+		bottomRightText: 'Nurturing',
 	},
 	{
 		id: '002',
 		label: 'Jason A. - VP of Sales',
 		topRightText: '92',
 		bottomLeftText: 'Case Management Solutions',
-		bottomRightText: 'Contacted'
+		bottomRightText: 'Contacted',
 	},
 	{
 		id: '003',
 		label: 'Josh Smith',
 		topRightText: '90',
 		bottomLeftText: 'Acme, Inc.',
-		bottomRightText: 'Contacted'
+		bottomRightText: 'Contacted',
 	},
 	{
 		id: '004',
 		label: 'Bobby Tree',
 		topRightText: '89',
 		bottomLeftText: 'Salesforce, Inc.',
-		bottomRightText: 'Closing'
+		bottomRightText: 'Closing',
 	},
 	{
 		id: '005',
 		label: 'Riley Shultz',
 		topRightText: '74',
 		bottomLeftText: 'Tesla',
-		bottomRightText: 'Contacted'
+		bottomRightText: 'Contacted',
 	},
 	{
 		id: '006',
 		label: 'Andy Smith',
 		topRightText: '72',
 		bottomLeftText: 'Universal Technologies',
-		bottomRightText: 'New'
+		bottomRightText: 'New',
 	},
 	{
 		id: '007',
 		label: 'Jim Steele',
 		topRightText: '71',
 		bottomLeftText: 'BigList, Inc.',
-		bottomRightText: 'New'
+		bottomRightText: 'New',
 	},
 	{
 		id: '008',
 		label: 'John Gardner',
 		topRightText: '70',
 		bottomLeftText: '3C Systems',
-		bottomRightText: 'Contacted'
+		bottomRightText: 'Contacted',
 	},
 	{
 		id: '009',
 		label: 'Sarah Loehr',
 		topRightText: '68',
 		bottomLeftText: 'MedLife, Inc.',
-		bottomRightText: 'New'
-	}
+		bottomRightText: 'New',
+	},
 ];
 
 const headerNavRight = (
@@ -88,7 +88,7 @@ const headerNavRight = (
 			iconVariant="border-filled"
 			options={[
 				{ label: 'Menu Item One', value: 'A0' },
-				{ label: 'Menu Item Two', value: 'B0' }
+				{ label: 'Menu Item Two', value: 'B0' },
 			]}
 		/>
 	</div>
@@ -116,17 +116,17 @@ const headerContentRight = (
 					value: 'A0',
 					rightIcon: {
 						category: 'utility',
-						name: 'table'
-					}
+						name: 'table',
+					},
 				},
 				{
 					label: 'List View',
 					value: 'B0',
 					rightIcon: {
 						category: 'utility',
-						name: 'side_list'
-					}
-				}
+						name: 'side_list',
+					},
+				},
 			]}
 			value="B0"
 		/>
@@ -150,7 +150,7 @@ const headerTitle = (
 					{ label: 'Menu Item Two', value: 'B0' },
 					{ label: 'Menu Item Three', value: 'C0' },
 					{ type: 'divider' },
-					{ label: 'Menu Item Four', value: 'D0' }
+					{ label: 'Menu Item Four', value: 'D0' },
 				]}
 			>
 				<DropdownTrigger>
@@ -177,7 +177,7 @@ class Example extends React.Component {
 			selected: [listOptions[listOptions.length - 2]],
 			unread: [listOptions[0], listOptions[2]],
 			sortDirection: SORT_OPTIONS.DOWN,
-			isOpen: true
+			isOpen: true,
 		};
 
 		this.sortList = this.sortList.bind(this);
@@ -210,7 +210,7 @@ class Example extends React.Component {
 			<SplitViewListbox
 				key="2"
 				labels={{
-					header: 'Lead Score'
+					header: 'Lead Score',
 				}}
 				sortDirection={this.state.sortDirection}
 				options={this.state.options}
@@ -219,13 +219,13 @@ class Example extends React.Component {
 					onSelect: (event, { selectedItems, item }) => {
 						this.setState({
 							unread: this.state.unread.filter((i) => i !== item),
-							selected: selectedItems
+							selected: selectedItems,
 						});
-					}
+					},
 				}}
 				selection={this.state.selected}
 				unread={this.state.unread}
-			/>
+			/>,
 		];
 	}
 
@@ -301,7 +301,7 @@ class Example extends React.Component {
 						? a.label > b.label
 						: b.label > a.label)
 			),
-			sortDirection
+			sortDirection,
 		});
 	}
 
@@ -326,7 +326,7 @@ class Example extends React.Component {
 						<SplitView
 							events={{
 								onOpen: (e) => this.onSplitViewOpen(e),
-								onClose: (e) => this.onSplitViewClose(e)
+								onClose: (e) => this.onSplitViewClose(e),
 							}}
 							isOpen={this.state.isOpen}
 							master={this.masterView()}

--- a/components/split-view/__examples__/external-state.jsx
+++ b/components/split-view/__examples__/external-state.jsx
@@ -81,7 +81,7 @@ const listOptions = [
 const headerNavRight = (
 	<div>
 		<Dropdown
-			id={'header-nav-right-more'}
+			id="header-nav-right-more"
 			align="right"
 			assistiveText="More Options"
 			iconName="down"
@@ -97,8 +97,8 @@ const headerNavRight = (
 const headerContentRight = (
 	<div>
 		<Dropdown
-			id={'header-right-refresh'}
-			buttonClassName={'slds-m-right_xx-small'}
+			id="header-right-refresh"
+			buttonClassName="slds-m-right_xx-small"
 			assistiveText="Checkmark with right icon"
 			buttonVariant="icon"
 			checkmark
@@ -141,10 +141,10 @@ const headerContentRight = (
 );
 
 const headerTitle = (
-	<div className={'slds-media__body'}>
+	<div className="slds-media__body">
 		<h1 className="slds-text-heading_small slds-text-color_default slds-p-right_x-small">
 			<Dropdown
-				id={'header-title-leads'}
+				id="header-title-leads"
 				options={[
 					{ label: 'Menu Item One', value: 'A0' },
 					{ label: 'Menu Item Two', value: 'B0' },
@@ -196,7 +196,7 @@ class Example extends React.Component {
 	masterView () {
 		return [
 			<SplitViewHeader
-				key={'1'}
+				key="1"
 				contentRight={headerContentRight}
 				navRight={headerNavRight}
 				iconAssistiveText="User"
@@ -208,7 +208,7 @@ class Example extends React.Component {
 				variant="objectHome"
 			/>,
 			<SplitViewListbox
-				key={'2'}
+				key="2"
 				labels={{
 					header: 'Lead Score'
 				}}
@@ -309,17 +309,17 @@ class Example extends React.Component {
 		return (
 			<IconSettings iconPath="/assets/icons">
 				<div>
-					<div className={'slds-box slds-m-bottom_large'}>
-						<div className={'slds-text-title_caps slds-m-bottom_small'}>
+					<div className="slds-box slds-m-bottom_large">
+						<div className="slds-text-title_caps slds-m-bottom_small">
 							Externally control the split view
 						</div>
 						<Button
 							onClick={() => this.setState({ isOpen: true })}
-							label={'Open the split view'}
+							label="Open the split view"
 						/>
 						<Button
 							onClick={() => this.setState({ isOpen: false })}
-							label={'Close the split view'}
+							label="Close the split view"
 						/>
 					</div>
 					<div style={{ height: '80vh' }}>

--- a/components/split-view/__tests__/split-view.listbox.browser-test.jsx
+++ b/components/split-view/__tests__/split-view.listbox.browser-test.jsx
@@ -15,29 +15,29 @@ const listOptions = [
 		label: 'Riley Shultz',
 		topRightText: '99',
 		bottomLeftText: 'Biotech, Inc.',
-		bottomRightText: 'Nurturing'
+		bottomRightText: 'Nurturing',
 	},
 	{
 		id: 'option2',
 		label: 'Jason A. - VP of Sales',
 		topRightText: '92',
 		bottomLeftText: 'Case Management Solutions',
-		bottomRightText: 'Contacted'
+		bottomRightText: 'Contacted',
 	},
 	{
 		id: 'option3',
 		label: 'Josh Smith',
 		topRightText: '90',
 		bottomLeftText: 'Acme, Inc.',
-		bottomRightText: 'Contacted'
+		bottomRightText: 'Contacted',
 	},
 	{
 		id: 'option4',
 		label: 'Bobby Tree',
 		topRightText: '89',
 		bottomLeftText: 'Salesforce, Inc.',
-		bottomRightText: 'Closing'
-	}
+		bottomRightText: 'Closing',
+	},
 ];
 
 describe('SLDSSplitView - Listbox', () => {
@@ -77,8 +77,8 @@ describe('SLDSSplitView - Listbox', () => {
 				options: listOptions,
 				selection: [listOptions[1]],
 				events: {
-					onSelect: sinon.spy()
-				}
+					onSelect: sinon.spy(),
+				},
 			});
 
 			expectItemFocused(1);
@@ -88,8 +88,8 @@ describe('SLDSSplitView - Listbox', () => {
 			component = mountComponent({
 				options: listOptions,
 				events: {
-					onSelect: sinon.spy()
-				}
+					onSelect: sinon.spy(),
+				},
 			});
 
 			expectItemFocused(0);
@@ -102,8 +102,8 @@ describe('SLDSSplitView - Listbox', () => {
 				component = mountComponent({
 					options: listOptions,
 					events: {
-						onSelect: () => {}
-					}
+						onSelect: () => {},
+					},
 				});
 
 				component
@@ -120,8 +120,8 @@ describe('SLDSSplitView - Listbox', () => {
 					events: {
 						onSelect: (event, { selectedItems }) => {
 							component.setProps({ selection: selectedItems });
-						}
-					}
+						},
+					},
 				});
 
 				component
@@ -140,8 +140,8 @@ describe('SLDSSplitView - Listbox', () => {
 						events: {
 							onSelect: (event, { selectedItems }) => {
 								component.setProps({ selection: selectedItems });
-							}
-						}
+							},
+						},
 					});
 				});
 
@@ -185,8 +185,8 @@ describe('SLDSSplitView - Listbox', () => {
 					events: {
 						onSelect: (event, { selectedItems }) => {
 							component.setProps({ selection: selectedItems });
-						}
-					}
+						},
+					},
 				});
 			});
 

--- a/components/split-view/__tests__/split-view.listbox.header.browser-test.jsx
+++ b/components/split-view/__tests__/split-view.listbox.header.browser-test.jsx
@@ -6,7 +6,7 @@ import sinon from 'sinon';
 
 import IconSettings from '../../../components/icon-settings';
 import SplitViewListbox, {
-	SORT_OPTIONS
+	SORT_OPTIONS,
 } from '../../../components/split-view/listbox';
 
 chai.use(chaiEnzyme());
@@ -17,29 +17,29 @@ const listOptions = [
 		label: 'Riley Shultz',
 		topRightText: '99',
 		bottomLeftText: 'Biotech, Inc.',
-		bottomRightText: 'Nurturing'
+		bottomRightText: 'Nurturing',
 	},
 	{
 		id: 'option2',
 		label: 'Jason A. - VP of Sales',
 		topRightText: '92',
 		bottomLeftText: 'Case Management Solutions',
-		bottomRightText: 'Contacted'
+		bottomRightText: 'Contacted',
 	},
 	{
 		id: 'option3',
 		label: 'Josh Smith',
 		topRightText: '90',
 		bottomLeftText: 'Acme, Inc.',
-		bottomRightText: 'Contacted'
+		bottomRightText: 'Contacted',
 	},
 	{
 		id: 'option4',
 		label: 'Bobby Tree',
 		topRightText: '89',
 		bottomLeftText: 'Salesforce, Inc.',
-		bottomRightText: 'Closing'
-	}
+		bottomRightText: 'Closing',
+	},
 ];
 
 describe('SLDSSplitView - Listbox header', () => {
@@ -56,22 +56,22 @@ describe('SLDSSplitView - Listbox header', () => {
 	const props = {
 		options: listOptions,
 		labels: {
-			header: 'test header'
+			header: 'test header',
 		},
 		assistiveText: {
 			sort: {
 				sortedBy: 'test sort by',
 				descending: 'test descending',
-				ascending: 'test ascending'
-			}
+				ascending: 'test ascending',
+			},
 		},
 		sortDirection: SORT_OPTIONS.DOWN,
 		events: {
 			onSort: sinon.spy(),
 			onSelect: (event, { selectedItems }) => {
 				component.setProps({ selection: selectedItems });
-			}
-		}
+			},
+		},
 	};
 
 	beforeEach(() => {

--- a/components/split-view/__tests__/split-view.listbox.unread.browser-test.jsx
+++ b/components/split-view/__tests__/split-view.listbox.unread.browser-test.jsx
@@ -6,7 +6,7 @@ import sinon from 'sinon';
 
 import IconSettings from '../../../components/icon-settings';
 import SplitViewListbox, {
-	SORT_OPTIONS
+	SORT_OPTIONS,
 } from '../../../components/split-view/listbox';
 
 chai.use(chaiEnzyme());
@@ -17,29 +17,29 @@ const listOptions = [
 		label: 'Riley Shultz',
 		topRightText: '99',
 		bottomLeftText: 'Biotech, Inc.',
-		bottomRightText: 'Nurturing'
+		bottomRightText: 'Nurturing',
 	},
 	{
 		id: 'option2',
 		label: 'Jason A. - VP of Sales',
 		topRightText: '92',
 		bottomLeftText: 'Case Management Solutions',
-		bottomRightText: 'Contacted'
+		bottomRightText: 'Contacted',
 	},
 	{
 		id: 'option3',
 		label: 'Josh Smith',
 		topRightText: '90',
 		bottomLeftText: 'Acme, Inc.',
-		bottomRightText: 'Contacted'
+		bottomRightText: 'Contacted',
 	},
 	{
 		id: 'option4',
 		label: 'Bobby Tree',
 		topRightText: '89',
 		bottomLeftText: 'Salesforce, Inc.',
-		bottomRightText: 'Closing'
-	}
+		bottomRightText: 'Closing',
+	},
 ];
 
 describe('SLDSSplitView - Listbox header', () => {
@@ -57,23 +57,23 @@ describe('SLDSSplitView - Listbox header', () => {
 		options: listOptions,
 		unread: [listOptions[1], listOptions[3]],
 		labels: {
-			header: 'test header'
+			header: 'test header',
 		},
 		assistiveText: {
 			sort: {
 				sortedBy: 'test sort by',
 				descending: 'test descending',
-				ascending: 'test ascending'
+				ascending: 'test ascending',
 			},
-			unreadItem: 'test unread'
+			unreadItem: 'test unread',
 		},
 		sortDirection: SORT_OPTIONS.DOWN,
 		events: {
 			onSort: sinon.spy(),
 			onSelect: (event, { selectedItems }) => {
 				component.setProps({ selection: selectedItems });
-			}
-		}
+			},
+		},
 	};
 
 	beforeEach(() => {

--- a/components/split-view/__tests__/split-view.snapshot-test.jsx
+++ b/components/split-view/__tests__/split-view.snapshot-test.jsx
@@ -10,8 +10,8 @@ testDOMandHTML({
 	test,
 	Component: Base,
 	props: {
-		isOpen: true
-	}
+		isOpen: true,
+	},
 });
 
 testDOMandHTML({
@@ -19,18 +19,18 @@ testDOMandHTML({
 	test,
 	Component: Base,
 	props: {
-		isOpen: false
-	}
+		isOpen: false,
+	},
 });
 
 testDOMandHTML({
 	name: 'Base Multiple',
 	test,
-	Component: BaseMultiple
+	Component: BaseMultiple,
 });
 
 testDOMandHTML({
 	name: 'Custom',
 	test,
-	Component: Custom
+	Component: Custom,
 });

--- a/components/split-view/index.jsx
+++ b/components/split-view/index.jsx
@@ -175,7 +175,7 @@ class SplitView extends React.Component {
 					style={{
 						marginLeft: TOGGLE_BUTTON_WIDTH
 					}}
-					className={'slds-grow slds-scrollable_y'}
+					className="slds-grow slds-scrollable_y"
 				>
 					{this.props.detail}
 				</div>

--- a/components/split-view/index.jsx
+++ b/components/split-view/index.jsx
@@ -19,7 +19,7 @@ const propTypes = {
 	 */
 	assistiveText: PropTypes.shape({
 		toggleButtonOpen: PropTypes.string,
-		toggleButtonClose: PropTypes.string
+		toggleButtonClose: PropTypes.string,
 	}),
 	/**
 	 * HTML Id for the component.
@@ -31,7 +31,7 @@ const propTypes = {
 	className: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * Sets the split view to be open or closed.
@@ -44,7 +44,7 @@ const propTypes = {
 	 */
 	events: PropTypes.shape({
 		onClose: PropTypes.func,
-		onOpen: PropTypes.func
+		onOpen: PropTypes.func,
 	}),
 	/**
 	 * The React component that is rendered in the master section.
@@ -53,7 +53,7 @@ const propTypes = {
 	 */
 	master: PropTypes.oneOfType([
 		PropTypes.arrayOf(PropTypes.element),
-		PropTypes.element
+		PropTypes.element,
 	]).isRequired,
 	/**
 	 * The width of the master section.
@@ -64,17 +64,17 @@ const propTypes = {
 	 */
 	detail: PropTypes.oneOfType([
 		PropTypes.arrayOf(PropTypes.element),
-		PropTypes.element
-	]).isRequired
+		PropTypes.element,
+	]).isRequired,
 };
 
 const defaultProps = {
 	assistiveText: {
 		toggleButtonOpen: 'Close split view',
-		toggleButtonClose: 'Open split view'
+		toggleButtonClose: 'Open split view',
 	},
 	events: {},
-	masterWidth: '20rem'
+	masterWidth: '20rem',
 };
 
 /**
@@ -89,7 +89,7 @@ class SplitView extends React.Component {
 		super(props);
 
 		this.state = {
-			isOpen: true
+			isOpen: true,
 		};
 	}
 
@@ -116,7 +116,7 @@ class SplitView extends React.Component {
 	setIsOpen (isOpen) {
 		if (isBoolean(isOpen)) {
 			this.setState({
-				isOpen
+				isOpen,
 			});
 		}
 	}
@@ -148,12 +148,12 @@ class SplitView extends React.Component {
 				id={this.getId()}
 				className={classNames('slds-grid', this.props.className)}
 				style={{
-					height: '100%'
+					height: '100%',
 				}}
 			>
 				<div
 					style={{
-						maxWidth: this.state.isOpen ? this.props.masterWidth : '0'
+						maxWidth: this.state.isOpen ? this.props.masterWidth : '0',
 					}}
 					className={classNames(
 						'slds-split-view_container',
@@ -166,14 +166,14 @@ class SplitView extends React.Component {
 						ariaControls={this.getMasterViewId()}
 						isOpen={this.state.isOpen}
 						events={{
-							onClick: (event) => this.toggle(event)
+							onClick: (event) => this.toggle(event),
 						}}
 					/>
 					{this.masterContent()}
 				</div>
 				<div
 					style={{
-						marginLeft: TOGGLE_BUTTON_WIDTH
+						marginLeft: TOGGLE_BUTTON_WIDTH,
 					}}
 					className="slds-grow slds-scrollable_y"
 				>

--- a/components/split-view/listbox.jsx
+++ b/components/split-view/listbox.jsx
@@ -16,7 +16,7 @@ import listItemWithContent from './private/list-item-with-content';
 
 export const SORT_OPTIONS = Object.freeze({
 	UP: 'up',
-	DOWN: 'down'
+	DOWN: 'down',
 });
 
 const propTypes = {
@@ -33,9 +33,9 @@ const propTypes = {
 		sort: PropTypes.shape({
 			sortedBy: PropTypes.string,
 			descending: PropTypes.string,
-			ascending: PropTypes.string
+			ascending: PropTypes.string,
 		}),
-		unreadItem: PropTypes.string
+		unreadItem: PropTypes.string,
 	}),
 	/**
 	 * CSS classes to be added to the parent `div` tag.
@@ -43,7 +43,7 @@ const propTypes = {
 	className: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * Event Callbacks
@@ -57,7 +57,7 @@ const propTypes = {
 	 */
 	events: PropTypes.shape({
 		onSelect: PropTypes.func.isRequired,
-		onSort: PropTypes.func
+		onSort: PropTypes.func,
 	}),
 	/**
 	 * HTML id for component.
@@ -68,7 +68,7 @@ const propTypes = {
 	 * * `header`: This is the header of the list.
 	 */
 	labels: PropTypes.shape({
-		header: PropTypes.string
+		header: PropTypes.string,
 	}),
 	/**
 	 * The direction of the sort arrow. Option are:
@@ -97,7 +97,7 @@ const propTypes = {
 	 * Custom list item template for the list item content. The select and unread functionality wraps the custom list item.
 	 * This should be a React component that accepts props.
 	 */
-	listItem: PropTypes.func
+	listItem: PropTypes.func,
 };
 
 const defaultProps = {
@@ -106,13 +106,13 @@ const defaultProps = {
 		sort: {
 			sortedBy: 'Sorted by',
 			descending: 'Descending',
-			ascending: 'Ascending'
-		}
+			ascending: 'Ascending',
+		},
 	},
 	events: {},
 	labels: {},
 	selection: [],
-	unread: []
+	unread: [],
 };
 
 class SplitViewListbox extends React.Component {
@@ -129,8 +129,8 @@ class SplitViewListbox extends React.Component {
 			currentSelectedItem: null,
 			currentFocusedListItem: {
 				index: 0,
-				item: null
-			}
+				item: null,
+			},
 		};
 	}
 
@@ -223,8 +223,8 @@ class SplitViewListbox extends React.Component {
 		this.setState({
 			currentFocusedListItem: {
 				index,
-				item
-			}
+				item,
+			},
 		});
 	}
 
@@ -232,14 +232,14 @@ class SplitViewListbox extends React.Component {
 		this.setState({ currentSelectedItem: null });
 		this.props.events.onSelect(event, {
 			selectedItems: [],
-			item: null
+			item: null,
 		});
 	}
 
 	selectAllListItems (event) {
 		this.props.events.onSelect(event, {
 			selectedItems: this.props.options,
-			item: this.state.currentSelectedItem
+			item: this.state.currentSelectedItem,
 		});
 	}
 
@@ -254,14 +254,14 @@ class SplitViewListbox extends React.Component {
 			} else if (event.shiftKey) {
 				const [begin, end] = [
 					this.props.options.indexOf(this.state.currentSelectedItem),
-					this.props.options.indexOf(item)
+					this.props.options.indexOf(item),
 				].sort();
 
 				const addToSelection = this.props.options.slice(begin, end + 1);
 
 				selectedItems = [
 					...addToSelection,
-					...this.props.selection.filter((i) => !addToSelection.includes(i))
+					...this.props.selection.filter((i) => !addToSelection.includes(i)),
 				];
 			}
 		}
@@ -345,7 +345,7 @@ class SplitViewListbox extends React.Component {
 			<ListItemWithContent
 				key={item.id || index}
 				assistiveText={{
-					unreadItem: this.props.assistiveText.unreadItem
+					unreadItem: this.props.assistiveText.unreadItem,
 				}}
 				listItemRef={(component) => {
 					this.addListItemComponent(component, index);
@@ -355,7 +355,7 @@ class SplitViewListbox extends React.Component {
 				isSelected={this.isSelected(item)}
 				isUnread={this.isUnread(item)}
 				events={{
-					onClick: (event, meta) => this.handleOnSelect(event, meta)
+					onClick: (event, meta) => this.handleOnSelect(event, meta),
 				}}
 				multiple={this.props.multiple}
 			/>

--- a/components/split-view/listbox.jsx
+++ b/components/split-view/listbox.jsx
@@ -279,14 +279,14 @@ class SplitViewListbox extends React.Component {
 	sortDirection () {
 		return this.props.sortDirection ? (
 			<Icon
-				category={'utility'}
+				category="utility"
 				name={
 					this.props.sortDirection === SORT_OPTIONS.DOWN
 						? 'arrowdown'
 						: 'arrowup'
 				}
-				size={'xx-small'}
-				className={'slds-align-top'}
+				size="xx-small"
+				className="slds-align-top"
 			/>
 		) : null;
 	}

--- a/components/split-view/private/list-item-content.jsx
+++ b/components/split-view/private/list-item-content.jsx
@@ -18,8 +18,8 @@ const propTypes = {
 		label: PropTypes.string,
 		topRightText: PropTypes.string,
 		bottomLeftText: PropTypes.string,
-		bottomRightText: PropTypes.string
-	})
+		bottomRightText: PropTypes.string,
+	}),
 };
 
 const defaultProps = {};

--- a/components/split-view/private/list-item-with-content.jsx
+++ b/components/split-view/private/list-item-with-content.jsx
@@ -86,7 +86,7 @@ const listItemWithContent = (ListItemContent) => {
 		unread () {
 			return this.props.isUnread ? (
 				<abbr
-					className={'slds-indicator_unread'}
+					className="slds-indicator_unread"
 					title={this.props.assistiveText.unreadItem}
 					aria-label={this.props.assistiveText.unreadItem}
 				>

--- a/components/split-view/private/list-item-with-content.jsx
+++ b/components/split-view/private/list-item-with-content.jsx
@@ -15,7 +15,7 @@ const propsTypes = {
 	 * * `unreadItem`: The unread indicator.
 	 */
 	assistiveText: PropTypes.shape({
-		unreadItem: PropTypes.string
+		unreadItem: PropTypes.string,
 	}),
 	/**
 	 * Item to be displayed
@@ -47,19 +47,19 @@ const propsTypes = {
 	 * * * * `isUnread`: Is the item unread.
 	 */
 	events: PropTypes.shape({
-		onClick: PropTypes.func.isRequired
+		onClick: PropTypes.func.isRequired,
 	}),
 	/**
 	 * Reference to the list item component
 	 */
-	listItemRef: PropTypes.func
+	listItemRef: PropTypes.func,
 };
 
 const defaultProps = {
 	assistiveText: {
-		unreadItem: 'Unread Item'
+		unreadItem: 'Unread Item',
 	},
-	events: {}
+	events: {},
 };
 
 /**
@@ -79,7 +79,7 @@ const listItemWithContent = (ListItemContent) => {
 			this.props.events.onClick(event, {
 				item: this.props.item,
 				isSelected: this.props.isSelected,
-				isUnread: this.props.isUnread
+				isUnread: this.props.isUnread,
 			});
 		}
 
@@ -99,7 +99,7 @@ const listItemWithContent = (ListItemContent) => {
 			return (
 				<li
 					className={classNames('slds-split-view__list-item', {
-						'slds-is-unread': this.props.isUnread
+						'slds-is-unread': this.props.isUnread,
 					})}
 					role="presentation"
 				>

--- a/components/split-view/private/toggle-button.jsx
+++ b/components/split-view/private/toggle-button.jsx
@@ -17,7 +17,7 @@ const propsTypes = {
 	 */
 	assistiveText: PropTypes.shape({
 		toggleButtonOpen: PropTypes.string.isRequired,
-		toggleButtonClose: PropTypes.string.isRequired
+		toggleButtonClose: PropTypes.string.isRequired,
 	}),
 	/**
 	 * Unique html id placed on the button for aria-controls
@@ -32,8 +32,8 @@ const propsTypes = {
 	 * * `onClick`: Called when the button is clicked.
 	 */
 	events: PropTypes.shape({
-		onClick: PropTypes.func.isRequired
-	})
+		onClick: PropTypes.func.isRequired,
+	}),
 };
 
 const defaultProps = {};
@@ -42,7 +42,7 @@ const SplitViewToggleButton = ({
 	isOpen,
 	assistiveText,
 	ariaControls,
-	events
+	events,
 }) => {
 	const toggleAssistiveText = isOpen
 		? assistiveText.toggleButtonOpen

--- a/components/split-view/private/toggle-button.jsx
+++ b/components/split-view/private/toggle-button.jsx
@@ -57,10 +57,10 @@ const SplitViewToggleButton = ({
 			aria-expanded={isOpen}
 			aria-controls={ariaControls}
 			title={toggleAssistiveText}
-			variant={'base'}
-			iconName={'left'}
-			iconCategory={'utility'}
-			iconSize={'x-small'}
+			variant="base"
+			iconName="left"
+			iconCategory="utility"
+			iconSize="x-small"
 			onClick={events.onClick}
 			assistiveText={toggleAssistiveText}
 		/>

--- a/components/tabs/__docs__/site-stories.js
+++ b/components/tabs/__docs__/site-stories.js
@@ -5,7 +5,7 @@
 
 const siteStories = [
 	require('raw-loader!@salesforce/design-system-react/components/tabs/__examples__/default.jsx'),
-	require('raw-loader!@salesforce/design-system-react/components/tabs/__examples__/scoped.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/tabs/__examples__/scoped.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/tabs/__docs__/storybook-stories.jsx
+++ b/components/tabs/__docs__/storybook-stories.jsx
@@ -211,8 +211,8 @@ const DemoTabsConditional = createReactClass({
 		className: PropTypes.oneOfType([
 			PropTypes.array,
 			PropTypes.object,
-			PropTypes.string
-		])
+			PropTypes.string,
+		]),
 	},
 
 	getInitialState () {
@@ -222,7 +222,7 @@ const DemoTabsConditional = createReactClass({
 			showC: true,
 			disableA: false,
 			disableB: true,
-			disableC: true
+			disableC: true,
 		};
 	},
 
@@ -320,7 +320,7 @@ const DemoTabsConditional = createReactClass({
 				</Tabs>
 			</div>
 		);
-	}
+	},
 });
 
 const DemoTabsOutsideControl = createReactClass({
@@ -334,19 +334,19 @@ const DemoTabsOutsideControl = createReactClass({
 		className: PropTypes.oneOfType([
 			PropTypes.array,
 			PropTypes.object,
-			PropTypes.string
+			PropTypes.string,
 		]),
 		/**
 		 * The Tab (and corresponding TabPanel) that is selected when the component renders. Defaults to `0`.
 		 */
 		whichOneSelectedYo: PropTypes.number,
-		prevOneSelectedYo: PropTypes.number
+		prevOneSelectedYo: PropTypes.number,
 	},
 
 	getInitialState () {
 		return {
 			whichOneSelectedYo: this.props.whichOneSelectedYo || 0,
-			prevOneSelectedYo: this.props.prevOneSelectedYo || 0
+			prevOneSelectedYo: this.props.prevOneSelectedYo || 0,
 		};
 	},
 
@@ -484,7 +484,7 @@ const DemoTabsOutsideControl = createReactClass({
 				</Tabs>
 			</div>
 		);
-	}
+	},
 });
 
 /* eslint-disable react/display-name */
@@ -612,7 +612,7 @@ const DemoTabsInterceptSelect = createReactClass({
 				</Tabs>
 			</div>
 		);
-	}
+	},
 });
 
 storiesOf(TABS, module)

--- a/components/tabs/__examples__/default.jsx
+++ b/components/tabs/__examples__/default.jsx
@@ -20,7 +20,7 @@ const Example = createReactClass({
 				</Tabs>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/tabs/__examples__/scoped.jsx
+++ b/components/tabs/__examples__/scoped.jsx
@@ -20,7 +20,7 @@ const Example = createReactClass({
 				</Tabs>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/tabs/__tests__/tabs.browser-test.jsx
+++ b/components/tabs/__tests__/tabs.browser-test.jsx
@@ -17,7 +17,7 @@ import Panel from '../../tabs/panel';
  */
 import {
 	mountComponent,
-	unmountComponent
+	unmountComponent,
 } from '../../../tests/enzyme-helpers';
 
 /* Set Chai to use chaiEnzyme for enzyme compatible assertions:
@@ -34,7 +34,7 @@ const COMPONENT_CSS_CLASSES = {
 	item: 'slds-tabs--default__item',
 	link: 'slds-tabs--default__link',
 	content: 'slds-tabs--default__content',
-	testClass: 'this-is-a-css-class-name'
+	testClass: 'this-is-a-css-class-name',
 };
 
 /* A re-usable demo component fixture outside of `describe` sections
@@ -53,7 +53,7 @@ const TabsDemoComponent = createReactClass({
 		className: PropTypes.oneOfType([
 			PropTypes.array,
 			PropTypes.object,
-			PropTypes.string
+			PropTypes.string,
 		]),
 		/**
 		 * HTML `id` attribute of primary element that has `.slds-tabs--default` on it. Optional: If one is not supplied, a `shortid` will be created.
@@ -62,7 +62,7 @@ const TabsDemoComponent = createReactClass({
 		/**
 		 * Function that triggers when a tab is selected.
 		 */
-		onSelect: PropTypes.func
+		onSelect: PropTypes.func,
 	},
 
 	render () {
@@ -113,7 +113,7 @@ const TabsDemoComponent = createReactClass({
 				</Tabs>
 			</div>
 		);
-	}
+	},
 });
 
 describe('Tabs', () => {
@@ -360,12 +360,12 @@ describe('Tabs', () => {
 			Simulate.keyDown(myTabsListItems.nodes[0], {
 				key: 'Tab',
 				keyCode: 9,
-				which: 9
+				which: 9,
 			});
 			Simulate.keyDown(myTabsListItems.nodes[0], {
 				key: 'Right',
 				keyCode: 39,
-				which: 39
+				which: 39,
 			});
 
 			expect(myFirstPanel.hasClass('slds-show')).to.equal(false);
@@ -398,12 +398,12 @@ describe('Tabs', () => {
 			Simulate.keyDown(myTabsListItems.nodes[0], {
 				key: 'Tab',
 				keyCode: 9,
-				which: 9
+				which: 9,
 			});
 			Simulate.keyDown(myTabsListItems.nodes[0], {
 				key: 'Right',
 				keyCode: 39,
-				which: 39
+				which: 39,
 			});
 
 			expect(myFirstPanel.hasClass('slds-show')).to.equal(false);

--- a/components/tabs/index.jsx
+++ b/components/tabs/index.jsx
@@ -90,7 +90,7 @@ const propTypes = {
 	children: PropTypes.oneOfType([
 		PropTypes.arrayOf(PropTypes.node),
 		PropTypes.node,
-		PropTypes.element
+		PropTypes.element,
 	]).isRequired,
 
 	/**
@@ -99,7 +99,7 @@ const propTypes = {
 	className: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 
 	/**
@@ -120,11 +120,11 @@ const propTypes = {
 	/**
 	 * The Tab (and corresponding TabPanel) that is currently selected.
 	 */
-	selectedIndex: PropTypes.number
+	selectedIndex: PropTypes.number,
 };
 const defaultProps = {
 	defaultSelectedIndex: 0,
-	variant: 'default'
+	variant: 'default',
 };
 
 class Tabs extends React.Component {
@@ -138,7 +138,7 @@ class Tabs extends React.Component {
 		this.generatedId = shortid.generate();
 		this.flavor = this.getVariant();
 		this.setState({
-			selectedIndex: this.props.defaultSelectedIndex
+			selectedIndex: this.props.defaultSelectedIndex,
 		});
 	}
 
@@ -369,7 +369,7 @@ class Tabs extends React.Component {
 		const {
 			className,
 			id = this.generatedId,
-			variant = this.getVariant
+			variant = this.getVariant,
 		} = this.props;
 
 		if (this.state.focus) {
@@ -385,7 +385,7 @@ class Tabs extends React.Component {
 				className={classNames(
 					{
 						'slds-tabs--default': variant === 'default',
-						'slds-tabs--scoped': variant === 'scoped'
+						'slds-tabs--scoped': variant === 'scoped',
 					},
 					className
 				)}

--- a/components/tabs/panel.jsx
+++ b/components/tabs/panel.jsx
@@ -49,8 +49,8 @@ Panel.propTypes = {
 	children: PropTypes.oneOfType([
 		PropTypes.arrayOf(PropTypes.node),
 		PropTypes.node,
-		PropTypes.element
-	]).isRequired
+		PropTypes.element,
+	]).isRequired,
 };
 
 export default Panel;

--- a/components/tabs/private/tab-panel.jsx
+++ b/components/tabs/private/tab-panel.jsx
@@ -31,7 +31,7 @@ const TabPanel = ({
 			'slds-show': selected,
 			'slds-hide': !selected,
 			'slds-tabs--default__content': variant === 'default',
-			'slds-tabs--scoped__content': variant === 'scoped'
+			'slds-tabs--scoped__content': variant === 'scoped',
 		})}
 		id={id}
 		role="tabpanel"
@@ -69,7 +69,7 @@ TabPanel.propTypes = {
 	children: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 
 	/**
@@ -95,12 +95,12 @@ TabPanel.propTypes = {
 	/**
 	 * The HTML ID of the `<Tab />` that controls this panel.
 	 */
-	tabId: PropTypes.string
+	tabId: PropTypes.string,
 };
 
 TabPanel.defaultProps = {
 	variant: 'default',
-	selected: false
+	selected: false,
 };
 
 export default TabPanel;

--- a/components/tabs/private/tab.jsx
+++ b/components/tabs/private/tab.jsx
@@ -75,7 +75,7 @@ const Tab = createReactClass({
 		/**
 		 * If the Tabs should be scopped, defaults to false
 		 */
-		variant: PropTypes.oneOf(['default', 'scoped'])
+		variant: PropTypes.oneOf(['default', 'scoped']),
 	},
 
 	getDefaultProps () {
@@ -84,7 +84,7 @@ const Tab = createReactClass({
 			selected: false,
 			activeTabClassName: 'slds-active',
 			disabledTabClassName: 'slds-disabled',
-			variant: 'default'
+			variant: 'default',
 		};
 	},
 
@@ -112,7 +112,7 @@ const Tab = createReactClass({
 			className,
 			children,
 			id,
-			variant
+			variant,
 		} = this.props;
 		let tabIndex;
 
@@ -130,7 +130,7 @@ const Tab = createReactClass({
 					[activeTabClassName]: selected,
 					[disabledTabClassName]: disabled,
 					'slds-tabs--default__item': variant === 'default',
-					'slds-tabs--scoped__item': variant === 'scoped'
+					'slds-tabs--scoped__item': variant === 'scoped',
 				})}
 				role="tab"
 				ref={(node) => {
@@ -148,7 +148,7 @@ const Tab = createReactClass({
 						[activeTabClassName]: selected,
 						[disabledTabClassName]: disabled,
 						'slds-tabs--default__link': variant === 'default',
-						'slds-tabs--scoped__link': variant === 'scoped'
+						'slds-tabs--scoped__link': variant === 'scoped',
 					})}
 					href="javascript:void(0);" // eslint-disable-line no-script-url
 					role="presentation"
@@ -159,7 +159,7 @@ const Tab = createReactClass({
 				</a>
 			</li>
 		);
-	}
+	},
 });
 
 export default Tab;

--- a/components/tabs/private/tabs-list.jsx
+++ b/components/tabs/private/tabs-list.jsx
@@ -20,7 +20,7 @@ const TabsList = ({ id, className, children, variant }) => (
 		id={`${id}-slds-tabs__nav`}
 		className={classNames(className, {
 			'slds-tabs--default__nav': variant === 'default',
-			'slds-tabs--scoped__nav': variant === 'scoped'
+			'slds-tabs--scoped__nav': variant === 'scoped',
 		})}
 		role="tablist"
 	>
@@ -42,7 +42,7 @@ TabsList.propTypes = {
 	className: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 
 	/**
@@ -53,7 +53,7 @@ TabsList.propTypes = {
 	/**
 	 * If the Tabs should be scopped, defaults to false
 	 */
-	variant: PropTypes.oneOf(['default', 'scoped'])
+	variant: PropTypes.oneOf(['default', 'scoped']),
 };
 
 export default TabsList;

--- a/components/time-picker/__docs__/site-stories.js
+++ b/components/time-picker/__docs__/site-stories.js
@@ -4,7 +4,7 @@
 /* eslint-disable global-require */
 
 const siteStories = [
-	require('raw-loader!@salesforce/design-system-react/components/time-picker/__examples__/default.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/time-picker/__examples__/default.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/time-picker/__docs__/storybook-stories.jsx
+++ b/components/time-picker/__docs__/storybook-stories.jsx
@@ -20,6 +20,6 @@ storiesOf(TIME_PICKER, module)
 			label: 'Time',
 			required: true,
 			stepInMinutes: 30,
-			onDateChange: action('onDateChange')
+			onDateChange: action('onDateChange'),
 		})
 	);

--- a/components/time-picker/__examples__/default.jsx
+++ b/components/time-picker/__examples__/default.jsx
@@ -18,7 +18,7 @@ const Example = createReactClass({
 				/>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/time-picker/__tests__/time-picker.browser-test.jsx
+++ b/components/time-picker/__tests__/time-picker.browser-test.jsx
@@ -10,7 +10,7 @@ import assign from 'lodash.assign';
 const {
 	Simulate,
 	findRenderedDOMComponentWithTag,
-	findRenderedDOMComponentWithClass
+	findRenderedDOMComponentWithClass,
 } = TestUtils;
 
 import SLDSTimepicker from '../../time-picker';
@@ -26,7 +26,7 @@ const defaultStrValue = formatter(dateTimeNow);
 const defaultProps = {
 	onDateChange: () => {},
 	value: dateTimeNow,
-	strValue: defaultStrValue
+	strValue: defaultStrValue,
 };
 
 describe('SLDSTimepicker: ', () => {
@@ -43,7 +43,7 @@ describe('SLDSTimepicker: ', () => {
 						return {
 							isOpen: false,
 							value: futureDateTime,
-							strValue: formatter(futureDateTime)
+							strValue: formatter(futureDateTime),
 						};
 					},
 					render () {
@@ -52,7 +52,7 @@ describe('SLDSTimepicker: ', () => {
 								<SLDSTimepicker ref="timePicker" {...defaultProps} />
 							</IconSettings>
 						);
-					}
+					},
 				})
 			);
 

--- a/components/time-picker/index.jsx
+++ b/components/time-picker/index.jsx
@@ -61,7 +61,7 @@ const Timepicker = createReactClass({
 		menuPosition: PropTypes.oneOf([
 			'absolute',
 			'overflowBoundaryElement',
-			'relative'
+			'relative',
 		]),
 		/**
 		 * Receives the props `(dateValue, stringValue)`
@@ -84,7 +84,7 @@ const Timepicker = createReactClass({
 		/**
 		 * Date
 		 */
-		value: PropTypes.instanceOf(Date)
+		value: PropTypes.instanceOf(Date),
 	},
 
 	getDefaultProps () {
@@ -93,7 +93,7 @@ const Timepicker = createReactClass({
 				if (date) {
 					return date.toLocaleTimeString(navigator.language, {
 						hour: '2-digit',
-						minute: '2-digit'
+						minute: '2-digit',
 					});
 				}
 
@@ -104,14 +104,14 @@ const Timepicker = createReactClass({
 				const dateStr = date.toLocaleString(navigator.language, {
 					year: 'numeric',
 					month: 'numeric',
-					day: 'numeric'
+					day: 'numeric',
 				});
 				return new Date(`${dateStr} ${timeStr}`);
 			},
 			menuPosition: 'absolute',
 			placeholder: 'Pick Time',
 			value: null,
-			stepInMinutes: 30
+			stepInMinutes: 30,
 		};
 	},
 
@@ -119,7 +119,7 @@ const Timepicker = createReactClass({
 		return {
 			value: this.props.value,
 			strValue: this.props.strValue,
-			options: this.getOptions()
+			options: this.getOptions(),
 		};
 	},
 
@@ -136,7 +136,7 @@ const Timepicker = createReactClass({
 			if (currentTime !== nextTime) {
 				this.setState({
 					value: nextProps.value,
-					strValue: this.props.formatter(nextProps.value)
+					strValue: this.props.formatter(nextProps.value),
 				});
 			}
 		}
@@ -158,7 +158,7 @@ const Timepicker = createReactClass({
 
 			options.push({
 				label: formatted,
-				value: new Date(curDate)
+				value: new Date(curDate),
 			});
 
 			curDate.setMinutes(curDate.getMinutes() + this.props.stepInMinutes);
@@ -182,7 +182,7 @@ const Timepicker = createReactClass({
 	handleChange (date, strValue) {
 		this.setState({
 			value: date,
-			strValue
+			strValue,
 		});
 
 		if (this.props.onDateChange) {
@@ -200,7 +200,7 @@ const Timepicker = createReactClass({
 		const strValue = event.target.value;
 
 		this.setState({
-			strValue
+			strValue,
 		});
 
 		if (this.props.onDateChange) {
@@ -223,7 +223,7 @@ const Timepicker = createReactClass({
 				menuStyle={{
 					maxHeight: '20em',
 					overflowX: 'hidden',
-					minWidth: '100%'
+					minWidth: '100%',
 				}}
 				menuPosition={this.props.menuPosition}
 				onSelect={this.handleSelect}
@@ -239,7 +239,7 @@ const Timepicker = createReactClass({
 				/>
 			</MenuDropdown>
 		);
-	}
+	},
 });
 
 export default Timepicker;

--- a/components/time-picker/private/dropdown-trigger.jsx
+++ b/components/time-picker/private/dropdown-trigger.jsx
@@ -73,7 +73,7 @@ const TimepickerDropdownTrigger = createReactClass({
 		/**
 		 * Date
 		 */
-		value: PropTypes.string
+		value: PropTypes.string,
 	},
 
 	handleKeyDown (event) {
@@ -116,7 +116,7 @@ const TimepickerDropdownTrigger = createReactClass({
 				</Input>
 			</div>
 		);
-	}
+	},
 });
 
 export default TimepickerDropdownTrigger;

--- a/components/toast/__docs__/site-stories.js
+++ b/components/toast/__docs__/site-stories.js
@@ -8,7 +8,7 @@ const siteStories = [
 	require('raw-loader!@salesforce/design-system-react/components/toast/__examples__/success.jsx'),
 	require('raw-loader!@salesforce/design-system-react/components/toast/__examples__/warning.jsx'),
 	require('raw-loader!@salesforce/design-system-react/components/toast/__examples__/error.jsx'),
-	require('raw-loader!@salesforce/design-system-react/components/toast/__examples__/error-with-details.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/toast/__examples__/error-with-details.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/toast/__examples__/close-toast.jsx
+++ b/components/toast/__examples__/close-toast.jsx
@@ -10,7 +10,7 @@ class Example extends React.Component {
 		super(props);
 
 		this.state = {
-			isOpen: false
+			isOpen: false,
 		};
 	}
 
@@ -23,7 +23,7 @@ class Example extends React.Component {
 							<Toast
 								labels={{
 									heading: '26 potential duplicate leads were found.',
-									headingLink: 'Select Leads to Merge'
+									headingLink: 'Select Leads to Merge',
 								}}
 								onClickHeadingLink={() => {
 									console.log('Link clicked.');

--- a/components/toast/__examples__/custom-class-name.jsx
+++ b/components/toast/__examples__/custom-class-name.jsx
@@ -13,7 +13,7 @@ class Example extends React.Component {
 						className="this-is-the-alert"
 						labels={{
 							heading: '26 potential duplicate leads were found.',
-							headingLink: 'Select Leads to Merge'
+							headingLink: 'Select Leads to Merge',
 						}}
 					/>
 				</ToastContainer>

--- a/components/toast/__examples__/duration-toast.jsx
+++ b/components/toast/__examples__/duration-toast.jsx
@@ -10,7 +10,7 @@ class Example extends React.Component {
 		super(props);
 
 		this.state = {
-			isOpen: true
+			isOpen: true,
 		};
 	}
 
@@ -24,7 +24,7 @@ class Example extends React.Component {
 								duration={1000}
 								labels={{
 									heading: '26 potential duplicate leads were found.',
-									headingLink: 'Select Leads to Merge'
+									headingLink: 'Select Leads to Merge',
 								}}
 								onClickHeadingLink={() => {
 									console.log('Link clicked.');

--- a/components/toast/__examples__/error-with-details.jsx
+++ b/components/toast/__examples__/error-with-details.jsx
@@ -14,7 +14,7 @@ class Example extends React.Component {
 							heading:
 								"You've encountered some errors when trying to save edits to Samuel Smith.",
 							details:
-								"Here's some detail of what happened, being very descriptive and transparent."
+								"Here's some detail of what happened, being very descriptive and transparent.",
 						}}
 						variant="error"
 					/>

--- a/components/toast/__examples__/error.jsx
+++ b/components/toast/__examples__/error.jsx
@@ -12,7 +12,7 @@ class Example extends React.Component {
 					<Toast
 						labels={{
 							heading:
-								'Can’t save lead “Sally Wong” because another lead has the same name.'
+								'Can’t save lead “Sally Wong” because another lead has the same name.',
 						}}
 						variant="error"
 					/>

--- a/components/toast/__examples__/info.jsx
+++ b/components/toast/__examples__/info.jsx
@@ -12,7 +12,7 @@ class Example extends React.Component {
 					<Toast
 						labels={{
 							heading: '26 potential duplicate leads were found.',
-							headingLink: 'Select Leads to Merge'
+							headingLink: 'Select Leads to Merge',
 						}}
 						onClickHeadingLink={() => {
 							console.log('Link clicked.');

--- a/components/toast/__examples__/success.jsx
+++ b/components/toast/__examples__/success.jsx
@@ -16,8 +16,8 @@ class Example extends React.Component {
 								<a key="acme-100" href="javascript:void(0);">
 									ACME - 100
 								</a>,
-								' widgets was created.'
-							]
+								' widgets was created.',
+							],
 						}}
 						variant="success"
 					/>

--- a/components/toast/__examples__/warning.jsx
+++ b/components/toast/__examples__/warning.jsx
@@ -12,7 +12,7 @@ class Example extends React.Component {
 					<Toast
 						labels={{
 							heading:
-								'Can’t share file “report-q3.pdf” with the selected users.'
+								'Can’t share file “report-q3.pdf” with the selected users.',
 						}}
 						variant="warning"
 					/>

--- a/components/toast/__tests__/toast.browser-test.jsx
+++ b/components/toast/__tests__/toast.browser-test.jsx
@@ -7,7 +7,7 @@ import chai, { expect } from 'chai';
 import chaiEnzyme from 'chai-enzyme';
 import {
 	mountComponent,
-	unmountComponent
+	unmountComponent,
 } from '../../../tests/enzyme-helpers';
 
 chai.use(chaiEnzyme());
@@ -23,7 +23,7 @@ class DemoComponent extends React.Component {
 		super(props);
 
 		this.state = {
-			isOpen: true
+			isOpen: true,
 		};
 	}
 
@@ -38,7 +38,7 @@ class DemoComponent extends React.Component {
 								icon={<Icon category="utility" name="user" />}
 								labels={{
 									heading: 'Logged in as John Smith (johnsmith@acme.com).',
-									headingLink: 'Log out'
+									headingLink: 'Log out',
 								}}
 								onRequestClose={() => {
 									this.setState({ isOpen: false });

--- a/components/toast/__tests__/toast.snapshot-test.jsx
+++ b/components/toast/__tests__/toast.snapshot-test.jsx
@@ -11,35 +11,35 @@ import CustomClassNames from '../__examples__/custom-class-name';
 testDOMandHTML({
 	name: 'Toast Info',
 	test,
-	Component: Info
+	Component: Info,
 });
 
 testDOMandHTML({
 	name: 'Toast Warning',
 	test,
-	Component: Warning
+	Component: Warning,
 });
 
 testDOMandHTML({
 	name: 'Toast Error',
 	test,
-	Component: ErrorAlert
+	Component: ErrorAlert,
 });
 
 testDOMandHTML({
 	name: 'Toast Error With details',
 	test,
-	Component: ErrorWithDetailsAlert
+	Component: ErrorWithDetailsAlert,
 });
 
 testDOMandHTML({
 	name: 'Toast Success',
 	test,
-	Component: Success
+	Component: Success,
 });
 
 testDOMandHTML({
 	name: 'Toast Custom Class Name',
 	test,
-	Component: CustomClassNames
+	Component: CustomClassNames,
 });

--- a/components/toast/container.jsx
+++ b/components/toast/container.jsx
@@ -15,12 +15,12 @@ const propTypes = {
 	className: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * Toast components
 	 */
-	children: PropTypes.node
+	children: PropTypes.node,
 };
 
 /**

--- a/components/toast/index.jsx
+++ b/components/toast/index.jsx
@@ -24,7 +24,7 @@ const propTypes = {
 	 * _Tested with snapshot testing._
 	 */
 	assistiveText: shape({
-		closeButton: PropTypes.oneOfType([PropTypes.string, PropTypes.node])
+		closeButton: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
 	}),
 	/**
 	 * CSS classes to be added to tag with `.slds-notify_toast`. Uses `classNames` [API](https://github.com/JedWatson/classnames).
@@ -33,7 +33,7 @@ const propTypes = {
 	className: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * If duration exists, the Toast will disappear after that amount of time. Time in milliseconds. _Tested with Mocha testing._
@@ -51,7 +51,7 @@ const propTypes = {
 	labels: shape({
 		details: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
 		heading: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-		headingLink: PropTypes.oneOfType([PropTypes.string, PropTypes.node])
+		headingLink: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
 	}),
 	/**
 	 * Triggered by link. _Tested with Mocha testing._
@@ -74,14 +74,14 @@ const propTypes = {
 	/**
 	 * The type of Toast. _Tested with snapshot testing._
 	 */
-	variant: PropTypes.oneOf(['error', 'info', 'success', 'warning']).isRequired
+	variant: PropTypes.oneOf(['error', 'info', 'success', 'warning']).isRequired,
 };
 
 const defaultProps = {
 	assistiveText: {
-		closeButton: 'Close'
+		closeButton: 'Close',
 	},
-	variant: 'info'
+	variant: 'info',
 };
 
 /**
@@ -92,7 +92,7 @@ class Toast extends React.Component {
 	constructor (props) {
 		super(props);
 		this.state = {
-			isInitialRender: true
+			isInitialRender: true,
 		};
 		this.timeout = null;
 	}
@@ -150,14 +150,14 @@ class Toast extends React.Component {
 			info: 'info',
 			success: 'success',
 			warning: 'warning',
-			error: 'error'
+			error: 'error',
 		};
 
 		const defaultIcons = {
 			info: <Icon category="utility" name="info" />,
 			success: <Icon category="utility" name="success" />,
 			warning: <Icon category="utility" name="warning" />,
-			error: <Icon category="utility" name="error" />
+			error: <Icon category="utility" name="error" />,
 		};
 
 		const icon = this.props.icon
@@ -167,7 +167,7 @@ class Toast extends React.Component {
 		const clonedIcon = React.cloneElement(icon, {
 			containerClassName: 'slds-m-right_small slds-no-flex slds-align-top',
 			inverse: true,
-			size: 'small'
+			size: 'small',
 		});
 
 		/* eslint-disable no-script-url */
@@ -179,7 +179,7 @@ class Toast extends React.Component {
 						'slds-theme_info': this.props.variant === 'info',
 						'slds-theme_success': this.props.variant === 'success',
 						'slds-theme_warning': this.props.variant === 'warning',
-						'slds-theme_error': this.props.variant === 'error'
+						'slds-theme_error': this.props.variant === 'error',
 					},
 					this.props.className
 				)}

--- a/components/tooltip/__docs__/site-stories.js
+++ b/components/tooltip/__docs__/site-stories.js
@@ -6,7 +6,7 @@
 const siteStories = [
 	require('raw-loader!@salesforce/design-system-react/components/tooltip/__examples__/base.jsx'),
 	require('raw-loader!@salesforce/design-system-react/components/tooltip/__examples__/button.jsx'),
-	require('raw-loader!@salesforce/design-system-react/components/tooltip/__examples__/button-group.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/tooltip/__examples__/button-group.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/tooltip/__docs__/storybook-stories.jsx
+++ b/components/tooltip/__docs__/storybook-stories.jsx
@@ -35,7 +35,7 @@ const getPopoverTooltipAlign = (props) => {
 		'bottom right',
 		'left',
 		'left top',
-		'left bottom'
+		'left bottom',
 	];
 
 	align.forEach((value) => {
@@ -58,7 +58,7 @@ storiesOf(POPOVER_TOOLTIP, module)
 			style={{
 				margin: '100px auto',
 				textAlign: 'center',
-				width: '500px'
+				width: '500px',
 			}}
 		>
 			<IconSettings iconPath="/assets/icons">{getStory()}</IconSettings>
@@ -69,7 +69,7 @@ storiesOf(POPOVER_TOOLTIP, module)
 			align: 'bottom',
 			id: 'myPopoverId',
 			content:
-				'wjeifowejfiwoefjweoifjweiofjweiofwjefiowejfiowejfiowefjweiofjweiofjweiofjiwoefjowiefjoiwejfiowejfoie'
+				'wjeifowejfiwoefjweoifjweiofjweiofwjefiowejfiowejfiowefjweiofjweiofjweiofjiwoefjowiefjoiwejfiowejfoie',
 		})
 	)
 	.add('Button Group', () => <ButtonGroupExample />)
@@ -80,7 +80,7 @@ storiesOf(POPOVER_TOOLTIP, module)
 			isOpen: true,
 			id: 'myPopoverId',
 			content:
-				'wjeifowejfiwoefjweoifjweiofjweiofwjefiowejfiowejfiowefjweiofjweiofjweiofjiwoefjowiefjoiwejfiowejfoie'
+				'wjeifowejfiwoefjweoifjweiofjweiofwjefiowejfiowejfiowefjweiofjweiofjweiofjiwoefjowiefjoiwejfiowejfoie',
 		})
 	)
 	.add('Alignment (Button)', () =>
@@ -89,7 +89,7 @@ storiesOf(POPOVER_TOOLTIP, module)
 			isOpen: true,
 			content:
 				'wjeifowejfiwoefjweoifjweiofjweiofwjefiowejfiowejfiowefjweiofjweiofjweiofjiwoefjowiefjoiwejfiowejfoie',
-			trigger: <Button label="Trigger Tooltip" />
+			trigger: <Button label="Trigger Tooltip" />,
 		})
 	)
 	.add('Alignment (span)', () =>
@@ -102,7 +102,7 @@ storiesOf(POPOVER_TOOLTIP, module)
 				<span tabIndex="0" key="trigger">
 					Trigger Tooltip
 				</span>
-			)
+			),
 		})
 	)
 	.add('Alignment (icon)', () =>
@@ -122,6 +122,6 @@ storiesOf(POPOVER_TOOLTIP, module)
 					size="small"
 					tabIndex="0"
 				/>
-			)
+			),
 		})
 	);

--- a/components/tooltip/__examples__/base.jsx
+++ b/components/tooltip/__examples__/base.jsx
@@ -25,7 +25,7 @@ const Example = createReactClass({
 				</PopoverTooltip>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/tooltip/__examples__/button-group.jsx
+++ b/components/tooltip/__examples__/button-group.jsx
@@ -28,13 +28,13 @@ const Example = createReactClass({
 						options={[
 							{ label: 'A Option', value: 'A0' },
 							{ label: 'B Option', value: 'B0' },
-							{ label: 'C Option', value: 'C0' }
+							{ label: 'C Option', value: 'C0' },
 						]}
 					/>
 				</ButtonGroup>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/tooltip/__examples__/button.jsx
+++ b/components/tooltip/__examples__/button.jsx
@@ -15,7 +15,7 @@ const Example = createReactClass({
 				</PopoverTooltip>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/tooltip/__tests__/tooltip.browser-test.jsx
+++ b/components/tooltip/__tests__/tooltip.browser-test.jsx
@@ -11,7 +11,7 @@ import SLDSButton from '../../button';
 const {
 	Simulate,
 	findRenderedDOMComponentWithTag,
-	findRenderedDOMComponentWithClass
+	findRenderedDOMComponentWithClass,
 } = TestUtils;
 
 describe('SLDSTooltip: ', function () {
@@ -26,7 +26,7 @@ describe('SLDSTooltip: ', function () {
 			</span>
 		),
 		hasStaticAlignment: true,
-		id: 'myTooltip123'
+		id: 'myTooltip123',
 	};
 
 	afterEach(() => {
@@ -71,7 +71,7 @@ describe('SLDSTooltip: ', function () {
 			rootNode = generateTooltip(
 				{
 					...defaultProps,
-					align: 'top'
+					align: 'top',
 				},
 				defaultTrigger
 			);
@@ -133,7 +133,7 @@ describe('SLDSTooltip: ', function () {
 			const rootNode = generateTooltip(
 				{
 					...defaultProps,
-					isOpen: false
+					isOpen: false,
 				},
 				defaultTrigger
 			);
@@ -173,7 +173,7 @@ describe('SLDSTooltip: ', function () {
 							{defaultTextContent}
 						</span>
 					),
-					isOpen: true
+					isOpen: true,
 				},
 				defaultTrigger
 			);

--- a/components/tooltip/index.jsx
+++ b/components/tooltip/index.jsx
@@ -48,7 +48,7 @@ const propTypes = {
 		'bottom right',
 		'left',
 		'left top',
-		'left bottom'
+		'left bottom',
 	]).isRequired,
 	/**
 	 * Pass the one element that triggers the Tooltip as a child. It must be an element with `tabIndex` or an element that already has a `tabIndex` set such as an anchor or a button, so that keyboard users can tab to it.
@@ -80,7 +80,7 @@ const propTypes = {
 	triggerClassName: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * Please select one of the following:
@@ -91,7 +91,7 @@ const propTypes = {
 	position: PropTypes.oneOf([
 		'absolute',
 		'overflowBoundaryElement',
-		'relative'
+		'relative',
 	]),
 	/**
 	 * Custom styles to be added to wrapping triggering `div`.
@@ -100,7 +100,7 @@ const propTypes = {
 	/**
 	 * Determines the variant of tooltip: for informative purpose (blue background) or warning purpose (red background)
 	 */
-	variant: PropTypes.oneOf(['info', 'error'])
+	variant: PropTypes.oneOf(['info', 'error']),
 };
 
 const defaultProps = {
@@ -108,7 +108,7 @@ const defaultProps = {
 	content: <span>Tooltip</span>,
 	hoverCloseDelay: 50,
 	position: 'absolute',
-	variant: 'info'
+	variant: 'info',
 };
 
 /**
@@ -120,7 +120,7 @@ class PopoverTooltip extends React.Component {
 
 		this.state = {
 			isClosing: false,
-			isOpen: false
+			isOpen: false,
 		};
 	}
 
@@ -145,7 +145,7 @@ class PopoverTooltip extends React.Component {
 					onBlur: this.handleMouseLeave,
 					onFocus: this.handleMouseEnter,
 					onMouseEnter: this.handleMouseEnter,
-					onMouseLeave: this.handleMouseLeave
+					onMouseLeave: this.handleMouseLeave,
 				},
 				this.grandKidsWithAsstText(child)
 			)
@@ -174,7 +174,7 @@ class PopoverTooltip extends React.Component {
 					marginBottom: getMargin.bottom(align),
 					marginLeft: getMargin.left(align),
 					marginRight: getMargin.right(align),
-					marginTop: getMargin.top(align)
+					marginTop: getMargin.top(align),
 				}}
 				variant="tooltip"
 			>
@@ -225,14 +225,14 @@ class PopoverTooltip extends React.Component {
 	handleCancel = () => {
 		this.setState({
 			isOpen: false,
-			isClosing: false
+			isClosing: false,
 		});
 	};
 
 	handleMouseEnter = () => {
 		this.setState({
 			isOpen: true,
-			isClosing: false
+			isClosing: false,
 		});
 	};
 
@@ -243,7 +243,7 @@ class PopoverTooltip extends React.Component {
 			if (!this.isUnmounting && this.state.isClosing) {
 				this.setState({
 					isOpen: false,
-					isClosing: false
+					isClosing: false,
 				});
 			}
 		}, this.props.hoverCloseDelay);
@@ -285,7 +285,7 @@ class PopoverTooltip extends React.Component {
 }
 
 PopoverTooltip.contextTypes = {
-	iconPath: PropTypes.string
+	iconPath: PropTypes.string,
 };
 
 PopoverTooltip.displayName = displayName;

--- a/components/tree/__docs__/site-stories.js
+++ b/components/tree/__docs__/site-stories.js
@@ -4,7 +4,7 @@
 /* eslint-disable global-require */
 
 const siteStories = [
-	require('raw-loader!@salesforce/design-system-react/components/tree/__examples__/default.jsx')
+	require('raw-loader!@salesforce/design-system-react/components/tree/__examples__/default.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/tree/__docs__/storybook-stories.jsx
+++ b/components/tree/__docs__/storybook-stories.jsx
@@ -23,13 +23,13 @@ const DemoTree = createReactClass({
 		noBranchSelection: PropTypes.bool,
 		searchTerm: PropTypes.string,
 		searchable: PropTypes.bool,
-		singleSelection: PropTypes.bool
+		singleSelection: PropTypes.bool,
 	},
 
 	getDefaultProps () {
 		return {
 			exampleNodesIndex: 'sampleNodesDefault',
-			id: 'example-tree'
+			id: 'example-tree',
 		};
 	},
 
@@ -40,7 +40,7 @@ const DemoTree = createReactClass({
 		return {
 			nodes: initalNodes,
 			selectedNode: undefined,
-			searchTerm: this.props.searchable ? 'fruit' : undefined
+			searchTerm: this.props.searchable ? 'fruit' : undefined,
 		};
 	},
 
@@ -117,7 +117,7 @@ const DemoTree = createReactClass({
 				/>
 			</div>
 		);
-	}
+	},
 });
 
 storiesOf(TREE, module)
@@ -148,7 +148,7 @@ storiesOf(TREE, module)
 			exampleNodesIndex="sampleNodesWithLargeDataset"
 			listStyle={{
 				height: '300px',
-				overflowY: 'auto'
+				overflowY: 'auto',
 			}}
 		/>
 	))

--- a/components/tree/__examples__/default.jsx
+++ b/components/tree/__examples__/default.jsx
@@ -10,7 +10,7 @@ const sampleNodes = {
 			label: 'Grains',
 			type: 'item',
 			id: 1,
-			selected: true
+			selected: true,
 		},
 		{
 			label: 'Fruits',
@@ -26,20 +26,20 @@ const sampleNodes = {
 						{
 							label: 'Watermelon',
 							type: 'item',
-							id: 12
+							id: 12,
 						},
 						{
 							label: 'Canteloupe',
 							type: 'item',
 							_iconClass: 'glyphicon-file',
-							id: 13
+							id: 13,
 						},
 						{
 							label: 'Strawberries',
 							type: 'item',
-							id: 14
-						}
-					]
+							id: 14,
+						},
+					],
 				},
 				{
 					label: 'Tree Fruits',
@@ -50,13 +50,13 @@ const sampleNodes = {
 						{
 							label: 'Peaches',
 							type: 'item',
-							id: 15
+							id: 15,
 						},
 						{
 							label: 'Pears',
 							type: 'item',
 							_iconClass: 'glyphicon-file',
-							id: 16
+							id: 16,
 						},
 						{
 							label: 'Citrus',
@@ -66,24 +66,24 @@ const sampleNodes = {
 								{
 									label: 'Orange',
 									type: 'item',
-									id: 20
+									id: 20,
 								},
 								{
 									label: 'Grapefruit',
 									type: 'item',
-									id: 21
+									id: 21,
 								},
 								{
 									label: 'Lemon',
 									type: 'item',
-									id: 22
+									id: 22,
 								},
 								{
 									label: 'Lime',
 									type: 'item',
-									id: 23
-								}
-							]
+									id: 23,
+								},
+							],
 						},
 						{
 							label: 'Apples',
@@ -93,25 +93,25 @@ const sampleNodes = {
 								{
 									label: 'Granny Smith',
 									type: 'item',
-									id: 24
+									id: 24,
 								},
 								{
 									label: 'Pinklady',
 									type: 'item',
 									_iconClass: 'glyphicon-file',
-									id: 25
+									id: 25,
 								},
 								{
 									label: 'Rotten',
 									type: 'item',
-									id: 26
+									id: 26,
 								},
 								{
 									label: 'Jonathan',
 									type: 'item',
-									id: 27
-								}
-							]
+									id: 27,
+								},
+							],
 						},
 						{
 							label: 'Cherries',
@@ -121,43 +121,43 @@ const sampleNodes = {
 								{
 									label: 'Balaton',
 									type: 'item',
-									id: 28
+									id: 28,
 								},
 								{
 									label: 'Erdi Botermo',
 									type: 'item',
-									id: 29
+									id: 29,
 								},
 								{
 									label: 'Montmorency',
 									type: 'item',
-									id: 30
+									id: 30,
 								},
 								{
 									label: 'Queen Ann',
 									type: 'item',
-									id: 31
+									id: 31,
 								},
 								{
 									label: 'Ulster',
 									type: 'item',
-									id: 32
+									id: 32,
 								},
 								{
 									label: 'Viva',
 									type: 'item',
-									id: 33
-								}
-							]
+									id: 33,
+								},
+							],
 						},
 						{
 							label: 'Raspberries',
 							type: 'item',
-							id: 6
-						}
-					]
-				}
-			]
+							id: 6,
+						},
+					],
+				},
+			],
 		},
 		{
 			label: 'Nuts',
@@ -168,38 +168,38 @@ const sampleNodes = {
 				{
 					label: 'Almonds',
 					type: 'item',
-					id: 8
+					id: 8,
 				},
 				{
 					label: 'Cashews',
 					type: 'item',
-					id: 9
+					id: 9,
 				},
 				{
 					label: 'Pecans',
 					type: 'item',
-					id: 10
+					id: 10,
 				},
 				{
 					label: 'Walnuts',
 					type: 'item',
-					id: 11
-				}
-			]
+					id: 11,
+				},
+			],
 		},
 		{
 			label: 'Empty folder',
 			type: 'branch',
 			id: 7,
-			expanded: true
-		}
+			expanded: true,
+		},
 	],
 
 	sampleNodesDefault: [
 		{
 			label: 'Grains',
 			type: 'item',
-			id: 1
+			id: 1,
 		},
 		{
 			label: 'Fruits',
@@ -214,20 +214,20 @@ const sampleNodes = {
 						{
 							label: 'Watermelon',
 							type: 'item',
-							id: 12
+							id: 12,
 						},
 						{
 							label: 'Canteloupe',
 							type: 'item',
 							_iconClass: 'glyphicon-file',
-							id: 13
+							id: 13,
 						},
 						{
 							label: 'Strawberries',
 							type: 'item',
-							id: 14
-						}
-					]
+							id: 14,
+						},
+					],
 				},
 				{
 					label: 'Tree Fruits',
@@ -237,13 +237,13 @@ const sampleNodes = {
 						{
 							label: 'Peaches',
 							type: 'item',
-							id: 15
+							id: 15,
 						},
 						{
 							label: 'Pears',
 							type: 'item',
 							_iconClass: 'glyphicon-file',
-							id: 16
+							id: 16,
 						},
 						{
 							label: 'Citrus',
@@ -253,24 +253,24 @@ const sampleNodes = {
 								{
 									label: 'Orange',
 									type: 'item',
-									id: 20
+									id: 20,
 								},
 								{
 									label: 'Grapefruit',
 									type: 'item',
-									id: 21
+									id: 21,
 								},
 								{
 									label: 'Lemon',
 									type: 'item',
-									id: 22
+									id: 22,
 								},
 								{
 									label: 'Lime',
 									type: 'item',
-									id: 23
-								}
-							]
+									id: 23,
+								},
+							],
 						},
 						{
 							label: 'Apples',
@@ -280,25 +280,25 @@ const sampleNodes = {
 								{
 									label: 'Granny Smith',
 									type: 'item',
-									id: 24
+									id: 24,
 								},
 								{
 									label: 'Pinklady',
 									type: 'item',
 									_iconClass: 'glyphicon-file',
-									id: 25
+									id: 25,
 								},
 								{
 									label: 'Rotten',
 									type: 'item',
-									id: 26
+									id: 26,
 								},
 								{
 									label: 'Jonathan',
 									type: 'item',
-									id: 27
-								}
-							]
+									id: 27,
+								},
+							],
 						},
 						{
 							label: 'Cherries',
@@ -308,43 +308,43 @@ const sampleNodes = {
 								{
 									label: 'Balaton',
 									type: 'item',
-									id: 28
+									id: 28,
 								},
 								{
 									label: 'Erdi Botermo',
 									type: 'item',
-									id: 29
+									id: 29,
 								},
 								{
 									label: 'Montmorency',
 									type: 'item',
-									id: 30
+									id: 30,
 								},
 								{
 									label: 'Queen Ann',
 									type: 'item',
-									id: 31
+									id: 31,
 								},
 								{
 									label: 'Ulster',
 									type: 'item',
-									id: 32
+									id: 32,
 								},
 								{
 									label: 'Viva',
 									type: 'item',
-									id: 33
-								}
-							]
+									id: 33,
+								},
+							],
 						},
 						{
 							label: 'Raspberries',
 							type: 'item',
-							id: 6
-						}
-					]
-				}
-			]
+							id: 6,
+						},
+					],
+				},
+			],
 		},
 		{
 			label: 'Nuts',
@@ -355,31 +355,31 @@ const sampleNodes = {
 				{
 					label: 'Almonds',
 					type: 'item',
-					id: 8
+					id: 8,
 				},
 				{
 					label: 'Cashews',
 					type: 'item',
-					id: 9
+					id: 9,
 				},
 				{
 					label: 'Pecans',
 					type: 'item',
-					id: 10
+					id: 10,
 				},
 				{
 					label: 'Walnuts',
 					type: 'item',
-					id: 11
-				}
-			]
+					id: 11,
+				},
+			],
 		},
 		{
 			label: 'Empty folder',
 			type: 'branch',
-			id: 7
-		}
-	]
+			id: 7,
+		},
+	],
 };
 
 const Example = createReactClass({
@@ -391,13 +391,13 @@ const Example = createReactClass({
 		noBranchSelection: PropTypes.bool,
 		searchTerm: PropTypes.string,
 		searchable: PropTypes.bool,
-		singleSelection: PropTypes.bool
+		singleSelection: PropTypes.bool,
 	},
 
 	getDefaultProps () {
 		return {
 			exampleNodesIndex: 'sampleNodesDefault',
-			id: 'example-tree'
+			id: 'example-tree',
 		};
 	},
 
@@ -407,7 +407,7 @@ const Example = createReactClass({
 			: sampleNodes.sampleNodesDefault;
 		return {
 			nodes: initalNodes,
-			searchTerm: this.props.searchable ? 'fruit' : undefined
+			searchTerm: this.props.searchable ? 'fruit' : undefined,
 		};
 	},
 
@@ -475,7 +475,7 @@ const Example = createReactClass({
 				</div>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/tree/__tests__/tree.browser-test.jsx
+++ b/components/tree/__tests__/tree.browser-test.jsx
@@ -12,7 +12,7 @@ import chaiEnzyme from 'chai-enzyme';
 // `this.wrapper` and `this.dom` is set in the helpers file
 import {
 	mountComponent,
-	unmountComponent
+	unmountComponent,
 } from '../../../tests/enzyme-helpers';
 
 // ### isFunction
@@ -27,7 +27,7 @@ import Search from '../../forms/input/search';
 chai.use(chaiEnzyme());
 
 const COMPONENT_CSS_CLASSES = {
-	base: 'slds-tree'
+	base: 'slds-tree',
 };
 
 const DemoTree = createReactClass({
@@ -43,13 +43,13 @@ const DemoTree = createReactClass({
 		searchTerm: PropTypes.string,
 		searchable: PropTypes.bool,
 		singleSelection: PropTypes.bool,
-		treeScrolled: PropTypes.func
+		treeScrolled: PropTypes.func,
 	},
 
 	getDefaultProps () {
 		return {
 			exampleNodesIndex: 'sampleNodesDefault',
-			id: 'example-tree'
+			id: 'example-tree',
 		};
 	},
 
@@ -59,7 +59,7 @@ const DemoTree = createReactClass({
 			: sampleNodes.sampleNodesDefault;
 		return {
 			nodes: initalNodes,
-			searchTerm: this.props.searchable ? 'fruit' : undefined
+			searchTerm: this.props.searchable ? 'fruit' : undefined,
 		};
 	},
 
@@ -142,7 +142,7 @@ const DemoTree = createReactClass({
 				</div>
 			</IconSettings>
 		);
-	}
+	},
 });
 
 describe('Tree: ', () => {
@@ -318,7 +318,7 @@ describe('Tree: ', () => {
 					onScroll={onScroll}
 					listStyle={{
 						height: '300px',
-						overflowY: 'auto'
+						overflowY: 'auto',
 					}}
 				/>
 			)

--- a/components/tree/check-props.js
+++ b/components/tree/check-props.js
@@ -14,7 +14,7 @@ if (process.env.NODE_ENV !== 'production') {
 		/* eslint-disable max-len */
 		oneOfRequiredProperty(COMPONENT, {
 			assistiveText: props.assistiveText,
-			heading: props.heading
+			heading: props.heading,
 		});
 		/* eslint-enable max-len */
 	};

--- a/components/tree/index.jsx
+++ b/components/tree/index.jsx
@@ -47,7 +47,7 @@ class Tree extends React.Component {
 			>
 				<h4
 					className={classNames('slds-text-title--caps', {
-						'slds-assistive-text': this.props.assistiveText
+						'slds-assistive-text': this.props.assistiveText,
 					})}
 					id={`${this.props.id}__heading`}
 				>
@@ -72,7 +72,7 @@ class Tree extends React.Component {
 }
 
 Tree.defaultProps = {
-	getNodes: (node) => node.nodes
+	getNodes: (node) => node.nodes,
 };
 
 // ### Display Name
@@ -91,7 +91,7 @@ Tree.propTypes = {
 	className: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * Class names to be added to the top-level `ul` element of the tree.
@@ -99,7 +99,7 @@ Tree.propTypes = {
 	listClassName: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/**
 	 * A function that will be called by every branch to receive its child nodes. The parent `node` object with the branch data is passed into this function: `getNodes(node)`. If your state engine is Flux or Redux, then your tree data structure will probably be flattened or normalized within the store. This will allow you to build out your tree without transversing an actual tree of data and may be more performant.
@@ -136,7 +136,7 @@ Tree.propTypes = {
 	/*
 	 * Styles to be added to the top-level `ul` element. Useful for `overflow:hidden`.
 	 */
-	listStyle: PropTypes.object
+	listStyle: PropTypes.object,
 };
 
 export default Tree;

--- a/components/tree/private/branch.jsx
+++ b/components/tree/private/branch.jsx
@@ -40,7 +40,7 @@ const handleExpandClick = (event, props) => {
 		props.onExpandClick(event, {
 			node: props.node,
 			expand: !props.node.expanded,
-			treeIndex: props.treeIndex
+			treeIndex: props.treeIndex,
 		});
 	}
 };
@@ -51,7 +51,7 @@ const handleClick = (event, props) => {
 		props.onClick(event, {
 			node: props.node,
 			select: !props.node.selected,
-			treeIndex: props.treeIndex
+			treeIndex: props.treeIndex,
 		});
 	}
 };
@@ -64,7 +64,7 @@ const handleScroll = (event, props) => {
 
 	if (isFunction(props.onScroll)) {
 		props.onScroll(event, {
-			percentage
+			percentage,
 		});
 	}
 };
@@ -100,12 +100,12 @@ renderInitialNode.propTypes = {
 	initalClassName: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	/*
 	 * Styles to be added to the top-level `ul` element. Useful for `overflow:hidden`.
 	 */
-	initialStyle: PropTypes.object
+	initialStyle: PropTypes.object,
 };
 
 // Most of these props come from the nodes array, not from the Tree props
@@ -119,7 +119,7 @@ const renderBranch = (children, props) => {
 			style={{
 				display: 'block',
 				paddingLeft: `${1.5 * props.level + 1.5}rem`,
-				marginTop: '.5rem'
+				marginTop: '.5rem',
 			}}
 		>
 			<div
@@ -129,7 +129,7 @@ const renderBranch = (children, props) => {
 					marginBottom: '.75rem',
 					height: '.5rem',
 					backgroundColor: 'rgb(224, 229, 238)',
-					width: '40%'
+					width: '40%',
 				}}
 			/>
 			<div
@@ -139,7 +139,7 @@ const renderBranch = (children, props) => {
 					marginBottom: '.75rem',
 					height: '.5rem',
 					backgroundColor: 'rgb(224, 229, 238)',
-					width: '80%'
+					width: '80%',
 				}}
 			/>
 			<div
@@ -149,7 +149,7 @@ const renderBranch = (children, props) => {
 					marginBottom: '.75rem',
 					height: '.5rem',
 					backgroundColor: 'rgb(224, 229, 238)',
-					width: '60%'
+					width: '60%',
 				}}
 			/>
 		</div>
@@ -166,7 +166,7 @@ const renderBranch = (children, props) => {
 			{/* eslint-disable jsx-a11y/no-static-element-interactions */}
 			<div
 				className={classNames('slds-tree__item', {
-					'slds-is-selected': isSelected
+					'slds-is-selected': isSelected,
 				})}
 				onClick={(event) => {
 					handleClick(event, props);
@@ -200,7 +200,7 @@ const renderBranch = (children, props) => {
 			<ul
 				className={classNames({
 					'slds-is-expanded': isExpanded,
-					'slds-is-collapsed': !isExpanded
+					'slds-is-collapsed': !isExpanded,
 				})}
 				role="group"
 				aria-labelledby={`${props.htmlId}__label`}
@@ -245,7 +245,7 @@ renderBranch.propTypes = {
 	/**
 	 * Location of node (zero index). First node is `0`. It's first child is `0-0`. This can be used to modify your nodes without searching for the node. This index is only valid if the `nodes` prop is the same as at the time of the event.
 	 */
-	treeIndex: PropTypes.string
+	treeIndex: PropTypes.string,
 };
 
 /**
@@ -337,7 +337,7 @@ Branch.propTypes = {
 	initalClassName: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.object,
-		PropTypes.string
+		PropTypes.string,
 	]),
 	initialStyle: PropTypes.object,
 	/**
@@ -371,13 +371,13 @@ Branch.propTypes = {
 	/**
 	 * Location of node (zero index). First node is `0`. It's first child is `0-0`. This can be used to modify your nodes without searching for the node. This index is only valid if the `nodes` prop is the same as at the time of the event.
 	 */
-	treeIndex: PropTypes.string
+	treeIndex: PropTypes.string,
 };
 
 Branch.defaultProps = {
 	level: 0,
 	label: '',
-	treeIndex: ''
+	treeIndex: '',
 };
 
 export default Branch;

--- a/components/tree/private/item.jsx
+++ b/components/tree/private/item.jsx
@@ -34,7 +34,7 @@ const handleClick = (event, props) => {
 		props.onClick(event, {
 			node: props.node,
 			select: !props.node.selected,
-			treeIndex: props.treeIndex
+			treeIndex: props.treeIndex,
 		});
 	}
 };
@@ -55,7 +55,7 @@ const Item = (props) => {
 			{/* eslint-disable jsx-a11y/no-static-element-interactions */}
 			<div
 				className={classNames('slds-tree__item', {
-					'slds-is-selected': isSelected
+					'slds-is-selected': isSelected,
 				})}
 				aria-selected={isSelected ? 'true' : 'false'}
 				onClick={(event) => {
@@ -123,11 +123,11 @@ Item.propTypes = {
 	/**
 	 * Location of node (zero index). First node is `0`. It's first child is `0-0`. This can be used to modify your nodes without searching for the node. This index is only valid if the `nodes` prop is the same as at the time of the event.
 	 */
-	treeIndex: PropTypes.string
+	treeIndex: PropTypes.string,
 };
 
 Item.defaultProps = {
-	selected: false
+	selected: false,
 };
 
 export default Item;

--- a/components/utilities/dialog/index.jsx
+++ b/components/utilities/dialog/index.jsx
@@ -64,7 +64,7 @@ const Dialog = createReactClass({
 			'bottom right',
 			'left',
 			'left top',
-			'left bottom'
+			'left bottom',
 		]),
 		/**
 		 * CSS classes to be added to the absolutely positioned element.
@@ -72,7 +72,7 @@ const Dialog = createReactClass({
 		className: PropTypes.oneOfType([
 			PropTypes.array,
 			PropTypes.object,
-			PropTypes.string
+			PropTypes.string,
 		]),
 		/**
 		 * CSS classes to be added to the wrapping `div` of the contents of the dialog.
@@ -80,7 +80,7 @@ const Dialog = createReactClass({
 		contentsClassName: PropTypes.oneOfType([
 			PropTypes.array,
 			PropTypes.object,
-			PropTypes.string
+			PropTypes.string,
 		]),
 		/**
 		 * Contents of dialog
@@ -160,7 +160,7 @@ const Dialog = createReactClass({
 		position: PropTypes.oneOf([
 			'absolute',
 			'overflowBoundaryElement',
-			'relative'
+			'relative',
 		]).isRequired,
 		/**
 		 * An object of CSS styles that are applied to the immediate parent `div` of the contents. Use this instead of margin props.
@@ -169,21 +169,21 @@ const Dialog = createReactClass({
 		/**
 		 * Sets which focus UX pattern to follow. For instance, popovers trap focus and must be exited to regain focus. Dropdowns and Tooltips never have focus.
 		 */
-		variant: PropTypes.oneOf(['dropdown', 'popover', 'tooltip'])
+		variant: PropTypes.oneOf(['dropdown', 'popover', 'tooltip']),
 	},
 
 	getDefaultProps () {
 		return {
 			align: 'bottom left',
 			offset: '0px 0px',
-			outsideClickIgnoreClass: 'ignore-react-onclickoutside'
+			outsideClickIgnoreClass: 'ignore-react-onclickoutside',
 		};
 	},
 
 	getInitialState () {
 		return {
 			triggerPopperJS: false,
-			isOpen: false
+			isOpen: false,
 		};
 	},
 
@@ -229,7 +229,7 @@ const Dialog = createReactClass({
 		const offsetArray = offsetString.split(' ');
 		return {
 			vertical: parseInt(offsetArray[0], 10),
-			horizontal: parseInt(offsetArray[1], 10)
+			horizontal: parseInt(offsetArray[1], 10),
 		};
 	},
 
@@ -238,7 +238,7 @@ const Dialog = createReactClass({
 		if (!this.popper || !popperData) {
 			return {
 				position: 'absolute',
-				pointerEvents: 'none'
+				pointerEvents: 'none',
 			};
 		}
 
@@ -297,7 +297,7 @@ const Dialog = createReactClass({
 		if (this.props.variant === 'popover' && scopedElement) {
 			DOMElementFocus.storeActiveElement();
 			DOMElementFocus.setupScopedFocus({
-				ancestorElement: scopedElement.querySelector('.slds-popover')
+				ancestorElement: scopedElement.querySelector('.slds-popover'),
 			}); // eslint-disable-line react/no-find-dom-node
 			// Don't steal focus from inner elements
 			if (!DOMElementFocus.hasOrAncestorHasFocus()) {
@@ -325,7 +325,7 @@ const Dialog = createReactClass({
 			preventOverflow: {
 				enabled: true,
 				boundariesElement:
-					this.props.position === 'absolute' ? 'scrollParent' : 'viewport'
+					this.props.position === 'absolute' ? 'scrollParent' : 'viewport',
 			},
 			// By default, dialogs will flip their alignment if they extend beyond a boundary element such as a scrolling parent or a window/viewpoint
 			removeOnDestroy: true,
@@ -341,8 +341,8 @@ const Dialog = createReactClass({
 						this.setState({ popperData });
 					}
 					return popperData;
-				}
-			}
+				},
+			},
 			// arrow property can also point to an element
 		};
 		if (!reference) {
@@ -354,7 +354,7 @@ const Dialog = createReactClass({
 		this.popper = new Popper(reference, popper, {
 			placement,
 			eventsEnabled,
-			modifiers
+			modifiers,
 		});
 
 		this.popper.scheduleUpdate();
@@ -395,7 +395,7 @@ const Dialog = createReactClass({
 							'portal-positioned':
 								this.props.position === 'overflowBoundaryElement',
 							[`${this.props.outsideClickIgnoreClass}`]:
-								this.props.position === 'overflowBoundaryElement'
+								this.props.position === 'overflowBoundaryElement',
 						},
 						this.props.contentsClassName
 					) || undefined
@@ -420,15 +420,15 @@ const Dialog = createReactClass({
 						{contents}
 					</IconSettings>
 				</Portal>
-			)
+			),
 		};
 
 		return subRenders[this.props.position] && subRenders[this.props.position]();
-	}
+	},
 });
 
 Dialog.contextTypes = {
-	iconPath: PropTypes.string
+	iconPath: PropTypes.string,
 };
 
 export default Dialog;

--- a/components/utilities/dialog/portal.jsx
+++ b/components/utilities/dialog/portal.jsx
@@ -13,7 +13,7 @@ class Portal extends Component {
 		super(props);
 		this.portalNode = null;
 		this.state = {
-			isOpen: false
+			isOpen: false,
 		};
 	}
 
@@ -99,7 +99,7 @@ class Portal extends Component {
 				domContainerNode: this.portalNode,
 				updateCallback: () => {
 					this.updatePortal(); // update after subtree renders
-				}
+				},
 			});
 		} else {
 			// actual render
@@ -185,7 +185,7 @@ Portal.propTypes = {
 	 * />
 	 * ```
 	 */
-	portalMount: PropTypes.func
+	portalMount: PropTypes.func,
 };
 
 Portal.defaultProps = {
@@ -194,7 +194,7 @@ Portal.defaultProps = {
 	onMount: () => null,
 	onOpen: () => null,
 	onUpdate: () => null,
-	onUnmount: () => null
+	onUnmount: () => null,
 };
 
 export default Portal;

--- a/components/utilities/highlighter/index.jsx
+++ b/components/utilities/highlighter/index.jsx
@@ -84,13 +84,13 @@ Highlighter.propTypes = {
 		PropTypes.string,
 		PropTypes.number,
 		PropTypes.bool,
-		PropTypes.node
+		PropTypes.node,
 	]),
 	className: PropTypes.string,
 	/**
 	 * The string of text (or Regular Expression) to highlight.
 	 */
-	search: PropTypes.any
+	search: PropTypes.any,
 };
 
 export default Highlighter;

--- a/components/utilities/menu-list/index.jsx
+++ b/components/utilities/menu-list/index.jsx
@@ -65,14 +65,14 @@ const List = createReactClass({
 		/**
 		 * The id of the element which triggered this list (in a menu context).
 		 */
-		triggerId: PropTypes.string
+		triggerId: PropTypes.string,
 	},
 
 	getDefaultProps () {
 		return {
 			length: '5',
 			options: [],
-			selectedIndex: -1
+			selectedIndex: -1,
 		};
 	},
 
@@ -117,7 +117,7 @@ const List = createReactClass({
 				})}
 			</ul>
 		);
-	}
+	},
 });
 
 export default List;

--- a/components/utilities/menu-list/item-label.jsx
+++ b/components/utilities/menu-list/item-label.jsx
@@ -31,7 +31,7 @@ ListItemLabel.propTypes = {
 	inverted: PropTypes.bool,
 	isSelected: PropTypes.bool,
 	label: PropTypes.string,
-	value: PropTypes.any
+	value: PropTypes.any,
 };
 
 ListItemLabel.defaultProps = {
@@ -40,7 +40,7 @@ ListItemLabel.defaultProps = {
 	inverted: false,
 	isSelected: false,
 	label: '',
-	value: null
+	value: null,
 };
 
 export default ListItemLabel;

--- a/components/utilities/menu-list/item.jsx
+++ b/components/utilities/menu-list/item.jsx
@@ -38,7 +38,7 @@ const ListItem = createReactClass({
 		className: PropTypes.oneOfType([
 			PropTypes.array,
 			PropTypes.object,
-			PropTypes.string
+			PropTypes.string,
 		]),
 		checkmark: PropTypes.bool,
 		data: PropTypes.object,
@@ -52,15 +52,15 @@ const ListItem = createReactClass({
 		labelRenderer: PropTypes.func,
 		leftIcon: PropTypes.shape({
 			category: PropTypes.string,
-			name: PropTypes.string
+			name: PropTypes.string,
 		}),
 		onSelect: PropTypes.func.isRequired,
 		rightIcon: PropTypes.shape({
 			category: PropTypes.string,
-			name: PropTypes.string
+			name: PropTypes.string,
 		}),
 		type: PropTypes.string,
-		value: PropTypes.any
+		value: PropTypes.any,
 	},
 
 	getDefaultProps () {
@@ -71,7 +71,7 @@ const ListItem = createReactClass({
 			isSelected: false,
 			label: '',
 			labelRenderer: ListItemLabelRenderer,
-			value: null
+			value: null,
 		};
 	},
 
@@ -100,7 +100,7 @@ const ListItem = createReactClass({
 				classnames.push('slds-icon--selected');
 				iconProps = {
 					category: 'utility',
-					name: 'check'
+					name: 'check',
 				};
 			}
 
@@ -151,7 +151,7 @@ const ListItem = createReactClass({
 							{
 								'slds-has-divider--top-space': this.props.divider === 'top',
 								'slds-has-divider--bottom-space':
-									this.props.divider === 'bottom'
+									this.props.divider === 'bottom',
 							},
 							this.props.className
 						)}
@@ -182,7 +182,7 @@ const ListItem = createReactClass({
 						className={classNames(
 							'slds-dropdown__item',
 							{
-								'slds-is-selected': this.props.isSelected
+								'slds-is-selected': this.props.isSelected,
 							},
 							this.props.className
 						)}
@@ -206,7 +206,7 @@ const ListItem = createReactClass({
 				);
 			}
 		}
-	}
+	},
 });
 
 export default ListItem;

--- a/components/utilities/pill/index.jsx
+++ b/components/utilities/pill/index.jsx
@@ -24,7 +24,7 @@ const propTypes = {
 	 * * `pressDeleteOrBackspace`: Informs user of keyboard keys to press in order to remove a pill
 	 */
 	assistiveText: shape({
-		remove: PropTypes.string
+		remove: PropTypes.string,
 	}),
 	/*
 	 * Pills are often used for selection of a type of entity such as days in a daypicker. This prop allows you to pass in data that will be passed back to the event handler.
@@ -38,7 +38,7 @@ const propTypes = {
 		onRequestFocus: PropTypes.func.isRequired,
 		onRequestFocusOnNextPill: PropTypes.func.isRequired,
 		onRequestFocusOnPreviousPill: PropTypes.func.isRequired,
-		onRequestRemove: PropTypes.func.isRequired
+		onRequestRemove: PropTypes.func.isRequired,
 	}),
 	/*
 	 * The icon next to the pill label.
@@ -49,7 +49,7 @@ const propTypes = {
 	 */
 	labels: shape({
 		label: PropTypes.string.isRequired,
-		removeTitle: PropTypes.string
+		removeTitle: PropTypes.string,
 	}),
 	/*
 	 * If true and is active pill in listbox, will trigger `events.onRequestFocus`
@@ -62,17 +62,17 @@ const propTypes = {
 	/*
 	 * Allows the user to tab to the node
 	 */
-	tabIndex: PropTypes.number
+	tabIndex: PropTypes.number,
 };
 
 const defaultProps = {
 	assistiveText: shape({
-		remove: ', Press delete or backspace to remove'
+		remove: ', Press delete or backspace to remove',
 	}),
 	labels: {
-		remove: 'Remove'
+		remove: 'Remove',
 	},
-	events: {}
+	events: {},
 };
 
 const handleKeyDown = (event, { events, data }) => {
@@ -83,13 +83,13 @@ const handleKeyDown = (event, { events, data }) => {
 			[KEYS.DELETE]: { callback: events.onRequestRemove, data },
 			[KEYS.LEFT]: {
 				callback: events.onRequestFocusOnPreviousPill,
-				data: { ...data, direction: 'previous' }
+				data: { ...data, direction: 'previous' },
 			},
 			[KEYS.RIGHT]: {
 				callback: events.onRequestFocusOnNextPill,
-				data: { ...data, direction: 'next' }
-			}
-		}
+				data: { ...data, direction: 'next' },
+			},
+		},
 	});
 };
 
@@ -113,7 +113,7 @@ const Pill = (props) => {
 			variant="option"
 			labels={labels}
 			assistiveText={{
-				remove: assistiveText.remove
+				remove: assistiveText.remove,
 			}}
 			aria-selected={props.active}
 			onBlur={props.events.onBlur}
@@ -122,7 +122,7 @@ const Pill = (props) => {
 					? (event) => {
 						if (props.events.onClick) {
 							props.events.onClick(event, {
-								option: props.eventData
+								option: props.eventData,
 							});
 						}
 					}
@@ -132,13 +132,13 @@ const Pill = (props) => {
 				EventUtil.trap(event);
 				handleClickRemove(event, {
 					events: props.events,
-					eventData: props.eventData
+					eventData: props.eventData,
 				});
 			}}
 			onKeyDown={(event) => {
 				handleKeyDown(event, {
 					events: props.events,
-					data: props.eventData
+					data: props.eventData,
 				});
 			}}
 			ref={(component) => {

--- a/components/utilities/truncate/by-length.js
+++ b/components/utilities/truncate/by-length.js
@@ -5,7 +5,7 @@ export default function truncateByLength ({
 	inputString = '',
 	maxLength = 140,
 	truncationChars = '...',
-	startingLength = 0
+	startingLength = 0,
 }) {
 	let outputString;
 

--- a/components/utilities/truncate/index.jsx
+++ b/components/utilities/truncate/index.jsx
@@ -29,14 +29,14 @@ const TextTruncate = createReactClass({
 		text: PropTypes.string,
 		textTruncateChild: PropTypes.node,
 		truncateText: PropTypes.string,
-		wrapper: PropTypes.func
+		wrapper: PropTypes.func,
 	},
 
 	getDefaultProps () {
 		return {
 			line: 1,
 			text: '',
-			truncateText: '…'
+			truncateText: '…',
 		};
 	},
 
@@ -93,7 +93,7 @@ const TextTruncate = createReactClass({
 			style['font-weight'],
 			style['font-style'],
 			style['font-size'],
-			style['font-family']
+			style['font-family'],
 		].join(' ');
 
 		// return if display:none
@@ -224,7 +224,7 @@ const TextTruncate = createReactClass({
 				{this.state.renderText}
 			</div>
 		);
-	}
+	},
 });
 
 export default TextTruncate;

--- a/components/utilities/utility-icon/index.jsx
+++ b/components/utilities/utility-icon/index.jsx
@@ -37,7 +37,7 @@ const UtilityIcon = (
 		custom: SLDS_ICONS_CUSTOM,
 		doctype: SLDS_ICONS_DOCTYPE,
 		standard: SLDS_ICONS_STANDARD,
-		utility: SLDS_ICONS_UTILITY
+		utility: SLDS_ICONS_UTILITY,
 	};
 	let inlineData;
 
@@ -83,7 +83,7 @@ UtilityIcon.propTypes = {
 		'custom',
 		'doctype',
 		'standard',
-		'utility'
+		'utility',
 	]),
 	/**
 	 * An SVG object to use instead of name / category, look in `design-system-react/icons` for examples
@@ -96,11 +96,11 @@ UtilityIcon.propTypes = {
 	/**
 	 * Path to the icon. This will override any global icon settings.
 	 */
-	path: PropTypes.string
+	path: PropTypes.string,
 };
 
 UtilityIcon.defaultProps = {
-	category: 'utility'
+	category: 'utility',
 };
 
 UtilityIcon.contextTypes = {
@@ -109,7 +109,7 @@ UtilityIcon.contextTypes = {
 	customSprite: PropTypes.string,
 	doctypeSprite: PropTypes.string,
 	standardSprite: PropTypes.string,
-	utilitySprite: PropTypes.string
+	utilitySprite: PropTypes.string,
 };
 
 export default UtilityIcon;

--- a/components/utilities/utility-icon/svg.jsx
+++ b/components/utilities/utility-icon/svg.jsx
@@ -77,7 +77,7 @@ const Svg = createReactClass({
 		const { data, ...props } = this.props;
 
 		return data ? this.getSVG(data, props) : null;
-	}
+	},
 });
 
 export default Svg;

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,7 +15,7 @@ webpackConfig.externals = {
 	'react/lib/ReactContext': true,
 	'react/lib/ExecutionEnvironment': true,
 	'react/addons': true,
-	cheerio: 'window'
+	cheerio: 'window',
 };
 
 // Karma configuration
@@ -34,7 +34,7 @@ const configExport = function (config) {
 			'tests/fixtures/phantomjs-shims.js',
 			'./node_modules/phantomjs-polyfill-find-index/findIndex-polyfill.js',
 			'./node_modules/phantomjs-polyfill-includes/includes-polyfill.js',
-			'components/tests-bundle.js'
+			'components/tests-bundle.js',
 		],
 
 		// list of files to exclude
@@ -43,7 +43,7 @@ const configExport = function (config) {
 		// preprocess matching files before serving them to the browser
 		// available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
 		preprocessors: {
-			'components/tests-bundle.js': ['webpack', 'sourcemap']
+			'components/tests-bundle.js': ['webpack', 'sourcemap'],
 		},
 
 		// test results reporter to use
@@ -52,7 +52,7 @@ const configExport = function (config) {
 		reporters: ['spec', 'coverage'],
 
 		coverageReporter: {
-			reporters: [{ type: 'html', dir: 'coverage/' }, { type: 'text' }]
+			reporters: [{ type: 'html', dir: 'coverage/' }, { type: 'text' }],
 		},
 
 		// web server port
@@ -86,8 +86,8 @@ const configExport = function (config) {
 			karmaPhantomjsLauncher,
 			karmaChromeLauncher,
 			karmaSpecReporter,
-			karmaCoverage
-		]
+			karmaCoverage,
+		],
 	});
 };
 

--- a/package.json
+++ b/package.json
@@ -207,7 +207,7 @@
     "jsxBracketSameLine": false,
     "semi": true,
     "singleQuote": true,
-    "trailingComma": "none",
+    "trailingComma": "es5",
     "useTabs": true
   },
   "components": [

--- a/preset/index.js
+++ b/preset/index.js
@@ -7,15 +7,15 @@ module.exports = function buildPreset () {
 			require('babel-preset-env').default(null, {
 				targets: {
 					browsers: ['last 2 versions', 'ie 11'],
-					node: '6.8'
-				}
+					node: '6.8',
+				},
 			}),
-			require('babel-preset-react')
+			require('babel-preset-react'),
 		],
 		plugins: [
 			require('babel-plugin-transform-object-rest-spread'),
 			require('babel-plugin-transform-class-properties'),
-			require('babel-plugin-transform-export-extensions')
-		]
+			require('babel-plugin-transform-export-extensions'),
+		],
 	};
 };

--- a/scripts/build-docs.js
+++ b/scripts/build-docs.js
@@ -64,8 +64,8 @@ components.map((node) => {
 			// enable jsx and flow syntax
 			'jsx',
 			'objectRestSpread',
-			'classProperties'
-		]
+			'classProperties',
+		],
 	});
 	const cleanRoute = kebabCase(node['display-name']);
 
@@ -89,7 +89,7 @@ components.map((node) => {
 				util.inspect(depInputPathToUse.replace(dirName, '.'), {
 					showHidden: true,
 					depth: null,
-					colors: true
+					colors: true,
 				})
 			);
 
@@ -106,7 +106,7 @@ components.map((node) => {
 						util.inspect(err.message, {
 							showHidden: true,
 							depth: null,
-							colors: true
+							colors: true,
 						}),
 						`\n  ${depInputPathToUse.replace(
 							dirName,

--- a/scripts/command-line-utilities.js
+++ b/scripts/command-line-utilities.js
@@ -18,7 +18,7 @@ const exec = (
 		command,
 		{
 			cwd: path.resolve(rootPath, dir),
-			maxBuffer: 1024 * 500
+			maxBuffer: 1024 * 500,
 		},
 		(err) => {
 			callback(err);

--- a/scripts/dist.js
+++ b/scripts/dist.js
@@ -34,7 +34,7 @@ async.series(
 			// Used by documentation site
 			// Can be used for CI tests by consuming applications
 			packageJSON.SLDS = {
-				gitURL: packageJSON.devDependencies['@salesforce-ux/design-system']
+				gitURL: packageJSON.devDependencies['@salesforce-ux/design-system'],
 			};
 			delete packageJSON.scripts;
 			delete packageJSON.jest;
@@ -51,7 +51,7 @@ async.series(
 				JSON.stringify(packageJSON, null, 2),
 				done
 			);
-		}
+		},
 	],
 	(err) => {
 		if (err) throw err;

--- a/scripts/inline-icons.js
+++ b/scripts/inline-icons.js
@@ -32,7 +32,7 @@ const inlineIcons = (spriteType, done) => {
 	// This string replacement includes icons in the bundle. The default condition is an equality comparison of two constants, `'__EXCLUDE_SLDS_ICONS__' === '__INCLUDE_SLDS_ICONS__'`, which will allow minification to remove the inline icons and save 100KBs in size when bundling for production.
 	const index = [
 		license,
-		"let icons = {}; if ('__EXCLUDE_SLDS_ICONS__' === '__INCLUDE_SLDS_ICONS__') { icons = {"
+		"let icons = {}; if ('__EXCLUDE_SLDS_ICONS__' === '__INCLUDE_SLDS_ICONS__') { icons = {",
 	];
 
 	const sprite = JSON.parse(parser.toJson(text));

--- a/scripts/npm-transform.js
+++ b/scripts/npm-transform.js
@@ -40,7 +40,7 @@ async.series(
 				JSON.stringify(packageJSON, null, 2),
 				done
 			);
-		}
+		},
 	],
 	(err) => {
 		if (err) throw err;

--- a/scripts/publish-to-git.js
+++ b/scripts/publish-to-git.js
@@ -58,7 +58,7 @@ const publish = (done, type) => {
 	let actions = [
 		{ command: 'git init', dir: tmpDir, rootPath },
 		{ command: `cp ${gitDir}/config ${tmpDir}/.git`, rootPath },
-		{ command: 'git add -A', dir: tmpDir, rootPath }
+		{ command: 'git add -A', dir: tmpDir, rootPath },
 	];
 
 	if (argv.tag) {
@@ -69,14 +69,14 @@ const publish = (done, type) => {
 					argv.tag
 				}-${type} [ci skip]"`,
 				dir: tmpDir,
-				rootPath
+				rootPath,
 			},
 			{ command: `git tag ${argv.tag}${typeSuffix}`, dir: tmpDir, rootPath },
 			{
 				command: `git push ${remote} -f --tags ${argv.tag}${typeSuffix}`,
 				dir: tmpDir,
-				rootPath
-			}
+				rootPath,
+			},
 		];
 	} else {
 		actions = [
@@ -84,19 +84,19 @@ const publish = (done, type) => {
 			{
 				command: `git commit -m "Release commit for ${version}-${type} [ci skip]"`,
 				dir: tmpDir,
-				rootPath
+				rootPath,
 			},
 			{ command: `git tag v${version}${typeSuffix}`, dir: tmpDir, rootPath },
 			{
 				command: `git push ${remote} --tags v${version}${typeSuffix}`,
 				dir: tmpDir,
-				rootPath
-			}
+				rootPath,
+			},
 		];
 	}
 
 	actions = [
-		...actions
+		...actions,
 		// { command: `rm -r ${tmpDir}`, rootPath }
 	];
 
@@ -115,7 +115,7 @@ async.series(
 			exec(
 				{
 					command: 'npm run dist',
-					rootPath
+					rootPath,
 				},
 				done
 			),
@@ -127,7 +127,7 @@ async.series(
 		(done) => publish(done, 'commonjs'),
 
 		(done) => cleanPackageJson(done, 'amd'),
-		(done) => publish(done, 'amd')
+		(done) => publish(done, 'amd'),
 	],
 	(err) => {
 		if (err) throw err;

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -31,94 +31,94 @@ const tasks = ({ release, done }) => {
 	const commands = [
 		{
 			message: `# Check if ${remote} remote exists`,
-			command: `git ls-remote ${remote} --exit-code --quiet`
+			command: `git ls-remote ${remote} --exit-code --quiet`,
 		},
 		{
 			ignoreCommand: isBuildServer,
 			message:
 				'# Checking out master branch. Please ignore "RELEASENOTES.md - Your branch and \'upstream/master\' have diverged."',
-			command: 'git checkout master'
+			command: 'git checkout master',
 		},
 		{
 			ignoreCommand: isBuildServer,
 			message: '# Pruning NPM dependencies',
-			command: 'npm prune'
+			command: 'npm prune',
 		},
 		{
 			ignoreCommand: isBuildServer,
 			message: '# Running NPM install',
 			command: 'npm install',
-			verbose: false
+			verbose: false,
 		},
 		{
 			message: '# Build icons from latest icon module',
-			command: 'npm run icons'
+			command: 'npm run icons',
 		},
 		{
 			ignoreCommand: isBuildServer,
 			message: '# Running test suite',
 			command: 'npm test',
-			verbose: false
+			verbose: false,
 		},
 		{
 			ignoreCommand: isBuildServer,
 			message:
 				'# Update release notes, inline icons (if needed), and site component documentation',
-			command: 'git add RELEASENOTES.md'
+			command: 'git add RELEASENOTES.md',
 		},
 		{ command: 'git add icons/*' },
 		{ command: 'npm run build-docs' },
 		{ command: 'git add components/component-docs.json' },
 		{
 			ignoreCommand: !isBuildServer,
-			command: `rm -f ${release}.md`
+			command: `rm -f ${release}.md`,
 		},
 		{
 			// always commit because ${release}.md just got deleted if it is a release commit
 			ignoreCommand: !isBuildServer,
 			command:
-				'git commit -a -m "Clean up for release" -m "Build Server commit: Update release notes, commit inline icons (if needed), site component documentation (if needed). Remove patch.md or minor.md"'
+				'git commit -a -m "Clean up for release" -m "Build Server commit: Update release notes, commit inline icons (if needed), site component documentation (if needed). Remove patch.md or minor.md"',
 		},
 		{
 			// test if any files have changed, if they have then commit them
 			ignoreCommand: isBuildServer,
 			command:
-				'git diff-index --quiet HEAD || git commit -m "Update release notes, inline icons (if needed), and site component documentation"'
+				'git diff-index --quiet HEAD || git commit -m "Update release notes, inline icons (if needed), and site component documentation"',
 		},
 		{
 			ignoreCommand: isBuildServer,
-			command: 'git pull upstream master'
+			command: 'git pull upstream master',
 		},
 		{
 			ignoreCommand: isBuildServer,
-			command: 'git diff --exit-code'
+			command: 'git diff --exit-code',
 		},
 		{
 			message:
 				'# Bumping version in package.json, committing RELEASENOTES.md, and checking that there are no files in local working copy. Published package is based on current state of local files, not versioned files.',
-			command: `npm --no-git-tag-version version ${release}`
+			command: `npm --no-git-tag-version version ${release}`,
 		},
 		{
 			message: `# Building and publishing tag to ${remote} remote`,
 			command: `./node_modules/.bin/babel-node scripts/publish-to-git.js --remote=${remote}`,
-			verbose: false
+			verbose: false,
 		},
 		{
 			message: `# Pushing local master branch to ${remote} remote`,
-			command: `git push ${remote} master --no-verify`
+			command: `git push ${remote} master --no-verify`,
 		},
 		{
 			message: '# Set up NPM configuration',
-			command: 'cp scripts/.npmrc .npmrc'
+			command: 'cp scripts/.npmrc .npmrc',
 		},
 		{
 			message: '# Publish to NPM',
-			command: 'npm publish .tmp-npm --access public'
+			command: 'npm publish .tmp-npm --access public',
 		},
 		{
 			message: '# Remove NPM configuration',
-			command: 'rm .npmrc'
-		}
+			command: 'rm .npmrc',
+		},
 	]
 		.filter((item) => !item.ignoreCommand)
 		.map((item) => ({ ...item, rootPath }));
@@ -152,9 +152,9 @@ const releaseNotesSchema = {
 		releasenotes: {
 			default: 'y',
 			message:
-				"Have you written release notes (y/n)? 'n' will open RELEASENOTES.MD."
-		}
-	}
+				"Have you written release notes (y/n)? 'n' will open RELEASENOTES.MD.",
+		},
+	},
 };
 
 // START HERE
@@ -179,7 +179,7 @@ if (isBuildServer) {
 			exec(
 				{
 					command: 'open RELEASENOTES.MD',
-					rootPath
+					rootPath,
 				},
 				() => {}
 			);

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -29,7 +29,9 @@ do
 	echo "    ${COMMAND}"
 done
 
+echo -en 'travis_fold:start:npm ls\\r'
 npm ls --silent
+echo -en 'travis_fold:end:npm ls\\r'
 
 for COMMAND in "${COMMANDS[@]}"
 do

--- a/tests/app.js
+++ b/tests/app.js
@@ -13,7 +13,7 @@ const compiler = webpack(webpackConfig);
 app.use(
 	webpackDevMiddleware(compiler, {
 		noInfo: true,
-		publicPath: webpackConfig.output.publicPath
+		publicPath: webpackConfig.output.publicPath,
 	})
 );
 
@@ -21,7 +21,7 @@ app.use(
 	webpackHotMiddleware(compiler, {
 		log: console.log,
 		path: '/__webpack_hmr',
-		heartbeat: 10 * 1000
+		heartbeat: 10 * 1000,
 	})
 );
 

--- a/tests/settings.js
+++ b/tests/settings.js
@@ -4,8 +4,8 @@
 
 const Settings = {
 	jsBeautify: {
-		indent_size: 2
-	}
+		indent_size: 2,
+	},
 };
 
 export default Settings;

--- a/tests/story-based-tests.snapshot-test.js
+++ b/tests/story-based-tests.snapshot-test.js
@@ -30,7 +30,7 @@ app.use(express.static(`${rootPath}/storybook-based-tests`));
 // Create DOM snapshot tests from Storybook stories
 initStoryshots({
 	configPath: '.storybook-based-tests',
-	suite: 'DOM snapshots'
+	suite: 'DOM snapshots',
 });
 
 /* jest-image-snapshot
@@ -41,7 +41,7 @@ const getMatchOptions = ({ context: { kind, story }, url }) => ({
 	failureThreshold: 0.2,
 	failureThresholdType: 'percent',
 	// 0.02 appears to ignore slight gray changes in SLDS
-	customDiffConfig: { threshold: 0.02 }
+	customDiffConfig: { threshold: 0.02 },
 });
 
 let server;
@@ -69,7 +69,7 @@ describe('Image Snapshots', function imageSnapshotFunction () {
 		suite: 'Image storyshots',
 		test: imageSnapshot({
 			storybookUrl: `http://localhost:${port}`,
-			getMatchOptions
-		})
+			getMatchOptions,
+		}),
 	});
 });

--- a/utilities/date.js
+++ b/utilities/date.js
@@ -80,7 +80,7 @@ const DateUtil = {
 			30,
 			31,
 			30,
-			31
+			31,
 		][month];
 	},
 
@@ -96,7 +96,7 @@ const DateUtil = {
 			)
 		);
 		return newDate;
-	}
+	},
 };
 
 export default DateUtil;

--- a/utilities/dialog-helpers.js
+++ b/utilities/dialog-helpers.js
@@ -50,7 +50,7 @@ const getNubbinClassName = (align) =>
 		'slds-nubbin--left':
 			align === 'right' || align === 'right bottom' || align === 'right top',
 		'slds-nubbin--right':
-			align === 'left' || align === 'left bottom' || align === 'left top'
+			align === 'left' || align === 'left bottom' || align === 'left top',
 	});
 
 const getAlignment = {};
@@ -116,5 +116,5 @@ export {
 	getMargin,
 	getAlignment,
 	getNubbinClassName,
-	mapPropToPopperPlacement
+	mapPropToPopperPlacement,
 };

--- a/utilities/dom-element-focus.js
+++ b/utilities/dom-element-focus.js
@@ -60,7 +60,7 @@ const ElementFocus = {
 		if (canUseDOM) {
 			window.removeEventListener('keydown', handleScopedKeyDown);
 		}
-	}
+	},
 };
 
 export default ElementFocus;

--- a/utilities/event.js
+++ b/utilities/event.js
@@ -27,7 +27,7 @@ const EventUtil = {
 		}
 
 		EventUtil.trap(event);
-	}
+	},
 };
 
 export default EventUtil;

--- a/utilities/execution-environment.js
+++ b/utilities/execution-environment.js
@@ -12,7 +12,7 @@ const ExecutionEnvironment = {
 	canUseWorkers: typeof Worker !== 'undefined',
 	canUseEventListeners:
 		canUseDOM && !!(window.addEventListener || window.attachEvent),
-	canUseViewport: canUseDOM && !!window.screen
+	canUseViewport: canUseDOM && !!window.screen,
 };
 
 export default ExecutionEnvironment;

--- a/utilities/key-code.js
+++ b/utilities/key-code.js
@@ -8,7 +8,7 @@ const keys = {
 	DOWN: 40,
 	TAB: 9,
 	DELETE: 46,
-	BACKSPACE: 8
+	BACKSPACE: 8,
 };
 
 // Helpful for interaction/event tests. Use with simulate:
@@ -26,8 +26,8 @@ const keyObjects = {
 	BACKSPACE: {
 		key: 'Backspace',
 		keyCode: keys.BACKSPACE,
-		which: keys.BACKSPACE
-	}
+		which: keys.BACKSPACE,
+	},
 };
 
 export default keys;

--- a/utilities/keyboard-navigable-dialog.js
+++ b/utilities/keyboard-navigable-dialog.js
@@ -38,7 +38,7 @@ const KeyboardNavigableDialog = ({
 	keyCode,
 	eventTarget,
 	trigger,
-	toggleOpen
+	toggleOpen,
 }) => {
 	switch (keyCode) {
 		case KEYS.ESCAPE:
@@ -51,7 +51,7 @@ const KeyboardNavigableDialog = ({
 				internalHandleClick({
 					trigger,
 					eventTarget,
-					handleClick
+					handleClick,
 				});
 			}
 			break;

--- a/utilities/keyboard-navigable-menu.js
+++ b/utilities/keyboard-navigable-menu.js
@@ -53,7 +53,7 @@ export function getNavigableItems (items) {
 			if (itemIsSelectable(item)) {
 				navigableItems.push({
 					index,
-					text: `${item.label}`.toLowerCase()
+					text: `${item.label}`.toLowerCase(),
 				});
 
 				navigableItems.indexes.push(index);
@@ -75,7 +75,7 @@ export function keyboardNavigate ({
 	onFocus,
 	onSelect,
 	target,
-	toggleOpen
+	toggleOpen,
 }) {
 	const indexes = navigableItems.indexes;
 	const lastIndex = indexes.length - 1;
@@ -187,7 +187,7 @@ export const KeyboardNavigableMixin = {
 		onFocus = this.handleKeyboardFocus,
 		onSelect,
 		target,
-		toggleOpen = noop
+		toggleOpen = noop,
 	}) {
 		keyboardNavigate({
 			componentContext: this,
@@ -199,7 +199,7 @@ export const KeyboardNavigableMixin = {
 			onFocus,
 			onSelect,
 			target,
-			toggleOpen
+			toggleOpen,
 		});
 	},
 
@@ -255,7 +255,7 @@ export const KeyboardNavigableMixin = {
 				}
 			}
 		}
-	}
+	},
 };
 
 export default KeyboardNavigableMixin;

--- a/utilities/letter-key-code.js
+++ b/utilities/letter-key-code.js
@@ -9,7 +9,7 @@ for (let i = 65; i <= 122; i++) {
 	keyObjects[`${String.fromCharCode(i)}`] = {
 		key: `${String.fromCharCode(i)}`,
 		keyCode: i,
-		which: i
+		which: i,
 	};
 }
 

--- a/utilities/sample-data/global-navigation-bar/index.jsx
+++ b/utilities/sample-data/global-navigation-bar/index.jsx
@@ -10,22 +10,22 @@ const dropdownCollection = [
 		value: '1',
 		iconCategory: 'utility',
 		iconName: 'table',
-		href: 'http://www.google.com'
+		href: 'http://www.google.com',
 	},
 	{
 		label: 'Menu Item Two',
 		value: '2',
 		iconCategory: 'utility',
 		iconName: 'kanban',
-		href: 'http://www.google.com'
+		href: 'http://www.google.com',
 	},
 	{
 		label: 'Menu Item Three',
 		value: '3',
 		iconCategory: 'utility',
 		iconName: 'side_list',
-		href: 'http://www.google.com'
-	}
+		href: 'http://www.google.com',
+	},
 ];
 
 const propSets = {
@@ -35,25 +35,25 @@ const propSets = {
 			appLauncher: {
 				assistiveText: 'Open App Launcher',
 				id: 'app-launcher-trigger',
-				triggerName: 'App Name'
-			}
-		}
+				triggerName: 'App Name',
+			},
+		},
 	},
 	hybrid: {
 		props: {
-			openOn: 'hybrid'
+			openOn: 'hybrid',
 		},
 		primaryRegionProps: {
 			appLauncher: {
 				assistiveText: 'Open App Launcher',
 				id: 'app-launcher-trigger',
-				triggerName: 'App Name'
-			}
-		}
+				triggerName: 'App Name',
+			},
+		},
 	},
 	customCloud: {
 		props: {
-			cloud: 'marketing'
+			cloud: 'marketing',
 		},
 		primaryRegionProps: {
 			truncate: false,
@@ -79,14 +79,14 @@ const propSets = {
 							</span>
 						</div>
 					</div>
-				)
-			}
-		}
+				),
+			},
+		},
 	},
 	lightTheme: {
 		props: {
-			theme: 'light'
-		}
+			theme: 'light',
+		},
 	},
 	noNav: {
 		props: {},
@@ -94,10 +94,10 @@ const propSets = {
 			appLauncher: {
 				assistiveText: 'Open App Launcher',
 				id: 'app-launcher-trigger',
-				triggerName: 'App Name'
-			}
-		}
-	}
+				triggerName: 'App Name',
+			},
+		},
+	},
 };
 
 export { dropdownCollection, propSets };

--- a/utilities/sample-data/navigation/index.jsx
+++ b/utilities/sample-data/navigation/index.jsx
@@ -7,8 +7,8 @@ const sampleReportCategories = [
 			{ id: 'my_reports', label: 'Created by Me' },
 			{ id: 'private_reports', label: 'Private Reports' },
 			{ id: 'public_reports', label: 'Public Reports' },
-			{ id: 'all_reports', label: 'All Reports' }
-		]
+			{ id: 'all_reports', label: 'All Reports' },
+		],
 	},
 	{
 		id: 'folders',
@@ -17,12 +17,12 @@ const sampleReportCategories = [
 			{
 				id: 'my_folders',
 				label: 'Created by Me',
-				url: 'http://www.google.com'
+				url: 'http://www.google.com',
 			},
 			{ id: 'shared_folders', label: 'Shared with Me' },
-			{ id: 'all_folders', label: 'All Folders' }
-		]
-	}
+			{ id: 'all_folders', label: 'All Folders' },
+		],
+	},
 ];
 
 const sampleSearchCategories = [
@@ -39,8 +39,8 @@ const sampleSearchCategories = [
 			{ id: 'files', label: 'Files' },
 			{ id: 'dashboards', label: 'Dashboards' },
 			{ id: 'reports', label: 'Reports' },
-			{ id: 'feeds', label: 'Feeds' }
-		]
+			{ id: 'feeds', label: 'Feeds' },
+		],
 	},
 	{
 		id: 'external_results',
@@ -48,9 +48,9 @@ const sampleSearchCategories = [
 		items: [
 			{ id: 'app_one', label: 'App One' },
 			{ id: 'app_two', label: 'App Two' },
-			{ id: 'app_three', label: 'App Three' }
-		]
-	}
+			{ id: 'app_three', label: 'App Three' },
+		],
+	},
 ];
 
 export { sampleReportCategories, sampleSearchCategories };

--- a/utilities/sample-data/tree/index.jsx
+++ b/utilities/sample-data/tree/index.jsx
@@ -5,7 +5,7 @@ const sampleNodesDefault = [
 	{
 		label: 'Grains',
 		type: 'item',
-		id: 1
+		id: 1,
 	},
 	{
 		label: 'Fruits',
@@ -20,20 +20,20 @@ const sampleNodesDefault = [
 					{
 						label: 'Watermelon',
 						type: 'item',
-						id: 12
+						id: 12,
 					},
 					{
 						label: 'Canteloupe',
 						type: 'item',
 						_iconClass: 'glyphicon-file',
-						id: 13
+						id: 13,
 					},
 					{
 						label: 'Strawberries',
 						type: 'item',
-						id: 14
-					}
-				]
+						id: 14,
+					},
+				],
 			},
 			{
 				label: 'Tree Fruits',
@@ -43,13 +43,13 @@ const sampleNodesDefault = [
 					{
 						label: 'Peaches',
 						type: 'item',
-						id: 15
+						id: 15,
 					},
 					{
 						label: 'Pears',
 						type: 'item',
 						_iconClass: 'glyphicon-file',
-						id: 16
+						id: 16,
 					},
 					{
 						label: 'Citrus',
@@ -59,24 +59,24 @@ const sampleNodesDefault = [
 							{
 								label: 'Orange',
 								type: 'item',
-								id: 20
+								id: 20,
 							},
 							{
 								label: 'Grapefruit',
 								type: 'item',
-								id: 21
+								id: 21,
 							},
 							{
 								label: 'Lemon',
 								type: 'item',
-								id: 22
+								id: 22,
 							},
 							{
 								label: 'Lime',
 								type: 'item',
-								id: 23
-							}
-						]
+								id: 23,
+							},
+						],
 					},
 					{
 						label: 'Apples',
@@ -86,25 +86,25 @@ const sampleNodesDefault = [
 							{
 								label: 'Granny Smith',
 								type: 'item',
-								id: 24
+								id: 24,
 							},
 							{
 								label: 'Pinklady',
 								type: 'item',
 								_iconClass: 'glyphicon-file',
-								id: 25
+								id: 25,
 							},
 							{
 								label: 'Rotten',
 								type: 'item',
-								id: 26
+								id: 26,
 							},
 							{
 								label: 'Jonathan',
 								type: 'item',
-								id: 27
-							}
-						]
+								id: 27,
+							},
+						],
 					},
 					{
 						label: 'Cherries',
@@ -114,43 +114,43 @@ const sampleNodesDefault = [
 							{
 								label: 'Balaton',
 								type: 'item',
-								id: 28
+								id: 28,
 							},
 							{
 								label: 'Erdi Botermo',
 								type: 'item',
-								id: 29
+								id: 29,
 							},
 							{
 								label: 'Montmorency',
 								type: 'item',
-								id: 30
+								id: 30,
 							},
 							{
 								label: 'Queen Ann',
 								type: 'item',
-								id: 31
+								id: 31,
 							},
 							{
 								label: 'Ulster',
 								type: 'item',
-								id: 32
+								id: 32,
 							},
 							{
 								label: 'Viva',
 								type: 'item',
-								id: 33
-							}
-						]
+								id: 33,
+							},
+						],
 					},
 					{
 						label: 'Raspberries',
 						type: 'item',
-						id: 6
-					}
-				]
-			}
-		]
+						id: 6,
+					},
+				],
+			},
+		],
 	},
 	{
 		label: 'Nuts',
@@ -161,36 +161,36 @@ const sampleNodesDefault = [
 			{
 				label: 'Almonds',
 				type: 'item',
-				id: 8
+				id: 8,
 			},
 			{
 				label: 'Cashews',
 				type: 'item',
-				id: 9
+				id: 9,
 			},
 			{
 				label: 'Pecans',
 				type: 'item',
-				id: 10
+				id: 10,
 			},
 			{
 				label: 'Walnuts',
 				type: 'item',
-				id: 11
-			}
-		]
+				id: 11,
+			},
+		],
 	},
 	{
 		label: 'Empty folder',
 		type: 'branch',
-		id: 7
-	}
+		id: 7,
+	},
 ];
 
 const sampleNodes = {
 	sampleNodesDefault,
 	sampleNodesWithLargeDataset,
-	sampleNodesWithInitialState
+	sampleNodesWithInitialState,
 };
 
 export default sampleNodes;

--- a/utilities/sample-data/tree/sample-nodes-with-initial-state.jsx
+++ b/utilities/sample-data/tree/sample-nodes-with-initial-state.jsx
@@ -3,7 +3,7 @@ const treeNodesWithInitialState = [
 		label: 'Grains',
 		type: 'item',
 		id: 1,
-		selected: true
+		selected: true,
 	},
 	{
 		label: 'Fruits',
@@ -19,20 +19,20 @@ const treeNodesWithInitialState = [
 					{
 						label: 'Watermelon',
 						type: 'item',
-						id: 12
+						id: 12,
 					},
 					{
 						label: 'Canteloupe',
 						type: 'item',
 						_iconClass: 'glyphicon-file',
-						id: 13
+						id: 13,
 					},
 					{
 						label: 'Strawberries',
 						type: 'item',
-						id: 14
-					}
-				]
+						id: 14,
+					},
+				],
 			},
 			{
 				label: 'Tree Fruits',
@@ -43,13 +43,13 @@ const treeNodesWithInitialState = [
 					{
 						label: 'Peaches',
 						type: 'item',
-						id: 15
+						id: 15,
 					},
 					{
 						label: 'Pears',
 						type: 'item',
 						_iconClass: 'glyphicon-file',
-						id: 16
+						id: 16,
 					},
 					{
 						label: 'Citrus',
@@ -59,24 +59,24 @@ const treeNodesWithInitialState = [
 							{
 								label: 'Orange',
 								type: 'item',
-								id: 20
+								id: 20,
 							},
 							{
 								label: 'Grapefruit',
 								type: 'item',
-								id: 21
+								id: 21,
 							},
 							{
 								label: 'Lemon',
 								type: 'item',
-								id: 22
+								id: 22,
 							},
 							{
 								label: 'Lime',
 								type: 'item',
-								id: 23
-							}
-						]
+								id: 23,
+							},
+						],
 					},
 					{
 						label: 'Apples',
@@ -86,25 +86,25 @@ const treeNodesWithInitialState = [
 							{
 								label: 'Granny Smith',
 								type: 'item',
-								id: 24
+								id: 24,
 							},
 							{
 								label: 'Pinklady',
 								type: 'item',
 								_iconClass: 'glyphicon-file',
-								id: 25
+								id: 25,
 							},
 							{
 								label: 'Rotten',
 								type: 'item',
-								id: 26
+								id: 26,
 							},
 							{
 								label: 'Jonathan',
 								type: 'item',
-								id: 27
-							}
-						]
+								id: 27,
+							},
+						],
 					},
 					{
 						label: 'Cherries',
@@ -114,43 +114,43 @@ const treeNodesWithInitialState = [
 							{
 								label: 'Balaton',
 								type: 'item',
-								id: 28
+								id: 28,
 							},
 							{
 								label: 'Erdi Botermo',
 								type: 'item',
-								id: 29
+								id: 29,
 							},
 							{
 								label: 'Montmorency',
 								type: 'item',
-								id: 30
+								id: 30,
 							},
 							{
 								label: 'Queen Ann',
 								type: 'item',
-								id: 31
+								id: 31,
 							},
 							{
 								label: 'Ulster',
 								type: 'item',
-								id: 32
+								id: 32,
 							},
 							{
 								label: 'Viva',
 								type: 'item',
-								id: 33
-							}
-						]
+								id: 33,
+							},
+						],
 					},
 					{
 						label: 'Raspberries',
 						type: 'item',
-						id: 6
-					}
-				]
-			}
-		]
+						id: 6,
+					},
+				],
+			},
+		],
 	},
 	{
 		label: 'Nuts',
@@ -161,31 +161,31 @@ const treeNodesWithInitialState = [
 			{
 				label: 'Almonds',
 				type: 'item',
-				id: 8
+				id: 8,
 			},
 			{
 				label: 'Cashews',
 				type: 'item',
-				id: 9
+				id: 9,
 			},
 			{
 				label: 'Pecans',
 				type: 'item',
-				id: 10
+				id: 10,
 			},
 			{
 				label: 'Walnuts',
 				type: 'item',
-				id: 11
-			}
-		]
+				id: 11,
+			},
+		],
 	},
 	{
 		label: 'Empty folder',
 		type: 'branch',
 		id: 7,
-		expanded: true
-	}
+		expanded: true,
+	},
 ];
 
 export default treeNodesWithInitialState;

--- a/utilities/sample-data/tree/sample-nodes-with-large-dataset.js
+++ b/utilities/sample-data/tree/sample-nodes-with-large-dataset.js
@@ -4,90 +4,90 @@ export default [
 		id: 4002,
 		label: 'gakhu',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4005, label: 'doh', type: 'item', _isExpandable: false },
-			{ id: 4003, label: 'kapo', type: 'item', _isExpandable: false }
+			{ id: 4003, label: 'kapo', type: 'item', _isExpandable: false },
 		],
 		id: 4006,
 		label: 'lamaige',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 4007, label: 'zuhidzo', type: 'item', _isExpandable: false }
+					{ id: 4007, label: 'zuhidzo', type: 'item', _isExpandable: false },
 				],
 				id: 4008,
 				label: 'iftop',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4009,
 		label: 'gede',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 4012, label: 'tefmemez', type: 'item', _isExpandable: false }
+					{ id: 4012, label: 'tefmemez', type: 'item', _isExpandable: false },
 				],
 				id: 4013,
 				label: 'cev',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
-			{ id: 4010, label: 'uwuzot', type: 'item', _isExpandable: false }
+			{ id: 4010, label: 'uwuzot', type: 'item', _isExpandable: false },
 		],
 		id: 4014,
 		label: 'sosi',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 4020, label: 'acu', type: 'item', _isExpandable: false },
-					{ id: 4017, label: 'vovo', type: 'item', _isExpandable: false }
+					{ id: 4017, label: 'vovo', type: 'item', _isExpandable: false },
 				],
 				id: 4021,
 				label: 'le',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
-			{ id: 4015, label: 'ba', type: 'item', _isExpandable: false }
+			{ id: 4015, label: 'ba', type: 'item', _isExpandable: false },
 		],
 		id: 4022,
 		label: 'vurumere',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
-			{ id: 4023, label: 'vohdujka', type: 'item', _isExpandable: false }
+			{ id: 4023, label: 'vohdujka', type: 'item', _isExpandable: false },
 		],
 		id: 4024,
 		label: 'culav',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4027, label: 'hanatban', type: 'item', _isExpandable: false },
-			{ id: 4025, label: 'wiv', type: 'item', _isExpandable: false }
+			{ id: 4025, label: 'wiv', type: 'item', _isExpandable: false },
 		],
 		id: 4028,
 		label: 'hok',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -96,69 +96,69 @@ export default [
 				id: 4032,
 				label: 'hinow',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
-			{ id: 4029, label: 'kiwuzro', type: 'item', _isExpandable: false }
+			{ id: 4029, label: 'kiwuzro', type: 'item', _isExpandable: false },
 		],
 		id: 4033,
 		label: 'hoc',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 4043, label: 'pe', type: 'item', _isExpandable: false },
-					{ id: 4040, label: 'ecositif', type: 'item', _isExpandable: false }
+					{ id: 4040, label: 'ecositif', type: 'item', _isExpandable: false },
 				],
 				id: 4044,
 				label: 'kawnuve',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
 			{
 				nodes: [
 					{ id: 4037, label: 'adehire', type: 'item', _isExpandable: false },
-					{ id: 4034, label: 'tuh', type: 'item', _isExpandable: false }
+					{ id: 4034, label: 'tuh', type: 'item', _isExpandable: false },
 				],
 				id: 4038,
 				label: 'zukefne',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4045,
 		label: 'marpok',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4048, label: 'hazuggel', type: 'item', _isExpandable: false },
-			{ id: 4046, label: 'ziv', type: 'item', _isExpandable: false }
+			{ id: 4046, label: 'ziv', type: 'item', _isExpandable: false },
 		],
 		id: 4049,
 		label: 'suksire',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4050, label: 'cuf', type: 'item', _isExpandable: false }],
 		id: 4051,
 		label: 'nadah',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4054, label: 'tufi', type: 'item', _isExpandable: false },
-			{ id: 4052, label: 'jiedvu', type: 'item', _isExpandable: false }
+			{ id: 4052, label: 'jiedvu', type: 'item', _isExpandable: false },
 		],
 		id: 4055,
 		label: 'oteaca',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -168,133 +168,133 @@ export default [
 				id: 4057,
 				label: 'dumla',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4060,
 		label: 'azmo',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 4067, label: 'ojebebos', type: 'item', _isExpandable: false }
+					{ id: 4067, label: 'ojebebos', type: 'item', _isExpandable: false },
 				],
 				id: 4068,
 				label: 'hu',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
 			{
 				nodes: [
 					{ id: 4064, label: 'bu', type: 'item', _isExpandable: false },
-					{ id: 4061, label: 'zaw', type: 'item', _isExpandable: false }
+					{ id: 4061, label: 'zaw', type: 'item', _isExpandable: false },
 				],
 				id: 4065,
 				label: 'up',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4069,
 		label: 'fap',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4070, label: 'jafus', type: 'item', _isExpandable: false }],
 		id: 4071,
 		label: 'teomu',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 4075, label: 'aze', type: 'item', _isExpandable: false },
-					{ id: 4072, label: 'vibjo', type: 'item', _isExpandable: false }
+					{ id: 4072, label: 'vibjo', type: 'item', _isExpandable: false },
 				],
 				id: 4076,
 				label: 'zezer',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4077,
 		label: 'jogaf',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4081, label: 'curguko', type: 'item', _isExpandable: false },
 			{
 				nodes: [
-					{ id: 4078, label: 'cifbaz', type: 'item', _isExpandable: false }
+					{ id: 4078, label: 'cifbaz', type: 'item', _isExpandable: false },
 				],
 				id: 4079,
 				label: 'cahihet',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4082,
 		label: 'cazrinaw',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4086, label: 'mirjago', type: 'item', _isExpandable: false },
 			{
 				nodes: [
-					{ id: 4083, label: 'hawkiup', type: 'item', _isExpandable: false }
+					{ id: 4083, label: 'hawkiup', type: 'item', _isExpandable: false },
 				],
 				id: 4084,
 				label: 'zisehar',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4087,
 		label: 'kosta',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4088, label: 'ocibeb', type: 'item', _isExpandable: false }],
 		id: 4089,
 		label: 'vufeesi',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4090, label: 'mulcav', type: 'item', _isExpandable: false }],
 		id: 4091,
 		label: 'ukizi',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 4094, label: 'odri', type: 'item', _isExpandable: false }
+					{ id: 4094, label: 'odri', type: 'item', _isExpandable: false },
 				],
 				id: 4095,
 				label: 'ja',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
-			{ id: 4092, label: 'gu', type: 'item', _isExpandable: false }
+			{ id: 4092, label: 'gu', type: 'item', _isExpandable: false },
 		],
 		id: 4096,
 		label: 'pacedu',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -304,69 +304,69 @@ export default [
 				id: 4098,
 				label: 'ka',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4101,
 		label: 'parwafsu',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4104, label: 'cipem', type: 'item', _isExpandable: false },
-			{ id: 4102, label: 'hoombo', type: 'item', _isExpandable: false }
+			{ id: 4102, label: 'hoombo', type: 'item', _isExpandable: false },
 		],
 		id: 4105,
 		label: 'ja',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4108, label: 'lekdumu', type: 'item', _isExpandable: false },
-			{ id: 4106, label: 'ekla', type: 'item', _isExpandable: false }
+			{ id: 4106, label: 'ekla', type: 'item', _isExpandable: false },
 		],
 		id: 4109,
 		label: 'asago',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4110, label: 'vif', type: 'item', _isExpandable: false }],
 		id: 4111,
 		label: 'mipunuib',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4114, label: 'daabiwoh', type: 'item', _isExpandable: false },
-			{ id: 4112, label: 'japum', type: 'item', _isExpandable: false }
+			{ id: 4112, label: 'japum', type: 'item', _isExpandable: false },
 		],
 		id: 4115,
 		label: 'atabevul',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
-			{ id: 4116, label: 'hopacleb', type: 'item', _isExpandable: false }
+			{ id: 4116, label: 'hopacleb', type: 'item', _isExpandable: false },
 		],
 		id: 4117,
 		label: 'wa',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4120, label: 'kopeglud', type: 'item', _isExpandable: false },
-			{ id: 4118, label: 'hevtof', type: 'item', _isExpandable: false }
+			{ id: 4118, label: 'hevtof', type: 'item', _isExpandable: false },
 		],
 		id: 4121,
 		label: 'inujubfur',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -375,47 +375,47 @@ export default [
 				id: 4123,
 				label: 'wugmugzes',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4124,
 		label: 'ogtuhar',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 4125, label: 'wakebidu', type: 'item', _isExpandable: false }
+					{ id: 4125, label: 'wakebidu', type: 'item', _isExpandable: false },
 				],
 				id: 4126,
 				label: 'jeledsir',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4127,
 		label: 'bo',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4128, label: 'reziak', type: 'item', _isExpandable: false }],
 		id: 4129,
 		label: 'abucu',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4132, label: 'wimjeb', type: 'item', _isExpandable: false },
-			{ id: 4130, label: 'nac', type: 'item', _isExpandable: false }
+			{ id: 4130, label: 'nac', type: 'item', _isExpandable: false },
 		],
 		id: 4133,
 		label: 'egbo',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -423,135 +423,135 @@ export default [
 			{
 				nodes: [
 					{ id: 4137, label: 'tipzekewa', type: 'item', _isExpandable: false },
-					{ id: 4134, label: 'rejjotuw', type: 'item', _isExpandable: false }
+					{ id: 4134, label: 'rejjotuw', type: 'item', _isExpandable: false },
 				],
 				id: 4138,
 				label: 'pa',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4141,
 		label: 'seiz',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 4148, label: 'umeicu', type: 'item', _isExpandable: false }
+					{ id: 4148, label: 'umeicu', type: 'item', _isExpandable: false },
 				],
 				id: 4149,
 				label: 'aruz',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
 			{
 				nodes: [
 					{ id: 4145, label: 'hu', type: 'item', _isExpandable: false },
-					{ id: 4142, label: 'lil', type: 'item', _isExpandable: false }
+					{ id: 4142, label: 'lil', type: 'item', _isExpandable: false },
 				],
 				id: 4146,
 				label: 'zor',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4150,
 		label: 'ewgamij',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 4151, label: 'kegat', type: 'item', _isExpandable: false }
+					{ id: 4151, label: 'kegat', type: 'item', _isExpandable: false },
 				],
 				id: 4152,
 				label: 'fi',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4153,
 		label: 'putciceb',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 4157, label: 'disehi', type: 'item', _isExpandable: false },
-					{ id: 4154, label: 'ecoc', type: 'item', _isExpandable: false }
+					{ id: 4154, label: 'ecoc', type: 'item', _isExpandable: false },
 				],
 				id: 4158,
 				label: 'bicopo',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4159,
 		label: 'tabtod',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4162, label: 'hal', type: 'item', _isExpandable: false },
-			{ id: 4160, label: 'bobama', type: 'item', _isExpandable: false }
+			{ id: 4160, label: 'bobama', type: 'item', _isExpandable: false },
 		],
 		id: 4163,
 		label: 'ta',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4166, label: 'ti', type: 'item', _isExpandable: false },
-			{ id: 4164, label: 'posobeb', type: 'item', _isExpandable: false }
+			{ id: 4164, label: 'posobeb', type: 'item', _isExpandable: false },
 		],
 		id: 4167,
 		label: 'sivlo',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4171, label: 'ohanepaf', type: 'item', _isExpandable: false },
 			{
 				nodes: [
-					{ id: 4168, label: 'rivwi', type: 'item', _isExpandable: false }
+					{ id: 4168, label: 'rivwi', type: 'item', _isExpandable: false },
 				],
 				id: 4169,
 				label: 'va',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4172,
 		label: 'tajoipi',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4173, label: 'seifju', type: 'item', _isExpandable: false }],
 		id: 4174,
 		label: 'lefef',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4177, label: 'lu', type: 'item', _isExpandable: false },
-			{ id: 4175, label: 'uvipa', type: 'item', _isExpandable: false }
+			{ id: 4175, label: 'uvipa', type: 'item', _isExpandable: false },
 		],
 		id: 4178,
 		label: 'dah',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -559,18 +559,18 @@ export default [
 			{
 				nodes: [
 					{ id: 4182, label: 'ahaavu', type: 'item', _isExpandable: false },
-					{ id: 4179, label: 'vo', type: 'item', _isExpandable: false }
+					{ id: 4179, label: 'vo', type: 'item', _isExpandable: false },
 				],
 				id: 4183,
 				label: 'kaiwur',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4186,
 		label: 'kemja',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -580,38 +580,38 @@ export default [
 				id: 4188,
 				label: 'bali',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4191,
 		label: 'gohsupi',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 4194, label: 'ospa', type: 'item', _isExpandable: false }
+					{ id: 4194, label: 'ospa', type: 'item', _isExpandable: false },
 				],
 				id: 4195,
 				label: 'kajem',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
-			{ id: 4192, label: 'ukicap', type: 'item', _isExpandable: false }
+			{ id: 4192, label: 'ukicap', type: 'item', _isExpandable: false },
 		],
 		id: 4196,
 		label: 'ujaivuvo',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4197, label: 'im', type: 'item', _isExpandable: false }],
 		id: 4198,
 		label: 'dedgi',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -619,43 +619,43 @@ export default [
 			{
 				nodes: [
 					{ id: 4202, label: 'ho', type: 'item', _isExpandable: false },
-					{ id: 4199, label: 'rotjac', type: 'item', _isExpandable: false }
+					{ id: 4199, label: 'rotjac', type: 'item', _isExpandable: false },
 				],
 				id: 4203,
 				label: 'ceftuwli',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4206,
 		label: 'fiwzaf',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 4210, label: 'kucpanu', type: 'item', _isExpandable: false },
-					{ id: 4207, label: 'lakihevav', type: 'item', _isExpandable: false }
+					{ id: 4207, label: 'lakihevav', type: 'item', _isExpandable: false },
 				],
 				id: 4211,
 				label: 'lek',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4212,
 		label: 'ecbuuvo',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4213, label: 'piusta', type: 'item', _isExpandable: false }],
 		id: 4214,
 		label: 'nepone',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -663,236 +663,236 @@ export default [
 			{
 				nodes: [
 					{ id: 4218, label: 'jibfufgoj', type: 'item', _isExpandable: false },
-					{ id: 4215, label: 'sek', type: 'item', _isExpandable: false }
+					{ id: 4215, label: 'sek', type: 'item', _isExpandable: false },
 				],
 				id: 4219,
 				label: 'hip',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4222,
 		label: 'zuttoruji',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 4226, label: 'uw', type: 'item', _isExpandable: false },
-					{ id: 4223, label: 'gifvu', type: 'item', _isExpandable: false }
+					{ id: 4223, label: 'gifvu', type: 'item', _isExpandable: false },
 				],
 				id: 4227,
 				label: 'muvif',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4228,
 		label: 'kulivvi',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4231, label: 'jajfuere', type: 'item', _isExpandable: false },
-			{ id: 4229, label: 'de', type: 'item', _isExpandable: false }
+			{ id: 4229, label: 'de', type: 'item', _isExpandable: false },
 		],
 		id: 4232,
 		label: 'ek',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
-			{ id: 4233, label: 'salafecu', type: 'item', _isExpandable: false }
+			{ id: 4233, label: 'salafecu', type: 'item', _isExpandable: false },
 		],
 		id: 4234,
 		label: 'calaf',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4235, label: 'vib', type: 'item', _isExpandable: false }],
 		id: 4236,
 		label: 'vidib',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4239, label: 'uv', type: 'item', _isExpandable: false },
-			{ id: 4237, label: 'cag', type: 'item', _isExpandable: false }
+			{ id: 4237, label: 'cag', type: 'item', _isExpandable: false },
 		],
 		id: 4240,
 		label: 'hen',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4241, label: 'wempa', type: 'item', _isExpandable: false }],
 		id: 4242,
 		label: 'luf',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4245, label: 'or', type: 'item', _isExpandable: false },
-			{ id: 4243, label: 'weobo', type: 'item', _isExpandable: false }
+			{ id: 4243, label: 'weobo', type: 'item', _isExpandable: false },
 		],
 		id: 4246,
 		label: 'didmiur',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4247, label: 'nuz', type: 'item', _isExpandable: false }],
 		id: 4248,
 		label: 'roelgu',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
-			{ id: 4249, label: 'sujvekibu', type: 'item', _isExpandable: false }
+			{ id: 4249, label: 'sujvekibu', type: 'item', _isExpandable: false },
 		],
 		id: 4250,
 		label: 'eldipo',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4251, label: 'er', type: 'item', _isExpandable: false }],
 		id: 4252,
 		label: 'abi',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
-			{ id: 4253, label: 'mifpiwis', type: 'item', _isExpandable: false }
+			{ id: 4253, label: 'mifpiwis', type: 'item', _isExpandable: false },
 		],
 		id: 4254,
 		label: 'danulpi',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 4261, label: 'cilviw', type: 'item', _isExpandable: false },
-					{ id: 4258, label: 'bawtum', type: 'item', _isExpandable: false }
+					{ id: 4258, label: 'bawtum', type: 'item', _isExpandable: false },
 				],
 				id: 4262,
 				label: 'hi',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
 			{
 				nodes: [{ id: 4255, label: 'ted', type: 'item', _isExpandable: false }],
 				id: 4256,
 				label: 'owu',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4263,
 		label: 'nasami',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4264, label: 'macoceb', type: 'item', _isExpandable: false }],
 		id: 4265,
 		label: 'tup',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4266, label: 'liwzauv', type: 'item', _isExpandable: false }],
 		id: 4267,
 		label: 'aletja',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 4268, label: 'esmuna', type: 'item', _isExpandable: false }
+					{ id: 4268, label: 'esmuna', type: 'item', _isExpandable: false },
 				],
 				id: 4269,
 				label: 'pu',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4270,
 		label: 'gekeb',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 4271, label: 'ruzwapo', type: 'item', _isExpandable: false }
+					{ id: 4271, label: 'ruzwapo', type: 'item', _isExpandable: false },
 				],
 				id: 4272,
 				label: 'as',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4273,
 		label: 'ivoisa',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 4280, label: 'ca', type: 'item', _isExpandable: false },
-					{ id: 4277, label: 'gufrika', type: 'item', _isExpandable: false }
+					{ id: 4277, label: 'gufrika', type: 'item', _isExpandable: false },
 				],
 				id: 4281,
 				label: 'biejlec',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
 			{
 				nodes: [{ id: 4274, label: 'in', type: 'item', _isExpandable: false }],
 				id: 4275,
 				label: 'tutothiv',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4282,
 		label: 'sofa',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4283, label: 'ne', type: 'item', _isExpandable: false }],
 		id: 4284,
 		label: 'bivena',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4287, label: 'ewhepi', type: 'item', _isExpandable: false },
-			{ id: 4285, label: 'iracojo', type: 'item', _isExpandable: false }
+			{ id: 4285, label: 'iracojo', type: 'item', _isExpandable: false },
 		],
 		id: 4288,
 		label: 'ihzo',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -902,13 +902,13 @@ export default [
 				id: 4290,
 				label: 'lavobe',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4293,
 		label: 'viwcet',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -917,103 +917,103 @@ export default [
 				id: 4295,
 				label: 'hajfo',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4296,
 		label: 'tanopivuw',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4299, label: 'uhurucuc', type: 'item', _isExpandable: false },
-			{ id: 4297, label: 'nupko', type: 'item', _isExpandable: false }
+			{ id: 4297, label: 'nupko', type: 'item', _isExpandable: false },
 		],
 		id: 4300,
 		label: 'jiche',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4301, label: 'om', type: 'item', _isExpandable: false }],
 		id: 4302,
 		label: 'kaztifa',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4303, label: 'diiho', type: 'item', _isExpandable: false }],
 		id: 4304,
 		label: 'pajbekto',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4305, label: 'sopmal', type: 'item', _isExpandable: false }],
 		id: 4306,
 		label: 'miad',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
-			{ id: 4307, label: 'rugpokij', type: 'item', _isExpandable: false }
+			{ id: 4307, label: 'rugpokij', type: 'item', _isExpandable: false },
 		],
 		id: 4308,
 		label: 'binahim',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
-			{ id: 4309, label: 'fonberar', type: 'item', _isExpandable: false }
+			{ id: 4309, label: 'fonberar', type: 'item', _isExpandable: false },
 		],
 		id: 4310,
 		label: 'jag',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 4317, label: 'dategu', type: 'item', _isExpandable: false }
+					{ id: 4317, label: 'dategu', type: 'item', _isExpandable: false },
 				],
 				id: 4318,
 				label: 'wep',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
 			{
 				nodes: [
 					{ id: 4314, label: 'ifedivos', type: 'item', _isExpandable: false },
-					{ id: 4311, label: 'oso', type: 'item', _isExpandable: false }
+					{ id: 4311, label: 'oso', type: 'item', _isExpandable: false },
 				],
 				id: 4315,
 				label: 'mojwubos',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4319,
 		label: 'omual',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4320, label: 'agocom', type: 'item', _isExpandable: false }],
 		id: 4321,
 		label: 'liz',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4322, label: 'huraz', type: 'item', _isExpandable: false }],
 		id: 4323,
 		label: 'sebwigi',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -1023,13 +1023,13 @@ export default [
 				id: 4325,
 				label: 'vircothew',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4328,
 		label: 'solsec',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -1037,18 +1037,18 @@ export default [
 			{
 				nodes: [
 					{ id: 4332, label: 'zejo', type: 'item', _isExpandable: false },
-					{ id: 4329, label: 'sevi', type: 'item', _isExpandable: false }
+					{ id: 4329, label: 'sevi', type: 'item', _isExpandable: false },
 				],
 				id: 4333,
 				label: 'sukaj',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4336,
 		label: 'mihawo',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -1057,29 +1057,29 @@ export default [
 				id: 4338,
 				label: 'hogis',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4339,
 		label: 'om',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4340, label: 'bufukil', type: 'item', _isExpandable: false }],
 		id: 4341,
 		label: 'pis',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
-			{ id: 4342, label: 'orcacvoh', type: 'item', _isExpandable: false }
+			{ id: 4342, label: 'orcacvoh', type: 'item', _isExpandable: false },
 		],
 		id: 4343,
 		label: 'ci',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -1089,13 +1089,13 @@ export default [
 				id: 4345,
 				label: 'selukic',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4348,
 		label: 'jupsiuc',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -1103,187 +1103,187 @@ export default [
 			{
 				nodes: [
 					{ id: 4352, label: 'mob', type: 'item', _isExpandable: false },
-					{ id: 4349, label: 'zu', type: 'item', _isExpandable: false }
+					{ id: 4349, label: 'zu', type: 'item', _isExpandable: false },
 				],
 				id: 4353,
 				label: 'bidwofis',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4356,
 		label: 'wecab',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 4357, label: 'puwaccok', type: 'item', _isExpandable: false }
+					{ id: 4357, label: 'puwaccok', type: 'item', _isExpandable: false },
 				],
 				id: 4358,
 				label: 'apca',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4359,
 		label: 'puk',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4362, label: 'nuuhior', type: 'item', _isExpandable: false },
-			{ id: 4360, label: 'sujo', type: 'item', _isExpandable: false }
+			{ id: 4360, label: 'sujo', type: 'item', _isExpandable: false },
 		],
 		id: 4363,
 		label: 'bece',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4364, label: 'so', type: 'item', _isExpandable: false }],
 		id: 4365,
 		label: 'ibo',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4368, label: 'kanokjoc', type: 'item', _isExpandable: false },
-			{ id: 4366, label: 'cu', type: 'item', _isExpandable: false }
+			{ id: 4366, label: 'cu', type: 'item', _isExpandable: false },
 		],
 		id: 4369,
 		label: 'maw',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 4373, label: 'idgove', type: 'item', _isExpandable: false }
+					{ id: 4373, label: 'idgove', type: 'item', _isExpandable: false },
 				],
 				id: 4374,
 				label: 'paajgi',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
 			{
 				nodes: [
-					{ id: 4370, label: 'akopi', type: 'item', _isExpandable: false }
+					{ id: 4370, label: 'akopi', type: 'item', _isExpandable: false },
 				],
 				id: 4371,
 				label: 'bewi',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4375,
 		label: 'atjojil',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 4382, label: 'bew', type: 'item', _isExpandable: false },
-					{ id: 4379, label: 'jeg', type: 'item', _isExpandable: false }
+					{ id: 4379, label: 'jeg', type: 'item', _isExpandable: false },
 				],
 				id: 4383,
 				label: 'fan',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
 			{
 				nodes: [{ id: 4376, label: 'tar', type: 'item', _isExpandable: false }],
 				id: 4377,
 				label: 'kuta',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4384,
 		label: 'zepebi',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4387, label: 'dun', type: 'item', _isExpandable: false },
-			{ id: 4385, label: 'diaghuk', type: 'item', _isExpandable: false }
+			{ id: 4385, label: 'diaghuk', type: 'item', _isExpandable: false },
 		],
 		id: 4388,
 		label: 'nogifa',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4389, label: 'calgu', type: 'item', _isExpandable: false }],
 		id: 4390,
 		label: 'jus',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 4393, label: 'gelewzop', type: 'item', _isExpandable: false }
+					{ id: 4393, label: 'gelewzop', type: 'item', _isExpandable: false },
 				],
 				id: 4394,
 				label: 'geveze',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
-			{ id: 4391, label: 'fid', type: 'item', _isExpandable: false }
+			{ id: 4391, label: 'fid', type: 'item', _isExpandable: false },
 		],
 		id: 4395,
 		label: 'jocot',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 4401, label: 'dicahfev', type: 'item', _isExpandable: false },
-					{ id: 4398, label: 'ralwak', type: 'item', _isExpandable: false }
+					{ id: 4398, label: 'ralwak', type: 'item', _isExpandable: false },
 				],
 				id: 4402,
 				label: 'jaguc',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
-			{ id: 4396, label: 'ja', type: 'item', _isExpandable: false }
+			{ id: 4396, label: 'ja', type: 'item', _isExpandable: false },
 		],
 		id: 4403,
 		label: 'daela',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4406, label: 'cegdemel', type: 'item', _isExpandable: false },
-			{ id: 4404, label: 'rezer', type: 'item', _isExpandable: false }
+			{ id: 4404, label: 'rezer', type: 'item', _isExpandable: false },
 		],
 		id: 4407,
 		label: 'oz',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4410, label: 'vubwatili', type: 'item', _isExpandable: false },
-			{ id: 4408, label: 'kivumudat', type: 'item', _isExpandable: false }
+			{ id: 4408, label: 'kivumudat', type: 'item', _isExpandable: false },
 		],
 		id: 4411,
 		label: 'nog',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -1291,45 +1291,45 @@ export default [
 			{
 				nodes: [
 					{ id: 4415, label: 'mu', type: 'item', _isExpandable: false },
-					{ id: 4412, label: 'cikec', type: 'item', _isExpandable: false }
+					{ id: 4412, label: 'cikec', type: 'item', _isExpandable: false },
 				],
 				id: 4416,
 				label: 'weali',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4419,
 		label: 'cuwamriw',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 4420, label: 'uvije', type: 'item', _isExpandable: false }
+					{ id: 4420, label: 'uvije', type: 'item', _isExpandable: false },
 				],
 				id: 4421,
 				label: 'gu',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4422,
 		label: 'fehvav',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4425, label: 'lepurapif', type: 'item', _isExpandable: false },
-			{ id: 4423, label: 'hijiwace', type: 'item', _isExpandable: false }
+			{ id: 4423, label: 'hijiwace', type: 'item', _isExpandable: false },
 		],
 		id: 4426,
 		label: 'wota',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -1338,13 +1338,13 @@ export default [
 				id: 4428,
 				label: 'regavapu',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4429,
 		label: 'tocam',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -1353,103 +1353,103 @@ export default [
 				id: 4431,
 				label: 'ukele',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4432,
 		label: 'ah',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 4436, label: 'icu', type: 'item', _isExpandable: false },
-					{ id: 4433, label: 'bor', type: 'item', _isExpandable: false }
+					{ id: 4433, label: 'bor', type: 'item', _isExpandable: false },
 				],
 				id: 4437,
 				label: 'rofimun',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4438,
 		label: 'cid',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
-			{ id: 4439, label: 'kafkonov', type: 'item', _isExpandable: false }
+			{ id: 4439, label: 'kafkonov', type: 'item', _isExpandable: false },
 		],
 		id: 4440,
 		label: 'lasaef',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 4441, label: 'ebcahhu', type: 'item', _isExpandable: false }
+					{ id: 4441, label: 'ebcahhu', type: 'item', _isExpandable: false },
 				],
 				id: 4442,
 				label: 'fi',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4443,
 		label: 'basduw',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 4444, label: 'muvjaeg', type: 'item', _isExpandable: false }
+					{ id: 4444, label: 'muvjaeg', type: 'item', _isExpandable: false },
 				],
 				id: 4445,
 				label: 'doh',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4446,
 		label: 'we',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4449, label: 'bim', type: 'item', _isExpandable: false },
-			{ id: 4447, label: 'pacag', type: 'item', _isExpandable: false }
+			{ id: 4447, label: 'pacag', type: 'item', _isExpandable: false },
 		],
 		id: 4450,
 		label: 'ozu',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 4456, label: 'socsog', type: 'item', _isExpandable: false },
-					{ id: 4453, label: 'hul', type: 'item', _isExpandable: false }
+					{ id: 4453, label: 'hul', type: 'item', _isExpandable: false },
 				],
 				id: 4457,
 				label: 'eritwe',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
-			{ id: 4451, label: 'so', type: 'item', _isExpandable: false }
+			{ id: 4451, label: 'so', type: 'item', _isExpandable: false },
 		],
 		id: 4458,
 		label: 'dupgerga',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -1458,49 +1458,49 @@ export default [
 				id: 4462,
 				label: 'lik',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
-			{ id: 4459, label: 'ekairtef', type: 'item', _isExpandable: false }
+			{ id: 4459, label: 'ekairtef', type: 'item', _isExpandable: false },
 		],
 		id: 4463,
 		label: 'ucoovwip',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4464, label: 'wi', type: 'item', _isExpandable: false }],
 		id: 4465,
 		label: 'kodga',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4468, label: 'tufki', type: 'item', _isExpandable: false },
-			{ id: 4466, label: 'imu', type: 'item', _isExpandable: false }
+			{ id: 4466, label: 'imu', type: 'item', _isExpandable: false },
 		],
 		id: 4469,
 		label: 'nelbeb',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 4472, label: 'asozurwi', type: 'item', _isExpandable: false }
+					{ id: 4472, label: 'asozurwi', type: 'item', _isExpandable: false },
 				],
 				id: 4473,
 				label: 'ohefarsut',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
-			{ id: 4470, label: 'joglihim', type: 'item', _isExpandable: false }
+			{ id: 4470, label: 'joglihim', type: 'item', _isExpandable: false },
 		],
 		id: 4474,
 		label: 'lim',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -1509,275 +1509,275 @@ export default [
 				id: 4476,
 				label: 'soaduma',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4477,
 		label: 'kersinho',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4481, label: 'pahil', type: 'item', _isExpandable: false },
 			{
 				nodes: [
-					{ id: 4478, label: 'poban', type: 'item', _isExpandable: false }
+					{ id: 4478, label: 'poban', type: 'item', _isExpandable: false },
 				],
 				id: 4479,
 				label: 'divum',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4482,
 		label: 'voowivec',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4485, label: 'hi', type: 'item', _isExpandable: false },
-			{ id: 4483, label: 'wigcojpi', type: 'item', _isExpandable: false }
+			{ id: 4483, label: 'wigcojpi', type: 'item', _isExpandable: false },
 		],
 		id: 4486,
 		label: 'baku',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 4490, label: 'cev', type: 'item', _isExpandable: false },
-					{ id: 4487, label: 'ucpehni', type: 'item', _isExpandable: false }
+					{ id: 4487, label: 'ucpehni', type: 'item', _isExpandable: false },
 				],
 				id: 4491,
 				label: 'wosawuud',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4492,
 		label: 'izce',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 4495, label: 'towdog', type: 'item', _isExpandable: false }
+					{ id: 4495, label: 'towdog', type: 'item', _isExpandable: false },
 				],
 				id: 4496,
 				label: 'bohas',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
-			{ id: 4493, label: 'upowalo', type: 'item', _isExpandable: false }
+			{ id: 4493, label: 'upowalo', type: 'item', _isExpandable: false },
 		],
 		id: 4497,
 		label: 'fa',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4498, label: 'rajru', type: 'item', _isExpandable: false }],
 		id: 4499,
 		label: 'ebki',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4500, label: 'polez', type: 'item', _isExpandable: false }],
 		id: 4501,
 		label: 'gapa',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4504, label: 'bar', type: 'item', _isExpandable: false },
-			{ id: 4502, label: 'zajuwjuh', type: 'item', _isExpandable: false }
+			{ id: 4502, label: 'zajuwjuh', type: 'item', _isExpandable: false },
 		],
 		id: 4505,
 		label: 'uwgali',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 4506, label: 'jumaum', type: 'item', _isExpandable: false }
+					{ id: 4506, label: 'jumaum', type: 'item', _isExpandable: false },
 				],
 				id: 4507,
 				label: 'godkurgo',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4508,
 		label: 'lafhogap',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 4514, label: 'laise', type: 'item', _isExpandable: false },
-					{ id: 4511, label: 'rouz', type: 'item', _isExpandable: false }
+					{ id: 4511, label: 'rouz', type: 'item', _isExpandable: false },
 				],
 				id: 4515,
 				label: 'uge',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
-			{ id: 4509, label: 'lo', type: 'item', _isExpandable: false }
+			{ id: 4509, label: 'lo', type: 'item', _isExpandable: false },
 		],
 		id: 4516,
 		label: 'tisruv',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 4520, label: 'ohluh', type: 'item', _isExpandable: false },
-					{ id: 4517, label: 'neev', type: 'item', _isExpandable: false }
+					{ id: 4517, label: 'neev', type: 'item', _isExpandable: false },
 				],
 				id: 4521,
 				label: 'heolluf',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4522,
 		label: 'buf',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 4526, label: 'ek', type: 'item', _isExpandable: false },
-					{ id: 4523, label: 'nubrursoh', type: 'item', _isExpandable: false }
+					{ id: 4523, label: 'nubrursoh', type: 'item', _isExpandable: false },
 				],
 				id: 4527,
 				label: 'vafer',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4528,
 		label: 'zu',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4531, label: 'neanru', type: 'item', _isExpandable: false },
-			{ id: 4529, label: 'rascu', type: 'item', _isExpandable: false }
+			{ id: 4529, label: 'rascu', type: 'item', _isExpandable: false },
 		],
 		id: 4532,
 		label: 'difahos',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4533, label: 'zus', type: 'item', _isExpandable: false }],
 		id: 4534,
 		label: 'daane',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 4538, label: 'reva', type: 'item', _isExpandable: false }
+					{ id: 4538, label: 'reva', type: 'item', _isExpandable: false },
 				],
 				id: 4539,
 				label: 'wu',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
 			{
 				nodes: [{ id: 4535, label: 'sem', type: 'item', _isExpandable: false }],
 				id: 4536,
 				label: 'cefehgul',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4540,
 		label: 'ubzi',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4541, label: 'poh', type: 'item', _isExpandable: false }],
 		id: 4542,
 		label: 'ak',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 4549, label: 'ozeele', type: 'item', _isExpandable: false }
+					{ id: 4549, label: 'ozeele', type: 'item', _isExpandable: false },
 				],
 				id: 4550,
 				label: 'weg',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
 			{
 				nodes: [
 					{ id: 4546, label: 'doccuan', type: 'item', _isExpandable: false },
-					{ id: 4543, label: 'pelu', type: 'item', _isExpandable: false }
+					{ id: 4543, label: 'pelu', type: 'item', _isExpandable: false },
 				],
 				id: 4547,
 				label: 'gibfanwa',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4551,
 		label: 'cogbu',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 4558, label: 'ud', type: 'item', _isExpandable: false },
-					{ id: 4555, label: 'po', type: 'item', _isExpandable: false }
+					{ id: 4555, label: 'po', type: 'item', _isExpandable: false },
 				],
 				id: 4559,
 				label: 'letilaj',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
 			{
 				nodes: [
-					{ id: 4552, label: 'landu', type: 'item', _isExpandable: false }
+					{ id: 4552, label: 'landu', type: 'item', _isExpandable: false },
 				],
 				id: 4553,
 				label: 'otamasuz',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4560,
 		label: 'igehohmew',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -1785,189 +1785,189 @@ export default [
 			{
 				nodes: [
 					{ id: 4564, label: 'vemapub', type: 'item', _isExpandable: false },
-					{ id: 4561, label: 'vurpop', type: 'item', _isExpandable: false }
+					{ id: 4561, label: 'vurpop', type: 'item', _isExpandable: false },
 				],
 				id: 4565,
 				label: 'nita',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4568,
 		label: 'ziedejuz',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 4574, label: 'sidgum', type: 'item', _isExpandable: false },
-					{ id: 4571, label: 'bo', type: 'item', _isExpandable: false }
+					{ id: 4571, label: 'bo', type: 'item', _isExpandable: false },
 				],
 				id: 4575,
 				label: 'nuote',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
-			{ id: 4569, label: 'esotif', type: 'item', _isExpandable: false }
+			{ id: 4569, label: 'esotif', type: 'item', _isExpandable: false },
 		],
 		id: 4576,
 		label: 'uthujpo',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 4583, label: 'ufdu', type: 'item', _isExpandable: false }
+					{ id: 4583, label: 'ufdu', type: 'item', _isExpandable: false },
 				],
 				id: 4584,
 				label: 'tacrisfe',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
 			{
 				nodes: [
 					{ id: 4580, label: 'idatawte', type: 'item', _isExpandable: false },
-					{ id: 4577, label: 'jifva', type: 'item', _isExpandable: false }
+					{ id: 4577, label: 'jifva', type: 'item', _isExpandable: false },
 				],
 				id: 4581,
 				label: 'tuzzibac',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4585,
 		label: 'loevede',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4586, label: 'fu', type: 'item', _isExpandable: false }],
 		id: 4587,
 		label: 'bogame',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4591, label: 'iphawluc', type: 'item', _isExpandable: false },
 			{
 				nodes: [
-					{ id: 4588, label: 'afimoziz', type: 'item', _isExpandable: false }
+					{ id: 4588, label: 'afimoziz', type: 'item', _isExpandable: false },
 				],
 				id: 4589,
 				label: 'wunjazrij',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4592,
 		label: 'ku',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 4593, label: 'raloh', type: 'item', _isExpandable: false }
+					{ id: 4593, label: 'raloh', type: 'item', _isExpandable: false },
 				],
 				id: 4594,
 				label: 'uw',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4595,
 		label: 'kugbo',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 4601, label: 'ag', type: 'item', _isExpandable: false },
-					{ id: 4598, label: 'ga', type: 'item', _isExpandable: false }
+					{ id: 4598, label: 'ga', type: 'item', _isExpandable: false },
 				],
 				id: 4602,
 				label: 'ducidfaz',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
-			{ id: 4596, label: 'rucu', type: 'item', _isExpandable: false }
+			{ id: 4596, label: 'rucu', type: 'item', _isExpandable: false },
 		],
 		id: 4603,
 		label: 'wefca',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 4613, label: 'hocvi', type: 'item', _isExpandable: false },
-					{ id: 4610, label: 'fuvujeno', type: 'item', _isExpandable: false }
+					{ id: 4610, label: 'fuvujeno', type: 'item', _isExpandable: false },
 				],
 				id: 4614,
 				label: 'mirzeki',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
 			{
 				nodes: [
 					{ id: 4607, label: 'zo', type: 'item', _isExpandable: false },
-					{ id: 4604, label: 'mokjauba', type: 'item', _isExpandable: false }
+					{ id: 4604, label: 'mokjauba', type: 'item', _isExpandable: false },
 				],
 				id: 4608,
 				label: 'usam',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4615,
 		label: 'ujimuvaj',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4619, label: 'biparu', type: 'item', _isExpandable: false },
 			{
 				nodes: [
-					{ id: 4616, label: 'atfahtow', type: 'item', _isExpandable: false }
+					{ id: 4616, label: 'atfahtow', type: 'item', _isExpandable: false },
 				],
 				id: 4617,
 				label: 'cof',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4620,
 		label: 'umilvu',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 4624, label: 'zosgec', type: 'item', _isExpandable: false },
-					{ id: 4621, label: 'safa', type: 'item', _isExpandable: false }
+					{ id: 4621, label: 'safa', type: 'item', _isExpandable: false },
 				],
 				id: 4625,
 				label: 'def',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4626,
 		label: 'woir',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -1976,100 +1976,100 @@ export default [
 				id: 4630,
 				label: 'bolaz',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
-			{ id: 4627, label: 'dum', type: 'item', _isExpandable: false }
+			{ id: 4627, label: 'dum', type: 'item', _isExpandable: false },
 		],
 		id: 4631,
 		label: 'puhubu',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 4632, label: 'amri', type: 'item', _isExpandable: false }
+					{ id: 4632, label: 'amri', type: 'item', _isExpandable: false },
 				],
 				id: 4633,
 				label: 'epdot',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4634,
 		label: 'silsel',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
-			{ id: 4635, label: 'bulzalci', type: 'item', _isExpandable: false }
+			{ id: 4635, label: 'bulzalci', type: 'item', _isExpandable: false },
 		],
 		id: 4636,
 		label: 'ke',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4637, label: 'ma', type: 'item', _isExpandable: false }],
 		id: 4638,
 		label: 'nihe',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 4642, label: 'ho', type: 'item', _isExpandable: false },
-					{ id: 4639, label: 'nogzazew', type: 'item', _isExpandable: false }
+					{ id: 4639, label: 'nogzazew', type: 'item', _isExpandable: false },
 				],
 				id: 4643,
 				label: 'jed',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4644,
 		label: 'ehebibmi',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4645, label: 'kemop', type: 'item', _isExpandable: false }],
 		id: 4646,
 		label: 'ibe',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 4650, label: 'ohmut', type: 'item', _isExpandable: false },
-					{ id: 4647, label: 'cegaefe', type: 'item', _isExpandable: false }
+					{ id: 4647, label: 'cegaefe', type: 'item', _isExpandable: false },
 				],
 				id: 4651,
 				label: 'we',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4652,
 		label: 'doeg',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4655, label: 'ni', type: 'item', _isExpandable: false },
-			{ id: 4653, label: 'fados', type: 'item', _isExpandable: false }
+			{ id: 4653, label: 'fados', type: 'item', _isExpandable: false },
 		],
 		id: 4656,
 		label: 'jigewi',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -2077,127 +2077,127 @@ export default [
 			{
 				nodes: [
 					{ id: 4660, label: 'epajif', type: 'item', _isExpandable: false },
-					{ id: 4657, label: 'ge', type: 'item', _isExpandable: false }
+					{ id: 4657, label: 'ge', type: 'item', _isExpandable: false },
 				],
 				id: 4661,
 				label: 'tazmewda',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4664,
 		label: 'ze',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4665, label: 'zibup', type: 'item', _isExpandable: false }],
 		id: 4666,
 		label: 'nien',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 4667, label: 'buzzom', type: 'item', _isExpandable: false }
+					{ id: 4667, label: 'buzzom', type: 'item', _isExpandable: false },
 				],
 				id: 4668,
 				label: 'lefo',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4669,
 		label: 'coczaved',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4672, label: 'izowe', type: 'item', _isExpandable: false },
-			{ id: 4670, label: 'lazapri', type: 'item', _isExpandable: false }
+			{ id: 4670, label: 'lazapri', type: 'item', _isExpandable: false },
 		],
 		id: 4673,
 		label: 'cipocja',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 4677, label: 'melsubut', type: 'item', _isExpandable: false },
-					{ id: 4674, label: 'iwe', type: 'item', _isExpandable: false }
+					{ id: 4674, label: 'iwe', type: 'item', _isExpandable: false },
 				],
 				id: 4678,
 				label: 'owo',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4679,
 		label: 'su',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 4682, label: 'becnuti', type: 'item', _isExpandable: false }
+					{ id: 4682, label: 'becnuti', type: 'item', _isExpandable: false },
 				],
 				id: 4683,
 				label: 'depmo',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
-			{ id: 4680, label: 'ogiaf', type: 'item', _isExpandable: false }
+			{ id: 4680, label: 'ogiaf', type: 'item', _isExpandable: false },
 		],
 		id: 4684,
 		label: 'vok',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4687, label: 'vum', type: 'item', _isExpandable: false },
-			{ id: 4685, label: 'rag', type: 'item', _isExpandable: false }
+			{ id: 4685, label: 'rag', type: 'item', _isExpandable: false },
 		],
 		id: 4688,
 		label: 'cu',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4691, label: 'libvu', type: 'item', _isExpandable: false },
-			{ id: 4689, label: 'poboani', type: 'item', _isExpandable: false }
+			{ id: 4689, label: 'poboani', type: 'item', _isExpandable: false },
 		],
 		id: 4692,
 		label: 'hog',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 4698, label: 'ehuusi', type: 'item', _isExpandable: false },
-					{ id: 4695, label: 'rah', type: 'item', _isExpandable: false }
+					{ id: 4695, label: 'rah', type: 'item', _isExpandable: false },
 				],
 				id: 4699,
 				label: 'ela',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
-			{ id: 4693, label: 'nunbirsed', type: 'item', _isExpandable: false }
+			{ id: 4693, label: 'nunbirsed', type: 'item', _isExpandable: false },
 		],
 		id: 4700,
 		label: 'kesir',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -2205,42 +2205,42 @@ export default [
 			{
 				nodes: [
 					{ id: 4704, label: 'duf', type: 'item', _isExpandable: false },
-					{ id: 4701, label: 'zopeweaji', type: 'item', _isExpandable: false }
+					{ id: 4701, label: 'zopeweaji', type: 'item', _isExpandable: false },
 				],
 				id: 4705,
 				label: 'va',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4708,
 		label: 'tetro',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4709, label: 'rehtel', type: 'item', _isExpandable: false }],
 		id: 4710,
 		label: 'pulmokut',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4713, label: 'ka', type: 'item', _isExpandable: false },
-			{ id: 4711, label: 'wolmaca', type: 'item', _isExpandable: false }
+			{ id: 4711, label: 'wolmaca', type: 'item', _isExpandable: false },
 		],
 		id: 4714,
 		label: 'jamude',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4715, label: 'uw', type: 'item', _isExpandable: false }],
 		id: 4716,
 		label: 'eziwahe',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -2249,22 +2249,22 @@ export default [
 				id: 4721,
 				label: 'ruzcaz',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
 			{
 				nodes: [
-					{ id: 4717, label: 'muarko', type: 'item', _isExpandable: false }
+					{ id: 4717, label: 'muarko', type: 'item', _isExpandable: false },
 				],
 				id: 4718,
 				label: 'ezeacepo',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4722,
 		label: 'hakutkem',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -2273,14 +2273,14 @@ export default [
 				id: 4726,
 				label: 'ga',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
-			{ id: 4723, label: 'lutowi', type: 'item', _isExpandable: false }
+			{ id: 4723, label: 'lutowi', type: 'item', _isExpandable: false },
 		],
 		id: 4727,
 		label: 'jufpoed',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -2289,136 +2289,136 @@ export default [
 				id: 4732,
 				label: 'belcocusa',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
 			{
 				nodes: [{ id: 4728, label: 'fof', type: 'item', _isExpandable: false }],
 				id: 4729,
 				label: 'bieg',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4733,
 		label: 'okefuz',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 4734, label: 'jezaiwa', type: 'item', _isExpandable: false }
+					{ id: 4734, label: 'jezaiwa', type: 'item', _isExpandable: false },
 				],
 				id: 4735,
 				label: 'osi',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4736,
 		label: 'vanje',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4740, label: 'zuwsumin', type: 'item', _isExpandable: false },
 			{
 				nodes: [
-					{ id: 4737, label: 'hebrupviv', type: 'item', _isExpandable: false }
+					{ id: 4737, label: 'hebrupviv', type: 'item', _isExpandable: false },
 				],
 				id: 4738,
 				label: 'lot',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4741,
 		label: 'lihmengur',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 4748, label: 'ihase', type: 'item', _isExpandable: false }
+					{ id: 4748, label: 'ihase', type: 'item', _isExpandable: false },
 				],
 				id: 4749,
 				label: 'calivat',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
 			{
 				nodes: [
 					{ id: 4745, label: 'ubajemneb', type: 'item', _isExpandable: false },
-					{ id: 4742, label: 'lovdoin', type: 'item', _isExpandable: false }
+					{ id: 4742, label: 'lovdoin', type: 'item', _isExpandable: false },
 				],
 				id: 4746,
 				label: 'pe',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4750,
 		label: 'jo',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
-			{ id: 4751, label: 'hazjobca', type: 'item', _isExpandable: false }
+			{ id: 4751, label: 'hazjobca', type: 'item', _isExpandable: false },
 		],
 		id: 4752,
 		label: 'tovejaz',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 4756, label: 'mod', type: 'item', _isExpandable: false },
-					{ id: 4753, label: 'ju', type: 'item', _isExpandable: false }
+					{ id: 4753, label: 'ju', type: 'item', _isExpandable: false },
 				],
 				id: 4757,
 				label: 'lin',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4758,
 		label: 'muhvu',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 4761, label: 'orotel', type: 'item', _isExpandable: false }
+					{ id: 4761, label: 'orotel', type: 'item', _isExpandable: false },
 				],
 				id: 4762,
 				label: 'wewaec',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
-			{ id: 4759, label: 'gadzorke', type: 'item', _isExpandable: false }
+			{ id: 4759, label: 'gadzorke', type: 'item', _isExpandable: false },
 		],
 		id: 4763,
 		label: 'uhugimip',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
-			{ id: 4764, label: 'egilihgu', type: 'item', _isExpandable: false }
+			{ id: 4764, label: 'egilihgu', type: 'item', _isExpandable: false },
 		],
 		id: 4765,
 		label: 'tucsih',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -2426,71 +2426,71 @@ export default [
 			{
 				nodes: [
 					{ id: 4769, label: 'obfilog', type: 'item', _isExpandable: false },
-					{ id: 4766, label: 'seca', type: 'item', _isExpandable: false }
+					{ id: 4766, label: 'seca', type: 'item', _isExpandable: false },
 				],
 				id: 4770,
 				label: 'dab',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4773,
 		label: 'misoopi',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4776, label: 'uzva', type: 'item', _isExpandable: false },
-			{ id: 4774, label: 'ke', type: 'item', _isExpandable: false }
+			{ id: 4774, label: 'ke', type: 'item', _isExpandable: false },
 		],
 		id: 4777,
 		label: 'ogre',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 4781, label: 'fi', type: 'item', _isExpandable: false },
-					{ id: 4778, label: 'cinawoje', type: 'item', _isExpandable: false }
+					{ id: 4778, label: 'cinawoje', type: 'item', _isExpandable: false },
 				],
 				id: 4782,
 				label: 'iccele',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4783,
 		label: 'lajliwiv',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4784, label: 'jezoki', type: 'item', _isExpandable: false }],
 		id: 4785,
 		label: 'rad',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 4789, label: 'tocbotali', type: 'item', _isExpandable: false },
-					{ id: 4786, label: 'buzjuwfu', type: 'item', _isExpandable: false }
+					{ id: 4786, label: 'buzjuwfu', type: 'item', _isExpandable: false },
 				],
 				id: 4790,
 				label: 'kausoube',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4791,
 		label: 'ge',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -2499,371 +2499,371 @@ export default [
 				id: 4795,
 				label: 'roveswuz',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
-			{ id: 4792, label: 'nivgil', type: 'item', _isExpandable: false }
+			{ id: 4792, label: 'nivgil', type: 'item', _isExpandable: false },
 		],
 		id: 4796,
 		label: 'ran',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4799, label: 'tu', type: 'item', _isExpandable: false },
-			{ id: 4797, label: 'abugi', type: 'item', _isExpandable: false }
+			{ id: 4797, label: 'abugi', type: 'item', _isExpandable: false },
 		],
 		id: 4800,
 		label: 'huvcakifi',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 4806, label: 'ilcihom', type: 'item', _isExpandable: false },
-					{ id: 4803, label: 'kawowuwu', type: 'item', _isExpandable: false }
+					{ id: 4803, label: 'kawowuwu', type: 'item', _isExpandable: false },
 				],
 				id: 4807,
 				label: 'comah',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
-			{ id: 4801, label: 'gasgufo', type: 'item', _isExpandable: false }
+			{ id: 4801, label: 'gasgufo', type: 'item', _isExpandable: false },
 		],
 		id: 4808,
 		label: 'fof',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 4812, label: 'judebli', type: 'item', _isExpandable: false },
-					{ id: 4809, label: 'lewi', type: 'item', _isExpandable: false }
+					{ id: 4809, label: 'lewi', type: 'item', _isExpandable: false },
 				],
 				id: 4813,
 				label: 'ticon',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4814,
 		label: 'pa',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 4817, label: 'zavef', type: 'item', _isExpandable: false }
+					{ id: 4817, label: 'zavef', type: 'item', _isExpandable: false },
 				],
 				id: 4818,
 				label: 'tezru',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
-			{ id: 4815, label: 'ga', type: 'item', _isExpandable: false }
+			{ id: 4815, label: 'ga', type: 'item', _isExpandable: false },
 		],
 		id: 4819,
 		label: 'eze',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 4823, label: 'woocpe', type: 'item', _isExpandable: false },
-					{ id: 4820, label: 'wu', type: 'item', _isExpandable: false }
+					{ id: 4820, label: 'wu', type: 'item', _isExpandable: false },
 				],
 				id: 4824,
 				label: 'begap',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4825,
 		label: 'on',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 4831, label: 'kumbi', type: 'item', _isExpandable: false },
-					{ id: 4828, label: 'ur', type: 'item', _isExpandable: false }
+					{ id: 4828, label: 'ur', type: 'item', _isExpandable: false },
 				],
 				id: 4832,
 				label: 'bo',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
-			{ id: 4826, label: 'mefnokeke', type: 'item', _isExpandable: false }
+			{ id: 4826, label: 'mefnokeke', type: 'item', _isExpandable: false },
 		],
 		id: 4833,
 		label: 'jibadnav',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4837, label: 'vusi', type: 'item', _isExpandable: false },
 			{
 				nodes: [
-					{ id: 4834, label: 'obac', type: 'item', _isExpandable: false }
+					{ id: 4834, label: 'obac', type: 'item', _isExpandable: false },
 				],
 				id: 4835,
 				label: 'majhu',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4838,
 		label: 'tofcira',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 4839, label: 'pimur', type: 'item', _isExpandable: false }
+					{ id: 4839, label: 'pimur', type: 'item', _isExpandable: false },
 				],
 				id: 4840,
 				label: 'mu',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4841,
 		label: 'awawek',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4842, label: 'pezzat', type: 'item', _isExpandable: false }],
 		id: 4843,
 		label: 'gioco',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 4853, label: 'ko', type: 'item', _isExpandable: false },
-					{ id: 4850, label: 'pujacsa', type: 'item', _isExpandable: false }
+					{ id: 4850, label: 'pujacsa', type: 'item', _isExpandable: false },
 				],
 				id: 4854,
 				label: 'imbe',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
 			{
 				nodes: [
 					{ id: 4847, label: 'nakov', type: 'item', _isExpandable: false },
-					{ id: 4844, label: 'ju', type: 'item', _isExpandable: false }
+					{ id: 4844, label: 'ju', type: 'item', _isExpandable: false },
 				],
 				id: 4848,
 				label: 'pa',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4855,
 		label: 'vup',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 4861, label: 'wog', type: 'item', _isExpandable: false },
-					{ id: 4858, label: 'sivpuafu', type: 'item', _isExpandable: false }
+					{ id: 4858, label: 'sivpuafu', type: 'item', _isExpandable: false },
 				],
 				id: 4862,
 				label: 'luptin',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
-			{ id: 4856, label: 'loenih', type: 'item', _isExpandable: false }
+			{ id: 4856, label: 'loenih', type: 'item', _isExpandable: false },
 		],
 		id: 4863,
 		label: 'dujfotfuf',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4866, label: 'optatce', type: 'item', _isExpandable: false },
-			{ id: 4864, label: 'enupoj', type: 'item', _isExpandable: false }
+			{ id: 4864, label: 'enupoj', type: 'item', _isExpandable: false },
 		],
 		id: 4867,
 		label: 'cabcurvuw',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4870, label: 'vus', type: 'item', _isExpandable: false },
-			{ id: 4868, label: 'esbebum', type: 'item', _isExpandable: false }
+			{ id: 4868, label: 'esbebum', type: 'item', _isExpandable: false },
 		],
 		id: 4871,
 		label: 'we',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 4877, label: 'ehave', type: 'item', _isExpandable: false },
-					{ id: 4874, label: 'ha', type: 'item', _isExpandable: false }
+					{ id: 4874, label: 'ha', type: 'item', _isExpandable: false },
 				],
 				id: 4878,
 				label: 'dub',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
-			{ id: 4872, label: 'low', type: 'item', _isExpandable: false }
+			{ id: 4872, label: 'low', type: 'item', _isExpandable: false },
 		],
 		id: 4879,
 		label: 'po',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4880, label: 'datuces', type: 'item', _isExpandable: false }],
 		id: 4881,
 		label: 'unfob',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4884, label: 'pabje', type: 'item', _isExpandable: false },
-			{ id: 4882, label: 'jajohco', type: 'item', _isExpandable: false }
+			{ id: 4882, label: 'jajohco', type: 'item', _isExpandable: false },
 		],
 		id: 4885,
 		label: 'kunhamviz',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4886, label: 'gitpe', type: 'item', _isExpandable: false }],
 		id: 4887,
 		label: 'ogkepo',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 4888, label: 'roegodej', type: 'item', _isExpandable: false }
+					{ id: 4888, label: 'roegodej', type: 'item', _isExpandable: false },
 				],
 				id: 4889,
 				label: 'zeri',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4890,
 		label: 'we',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4893, label: 'maami', type: 'item', _isExpandable: false },
-			{ id: 4891, label: 'fos', type: 'item', _isExpandable: false }
+			{ id: 4891, label: 'fos', type: 'item', _isExpandable: false },
 		],
 		id: 4894,
 		label: 'misil',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
-			{ id: 4895, label: 'iravidac', type: 'item', _isExpandable: false }
+			{ id: 4895, label: 'iravidac', type: 'item', _isExpandable: false },
 		],
 		id: 4896,
 		label: 'eg',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
-			{ id: 4897, label: 'batjiugu', type: 'item', _isExpandable: false }
+			{ id: 4897, label: 'batjiugu', type: 'item', _isExpandable: false },
 		],
 		id: 4898,
 		label: 'emoke',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4899, label: 'ohni', type: 'item', _isExpandable: false }],
 		id: 4900,
 		label: 'jozuw',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4903, label: 'as', type: 'item', _isExpandable: false },
-			{ id: 4901, label: 'puivowu', type: 'item', _isExpandable: false }
+			{ id: 4901, label: 'puivowu', type: 'item', _isExpandable: false },
 		],
 		id: 4904,
 		label: 'suzgez',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4907, label: 'ubofiza', type: 'item', _isExpandable: false },
-			{ id: 4905, label: 'tiha', type: 'item', _isExpandable: false }
+			{ id: 4905, label: 'tiha', type: 'item', _isExpandable: false },
 		],
 		id: 4908,
 		label: 'ez',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4909, label: 'ut', type: 'item', _isExpandable: false }],
 		id: 4910,
 		label: 'af',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4911, label: 'ale', type: 'item', _isExpandable: false }],
 		id: 4912,
 		label: 'jofumza',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4915, label: 'renhas', type: 'item', _isExpandable: false },
-			{ id: 4913, label: 'hogoso', type: 'item', _isExpandable: false }
+			{ id: 4913, label: 'hogoso', type: 'item', _isExpandable: false },
 		],
 		id: 4916,
 		label: 'zoc',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4917, label: 'atout', type: 'item', _isExpandable: false }],
 		id: 4918,
 		label: 'iveuf',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -2872,380 +2872,380 @@ export default [
 				id: 4920,
 				label: 'jun',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4921,
 		label: 'sudiac',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4922, label: 'guwkiku', type: 'item', _isExpandable: false }],
 		id: 4923,
 		label: 'molzofoti',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4924, label: 'zosumdi', type: 'item', _isExpandable: false }],
 		id: 4925,
 		label: 'kesel',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 4926, label: 'avigenca', type: 'item', _isExpandable: false }
+					{ id: 4926, label: 'avigenca', type: 'item', _isExpandable: false },
 				],
 				id: 4927,
 				label: 'akbisar',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4928,
 		label: 'ape',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 4932, label: 'linna', type: 'item', _isExpandable: false },
-					{ id: 4929, label: 'ro', type: 'item', _isExpandable: false }
+					{ id: 4929, label: 'ro', type: 'item', _isExpandable: false },
 				],
 				id: 4933,
 				label: 'fu',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4934,
 		label: 'gocrehe',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4937, label: 'cesosi', type: 'item', _isExpandable: false },
-			{ id: 4935, label: 'joliwol', type: 'item', _isExpandable: false }
+			{ id: 4935, label: 'joliwol', type: 'item', _isExpandable: false },
 		],
 		id: 4938,
 		label: 'zu',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 4942, label: 'sunzatni', type: 'item', _isExpandable: false },
-					{ id: 4939, label: 'didpoj', type: 'item', _isExpandable: false }
+					{ id: 4939, label: 'didpoj', type: 'item', _isExpandable: false },
 				],
 				id: 4943,
 				label: 'hufregito',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4944,
 		label: 'idicebge',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4945, label: 'tajevu', type: 'item', _isExpandable: false }],
 		id: 4946,
 		label: 'udhup',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 4947, label: 'kajzemi', type: 'item', _isExpandable: false }
+					{ id: 4947, label: 'kajzemi', type: 'item', _isExpandable: false },
 				],
 				id: 4948,
 				label: 'ri',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4949,
 		label: 'sudat',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4950, label: 'ca', type: 'item', _isExpandable: false }],
 		id: 4951,
 		label: 'du',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 4955, label: 'ikezi', type: 'item', _isExpandable: false },
-					{ id: 4952, label: 'asancos', type: 'item', _isExpandable: false }
+					{ id: 4952, label: 'asancos', type: 'item', _isExpandable: false },
 				],
 				id: 4956,
 				label: 'fijtonog',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4957,
 		label: 'vi',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4958, label: 'aniter', type: 'item', _isExpandable: false }],
 		id: 4959,
 		label: 'koleb',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 4960, label: 'hetesof', type: 'item', _isExpandable: false }
+					{ id: 4960, label: 'hetesof', type: 'item', _isExpandable: false },
 				],
 				id: 4961,
 				label: 'lo',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4962,
 		label: 'mopo',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4963, label: 'oczel', type: 'item', _isExpandable: false }],
 		id: 4964,
 		label: 'tej',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 4971, label: 'liwvowu', type: 'item', _isExpandable: false }
+					{ id: 4971, label: 'liwvowu', type: 'item', _isExpandable: false },
 				],
 				id: 4972,
 				label: 'sor',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
 			{
 				nodes: [
 					{ id: 4968, label: 'vaobe', type: 'item', _isExpandable: false },
-					{ id: 4965, label: 'buhu', type: 'item', _isExpandable: false }
+					{ id: 4965, label: 'buhu', type: 'item', _isExpandable: false },
 				],
 				id: 4969,
 				label: 'we',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4973,
 		label: 'bedamizu',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 4979, label: 'ca', type: 'item', _isExpandable: false },
-					{ id: 4976, label: 'jacetbu', type: 'item', _isExpandable: false }
+					{ id: 4976, label: 'jacetbu', type: 'item', _isExpandable: false },
 				],
 				id: 4980,
 				label: 'si',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
-			{ id: 4974, label: 'hif', type: 'item', _isExpandable: false }
+			{ id: 4974, label: 'hif', type: 'item', _isExpandable: false },
 		],
 		id: 4981,
 		label: 'lopijna',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4982, label: 'dule', type: 'item', _isExpandable: false }],
 		id: 4983,
 		label: 'bodtotum',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
-			{ id: 4984, label: 'mippaliv', type: 'item', _isExpandable: false }
+			{ id: 4984, label: 'mippaliv', type: 'item', _isExpandable: false },
 		],
 		id: 4985,
 		label: 'lacwomur',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4986, label: 'niriv', type: 'item', _isExpandable: false }],
 		id: 4987,
 		label: 'hef',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 4988, label: 'doizaic', type: 'item', _isExpandable: false }],
 		id: 4989,
 		label: 'mos',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 4990, label: 'lojsuh', type: 'item', _isExpandable: false }
+					{ id: 4990, label: 'lojsuh', type: 'item', _isExpandable: false },
 				],
 				id: 4991,
 				label: 'ina',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 4992,
 		label: 'inevini',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 4995, label: 'deco', type: 'item', _isExpandable: false },
-			{ id: 4993, label: 'sukownim', type: 'item', _isExpandable: false }
+			{ id: 4993, label: 'sukownim', type: 'item', _isExpandable: false },
 		],
 		id: 4996,
 		label: 'edijeoti',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 5000, label: 'sehdiesu', type: 'item', _isExpandable: false },
-					{ id: 4997, label: 'cazuv', type: 'item', _isExpandable: false }
+					{ id: 4997, label: 'cazuv', type: 'item', _isExpandable: false },
 				],
 				id: 5001,
 				label: 'pilawoji',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 5002,
 		label: 'se',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 5003, label: 'viw', type: 'item', _isExpandable: false }],
 		id: 5004,
 		label: 'cacgic',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 5008, label: 'hudfi', type: 'item', _isExpandable: false },
-					{ id: 5005, label: 'usedub', type: 'item', _isExpandable: false }
+					{ id: 5005, label: 'usedub', type: 'item', _isExpandable: false },
 				],
 				id: 5009,
 				label: 'wujok',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 5010,
 		label: 'bozbupag',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 5011, label: 'rotiv', type: 'item', _isExpandable: false }
+					{ id: 5011, label: 'rotiv', type: 'item', _isExpandable: false },
 				],
 				id: 5012,
 				label: 'ogpi',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 5013,
 		label: 'vurob',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 5017, label: 'wo', type: 'item', _isExpandable: false },
-					{ id: 5014, label: 'ira', type: 'item', _isExpandable: false }
+					{ id: 5014, label: 'ira', type: 'item', _isExpandable: false },
 				],
 				id: 5018,
 				label: 'olutetel',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 5019,
 		label: 'bu',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 5022, label: 'ri', type: 'item', _isExpandable: false },
-			{ id: 5020, label: 'avaoduvo', type: 'item', _isExpandable: false }
+			{ id: 5020, label: 'avaoduvo', type: 'item', _isExpandable: false },
 		],
 		id: 5023,
 		label: 'jablivoj',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 5029, label: 'zudviep', type: 'item', _isExpandable: false },
-					{ id: 5026, label: 'vewuez', type: 'item', _isExpandable: false }
+					{ id: 5026, label: 'vewuez', type: 'item', _isExpandable: false },
 				],
 				id: 5030,
 				label: 'bi',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
-			{ id: 5024, label: 'dor', type: 'item', _isExpandable: false }
+			{ id: 5024, label: 'dor', type: 'item', _isExpandable: false },
 		],
 		id: 5031,
 		label: 'wo',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -3254,33 +3254,33 @@ export default [
 				id: 5035,
 				label: 'navpo',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
-			{ id: 5032, label: 'ahe', type: 'item', _isExpandable: false }
+			{ id: 5032, label: 'ahe', type: 'item', _isExpandable: false },
 		],
 		id: 5036,
 		label: 'han',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 5042, label: 'risif', type: 'item', _isExpandable: false },
-					{ id: 5039, label: 'hur', type: 'item', _isExpandable: false }
+					{ id: 5039, label: 'hur', type: 'item', _isExpandable: false },
 				],
 				id: 5043,
 				label: 'tojini',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
-			{ id: 5037, label: 'up', type: 'item', _isExpandable: false }
+			{ id: 5037, label: 'up', type: 'item', _isExpandable: false },
 		],
 		id: 5044,
 		label: 'kateg',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -3289,185 +3289,185 @@ export default [
 				id: 5046,
 				label: 'isero',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 5047,
 		label: 'zisifide',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 5050, label: 'hukihagi', type: 'item', _isExpandable: false }
+					{ id: 5050, label: 'hukihagi', type: 'item', _isExpandable: false },
 				],
 				id: 5051,
 				label: 'ighas',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
-			{ id: 5048, label: 'gam', type: 'item', _isExpandable: false }
+			{ id: 5048, label: 'gam', type: 'item', _isExpandable: false },
 		],
 		id: 5052,
 		label: 'ihzej',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 5062, label: 'ruhot', type: 'item', _isExpandable: false },
-					{ id: 5059, label: 'solzawrig', type: 'item', _isExpandable: false }
+					{ id: 5059, label: 'solzawrig', type: 'item', _isExpandable: false },
 				],
 				id: 5063,
 				label: 'tucciwa',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
 			{
 				nodes: [
 					{ id: 5056, label: 'pig', type: 'item', _isExpandable: false },
-					{ id: 5053, label: 'sosroszek', type: 'item', _isExpandable: false }
+					{ id: 5053, label: 'sosroszek', type: 'item', _isExpandable: false },
 				],
 				id: 5057,
 				label: 'imuab',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 5064,
 		label: 'edkuto',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 5071, label: 'lolit', type: 'item', _isExpandable: false },
-					{ id: 5068, label: 'opogap', type: 'item', _isExpandable: false }
+					{ id: 5068, label: 'opogap', type: 'item', _isExpandable: false },
 				],
 				id: 5072,
 				label: 'zicute',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
 			{
 				nodes: [
-					{ id: 5065, label: 'jotu', type: 'item', _isExpandable: false }
+					{ id: 5065, label: 'jotu', type: 'item', _isExpandable: false },
 				],
 				id: 5066,
 				label: 'deifume',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 5073,
 		label: 'fit',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 5076, label: 'negeri', type: 'item', _isExpandable: false },
-			{ id: 5074, label: 'juriisi', type: 'item', _isExpandable: false }
+			{ id: 5074, label: 'juriisi', type: 'item', _isExpandable: false },
 		],
 		id: 5077,
 		label: 'mo',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
-			{ id: 5078, label: 'vigolizi', type: 'item', _isExpandable: false }
+			{ id: 5078, label: 'vigolizi', type: 'item', _isExpandable: false },
 		],
 		id: 5079,
 		label: 'sopevpuj',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 5080, label: 'badaz', type: 'item', _isExpandable: false }],
 		id: 5081,
 		label: 'dedwig',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 5085, label: 'geknozob', type: 'item', _isExpandable: false },
-					{ id: 5082, label: 'uvjo', type: 'item', _isExpandable: false }
+					{ id: 5082, label: 'uvjo', type: 'item', _isExpandable: false },
 				],
 				id: 5086,
 				label: 'vaiso',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 5087,
 		label: 'kojbob',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 5090, label: 'daeci', type: 'item', _isExpandable: false },
-			{ id: 5088, label: 'zazkonemo', type: 'item', _isExpandable: false }
+			{ id: 5088, label: 'zazkonemo', type: 'item', _isExpandable: false },
 		],
 		id: 5091,
 		label: 'rim',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 5094, label: 'gezba', type: 'item', _isExpandable: false },
-			{ id: 5092, label: 'caz', type: 'item', _isExpandable: false }
+			{ id: 5092, label: 'caz', type: 'item', _isExpandable: false },
 		],
 		id: 5095,
 		label: 'wotikke',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 5096, label: 'budobbaj', type: 'item', _isExpandable: false }
+					{ id: 5096, label: 'budobbaj', type: 'item', _isExpandable: false },
 				],
 				id: 5097,
 				label: 'ew',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 5098,
 		label: 'agu',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 5102, label: 'adiuz', type: 'item', _isExpandable: false },
-					{ id: 5099, label: 'fusdog', type: 'item', _isExpandable: false }
+					{ id: 5099, label: 'fusdog', type: 'item', _isExpandable: false },
 				],
 				id: 5103,
 				label: 'ho',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 5104,
 		label: 'unve',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -3476,39 +3476,39 @@ export default [
 				id: 5108,
 				label: 'gewkahfa',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
-			{ id: 5105, label: 'rirahip', type: 'item', _isExpandable: false }
+			{ id: 5105, label: 'rirahip', type: 'item', _isExpandable: false },
 		],
 		id: 5109,
 		label: 'mij',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 5113, label: 'keri', type: 'item', _isExpandable: false },
 			{
 				nodes: [
-					{ id: 5110, label: 'halosba', type: 'item', _isExpandable: false }
+					{ id: 5110, label: 'halosba', type: 'item', _isExpandable: false },
 				],
 				id: 5111,
 				label: 'awmiri',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 5114,
 		label: 'dat',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 5115, label: 'caopida', type: 'item', _isExpandable: false }],
 		id: 5116,
 		label: 'ruuf',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -3518,31 +3518,31 @@ export default [
 				id: 5118,
 				label: 'garpopel',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 5121,
 		label: 'uwa',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 5125, label: 'wej', type: 'item', _isExpandable: false },
-					{ id: 5122, label: 'ascimucu', type: 'item', _isExpandable: false }
+					{ id: 5122, label: 'ascimucu', type: 'item', _isExpandable: false },
 				],
 				id: 5126,
 				label: 'ot',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 5127,
 		label: 'toto',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -3551,173 +3551,173 @@ export default [
 				id: 5135,
 				label: 'mopopnav',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
 			{
 				nodes: [
 					{ id: 5131, label: 'lekkob', type: 'item', _isExpandable: false },
-					{ id: 5128, label: 'ekhupijo', type: 'item', _isExpandable: false }
+					{ id: 5128, label: 'ekhupijo', type: 'item', _isExpandable: false },
 				],
 				id: 5132,
 				label: 'papo',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 5136,
 		label: 'iksij',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 5139, label: 'ore', type: 'item', _isExpandable: false },
-			{ id: 5137, label: 'jiso', type: 'item', _isExpandable: false }
+			{ id: 5137, label: 'jiso', type: 'item', _isExpandable: false },
 		],
 		id: 5140,
 		label: 'olavewmo',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 5146, label: 'zo', type: 'item', _isExpandable: false },
-					{ id: 5143, label: 'hoj', type: 'item', _isExpandable: false }
+					{ id: 5143, label: 'hoj', type: 'item', _isExpandable: false },
 				],
 				id: 5147,
 				label: 'le',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
-			{ id: 5141, label: 'jeba', type: 'item', _isExpandable: false }
+			{ id: 5141, label: 'jeba', type: 'item', _isExpandable: false },
 		],
 		id: 5148,
 		label: 'doajutum',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 5154, label: 'nuogoze', type: 'item', _isExpandable: false },
-					{ id: 5151, label: 'wog', type: 'item', _isExpandable: false }
+					{ id: 5151, label: 'wog', type: 'item', _isExpandable: false },
 				],
 				id: 5155,
 				label: 'zizargap',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
-			{ id: 5149, label: 'iva', type: 'item', _isExpandable: false }
+			{ id: 5149, label: 'iva', type: 'item', _isExpandable: false },
 		],
 		id: 5156,
 		label: 'te',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 5162, label: 'niwascot', type: 'item', _isExpandable: false },
-					{ id: 5159, label: 'bu', type: 'item', _isExpandable: false }
+					{ id: 5159, label: 'bu', type: 'item', _isExpandable: false },
 				],
 				id: 5163,
 				label: 'wutjiho',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
-			{ id: 5157, label: 'cimevpad', type: 'item', _isExpandable: false }
+			{ id: 5157, label: 'cimevpad', type: 'item', _isExpandable: false },
 		],
 		id: 5164,
 		label: 'go',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 5167, label: 'ucmawlok', type: 'item', _isExpandable: false },
-			{ id: 5165, label: 'anac', type: 'item', _isExpandable: false }
+			{ id: 5165, label: 'anac', type: 'item', _isExpandable: false },
 		],
 		id: 5168,
 		label: 'ivjur',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 5171, label: 'turco', type: 'item', _isExpandable: false },
-			{ id: 5169, label: 'ujo', type: 'item', _isExpandable: false }
+			{ id: 5169, label: 'ujo', type: 'item', _isExpandable: false },
 		],
 		id: 5172,
 		label: 'civzep',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 5176, label: 'racupe', type: 'item', _isExpandable: false },
-					{ id: 5173, label: 'juhe', type: 'item', _isExpandable: false }
+					{ id: 5173, label: 'juhe', type: 'item', _isExpandable: false },
 				],
 				id: 5177,
 				label: 'il',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 5178,
 		label: 'liluhe',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 5181, label: 'ziocbo', type: 'item', _isExpandable: false },
-			{ id: 5179, label: 'vozijied', type: 'item', _isExpandable: false }
+			{ id: 5179, label: 'vozijied', type: 'item', _isExpandable: false },
 		],
 		id: 5182,
 		label: 'woife',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 5185, label: 'lujmohre', type: 'item', _isExpandable: false },
-			{ id: 5183, label: 'hasnib', type: 'item', _isExpandable: false }
+			{ id: 5183, label: 'hasnib', type: 'item', _isExpandable: false },
 		],
 		id: 5186,
 		label: 'ke',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 5190, label: 'ge', type: 'item', _isExpandable: false },
-					{ id: 5187, label: 'emtam', type: 'item', _isExpandable: false }
+					{ id: 5187, label: 'emtam', type: 'item', _isExpandable: false },
 				],
 				id: 5191,
 				label: 'duk',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 5192,
 		label: 'fotgup',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 5193, label: 'ec', type: 'item', _isExpandable: false }],
 		id: 5194,
 		label: 'temni',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -3727,13 +3727,13 @@ export default [
 				id: 5196,
 				label: 'wac',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 5199,
 		label: 'ro',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -3742,30 +3742,30 @@ export default [
 				id: 5204,
 				label: 'zogsojan',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
 			{
 				nodes: [{ id: 5200, label: 'dil', type: 'item', _isExpandable: false }],
 				id: 5201,
 				label: 'fompubze',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 5205,
 		label: 'we',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 5208, label: 'kacgimkoj', type: 'item', _isExpandable: false },
-			{ id: 5206, label: 'tanabfew', type: 'item', _isExpandable: false }
+			{ id: 5206, label: 'tanabfew', type: 'item', _isExpandable: false },
 		],
 		id: 5209,
 		label: 'noz',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -3773,72 +3773,72 @@ export default [
 			{
 				nodes: [
 					{ id: 5213, label: 'item', type: 'item', _isExpandable: false },
-					{ id: 5210, label: 'nioj', type: 'item', _isExpandable: false }
+					{ id: 5210, label: 'nioj', type: 'item', _isExpandable: false },
 				],
 				id: 5214,
 				label: 'saortig',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 5217,
 		label: 'dib',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 5218, label: 'patikdit', type: 'item', _isExpandable: false }
+					{ id: 5218, label: 'patikdit', type: 'item', _isExpandable: false },
 				],
 				id: 5219,
 				label: 'kiaf',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 5220,
 		label: 'buiso',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 5226, label: 'tit', type: 'item', _isExpandable: false },
-					{ id: 5223, label: 'popgawi', type: 'item', _isExpandable: false }
+					{ id: 5223, label: 'popgawi', type: 'item', _isExpandable: false },
 				],
 				id: 5227,
 				label: 'kuojde',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
-			{ id: 5221, label: 'ivude', type: 'item', _isExpandable: false }
+			{ id: 5221, label: 'ivude', type: 'item', _isExpandable: false },
 		],
 		id: 5228,
 		label: 'afmut',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 5232, label: 'meje', type: 'item', _isExpandable: false },
-					{ id: 5229, label: 'ep', type: 'item', _isExpandable: false }
+					{ id: 5229, label: 'ep', type: 'item', _isExpandable: false },
 				],
 				id: 5233,
 				label: 'semko',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 5234,
 		label: 'zollad',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -3846,104 +3846,104 @@ export default [
 			{
 				nodes: [
 					{ id: 5238, label: 'bahed', type: 'item', _isExpandable: false },
-					{ id: 5235, label: 'desas', type: 'item', _isExpandable: false }
+					{ id: 5235, label: 'desas', type: 'item', _isExpandable: false },
 				],
 				id: 5239,
 				label: 'mo',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 5242,
 		label: 'bem',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
-			{ id: 5243, label: 'tuwitzat', type: 'item', _isExpandable: false }
+			{ id: 5243, label: 'tuwitzat', type: 'item', _isExpandable: false },
 		],
 		id: 5244,
 		label: 'jowavsul',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 5247, label: 'ziiv', type: 'item', _isExpandable: false },
-			{ id: 5245, label: 'hopkejon', type: 'item', _isExpandable: false }
+			{ id: 5245, label: 'hopkejon', type: 'item', _isExpandable: false },
 		],
 		id: 5248,
 		label: 'ji',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 5251, label: 'uhecoud', type: 'item', _isExpandable: false },
-			{ id: 5249, label: 'tepjig', type: 'item', _isExpandable: false }
+			{ id: 5249, label: 'tepjig', type: 'item', _isExpandable: false },
 		],
 		id: 5252,
 		label: 'niham',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 5255, label: 'lut', type: 'item', _isExpandable: false },
-			{ id: 5253, label: 'ewgi', type: 'item', _isExpandable: false }
+			{ id: 5253, label: 'ewgi', type: 'item', _isExpandable: false },
 		],
 		id: 5256,
 		label: 'booludis',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 5259, label: 'fulza', type: 'item', _isExpandable: false },
-			{ id: 5257, label: 'ribow', type: 'item', _isExpandable: false }
+			{ id: 5257, label: 'ribow', type: 'item', _isExpandable: false },
 		],
 		id: 5260,
 		label: 'gakag',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 5266, label: 'hura', type: 'item', _isExpandable: false },
-					{ id: 5263, label: 'ebinojfo', type: 'item', _isExpandable: false }
+					{ id: 5263, label: 'ebinojfo', type: 'item', _isExpandable: false },
 				],
 				id: 5267,
 				label: 'homu',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
-			{ id: 5261, label: 'tezuhepe', type: 'item', _isExpandable: false }
+			{ id: 5261, label: 'tezuhepe', type: 'item', _isExpandable: false },
 		],
 		id: 5268,
 		label: 'pir',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 5271, label: 'duzuj', type: 'item', _isExpandable: false }
+					{ id: 5271, label: 'duzuj', type: 'item', _isExpandable: false },
 				],
 				id: 5272,
 				label: 'kemet',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
-			{ id: 5269, label: 'pi', type: 'item', _isExpandable: false }
+			{ id: 5269, label: 'pi', type: 'item', _isExpandable: false },
 		],
 		id: 5273,
 		label: 'tadvazzo',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -3952,92 +3952,92 @@ export default [
 				id: 5281,
 				label: 'dinazi',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
 			{
 				nodes: [
 					{ id: 5277, label: 'jufer', type: 'item', _isExpandable: false },
-					{ id: 5274, label: 'co', type: 'item', _isExpandable: false }
+					{ id: 5274, label: 'co', type: 'item', _isExpandable: false },
 				],
 				id: 5278,
 				label: 'zuedeuj',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 5282,
 		label: 'dov',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 5286, label: 'atdof', type: 'item', _isExpandable: false },
-					{ id: 5283, label: 'fatesar', type: 'item', _isExpandable: false }
+					{ id: 5283, label: 'fatesar', type: 'item', _isExpandable: false },
 				],
 				id: 5287,
 				label: 'besas',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 5288,
 		label: 'akegusok',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 5289, label: 'raka', type: 'item', _isExpandable: false }],
 		id: 5290,
 		label: 'arzovog',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 5297, label: 'suebca', type: 'item', _isExpandable: false }
+					{ id: 5297, label: 'suebca', type: 'item', _isExpandable: false },
 				],
 				id: 5298,
 				label: 'wig',
 				type: 'branch',
-				_isExpandable: true
+				_isExpandable: true,
 			},
 			{
 				nodes: [
 					{ id: 5294, label: 'fojda', type: 'item', _isExpandable: false },
-					{ id: 5291, label: 'depdeb', type: 'item', _isExpandable: false }
+					{ id: 5291, label: 'depdeb', type: 'item', _isExpandable: false },
 				],
 				id: 5295,
 				label: 'binhi',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 5299,
 		label: 'pa',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 5300, label: 'kijcij', type: 'item', _isExpandable: false }
+					{ id: 5300, label: 'kijcij', type: 'item', _isExpandable: false },
 				],
 				id: 5301,
 				label: 'fivnig',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 5302,
 		label: 'hummodno',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -4047,84 +4047,84 @@ export default [
 				id: 5304,
 				label: 'af',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 5307,
 		label: 'mome',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 5308, label: 'ca', type: 'item', _isExpandable: false }],
 		id: 5309,
 		label: 'nab',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 5310, label: 'tu', type: 'item', _isExpandable: false }],
 		id: 5311,
 		label: 'hi',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 5315, label: 'zi', type: 'item', _isExpandable: false },
-					{ id: 5312, label: 'fetso', type: 'item', _isExpandable: false }
+					{ id: 5312, label: 'fetso', type: 'item', _isExpandable: false },
 				],
 				id: 5316,
 				label: 'ap',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 5317,
 		label: 'seiwtuk',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 5321, label: 'uh', type: 'item', _isExpandable: false },
-					{ id: 5318, label: 'muh', type: 'item', _isExpandable: false }
+					{ id: 5318, label: 'muh', type: 'item', _isExpandable: false },
 				],
 				id: 5322,
 				label: 'cizovo',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 5323,
 		label: 'ej',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 5324, label: 'nozeh', type: 'item', _isExpandable: false }],
 		id: 5325,
 		label: 'vetofoso',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 5326, label: 'tolud', type: 'item', _isExpandable: false }],
 		id: 5327,
 		label: 'kop',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 5328, label: 'vu', type: 'item', _isExpandable: false }],
 		id: 5329,
 		label: 'ruhzi',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
@@ -4132,76 +4132,76 @@ export default [
 			{
 				nodes: [
 					{ id: 5333, label: 'uhu', type: 'item', _isExpandable: false },
-					{ id: 5330, label: 'rab', type: 'item', _isExpandable: false }
+					{ id: 5330, label: 'rab', type: 'item', _isExpandable: false },
 				],
 				id: 5334,
 				label: 'nifa',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 5337,
 		label: 'bukubmiv',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{ id: 5340, label: 'wo', type: 'item', _isExpandable: false },
-			{ id: 5338, label: 'af', type: 'item', _isExpandable: false }
+			{ id: 5338, label: 'af', type: 'item', _isExpandable: false },
 		],
 		id: 5341,
 		label: 'puhovala',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 5342, label: 'wo', type: 'item', _isExpandable: false }],
 		id: 5343,
 		label: 'ra',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
 					{ id: 5347, label: 'ka', type: 'item', _isExpandable: false },
-					{ id: 5344, label: 'cuk', type: 'item', _isExpandable: false }
+					{ id: 5344, label: 'cuk', type: 'item', _isExpandable: false },
 				],
 				id: 5348,
 				label: 'nehne',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 5349,
 		label: 'hipfizih',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [{ id: 5350, label: 'zed', type: 'item', _isExpandable: false }],
 		id: 5351,
 		label: 'iwaemeji',
 		type: 'branch',
-		_isExpandable: true
+		_isExpandable: true,
 	},
 	{
 		nodes: [
 			{
 				nodes: [
-					{ id: 5352, label: 'oroma', type: 'item', _isExpandable: false }
+					{ id: 5352, label: 'oroma', type: 'item', _isExpandable: false },
 				],
 				id: 5353,
 				label: 'fonfav',
 				type: 'branch',
-				_isExpandable: true
-			}
+				_isExpandable: true,
+			},
 		],
 		id: 5354,
 		label: 'bunewbim',
 		type: 'branch',
-		_isExpandable: true
-	}
+		_isExpandable: true,
+	},
 ];

--- a/utilities/warning/is-trigger-tabbable.js
+++ b/utilities/warning/is-trigger-tabbable.js
@@ -14,7 +14,7 @@ import {
 	DATE_PICKER,
 	FORMS_INPUT,
 	LOOKUP,
-	TIME_PICKER
+	TIME_PICKER,
 } from '../../utilities/constants';
 
 /* eslint-disable import/no-mutable-exports */

--- a/webpack.config.dist.js
+++ b/webpack.config.dist.js
@@ -15,21 +15,21 @@ const config = Object.assign({}, baseConfig, {
 			amd: 'react',
 			commonjs: 'react',
 			commonjs2: 'react',
-			root: 'React'
+			root: 'React',
 		},
 		'react/addons': {
 			amd: 'react',
 			commonjs: 'react',
 			commonjs2: 'react',
-			root: 'React'
+			root: 'React',
 		},
 		'react-dom': {
 			amd: 'react-dom',
 			commonjs: 'react-dom',
 			commonjs2: 'react-dom',
-			root: 'ReactDOM'
-		}
-	}
+			root: 'ReactDOM',
+		},
+	},
 });
 
 let FILENAME = process.env.INCLUDE_ICONS ? '[name].js' : '[name]-components.js';
@@ -37,8 +37,8 @@ if (process.env.MINIFY) {
 	config.plugins.push(
 		new webpack.optimize.UglifyJsPlugin({
 			mangle: {
-				except: ['$', 'exports', 'require']
-			}
+				except: ['$', 'exports', 'require'],
+			},
 		})
 	);
 	FILENAME = process.env.INCLUDE_ICONS
@@ -53,29 +53,29 @@ config.output.libraryTarget = 'umd';
 const replacementsArr = [
 	{
 		pattern: /__VERSION__/g,
-		replacement: () => packageJson.version
-	}
+		replacement: () => packageJson.version,
+	},
 ];
 
 // This string replacement includes icons in the bundle and affects `icons/**/index.js` which are built by `npm run icons`. The default condition is an equality comparison of two constants, `'__EXCLUDE_SLDS_ICONS__' === '__INCLUDE_SLDS_ICONS__'`, which will allow minification to remove the inline icons and save 100KBs in size when bundling for production. The following makes the condition equal.
 if (process.env.INCLUDE_ICONS) {
 	replacementsArr.push({
 		pattern: /__EXCLUDE_SLDS_ICONS__/g,
-		replacement: () => '__INCLUDE_SLDS_ICONS__'
+		replacement: () => '__INCLUDE_SLDS_ICONS__',
 	});
 }
 
 config.module.rules[0].loaders = [
 	'babel-loader',
 	StringReplacePlugin.replace({
-		replacements: replacementsArr
-	})
+		replacements: replacementsArr,
+	}),
 ];
 
 config.plugins.push(new webpack.BannerPlugin(header + license));
 config.plugins.push(
 	new webpack.DefinePlugin({
-		'process.env': { NODE_ENV: JSON.stringify('production') }
+		'process.env': { NODE_ENV: JSON.stringify('production') },
 	})
 );
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,16 +5,16 @@ const packageJson = require('./package.json');
 
 const config = {
 	entry: {
-		'design-system-react': ['./components']
+		'design-system-react': ['./components'],
 	},
 	resolve: {
-		extensions: ['.js', '.jsx']
+		extensions: ['.js', '.jsx'],
 	},
 	devtool: 'source-map',
 	output: {
 		path: path.join(__dirname, '.tmp'),
 		filename: '[name].js',
-		publicPath: '/'
+		publicPath: '/',
 	},
 	module: {
 		rules: [
@@ -26,38 +26,38 @@ const config = {
 						replacements: [
 							{
 								pattern: /__VERSION__/g,
-								replacement: () => packageJson.version
-							}
-						]
-					})
+								replacement: () => packageJson.version,
+							},
+						],
+					}),
 				],
 				include: [
 					path.join(__dirname, 'components'),
 					path.join(__dirname, 'css'),
 					path.join(__dirname, 'icons'),
 					path.join(__dirname, 'tests'),
-					path.join(__dirname, 'utilities')
-				]
+					path.join(__dirname, 'utilities'),
+				],
 			},
 			{
 				test: /\.json$/,
-				loader: 'json-loader'
+				loader: 'json-loader',
 			},
 			{
 				test: /\.css$/,
-				loaders: ['style-loader', 'css-loader']
+				loaders: ['style-loader', 'css-loader'],
 			},
 			{
 				test: /\.(svg|gif|jpe?g|png)$/,
-				loader: 'file-loader?limit=10000'
+				loader: 'file-loader?limit=10000',
 			},
 			{
 				test: /\.(eot|woff|woff2|ttf)$/,
-				loader: 'file-loader?limit=30&name=fonts/webfonts/[name].[ext]'
-			}
-		]
+				loader: 'file-loader?limit=30&name=fonts/webfonts/[name].[ext]',
+			},
+		],
 	},
-	plugins: [new StringReplacePlugin()]
+	plugins: [new StringReplacePlugin()],
 };
 
 module.exports = config;

--- a/webpack.config.test.js
+++ b/webpack.config.test.js
@@ -8,7 +8,7 @@ const StringReplacePlugin = require('string-replace-webpack-plugin');
 const config = require('./webpack.config');
 
 config.entry = {
-	tests: ['./components/tests-bundle.js', hotMiddlewareScript]
+	tests: ['./components/tests-bundle.js', hotMiddlewareScript],
 };
 
 // used by enzyme
@@ -16,7 +16,7 @@ config.externals = {
 	'react/lib/ReactContext': true,
 	'react/lib/ExecutionEnvironment': true,
 	'react/addons': true,
-	cheerio: 'window'
+	cheerio: 'window',
 };
 
 config.devtool = 'eval-source-map';
@@ -26,15 +26,15 @@ config.output = {
 	path: `${__dirname}/test-build/`,
 	publicPath: '/test-build/',
 	// [name] is config.entry object keys
-	filename: '[name].bundle.js'
+	filename: '[name].bundle.js',
 };
 
 config.plugins = [
 	new webpack.DefinePlugin({
-		'process.env': { NODE_ENV: JSON.stringify('development') }
+		'process.env': { NODE_ENV: JSON.stringify('development') },
 	}),
 	new StringReplacePlugin(),
-	new webpack.HotModuleReplacementPlugin()
+	new webpack.HotModuleReplacementPlugin(),
 ];
 
 module.exports = config;


### PR DESCRIPTION
Adds trailing comma to multiline iterables that are allowed in ES5.

Reasons to do this: https://medium.com/@nikgraf/why-you-should-enforce-dangling-commas-for-multiline-statements-d034c98e36f8

Also helps with copy/paste re-sort.

---

### Pull Request Review checklist (do not remove)

* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at snapshot strings.
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
