### PR TITLE
Update SLDS peer dependency to allow 2.6.0-alphas

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "design-system-react",
-	"version": "0.8.8-a",
+	"version": "0.8.8",
 	"description": "Salesforce Lightning Design System for React",
 	"license": "SEE LICENSE IN README.md",
 	"engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "design-system-react",
-	"version": "0.8.8",
+	"version": "0.8.8-a",
 	"description": "Salesforce Lightning Design System for React",
 	"license": "SEE LICENSE IN README.md",
 	"engines": {
@@ -111,7 +111,7 @@
 		"warning": "^3.0.0"
 	},
 	"peerDependencies": {
-		"@salesforce-ux/design-system": ">=2.4.x",
+		"@salesforce-ux/design-system": ">=2.4.x <=2.6.0-alpha",
 		"react": ">=15.4.1 <16",
 		"react-dom": ">=15.4.1 <16"
 	},

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
 		"warning": "^3.0.0"
 	},
 	"peerDependencies": {
-		"@salesforce-ux/design-system": ">=2.4.x <=2.6.0-alpha",
+		"@salesforce-ux/design-system": "^2.4.0 || ^2.6.0-alpha",
 		"react": ">=15.4.1 <16",
 		"react-dom": ">=15.4.1 <16"
 	},


### PR DESCRIPTION
Fixes https://github.com/salesforce/design-system-react/issues/1296

Allows SLDS v2.6.0-alpha in our allowable range.

---

### Pull Request Review checklist (do not remove)

* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at snapshot strings.
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.