### PR TITLE
Allow nubbin to change position when popover flips

### DIFF
--- a/components/popover/popover.jsx
+++ b/components/popover/popover.jsx
@@ -213,6 +213,7 @@ const Popover = createReactClass({
 	getInitialState () {
 		return {
 			isOpen: false,
+			nubbinPositionClass: getNubbinClassName(this.props.align)
 		};
 	},
 
@@ -422,6 +423,13 @@ const Popover = createReactClass({
 		}
 	},
 
+	handleNubbinPositionUpdate (placement) {
+		const nubbinClassName = getNubbinClassName(placement);
+		this.setState({
+			nubbinPositionClass: nubbinClassName
+		});
+	},
+
 	renderDialog (isOpen, outsideClickIgnoreClass) {
 		const props = this.props;
 		const offset = props.offset;
@@ -429,6 +437,7 @@ const Popover = createReactClass({
 
 		return isOpen ? (
 			<Dialog
+				handleNubbinPositionUpdate={this.handleNubbinPositionUpdate}
 				align={props.align}
 				contentsClassName={classNames(
 					this.props.contentsClassName,
@@ -463,7 +472,7 @@ const Popover = createReactClass({
 					aria-describedby={`${this.getId()}-dialog-body`}
 					className={classNames(
 						'slds-popover',
-						getNubbinClassName(props.align),
+						this.state.nubbinPositionClass,
 						props.className
 					)}
 					id={`${this.getId()}-popover`}

--- a/components/utilities/dialog/index.jsx
+++ b/components/utilities/dialog/index.jsx
@@ -249,6 +249,11 @@ const Dialog = createReactClass({
 		return { ...popperData.style, left, top, position };
 	},
 
+	onUpdate (data) {
+		const placement = data.placement;
+		this.props.handleNubbinPositionUpdate(placement);
+	},
+
 	// Render
 	setDialogContent (component) {
 		this.dialogContent = component;
@@ -313,7 +318,6 @@ const Dialog = createReactClass({
 	/**
 	 * Popper API and helper functions
 	 */
-
 	createPopper () {
 		const reference = this.props.onRequestTargetElement(); // eslint-disable-line react/no-find-dom-node
 		const popper = this.dialogContent;
@@ -352,6 +356,7 @@ const Dialog = createReactClass({
 			console.error('Popper node not found!', popper); // eslint-disable-line no-console
 		}
 		this.popper = new Popper(reference, popper, {
+			onUpdate: this.onUpdate,
 			placement,
 			eventsEnabled,
 			modifiers,
@@ -429,6 +434,7 @@ const Dialog = createReactClass({
 
 Dialog.contextTypes = {
 	iconPath: PropTypes.string,
+	handleNubbinPositionUpdate: PropTypes.func,
 };
 
 export default Dialog;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "design-system-react",
-  "version": "0.8.6",
+  "version": "0.8.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -201,14 +201,27 @@
       }
     },
     "@storybook/addon-links": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-3.3.12.tgz",
-      "integrity": "sha512-SgJ4ARhaWWBP9rvTkl9jz7psYP4DZrxNPK5kpRIl7k4Ak//AqKG3PUmy5gRkYbn5HVy8Vh1U/jxev3MJVfd7MA==",
+      "version": "3.4.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-3.4.0-alpha.8.tgz",
+      "integrity": "sha512-dyyhe7ThhErtCMqTCNLRYDGqFAy4y3Ew9AoXCgr/pHASwBlxF93ieA+0m1PPkh6mQNMpHkCxq1Zyp5B+SQk9RA==",
       "dev": true,
       "requires": {
-        "@storybook/components": "3.3.12",
+        "@storybook/components": "3.4.0-alpha.8",
         "global": "4.3.2",
         "prop-types": "15.6.0"
+      },
+      "dependencies": {
+        "@storybook/components": {
+          "version": "3.4.0-alpha.8",
+          "resolved": "https://registry.npmjs.org/@storybook/components/-/components-3.4.0-alpha.8.tgz",
+          "integrity": "sha512-zV87UiekOUYbGp/bubpmsQYplJGc43IgU1zALIA90GpLcy4BsqLNwl7zL4qSYsRBpZEHW8ckDUY4ynAOFhn7fA==",
+          "dev": true,
+          "requires": {
+            "glamor": "2.20.40",
+            "glamorous": "4.11.4",
+            "prop-types": "15.6.0"
+          }
+        }
       }
     },
     "@storybook/addon-storyshots": {
@@ -229,26 +242,26 @@
       }
     },
     "@storybook/addons": {
-      "version": "3.4.0-alpha.7",
-      "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-3.4.0-alpha.7.tgz",
-      "integrity": "sha512-tkAHIS4tcaQk9uwjPjnJ0DBV6UY50SOrCxvfTh5CJ1MdzMMD9vK3f7XGZtznufiujEH9jgDBdHd1D6OSyjHdOA==",
+      "version": "3.4.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-3.4.0-alpha.8.tgz",
+      "integrity": "sha512-fWjElmaUVqemgqhfxMU7m8V4F1JPubh/PGoHRhHeZ3XjFGTran/x5zJIHYApEqx7MR2Gw/Juw4a/aGb43sIDdQ==",
       "dev": true
     },
     "@storybook/channel-postmessage": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-3.3.12.tgz",
-      "integrity": "sha512-y1bMm8BXqI7BukhgVPxAmn1cmbdLd5osexZWj+QLqY5c05hMCUuflo3pyuX5N5gVbfVtjXjDwSuIhk+Z9YUTkQ==",
+      "version": "3.4.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-3.4.0-alpha.8.tgz",
+      "integrity": "sha512-ID5CzAlU0nNKsDIAnJALsQx91OXtx+mSg88tAhpl2EM9heoVgT9Ub2kEMQL+eU8pH4+XDmCLMFmRhvSwxkvZLw==",
       "dev": true,
       "requires": {
-        "@storybook/channels": "3.3.12",
+        "@storybook/channels": "3.4.0-alpha.8",
         "global": "4.3.2",
         "json-stringify-safe": "5.0.1"
       },
       "dependencies": {
         "@storybook/channels": {
-          "version": "3.3.12",
-          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-3.3.12.tgz",
-          "integrity": "sha512-efjX0zedhGYiJiXeWu07hBT5gwRp64w9WjbrnCzhI8qc/1SSM+gKPzOoab0ZIcmownwb0f1B89sLo3f4dP90DQ==",
+          "version": "3.4.0-alpha.8",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-3.4.0-alpha.8.tgz",
+          "integrity": "sha512-43RhXwqdPDYnEg52uyzY346hxq2GqV3lWd6g4xAddPyMZSGiti1W5s1GQlkC/xdZsTJ5XTjqhJ1JURA7uSOCVw==",
           "dev": true
         }
       }
@@ -276,79 +289,64 @@
         "prop-types": "15.6.0"
       }
     },
-    "@storybook/mantra-core": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@storybook/mantra-core/-/mantra-core-1.7.2.tgz",
-      "integrity": "sha512-GD4OYJ8GsayVhIg306sfgcKDk9j8YfuSKIAWvdB/g7IDlw0pDgueONALVEEE2XWJtCwcsUyDtCYzXFgCBWLEjA==",
+    "@storybook/core": {
+      "version": "3.4.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/@storybook/core/-/core-3.4.0-alpha.8.tgz",
+      "integrity": "sha512-K0rUoOKzxw3ADAa4TSbhFruQPB5qHRw55eMgezkNhJT/1zP2ElOoY3ecaem4RMfrmFEaFhU4xgEwHscgIe8HNQ==",
       "dev": true,
       "requires": {
-        "@storybook/react-komposer": "2.0.3",
-        "@storybook/react-simple-di": "1.3.0",
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "@storybook/react": {
-      "version": "3.2.19",
-      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-3.2.19.tgz",
-      "integrity": "sha512-/d9LjbmgV3fWnrPIb79o35W6MGjta0B+QDHxiZ1ndV1KbHqJJSXSx3maGyAlfKIovbIDE/Mo7wLLdbx/cV0OHw==",
-      "dev": true,
-      "requires": {
-        "@storybook/addon-actions": "3.3.12",
-        "@storybook/addon-links": "3.3.12",
-        "@storybook/addons": "3.3.12",
-        "@storybook/channel-postmessage": "3.3.12",
-        "@storybook/ui": "3.3.12",
-        "airbnb-js-shims": "1.4.1",
-        "autoprefixer": "7.2.5",
-        "babel-loader": "7.1.2",
-        "babel-plugin-react-docgen": "1.8.2",
-        "babel-plugin-transform-regenerator": "6.26.0",
-        "babel-plugin-transform-runtime": "6.23.0",
-        "babel-preset-env": "1.6.1",
-        "babel-preset-minify": "0.2.0",
-        "babel-preset-react": "6.24.1",
-        "babel-preset-react-app": "3.1.1",
-        "babel-preset-stage-0": "6.24.1",
+        "@storybook/addons": "3.4.0-alpha.8",
+        "@storybook/channel-postmessage": "3.4.0-alpha.8",
+        "@storybook/client-logger": "3.4.0-alpha.8",
+        "@storybook/node-logger": "3.4.0-alpha.8",
+        "@storybook/ui": "3.4.0-alpha.8",
+        "autoprefixer": "7.2.6",
         "babel-runtime": "6.26.0",
-        "case-sensitive-paths-webpack-plugin": "2.1.1",
-        "chalk": "2.3.0",
-        "commander": "2.13.0",
-        "common-tags": "1.7.2",
-        "configstore": "3.1.1",
-        "core-js": "2.5.3",
+        "chalk": "2.3.1",
+        "commander": "2.14.1",
         "css-loader": "0.28.9",
-        "dotenv-webpack": "1.5.4",
+        "dotenv": "4.0.0",
+        "events": "1.1.1",
         "express": "4.16.2",
-        "file-loader": "1.1.6",
-        "find-cache-dir": "1.0.0",
-        "glamor": "2.20.40",
-        "glamorous": "4.11.4",
+        "file-loader": "1.1.8",
         "global": "4.3.2",
         "json-loader": "0.5.7",
-        "json-stringify-safe": "5.0.1",
-        "json5": "0.5.1",
-        "lodash.flattendeep": "4.4.0",
         "postcss-flexbugs-fixes": "3.3.0",
         "postcss-loader": "2.1.0",
         "prop-types": "15.6.0",
         "qs": "6.5.1",
-        "redux": "3.7.2",
-        "request": "2.83.0",
+        "react": "16.2.0",
+        "react-dom": "16.2.0",
         "serve-favicon": "2.4.5",
-        "shelljs": "0.7.8",
-        "style-loader": "0.19.1",
+        "shelljs": "0.8.1",
+        "style-loader": "0.20.2",
         "url-loader": "0.6.2",
-        "util-deprecate": "1.0.2",
-        "uuid": "3.2.1",
-        "webpack": "3.10.0",
+        "webpack": "3.11.0",
         "webpack-dev-middleware": "1.12.2",
         "webpack-hot-middleware": "2.21.0"
       },
       "dependencies": {
-        "@storybook/addons": {
-          "version": "3.3.12",
-          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-3.3.12.tgz",
-          "integrity": "sha512-jKMei9Z3DAudXhWl9UFxBtzbrfh0C8r8POU8pjD0SEc7DAC6wF3R8tJhXNqcS47HqB8/mdVv8DmauL4SThmD9Q==",
+        "@storybook/client-logger": {
+          "version": "3.4.0-alpha.8",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-3.4.0-alpha.8.tgz",
+          "integrity": "sha512-/3xsXfywoMVKOpBL1w0LplWUMAl2O9KOIAHr7R+DDypXhYy6fUXdx8Mr4nFUUYQ2dvPR9SqpvUky04+cnviaHg==",
+          "dev": true
+        },
+        "ajv": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.1.1.tgz",
+          "integrity": "sha1-l41Zf7wrfQ5aXD3esUmmgvKr+g4=",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.1.0.tgz",
+          "integrity": "sha1-rCsnk5xUPpXSwG5/f1wnvkqlQ74=",
           "dev": true
         },
         "ansi-styles": {
@@ -361,34 +359,316 @@
           }
         },
         "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+          "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "supports-color": "5.2.0"
           }
+        },
+        "commander": {
+          "version": "2.14.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
+          "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
+          "dev": true
         },
         "file-loader": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-1.1.6.tgz",
-          "integrity": "sha512-873ztuL+/hfvXbLDJ262PGO6XjERnybJu2gW1/5j8HUfxSiFJI9Hj/DhZ50ZGRUxBvuNiazb/cM2rh9pqrxP6Q==",
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-1.1.8.tgz",
+          "integrity": "sha512-gVsHTw9n5Sp6U5vm5MmwMyKx4uOnlmDMwtWhXMdUmQJ7w3FgGaIjqPF2k4c8KZYhRd0Ltlt6mofRTv/NfqCLuA==",
           "dev": true,
           "requires": {
             "loader-utils": "1.1.0",
-            "schema-utils": "0.3.0"
+            "schema-utils": "0.4.5"
           }
         },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "react": {
+          "version": "16.2.0",
+          "resolved": "https://registry.npmjs.org/react/-/react-16.2.0.tgz",
+          "integrity": "sha512-ZmIomM7EE1DvPEnSFAHZn9Vs9zJl5A9H7el0EGTE6ZbW9FKe/14IYAlPbC8iH25YarEQxZL+E8VW7Mi7kfQrDQ==",
+          "dev": true,
+          "requires": {
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "prop-types": "15.6.0"
+          }
+        },
+        "react-dom": {
+          "version": "16.2.0",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.2.0.tgz",
+          "integrity": "sha512-zpGAdwHVn9K0091d+hr+R0qrjoJ84cIBFL2uU60KvWBPfZ7LPSrfqviTxGHWN0sjPZb2hxWzMexwrvJdKePvjg==",
+          "dev": true,
+          "requires": {
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "prop-types": "15.6.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        },
         "style-loader": {
-          "version": "0.19.1",
-          "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.19.1.tgz",
-          "integrity": "sha512-IRE+ijgojrygQi3rsqT0U4dd+UcPCqcVvauZpCnQrGAlEe+FUIyrK93bUDScamesjP08JlQNsFJU+KmPedP5Og==",
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.20.2.tgz",
+          "integrity": "sha512-FrLMGaOLVhS5pvoez3eJyc0ktchT1inEZziBSjBq1hHQBK3GFkF57Qd825DcrUhjaAWQk70MKrIl5bfjadR/Dg==",
           "dev": true,
           "requires": {
             "loader-utils": "1.1.0",
-            "schema-utils": "0.3.0"
+            "schema-utils": "0.4.5"
+          }
+        },
+        "supports-color": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        },
+        "webpack": {
+          "version": "3.11.0",
+          "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.11.0.tgz",
+          "integrity": "sha512-3kOFejWqj5ISpJk4Qj/V7w98h9Vl52wak3CLiw/cDOfbVTq7FeoZ0SdoHHY9PYlHr50ZS42OfvzE2vB4nncKQg==",
+          "dev": true,
+          "requires": {
+            "acorn": "5.4.1",
+            "acorn-dynamic-import": "2.0.2",
+            "ajv": "6.1.1",
+            "ajv-keywords": "3.1.0",
+            "async": "2.6.0",
+            "enhanced-resolve": "3.4.1",
+            "escope": "3.6.0",
+            "interpret": "1.1.0",
+            "json-loader": "0.5.7",
+            "json5": "0.5.1",
+            "loader-runner": "2.3.0",
+            "loader-utils": "1.1.0",
+            "memory-fs": "0.4.1",
+            "mkdirp": "0.5.1",
+            "node-libs-browser": "2.1.0",
+            "source-map": "0.5.7",
+            "supports-color": "4.5.0",
+            "tapable": "0.2.8",
+            "uglifyjs-webpack-plugin": "0.4.6",
+            "watchpack": "1.4.0",
+            "webpack-sources": "1.1.0",
+            "yargs": "8.0.2"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+              "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+              "dev": true
+            },
+            "supports-color": {
+              "version": "4.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+              "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "dev": true,
+              "requires": {
+                "has-flag": "2.0.0"
+              }
+            }
+          }
+        }
+      }
+    },
+    "@storybook/mantra-core": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@storybook/mantra-core/-/mantra-core-1.7.2.tgz",
+      "integrity": "sha512-GD4OYJ8GsayVhIg306sfgcKDk9j8YfuSKIAWvdB/g7IDlw0pDgueONALVEEE2XWJtCwcsUyDtCYzXFgCBWLEjA==",
+      "dev": true,
+      "requires": {
+        "@storybook/react-komposer": "2.0.3",
+        "@storybook/react-simple-di": "1.3.0",
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "@storybook/node-logger": {
+      "version": "3.4.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-3.4.0-alpha.8.tgz",
+      "integrity": "sha512-tvwaQyYqOJ9TmdaYh0xATLOLZRGkjNjtObSTC4Oft1EbIG4M8aLzuFBpr8y1l/3nXZHRdvW0+XsWBB8Yiu8XcA==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.1",
+        "npmlog": "4.1.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+          "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.2.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "@storybook/react": {
+      "version": "3.4.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-3.4.0-alpha.8.tgz",
+      "integrity": "sha512-zITIFlUVAnjXxLqy/BaVWHKiIeUGiADe2qXMK+sq2G8IKXWP1KAd0gxG529+hzpJYUV4p1khPWqN/1kqx3Yh3w==",
+      "dev": true,
+      "requires": {
+        "@storybook/addon-actions": "3.4.0-alpha.8",
+        "@storybook/addon-links": "3.4.0-alpha.8",
+        "@storybook/addons": "3.4.0-alpha.8",
+        "@storybook/channel-postmessage": "3.4.0-alpha.8",
+        "@storybook/client-logger": "3.4.0-alpha.8",
+        "@storybook/core": "3.4.0-alpha.8",
+        "@storybook/node-logger": "3.4.0-alpha.8",
+        "@storybook/ui": "3.4.0-alpha.8",
+        "airbnb-js-shims": "1.4.1",
+        "autoprefixer": "7.2.6",
+        "babel-loader": "7.1.2",
+        "babel-plugin-macros": "2.1.0",
+        "babel-plugin-react-docgen": "1.8.2",
+        "babel-plugin-transform-regenerator": "6.26.0",
+        "babel-plugin-transform-runtime": "6.23.0",
+        "babel-preset-env": "1.6.1",
+        "babel-preset-minify": "0.3.0",
+        "babel-preset-react": "6.24.1",
+        "babel-preset-react-app": "3.1.1",
+        "babel-preset-stage-0": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "case-sensitive-paths-webpack-plugin": "2.1.1",
+        "common-tags": "1.7.2",
+        "configstore": "3.1.1",
+        "core-js": "2.5.3",
+        "css-loader": "0.28.9",
+        "dotenv-webpack": "1.5.4",
+        "express": "4.16.2",
+        "file-loader": "1.1.8",
+        "find-cache-dir": "1.0.0",
+        "glamor": "2.20.40",
+        "glamorous": "4.11.4",
+        "global": "4.3.2",
+        "html-loader": "0.5.5",
+        "html-webpack-plugin": "2.30.1",
+        "json-loader": "0.5.7",
+        "json-stringify-safe": "5.0.1",
+        "json5": "0.5.1",
+        "lodash.flattendeep": "4.4.0",
+        "markdown-loader": "2.0.2",
+        "npmlog": "4.1.2",
+        "postcss-flexbugs-fixes": "3.3.0",
+        "postcss-loader": "2.1.0",
+        "prop-types": "15.6.0",
+        "qs": "6.5.1",
+        "react-dev-utils": "5.0.0",
+        "redux": "3.7.2",
+        "request": "2.83.0",
+        "style-loader": "0.20.2",
+        "uglifyjs-webpack-plugin": "1.2.0",
+        "url-loader": "0.6.2",
+        "util-deprecate": "1.0.2",
+        "webpack": "3.11.0"
+      },
+      "dependencies": {
+        "@storybook/addon-actions": {
+          "version": "3.4.0-alpha.8",
+          "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-3.4.0-alpha.8.tgz",
+          "integrity": "sha512-m25H9SGwTUEIV9oz2X9rh8R2GZ7GiU9YN0I2rz+WolmNXxkMJUaQm1Kgws/Wku0ENM7qnn0bFCYA7OdVWWyKAw==",
+          "dev": true,
+          "requires": {
+            "deep-equal": "1.0.1",
+            "global": "4.3.2",
+            "make-error": "1.3.4",
+            "prop-types": "15.6.0",
+            "react-inspector": "2.2.2",
+            "uuid": "3.2.1"
+          }
+        },
+        "@storybook/client-logger": {
+          "version": "3.4.0-alpha.8",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-3.4.0-alpha.8.tgz",
+          "integrity": "sha512-/3xsXfywoMVKOpBL1w0LplWUMAl2O9KOIAHr7R+DDypXhYy6fUXdx8Mr4nFUUYQ2dvPR9SqpvUky04+cnviaHg==",
+          "dev": true
+        },
+        "ajv": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.1.1.tgz",
+          "integrity": "sha1-l41Zf7wrfQ5aXD3esUmmgvKr+g4=",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.1.0.tgz",
+          "integrity": "sha1-rCsnk5xUPpXSwG5/f1wnvkqlQ74=",
+          "dev": true
+        },
+        "file-loader": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-1.1.8.tgz",
+          "integrity": "sha512-gVsHTw9n5Sp6U5vm5MmwMyKx4uOnlmDMwtWhXMdUmQJ7w3FgGaIjqPF2k4c8KZYhRd0Ltlt6mofRTv/NfqCLuA==",
+          "dev": true,
+          "requires": {
+            "loader-utils": "1.1.0",
+            "schema-utils": "0.4.5"
+          }
+        },
+        "make-error": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.4.tgz",
+          "integrity": "sha512-0Dab5btKVPhibSalc9QGXb559ED7G7iLjFXBaj9Wq8O3vorueR5K5jaE3hkG6ZQINyhA/JgG6Qk4qdFQjsYV6g==",
+          "dev": true
+        },
+        "style-loader": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.20.2.tgz",
+          "integrity": "sha512-FrLMGaOLVhS5pvoez3eJyc0ktchT1inEZziBSjBq1hHQBK3GFkF57Qd825DcrUhjaAWQk70MKrIl5bfjadR/Dg==",
+          "dev": true,
+          "requires": {
+            "loader-utils": "1.1.0",
+            "schema-utils": "0.4.5"
           }
         },
         "supports-color": {
@@ -398,6 +678,81 @@
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
+          }
+        },
+        "uglify-es": {
+          "version": "3.3.9",
+          "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
+          "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
+          "dev": true,
+          "requires": {
+            "commander": "2.13.0",
+            "source-map": "0.6.1"
+          }
+        },
+        "uglifyjs-webpack-plugin": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.0.tgz",
+          "integrity": "sha512-Bc2NeyTTSJAy2JuKaBpdvWyuySPSPHNcj70KFqu7FhfrfsjPo0Kta9jgAvPrQxnz86mOH1tk4n/I8wvZrXvetA==",
+          "dev": true,
+          "requires": {
+            "cacache": "10.0.4",
+            "find-cache-dir": "1.0.0",
+            "schema-utils": "0.4.5",
+            "serialize-javascript": "1.4.0",
+            "source-map": "0.6.1",
+            "uglify-es": "3.3.9",
+            "webpack-sources": "1.1.0",
+            "worker-farm": "1.5.2"
+          }
+        },
+        "webpack": {
+          "version": "3.11.0",
+          "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.11.0.tgz",
+          "integrity": "sha512-3kOFejWqj5ISpJk4Qj/V7w98h9Vl52wak3CLiw/cDOfbVTq7FeoZ0SdoHHY9PYlHr50ZS42OfvzE2vB4nncKQg==",
+          "dev": true,
+          "requires": {
+            "acorn": "5.4.1",
+            "acorn-dynamic-import": "2.0.2",
+            "ajv": "6.1.1",
+            "ajv-keywords": "3.1.0",
+            "async": "2.6.0",
+            "enhanced-resolve": "3.4.1",
+            "escope": "3.6.0",
+            "interpret": "1.1.0",
+            "json-loader": "0.5.7",
+            "json5": "0.5.1",
+            "loader-runner": "2.3.0",
+            "loader-utils": "1.1.0",
+            "memory-fs": "0.4.1",
+            "mkdirp": "0.5.1",
+            "node-libs-browser": "2.1.0",
+            "source-map": "0.5.7",
+            "supports-color": "4.5.0",
+            "tapable": "0.2.8",
+            "uglifyjs-webpack-plugin": "0.4.6",
+            "watchpack": "1.4.0",
+            "webpack-sources": "1.1.0",
+            "yargs": "8.0.2"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+              "dev": true
+            },
+            "uglifyjs-webpack-plugin": {
+              "version": "0.4.6",
+              "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
+              "integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
+              "dev": true,
+              "requires": {
+                "source-map": "0.5.7",
+                "uglify-js": "2.8.29",
+                "webpack-sources": "1.1.0"
+              }
+            }
           }
         }
       }
@@ -437,12 +792,12 @@
       }
     },
     "@storybook/ui": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/@storybook/ui/-/ui-3.3.12.tgz",
-      "integrity": "sha512-OoUBSuIfQXWuN31upTf+uLlpaiNE/kT753bh56z1WBngjft02mWw/xVcawBKFoTzqPZkD2IUmd0PYMM/ntmAow==",
+      "version": "3.4.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/@storybook/ui/-/ui-3.4.0-alpha.8.tgz",
+      "integrity": "sha512-zua5VsnAYxgDOwRsjYCUSlNdmxERc7rESOuLzGWidADBEOM6dAJoxKweriToyYgBUsazgcvkr1jBwTWjn26GyQ==",
       "dev": true,
       "requires": {
-        "@storybook/components": "3.3.12",
+        "@storybook/components": "3.4.0-alpha.8",
         "@storybook/mantra-core": "1.7.2",
         "@storybook/react-komposer": "2.0.3",
         "babel-runtime": "6.26.0",
@@ -458,19 +813,30 @@
         "podda": "1.2.2",
         "prop-types": "15.6.0",
         "qs": "6.5.1",
-        "react-fuzzy": "0.5.1",
+        "react-fuzzy": "0.5.2",
         "react-icons": "2.2.7",
         "react-inspector": "2.2.2",
-        "react-modal": "3.1.11",
-        "react-split-pane": "0.1.76",
+        "react-modal": "3.3.1",
+        "react-split-pane": "0.1.77",
         "react-treebeard": "2.1.0",
         "redux": "3.7.2"
       },
       "dependencies": {
+        "@storybook/components": {
+          "version": "3.4.0-alpha.8",
+          "resolved": "https://registry.npmjs.org/@storybook/components/-/components-3.4.0-alpha.8.tgz",
+          "integrity": "sha512-zV87UiekOUYbGp/bubpmsQYplJGc43IgU1zALIA90GpLcy4BsqLNwl7zL4qSYsRBpZEHW8ckDUY4ynAOFhn7fA==",
+          "dev": true,
+          "requires": {
+            "glamor": "2.20.40",
+            "glamorous": "4.11.4",
+            "prop-types": "15.6.0"
+          }
+        },
         "react-modal": {
-          "version": "3.1.11",
-          "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.1.11.tgz",
-          "integrity": "sha512-Pm4QAc+sWYrfRC+WRERV+JGeGZIfodZGdbvWmjPzeSWqP+EW5ATK4N1U/btNHZWFzKL1UOmkmNtozEQlEg7c+A==",
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.3.1.tgz",
+          "integrity": "sha512-d1A8xXIvW+YVKwRMrFY5qneuC5FSa4OnOE78hgqfz+MYLb1Ai/B3D3Dzx1Zrw4ZD5rS16SKiPe5rl4UZt+AjpQ==",
           "dev": true,
           "requires": {
             "exenv": "1.2.0",
@@ -479,18 +845,6 @@
           }
         }
       }
-    },
-    "@types/inline-style-prefixer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/inline-style-prefixer/-/inline-style-prefixer-3.0.1.tgz",
-      "integrity": "sha512-+kbOcYW1/noncDwRryRoB9tH87IYcMfdBGvw98iocK39LtTA2DFL7agmk4UHW/GxjzVfwrxfjlLrqrgA7MCtmg==",
-      "dev": true
-    },
-    "@types/react": {
-      "version": "16.0.36",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.0.36.tgz",
-      "integrity": "sha512-q33EVfy4i+fwhM31PL6/c6Job/DyjOiExHuR163bJK3rEMRf2ENkBrN4thQH5cwA+TiiN1vWDZU6D5H1AvQTlA==",
-      "dev": true
     },
     "abab": {
       "version": "1.0.4",
@@ -571,6 +925,12 @@
         }
       }
     },
+    "address": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/address/-/address-1.0.3.tgz",
+      "integrity": "sha512-z55ocwKBRLryBs394Sm3ushTtBeg6VAeuku7utSoSnsJKvKcnXFIyC6vh27n3rXyxSgkJBBCAvyOn7gSUcTYjg==",
+      "dev": true
+    },
     "after": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
@@ -604,21 +964,6 @@
         "promise.prototype.finally": "3.1.0",
         "string.prototype.padend": "3.0.0",
         "string.prototype.padstart": "3.0.0"
-      }
-    },
-    "airbnb-prop-types": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.8.1.tgz",
-      "integrity": "sha512-z7pAKmUyAsp/2SqLCTf9hzFc2JLspijB9t+I9D/i0NnYkkjUoV16+W00U6r7+HBM6Q3VqXSjYuUsLX1L71aciw==",
-      "requires": {
-        "array.prototype.find": "2.0.4",
-        "function.prototype.name": "1.1.0",
-        "has": "1.0.1",
-        "is-regex": "1.0.4",
-        "object.assign": "4.1.0",
-        "object.entries": "1.0.4",
-        "prop-types": "15.6.0",
-        "prop-types-exact": "1.1.2"
       }
     },
     "ajv": {
@@ -765,6 +1110,12 @@
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
+    "array-filter": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+      "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
+      "dev": true
+    },
     "array-find": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-find/-/array-find-1.0.0.tgz",
@@ -793,6 +1144,18 @@
         "es-abstract": "1.10.0"
       }
     },
+    "array-map": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+      "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
+      "dev": true
+    },
+    "array-reduce": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+      "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
+      "dev": true
+    },
     "array-slice": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
@@ -819,15 +1182,6 @@
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
       "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
       "dev": true
-    },
-    "array.prototype.find": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.0.4.tgz",
-      "integrity": "sha1-VWpcU2LAhkgyPdrrnenRS8GGTJA=",
-      "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.10.0"
-      }
     },
     "array.prototype.flatmap": {
       "version": "1.2.0",
@@ -958,17 +1312,25 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.5.tgz",
-      "integrity": "sha512-XqHfo8Ht0VU+T5P+eWEVoXza456KJ4l62BPewu3vpNf3LP9s2+zYXkXBznzYby4XeECXgG3N4i+hGvOhXErZmA==",
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.6.tgz",
+      "integrity": "sha512-Iq8TRIB+/9eQ8rbGhcP7ct5cYb/3qjNYAR2SnzLCEcwF6rvVOax8+9+fccgXk4bEhQGjOZd5TLhsksmAdsbGqQ==",
       "dev": true,
       "requires": {
         "browserslist": "2.11.3",
-        "caniuse-lite": "1.0.30000792",
+        "caniuse-lite": "1.0.30000810",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "6.0.17",
         "postcss-value-parser": "3.3.0"
+      },
+      "dependencies": {
+        "caniuse-lite": {
+          "version": "1.0.30000810",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000810.tgz",
+          "integrity": "sha512-/0Q00Oie9C72P8zQHtFvzmkrMC3oOFUnMWjCy5F2+BE8lzICm91hQPhh0+XIsAFPKOe2Dh3pKgbRmU3EKxfldA==",
+          "dev": true
+        }
       }
     },
     "aws-sign2": {
@@ -1174,9 +1536,9 @@
       }
     },
     "babel-helper-evaluate-path": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.2.0.tgz",
-      "integrity": "sha512-0EK9TUKMxHL549hWDPkQoS7R0Ozg1CDLheVBHYds2B2qoAvmr9ejY3zOXFsrICK73TN7bPhU14PBeKc8jcBTwg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.3.0.tgz",
+      "integrity": "sha512-dRFlMTqUJRGzx5a2smKxmptDdNCXKSkPcXWzKLwAV72hvIZumrd/0z9RcewHkr7PmAEq+ETtpD1GK6wZ6ZUXzw==",
       "dev": true
     },
     "babel-helper-explode-assignable-expression": {
@@ -1202,9 +1564,9 @@
       }
     },
     "babel-helper-flip-expressions": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.2.0.tgz",
-      "integrity": "sha512-rAsPA1pWBc7e2E6HepkP2e1sXugT+Oq/VCqhyuHJ8aJ2d/ifwnJfd4Qxjm21qlW43AN8tqaeByagKK6wECFMSw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.3.0.tgz",
+      "integrity": "sha512-kNGohWmtAG3b7tN1xocRQ5rsKkH/hpvZsMiGOJ1VwGJKhnwzR5KlB3rvKBaBPl5/IGHcopB2JN+r1SUEX1iMAw==",
       "dev": true
     },
     "babel-helper-function-name": {
@@ -1244,15 +1606,15 @@
       "dev": true
     },
     "babel-helper-is-void-0": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-is-void-0/-/babel-helper-is-void-0-0.2.0.tgz",
-      "integrity": "sha512-Axj1AYuD0E3Dl7nT3KxROP7VekEofz3XtEljzURf3fABalLpr8PamtgLFt+zuxtaCxRf9iuZmbAMMYWri5Bazw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-is-void-0/-/babel-helper-is-void-0-0.3.0.tgz",
+      "integrity": "sha512-JVqdX8y7Rf/x4NwbqtUI7mdQjL9HWoDnoAEQ8Gv8oxzjvbJv+n75f7l36m9Y8C7sCUltX3V5edndrp7Hp1oSXQ==",
       "dev": true
     },
     "babel-helper-mark-eval-scopes": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.2.0.tgz",
-      "integrity": "sha512-KJuwrOUcHbvbh6he4xRXZFLaivK9DF9o3CrvpWnK1Wp0B+1ANYABXBMgwrnNFIDK/AvicxQ9CNr8wsgivlp4Aw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.3.0.tgz",
+      "integrity": "sha512-nrho5Dg4vl0VUgURVpGpEGiwbst5JX7efIyDHFxmkCx/ocQFnrPt8ze9Kxl6TKjR29bJ7D/XKY1NMlSxOQJRbQ==",
       "dev": true
     },
     "babel-helper-optimise-call-expression": {
@@ -1287,9 +1649,9 @@
       }
     },
     "babel-helper-remove-or-void": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.2.0.tgz",
-      "integrity": "sha512-1Z41upf/XR+PwY7Nd+F15Jo5BiQi5205ZXUuKed3yoyQgDkMyoM7vAdjEJS/T+M6jy32sXjskMUgms4zeiVtRA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.3.0.tgz",
+      "integrity": "sha512-D68W1M3ibCcbg0ysh3ww4/O0g10X1CXK720oOuR8kpfY7w0yP4tVcpK7zDmI1JecynycTQYAZ1rhLJo9aVtIKQ==",
       "dev": true
     },
     "babel-helper-replace-supers": {
@@ -1306,9 +1668,9 @@
       }
     },
     "babel-helper-to-multiple-sequence-expressions": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.2.0.tgz",
-      "integrity": "sha512-ij9lpfdP3+Zc/7kNwa+NXbTrUlsYEWPwt/ugmQO0qflzLrveTIkbfOqQztvitk81aG5NblYDQXDlRohzu3oa8Q==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.3.0.tgz",
+      "integrity": "sha512-1uCrBD+EAaMnAYh7hc944n8Ga19y3daEnoXWPYDvFVsxMCc1l8aDjksApaCEaNSSuewq8BEcff47Cy1PbLg2Gw==",
       "dev": true
     },
     "babel-helpers": {
@@ -1393,99 +1755,138 @@
       "integrity": "sha1-r+3IU70/jcNUjqZx++adA8wsF2c=",
       "dev": true
     },
-    "babel-plugin-minify-builtins": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-builtins/-/babel-plugin-minify-builtins-0.2.0.tgz",
-      "integrity": "sha512-4i+8ntaS8gwVUcOz5y+zE+55OVOl2nTbmHV51D4wAIiKcRI8U5K//ip1GHfhsgk/NJrrHK7h97Oy5jpqt0Iixg==",
+    "babel-plugin-macros": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.1.0.tgz",
+      "integrity": "sha512-oqxZ3Ncj1iFBCEfg0iwxh7oleupqjLonJp9TQunCQITZxkrHo8QaXMQrn5w3ljmM2d2xZVKR8oweyty+hNgxFA==",
       "dev": true,
       "requires": {
-        "babel-helper-evaluate-path": "0.2.0"
+        "cosmiconfig": "4.0.0"
+      },
+      "dependencies": {
+        "cosmiconfig": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
+          "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
+          "dev": true,
+          "requires": {
+            "is-directory": "0.3.1",
+            "js-yaml": "3.10.0",
+            "parse-json": "4.0.0",
+            "require-from-string": "2.0.1"
+          }
+        },
+        "js-yaml": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+          "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.9",
+            "esprima": "4.0.0"
+          }
+        },
+        "require-from-string": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.1.tgz",
+          "integrity": "sha1-xUUjPp19pmFunVmt+zn8n1iGdv8=",
+          "dev": true
+        }
+      }
+    },
+    "babel-plugin-minify-builtins": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-builtins/-/babel-plugin-minify-builtins-0.3.0.tgz",
+      "integrity": "sha512-MqhSHlxkmgURqj3144qPksbZ/qof1JWdumcbucc4tysFcf3P3V3z3munTevQgKEFNMd8F5/ECGnwb63xogLjAg==",
+      "dev": true,
+      "requires": {
+        "babel-helper-evaluate-path": "0.3.0"
       }
     },
     "babel-plugin-minify-constant-folding": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.2.0.tgz",
-      "integrity": "sha512-B3ffQBEUQ8ydlIkYv2MkZtTCbV7FAkWAV7NkyhcXlGpD10PaCxNGQ/B9oguXGowR1m16Q5nGhvNn8Pkn1MO6Hw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.3.0.tgz",
+      "integrity": "sha512-1XeRpx+aY1BuNY6QU/cm6P+FtEi3ar3XceYbmC+4q4W+2Ewq5pL7V68oHg1hKXkBIE0Z4/FjSoHz6vosZLOe/A==",
       "dev": true,
       "requires": {
-        "babel-helper-evaluate-path": "0.2.0"
+        "babel-helper-evaluate-path": "0.3.0"
       }
     },
     "babel-plugin-minify-dead-code-elimination": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.2.0.tgz",
-      "integrity": "sha512-zE7y3pRyzA4zK5nBou0kTcwUTSQ/AiFrynt1cIEYN7vcO2gS9ZFZoI0aO9JYLUdct5fsC1vfB35408yrzTyVfg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.3.0.tgz",
+      "integrity": "sha512-SjM2Fzg85YZz+q/PNJ/HU4O3W98FKFOiP9K5z3sfonlamGOzvZw3Eup2OTiEBsbbqTeY8yzNCAv3qpJRYCgGmw==",
       "dev": true,
       "requires": {
-        "babel-helper-evaluate-path": "0.2.0",
-        "babel-helper-mark-eval-scopes": "0.2.0",
-        "babel-helper-remove-or-void": "0.2.0",
+        "babel-helper-evaluate-path": "0.3.0",
+        "babel-helper-mark-eval-scopes": "0.3.0",
+        "babel-helper-remove-or-void": "0.3.0",
         "lodash.some": "4.6.0"
       }
     },
     "babel-plugin-minify-flip-comparisons": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-flip-comparisons/-/babel-plugin-minify-flip-comparisons-0.2.0.tgz",
-      "integrity": "sha512-QOqXSEmD/LhT3LpM1WCyzAGcQZYYKJF7oOHvS6QbpomHenydrV53DMdPX2mK01icBExKZcJAHF209wvDBa+CSg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-flip-comparisons/-/babel-plugin-minify-flip-comparisons-0.3.0.tgz",
+      "integrity": "sha512-B8lK+ekcpSNVH7PZpWDe5nC5zxjRiiT4nTsa6h3QkF3Kk6y9qooIFLemdGlqBq6j0zALEnebvCpw8v7gAdpgnw==",
       "dev": true,
       "requires": {
-        "babel-helper-is-void-0": "0.2.0"
+        "babel-helper-is-void-0": "0.3.0"
       }
     },
     "babel-plugin-minify-guarded-expressions": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.2.0.tgz",
-      "integrity": "sha512-5+NSPdRQ9mnrHaA+zFj+D5OzmSiv90EX5zGH6cWQgR/OUqmCHSDqgTRPFvOctgpo8MJyO7Rt7ajs2UfLnlAwYg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.3.0.tgz",
+      "integrity": "sha512-O+6CvF5/Ttsth3LMg4/BhyvVZ82GImeKMXGdVRQGK/8jFiP15EjRpdgFlxv3cnqRjqdYxLCS6r28VfLpb9C/kA==",
       "dev": true,
       "requires": {
-        "babel-helper-flip-expressions": "0.2.0"
+        "babel-helper-flip-expressions": "0.3.0"
       }
     },
     "babel-plugin-minify-infinity": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-infinity/-/babel-plugin-minify-infinity-0.2.0.tgz",
-      "integrity": "sha512-U694vrla1lN6vDHWGrR832t3a/A2eh+kyl019LxEE2+sS4VTydyOPRsAOIYAdJegWRA4cMX1lm9azAN0cLIr8g==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-infinity/-/babel-plugin-minify-infinity-0.3.0.tgz",
+      "integrity": "sha512-Sj8ia3/w9158DWieUxU6/VvnYVy59geeFEkVgLZYBE8EBP+sN48tHtBM/jSgz0ejEdBlcfqJ6TnvPmVXTzR2BQ==",
       "dev": true
     },
     "babel-plugin-minify-mangle-names": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.2.0.tgz",
-      "integrity": "sha512-Gixuak1/CO7VCdjn15/8Bxe/QsAtDG4zPbnsNoe1mIJGCIH/kcmSjFhMlGJtXDQZd6EKzeMfA5WmX9+jvGRefw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.3.0.tgz",
+      "integrity": "sha512-PYTonhFWURsfAN8achDwvR5Xgy6EeTClLz+fSgGRqjAIXb0OyFm3/xfccbQviVi1qDXmlSnt6oJhBg8KE4Fn7Q==",
       "dev": true,
       "requires": {
-        "babel-helper-mark-eval-scopes": "0.2.0"
+        "babel-helper-mark-eval-scopes": "0.3.0"
       }
     },
     "babel-plugin-minify-numeric-literals": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-numeric-literals/-/babel-plugin-minify-numeric-literals-0.2.0.tgz",
-      "integrity": "sha512-VcLpb+r1YS7+RIOXdRsFVLLqoh22177USpHf+JM/g1nZbzdqENmfd5v534MLAbRErhbz6SyK+NQViVzVtBxu8g==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-numeric-literals/-/babel-plugin-minify-numeric-literals-0.3.0.tgz",
+      "integrity": "sha512-TgZj6ay8zDw74AS3yiIfoQ8vRSNJisYO/Du60S8nPV7EW7JM6fDMx5Sar6yVHlVuuwNgvDUBh191K33bVrAhpg==",
       "dev": true
     },
     "babel-plugin-minify-replace": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.2.0.tgz",
-      "integrity": "sha512-SEW6zoSVxh3OH6E1LCgyhhTWMnCv+JIRu5h5IlJDA11tU4ZeSF7uPQcO4vN/o52+FssRB26dmzJ/8D+z0QPg5Q==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.3.0.tgz",
+      "integrity": "sha512-VR6tTg2Lt0TicHIOw04fsUtpPw7RaRP8PC8YzSFwEixnzvguZjZJoL7TgG7ZyEWQD1cJ96UezswECmFNa815bg==",
       "dev": true
     },
     "babel-plugin-minify-simplify": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.2.0.tgz",
-      "integrity": "sha512-Mj3Mwy2zVosMfXDWXZrQH5/uMAyfJdmDQ1NVqit+ArbHC3LlXVzptuyC1JxTyai/wgFvjLaichm/7vSUshkWqw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.3.0.tgz",
+      "integrity": "sha512-2M16ytQOCqBi7bYMu4DCWn8e6KyFCA108F6+tVrBJxOmm5u2sOmTFEa8s94tR9RHRRNYmcUf+rgidfnzL3ik9Q==",
       "dev": true,
       "requires": {
-        "babel-helper-flip-expressions": "0.2.0",
+        "babel-helper-flip-expressions": "0.3.0",
         "babel-helper-is-nodes-equiv": "0.0.1",
-        "babel-helper-to-multiple-sequence-expressions": "0.2.0"
+        "babel-helper-to-multiple-sequence-expressions": "0.3.0"
       }
     },
     "babel-plugin-minify-type-constructors": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-minify-type-constructors/-/babel-plugin-minify-type-constructors-0.2.0.tgz",
-      "integrity": "sha512-NiOvvA9Pq6bki6nP4BayXwT5GZadw7DJFDDzHmkpnOQpENWe8RtHtKZM44MG1R6EQ5XxgbLdsdhswIzTkFlO5g==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-type-constructors/-/babel-plugin-minify-type-constructors-0.3.0.tgz",
+      "integrity": "sha512-XRXpvsUCPeVw9YEUw+9vSiugcSZfow81oIJT0yR9s8H4W7yJ6FHbImi5DJHoL8KcDUjYnL9wYASXk/fOkbyR6Q==",
       "dev": true,
       "requires": {
-        "babel-helper-is-void-0": "0.2.0"
+        "babel-helper-is-void-0": "0.3.0"
       }
     },
     "babel-plugin-react-docgen": {
@@ -1901,9 +2302,9 @@
       }
     },
     "babel-plugin-transform-inline-consecutive-adds": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.2.0.tgz",
-      "integrity": "sha512-GlhOuLOQ28ua9prg0hT33HslCrEmz9xWXy9ZNZSACppCyRxxRW+haYtRgm7uYXCcd0q8ggCWD2pfWEJp5iiZfQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.3.0.tgz",
+      "integrity": "sha512-iZsYAIjYLLfLK0yN5WVT7Xf7Y3wQ9Z75j9A8q/0IglQSpUt2ppTdHlwl/GeaXnxdaSmsxBu861klbTBbv2n+RA==",
       "dev": true
     },
     "babel-plugin-transform-member-expression-literals": {
@@ -1996,9 +2397,9 @@
       }
     },
     "babel-plugin-transform-regexp-constructors": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.2.0.tgz",
-      "integrity": "sha512-7IsQ6aQx6LAaOqy97/PthTf+5Nx9grZww3r6E62IdWe76Yr8KsuwVjxzqSPQvESJqTE3EMADQ9S0RtwWDGNG9Q==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.3.0.tgz",
+      "integrity": "sha512-h92YHzyl042rb0naKO8frTHntpRFwRgKkfWD8602kFHoQingjJNtbvZzvxqHncJ6XmKVyYvfrBpDOSkCTDIIxw==",
       "dev": true
     },
     "babel-plugin-transform-remove-console": {
@@ -2014,12 +2415,12 @@
       "dev": true
     },
     "babel-plugin-transform-remove-undefined": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.2.0.tgz",
-      "integrity": "sha512-O8v57tPMHkp89kA4ZfQEYds/pzgvz/QYerBJjIuL5/Jc7RnvMVRA5gJY9zFKP7WayW8WOSBV4vh8Y8FJRio+ow==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.3.0.tgz",
+      "integrity": "sha512-TYGQucc8iP3LJwN3kDZLEz5aa/2KuFrqpT+s8f8NnHsBU1sAgR3y8Opns0xhC+smyDYWscqFCKM1gbkWQOhhnw==",
       "dev": true,
       "requires": {
-        "babel-helper-evaluate-path": "0.2.0"
+        "babel-helper-evaluate-path": "0.3.0"
       }
     },
     "babel-plugin-transform-runtime": {
@@ -2157,31 +2558,31 @@
       }
     },
     "babel-preset-minify": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-minify/-/babel-preset-minify-0.2.0.tgz",
-      "integrity": "sha512-mR8Q44RmMzm18bM2Lqd9uiPopzk5GDCtVuquNbLFmX6lOKnqWoenaNBxnWW0UhBFC75lEHTIgNGCbnsRI0pJVw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-minify/-/babel-preset-minify-0.3.0.tgz",
+      "integrity": "sha512-+VV2GWEyak3eDOmzT1DDMuqHrw3VbE9nBNkx2LLVs4pH/Me32ND8DRpVDd8IRvk1xX5p75nygyRPtkMh6GIAbQ==",
       "dev": true,
       "requires": {
-        "babel-plugin-minify-builtins": "0.2.0",
-        "babel-plugin-minify-constant-folding": "0.2.0",
-        "babel-plugin-minify-dead-code-elimination": "0.2.0",
-        "babel-plugin-minify-flip-comparisons": "0.2.0",
-        "babel-plugin-minify-guarded-expressions": "0.2.0",
-        "babel-plugin-minify-infinity": "0.2.0",
-        "babel-plugin-minify-mangle-names": "0.2.0",
-        "babel-plugin-minify-numeric-literals": "0.2.0",
-        "babel-plugin-minify-replace": "0.2.0",
-        "babel-plugin-minify-simplify": "0.2.0",
-        "babel-plugin-minify-type-constructors": "0.2.0",
-        "babel-plugin-transform-inline-consecutive-adds": "0.2.0",
+        "babel-plugin-minify-builtins": "0.3.0",
+        "babel-plugin-minify-constant-folding": "0.3.0",
+        "babel-plugin-minify-dead-code-elimination": "0.3.0",
+        "babel-plugin-minify-flip-comparisons": "0.3.0",
+        "babel-plugin-minify-guarded-expressions": "0.3.0",
+        "babel-plugin-minify-infinity": "0.3.0",
+        "babel-plugin-minify-mangle-names": "0.3.0",
+        "babel-plugin-minify-numeric-literals": "0.3.0",
+        "babel-plugin-minify-replace": "0.3.0",
+        "babel-plugin-minify-simplify": "0.3.0",
+        "babel-plugin-minify-type-constructors": "0.3.0",
+        "babel-plugin-transform-inline-consecutive-adds": "0.3.0",
         "babel-plugin-transform-member-expression-literals": "6.9.0",
         "babel-plugin-transform-merge-sibling-variables": "6.9.0",
         "babel-plugin-transform-minify-booleans": "6.9.0",
         "babel-plugin-transform-property-literals": "6.9.0",
-        "babel-plugin-transform-regexp-constructors": "0.2.0",
+        "babel-plugin-transform-regexp-constructors": "0.3.0",
         "babel-plugin-transform-remove-console": "6.9.0",
         "babel-plugin-transform-remove-debugger": "6.9.0",
-        "babel-plugin-transform-remove-undefined": "0.2.0",
+        "babel-plugin-transform-remove-undefined": "0.3.0",
         "babel-plugin-transform-simplify-comparison-operators": "6.9.0",
         "babel-plugin-transform-undefined-to-void": "6.9.0",
         "lodash.isplainobject": "4.0.6"
@@ -2671,6 +3072,35 @@
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
       "dev": true
     },
+    "cacache": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
+      "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.5.1",
+        "chownr": "1.0.1",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "lru-cache": "4.1.1",
+        "mississippi": "2.0.0",
+        "mkdirp": "0.5.1",
+        "move-concurrently": "1.0.1",
+        "promise-inflight": "1.0.1",
+        "rimraf": "2.6.2",
+        "ssri": "5.2.4",
+        "unique-filename": "1.1.0",
+        "y18n": "4.0.0"
+      },
+      "dependencies": {
+        "y18n": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "dev": true
+        }
+      }
+    },
     "caller-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
@@ -2691,6 +3121,16 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
+    },
+    "camel-case": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+      "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+      "dev": true,
+      "requires": {
+        "no-case": "2.3.2",
+        "upper-case": "1.1.3"
+      }
     },
     "camelcase": {
       "version": "1.2.1",
@@ -2868,6 +3308,12 @@
         "readdirp": "2.1.0"
       }
     },
+    "chownr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+      "dev": true
+    },
     "ci-info": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
@@ -2903,6 +3349,33 @@
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
       "integrity": "sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0="
+    },
+    "clean-css": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.9.tgz",
+      "integrity": "sha1-Nc7ornaHpJuYA09w3gDE7dOCYwE=",
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.7"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "cli": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
+      "integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
+      "dev": true,
+      "requires": {
+        "exit": "0.1.2",
+        "glob": "7.1.2"
+      }
     },
     "cli-cursor": {
       "version": "2.1.0",
@@ -3263,6 +3736,20 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
       "dev": true
+    },
+    "copy-concurrently": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+      "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+      "dev": true,
+      "requires": {
+        "aproba": "1.2.0",
+        "fs-write-stream-atomic": "1.0.10",
+        "iferr": "0.1.5",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2",
+        "run-queue": "1.0.3"
+      }
     },
     "core-js": {
       "version": "2.5.3",
@@ -3676,6 +4163,12 @@
       "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
       "dev": true
     },
+    "cyclist": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+      "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
+      "dev": true
+    },
     "d": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
@@ -3789,6 +4282,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "dev": true,
       "requires": {
         "foreach": "2.0.5",
         "object-keys": "1.0.11"
@@ -3866,6 +4360,16 @@
         "repeating": "2.0.1"
       }
     },
+    "detect-port-alt": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/detect-port-alt/-/detect-port-alt-1.1.5.tgz",
+      "integrity": "sha512-PlE9BuBz44BSDV8sJvfUxkGquPcDW4oHSYa5wY4yKj943C2I4xNU5Gd/EFroqdWNur7W6yU2zOLqvmKJCB//aA==",
+      "dev": true,
+      "requires": {
+        "address": "1.0.3",
+        "debug": "2.6.9"
+      }
+    },
     "di": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
@@ -3902,6 +4406,23 @@
       "dev": true,
       "requires": {
         "esutils": "2.0.2"
+      }
+    },
+    "dom-converter": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.1.4.tgz",
+      "integrity": "sha1-pF71cnuJDJv/5tfIduexnLDhfzs=",
+      "dev": true,
+      "requires": {
+        "utila": "0.3.3"
+      },
+      "dependencies": {
+        "utila": {
+          "version": "0.3.3",
+          "resolved": "https://registry.npmjs.org/utila/-/utila-0.3.3.tgz",
+          "integrity": "sha1-1+jn1+MJEHCSsF+NloiCTWM6QiY=",
+          "dev": true
+        }
       }
     },
     "dom-helpers": {
@@ -3999,6 +4520,24 @@
       "dev": true,
       "requires": {
         "dotenv": "4.0.0"
+      }
+    },
+    "duplexer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+      "dev": true
+    },
+    "duplexify": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.3.tgz",
+      "integrity": "sha512-g8ID9OroF9hKt2POf8YLayy+9594PzmM3scI00/uBXocX3TWNgoB67hjzkFe9ITAbQOne/lLdBxHXvYUM4ZgGA==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "1.4.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "stream-shift": "1.0.0"
       }
     },
     "ecc-jsbn": {
@@ -4102,6 +4641,15 @@
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
         "iconv-lite": "0.4.19"
+      }
+    },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0"
       }
     },
     "engine.io": {
@@ -4313,6 +4861,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
       "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
+      "dev": true,
       "requires": {
         "es-to-primitive": "1.1.1",
         "function-bind": "1.1.1",
@@ -4325,6 +4874,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "dev": true,
       "requires": {
         "is-callable": "1.1.3",
         "is-date-object": "1.0.1",
@@ -4414,6 +4964,48 @@
       "requires": {
         "d": "1.0.0",
         "es5-ext": "0.10.38"
+      }
+    },
+    "es6-templates": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/es6-templates/-/es6-templates-0.2.3.tgz",
+      "integrity": "sha1-XLmsn7He1usSOTQrgdeSu7QHjuQ=",
+      "dev": true,
+      "requires": {
+        "recast": "0.11.23",
+        "through": "2.3.8"
+      },
+      "dependencies": {
+        "ast-types": {
+          "version": "0.9.6",
+          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
+          "integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk=",
+          "dev": true
+        },
+        "esprima": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+          "dev": true
+        },
+        "recast": {
+          "version": "0.11.23",
+          "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
+          "integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
+          "dev": true,
+          "requires": {
+            "ast-types": "0.9.6",
+            "esprima": "3.1.3",
+            "private": "0.1.8",
+            "source-map": "0.5.7"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
       }
     },
     "es6-weak-map": {
@@ -4613,6 +5205,71 @@
         "eslint-restricted-globals": "0.1.1"
       }
     },
+    "eslint-formatter-pretty": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-1.3.0.tgz",
+      "integrity": "sha512-5DY64Y1rYCm7cfFDHEGUn54bvCnK+wSUVF07N8oXeqUJFSd+gnYOTXbzelQ1HurESluY6gnEQPmXOIkB4Wa+gA==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "2.0.0",
+        "chalk": "2.3.1",
+        "log-symbols": "2.2.0",
+        "plur": "2.1.2",
+        "string-width": "2.1.1"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-2.0.0.tgz",
+          "integrity": "sha1-W65SvkJIeN2Xg+iRDj/Cki6DyBs=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+          "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.2.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "log-symbols": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+          "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.3.1"
+          }
+        },
+        "supports-color": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
     "eslint-import-resolver-node": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
@@ -4775,6 +5432,15 @@
         }
       }
     },
+    "eslint-plugin-json": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-json/-/eslint-plugin-json-1.2.0.tgz",
+      "integrity": "sha1-m6c7sL6Z1QCT6In1uWhGPSow764=",
+      "dev": true,
+      "requires": {
+        "jshint": "2.9.5"
+      }
+    },
     "eslint-plugin-jsx-a11y": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.0.3.tgz",
@@ -4788,6 +5454,16 @@
         "damerau-levenshtein": "1.0.4",
         "emoji-regex": "6.5.1",
         "jsx-ast-utils": "2.0.1"
+      }
+    },
+    "eslint-plugin-prettier": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.0.tgz",
+      "integrity": "sha512-floiaI4F7hRkTrFe8V2ItOK97QYrX75DjmdzmVITZoAP6Cn06oEDPQRsO6MlHEP/u2SxI3xQ52Kpjw6j5WGfeQ==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "1.1.2",
+        "jest-docblock": "21.2.0"
       }
     },
     "eslint-plugin-react": {
@@ -4898,6 +5574,15 @@
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
       "dev": true
     },
+    "eventsource": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
+      "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
+      "dev": true,
+      "requires": {
+        "original": "1.0.0"
+      }
+    },
     "evp_bytestokey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
@@ -4936,6 +5621,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.0.tgz",
       "integrity": "sha1-ODXxJ6vwdb/ggtCu1EhAV8eOPIk="
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
     },
     "exit-hook": {
       "version": "1.1.1",
@@ -5003,6 +5694,15 @@
       "dev": true,
       "requires": {
         "fill-range": "2.2.3"
+      }
+    },
+    "expand-tilde": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+      "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+      "dev": true,
+      "requires": {
+        "homedir-polyfill": "1.0.1"
       }
     },
     "expect": {
@@ -5206,6 +5906,12 @@
       "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
       "dev": true
     },
+    "fast-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
+      "dev": true
+    },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -5229,6 +5935,15 @@
       "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
       "integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg=",
       "dev": true
+    },
+    "faye-websocket": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
+      "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
+      "dev": true,
+      "requires": {
+        "websocket-driver": "0.7.0"
+      }
     },
     "fb-watchman": {
       "version": "2.0.0",
@@ -5312,6 +6027,12 @@
         "glob": "7.1.2",
         "minimatch": "3.0.4"
       }
+    },
+    "filesize": {
+      "version": "3.5.11",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.5.11.tgz",
+      "integrity": "sha512-ZH7loueKBoDb7yG9esn1U+fgq7BzlzW6NRi5/rMdxIZ05dj7GFD/Xc5rq2CDt5Yq86CyfSYVyx4242QQNZbx1g==",
+      "dev": true
     },
     "fill-range": {
       "version": "2.2.3",
@@ -5400,6 +6121,16 @@
       "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
       "dev": true
     },
+    "flush-write-stream": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.2.tgz",
+      "integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3"
+      }
+    },
     "fmerge": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/fmerge/-/fmerge-1.2.0.tgz",
@@ -5424,7 +6155,8 @@
     "foreach": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -5464,6 +6196,16 @@
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "dev": true
     },
+    "from2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3"
+      }
+    },
     "fs-access": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
@@ -5489,6 +6231,18 @@
       "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
       "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
       "dev": true
+    },
+    "fs-write-stream-atomic": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+      "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "iferr": "0.1.5",
+        "imurmurhash": "0.1.4",
+        "readable-stream": "2.3.3"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -6415,12 +7169,14 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "function.prototype.name": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.0.tgz",
       "integrity": "sha512-Bs0VRrTz4ghD8pTmbJQD1mZ8A/mN0ur/jGz+A6FBxPDUPkm1tNfF6bhTYPA7i7aF4lZJVr+OXTNNrnnIl58Wfg==",
+      "dev": true,
       "requires": {
         "define-properties": "1.1.2",
         "function-bind": "1.1.1",
@@ -6596,6 +7352,30 @@
         "process": "0.5.2"
       }
     },
+    "global-modules": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+      "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+      "dev": true,
+      "requires": {
+        "global-prefix": "1.0.2",
+        "is-windows": "1.0.2",
+        "resolve-dir": "1.0.1"
+      }
+    },
+    "global-prefix": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+      "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+      "dev": true,
+      "requires": {
+        "expand-tilde": "2.0.2",
+        "homedir-polyfill": "1.0.1",
+        "ini": "1.3.5",
+        "is-windows": "1.0.2",
+        "which": "1.3.0"
+      }
+    },
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
@@ -6658,6 +7438,15 @@
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
     },
+    "gzip-size": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz",
+      "integrity": "sha1-VGGI6b3DN/Zzdy+BZgRks4nc5SA=",
+      "dev": true,
+      "requires": {
+        "duplexer": "0.1.1"
+      }
+    },
     "handlebars": {
       "version": "4.0.11",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
@@ -6707,6 +7496,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "dev": true,
       "requires": {
         "function-bind": "1.1.1"
       }
@@ -6751,7 +7541,8 @@
     "has-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -6839,6 +7630,15 @@
         "os-tmpdir": "1.0.2"
       }
     },
+    "homedir-polyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+      "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+      "dev": true,
+      "requires": {
+        "parse-passwd": "1.0.0"
+      }
+    },
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
@@ -6881,11 +7681,86 @@
       "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=",
       "dev": true
     },
+    "html-loader": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/html-loader/-/html-loader-0.5.5.tgz",
+      "integrity": "sha512-7hIW7YinOYUpo//kSYcPB6dCKoceKLmOwjEMmhIobHuWGDVl0Nwe4l68mdG/Ru0wcUxQjVMEoZpkalZ/SE7zog==",
+      "dev": true,
+      "requires": {
+        "es6-templates": "0.2.3",
+        "fastparse": "1.1.1",
+        "html-minifier": "3.5.9",
+        "loader-utils": "1.1.0",
+        "object-assign": "4.1.1"
+      }
+    },
+    "html-minifier": {
+      "version": "3.5.9",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.9.tgz",
+      "integrity": "sha512-EZqO91XJwkj8BeLx9C12sKB/AHoTANaZax39vEOP9f/X/9jgJ3r1O2+neabuHqpz5kJO71TapP9JrtCY39su1A==",
+      "dev": true,
+      "requires": {
+        "camel-case": "3.0.0",
+        "clean-css": "4.1.9",
+        "commander": "2.14.1",
+        "he": "1.1.1",
+        "ncname": "1.0.0",
+        "param-case": "2.1.1",
+        "relateurl": "0.2.7",
+        "uglify-js": "3.3.11"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.14.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
+          "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
+          "dev": true
+        },
+        "uglify-js": {
+          "version": "3.3.11",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.11.tgz",
+          "integrity": "sha512-AKLsYcdV+sS5eAE4NtVXF6f2u/DCQynQm0jTGxF261+Vltu1dYNuHzjqDmk11gInj+H/zJIM2EAwXG3MzPb3VA==",
+          "dev": true,
+          "requires": {
+            "commander": "2.14.1",
+            "source-map": "0.6.1"
+          }
+        }
+      }
+    },
     "html-tag-names": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/html-tag-names/-/html-tag-names-1.1.2.tgz",
       "integrity": "sha1-9lFolkxanIJnXv2ogoddyyqHXCI=",
       "dev": true
+    },
+    "html-webpack-plugin": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-2.30.1.tgz",
+      "integrity": "sha1-f5xCG36pHsRg9WUn1430hO51N9U=",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.5.1",
+        "html-minifier": "3.5.9",
+        "loader-utils": "0.2.17",
+        "lodash": "4.17.5",
+        "pretty-error": "2.1.1",
+        "toposort": "1.0.6"
+      },
+      "dependencies": {
+        "loader-utils": {
+          "version": "0.2.17",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+          "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+          "dev": true,
+          "requires": {
+            "big.js": "3.2.0",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1",
+            "object-assign": "4.1.1"
+          }
+        }
+      }
     },
     "htmlparser2": {
       "version": "3.9.2",
@@ -6926,6 +7801,12 @@
           "dev": true
         }
       }
+    },
+    "http-parser-js": {
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.10.tgz",
+      "integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q=",
+      "dev": true
     },
     "http-proxy": {
       "version": "1.16.2",
@@ -7011,6 +7892,12 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
       "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
+      "dev": true
+    },
+    "iferr": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
       "dev": true
     },
     "ignore": {
@@ -7184,6 +8071,12 @@
       "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A=",
       "dev": true
     },
+    "irregular-plurals": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
+      "integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y=",
+      "dev": true
+    },
     "is-absolute-url": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
@@ -7223,7 +8116,8 @@
     "is-callable": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
+      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+      "dev": true
     },
     "is-ci": {
       "version": "1.1.0",
@@ -7237,7 +8131,8 @@
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
     },
     "is-directory": {
       "version": "0.3.1",
@@ -7405,6 +8300,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
       "requires": {
         "has": "1.0.1"
       }
@@ -7419,6 +8315,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
       "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "dev": true
+    },
+    "is-root": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz",
+      "integrity": "sha1-B7bCM7w5TNnQK6FclmvWZg1jQtU=",
       "dev": true
     },
     "is-stream": {
@@ -7444,7 +8346,8 @@
     "is-symbol": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+      "dev": true
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -7456,6 +8359,18 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
+    },
+    "is-wsl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
       "dev": true
     },
     "isarray": {
@@ -8959,6 +9874,94 @@
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
       "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
     },
+    "jshint": {
+      "version": "2.9.5",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.5.tgz",
+      "integrity": "sha1-HnJSkVzmgbQIJ+4UJIxG006apiw=",
+      "dev": true,
+      "requires": {
+        "cli": "1.0.1",
+        "console-browserify": "1.1.0",
+        "exit": "0.1.2",
+        "htmlparser2": "3.8.3",
+        "lodash": "3.7.0",
+        "minimatch": "3.0.4",
+        "shelljs": "0.3.0",
+        "strip-json-comments": "1.0.4"
+      },
+      "dependencies": {
+        "domhandler": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+          "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+          "dev": true,
+          "requires": {
+            "domelementtype": "1.3.0"
+          }
+        },
+        "entities": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+          "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
+          "dev": true
+        },
+        "htmlparser2": {
+          "version": "3.8.3",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+          "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+          "dev": true,
+          "requires": {
+            "domelementtype": "1.3.0",
+            "domhandler": "2.3.0",
+            "domutils": "1.5.1",
+            "entities": "1.0.0",
+            "readable-stream": "1.1.14"
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "3.7.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz",
+          "integrity": "sha1-Nni9irmVBXwHreg27S7wh9qBHUU=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "shelljs": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+          "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        },
+        "strip-json-comments": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+          "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+          "dev": true
+        }
+      }
+    },
     "json-loader": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
@@ -9310,6 +10313,12 @@
         "prelude-ls": "1.1.2",
         "type-check": "0.3.2"
       }
+    },
+    "lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "dev": true
     },
     "lint-staged": {
       "version": "3.6.1",
@@ -10043,6 +11052,12 @@
         "signal-exit": "3.0.2"
       }
     },
+    "lower-case": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
+      "dev": true
+    },
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
@@ -10097,6 +11112,16 @@
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
       "dev": true
+    },
+    "markdown-loader": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/markdown-loader/-/markdown-loader-2.0.2.tgz",
+      "integrity": "sha512-v/ej7DflZbb6t//3Yu9vg0T+sun+Q9EoqggifeyABKfvFROqPwwwpv+hd1NKT2QxTRg6VCFk10IIJcMI13yCoQ==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "1.1.0",
+        "marked": "0.3.12"
+      }
     },
     "marked": {
       "version": "0.3.12",
@@ -10423,6 +11448,24 @@
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
+    "mississippi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
+      "integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
+      "dev": true,
+      "requires": {
+        "concat-stream": "1.6.0",
+        "duplexify": "3.5.3",
+        "end-of-stream": "1.4.1",
+        "flush-write-stream": "1.0.2",
+        "from2": "2.3.0",
+        "parallel-transform": "1.1.0",
+        "pump": "2.0.1",
+        "pumpify": "1.4.0",
+        "stream-each": "1.2.2",
+        "through2": "2.0.3"
+      }
+    },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -10521,6 +11564,20 @@
       "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg==",
       "dev": true
     },
+    "move-concurrently": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+      "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+      "dev": true,
+      "requires": {
+        "aproba": "1.2.0",
+        "copy-concurrently": "1.0.5",
+        "fs-write-stream-atomic": "1.0.10",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2",
+        "run-queue": "1.0.3"
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -10550,6 +11607,15 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "ncname": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ncname/-/ncname-1.0.0.tgz",
+      "integrity": "sha1-W1etGLHKCShk72Kwse2BlPODtxw=",
+      "dev": true,
+      "requires": {
+        "xml-char-classes": "1.0.0"
+      }
+    },
     "ncp": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ncp/-/ncp-1.0.1.tgz",
@@ -10567,6 +11633,15 @@
       "resolved": "https://registry.npmjs.org/nested-object-assign/-/nested-object-assign-1.0.2.tgz",
       "integrity": "sha512-Ma9vkvU+v0/dPUMNQxu/6Ah2PoU+x52mxkn4FKhofJrzYocSds5eSpgMEdGSjM4IEqkHUqGugioI/+mgq9eBfw==",
       "dev": true
+    },
+    "no-case": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+      "dev": true,
+      "requires": {
+        "lower-case": "1.1.4"
+      }
     },
     "node-dir": {
       "version": "0.1.17",
@@ -11018,7 +12093,8 @@
     "object-keys": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+      "dev": true
     },
     "object-values": {
       "version": "1.0.0",
@@ -11030,6 +12106,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
       "requires": {
         "define-properties": "1.1.2",
         "function-bind": "1.1.1",
@@ -11041,6 +12118,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
       "integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
+      "dev": true,
       "requires": {
         "define-properties": "1.1.2",
         "es-abstract": "1.10.0",
@@ -11111,6 +12189,15 @@
       "dev": true,
       "requires": {
         "mimic-fn": "1.2.0"
+      }
+    },
+    "opn": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-5.2.0.tgz",
+      "integrity": "sha512-Jd/GpzPyHF4P2/aNOVmS3lfMSWV9J7cOhCG1s08XCEAsPkB7lp6ddiU0J7XzyQRDUh8BqJ7PchfINjR8jyofRQ==",
+      "dev": true,
+      "requires": {
+        "is-wsl": "1.1.0"
       }
     },
     "optimist": {
@@ -11194,6 +12281,27 @@
           "requires": {
             "exit-hook": "1.1.1",
             "onetime": "1.1.0"
+          }
+        }
+      }
+    },
+    "original": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/original/-/original-1.0.0.tgz",
+      "integrity": "sha1-kUf5P6FpbQS+YeAb1QuurKZWvTs=",
+      "dev": true,
+      "requires": {
+        "url-parse": "1.0.5"
+      },
+      "dependencies": {
+        "url-parse": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
+          "integrity": "sha1-CFSGBCKv3P7+tsllxmLUgAFpkns=",
+          "dev": true,
+          "requires": {
+            "querystringify": "0.0.4",
+            "requires-port": "1.0.0"
           }
         }
       }
@@ -11296,6 +12404,26 @@
       "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
       "dev": true
     },
+    "parallel-transform": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+      "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+      "dev": true,
+      "requires": {
+        "cyclist": "0.2.2",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3"
+      }
+    },
+    "param-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+      "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+      "dev": true,
+      "requires": {
+        "no-case": "2.3.2"
+      }
+    },
     "parse-asn1": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
@@ -11330,6 +12458,12 @@
         "error-ex": "1.3.1",
         "json-parse-better-errors": "1.0.1"
       }
+    },
+    "parse-passwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+      "dev": true
     },
     "parse5": {
       "version": "1.5.1",
@@ -11553,6 +12687,15 @@
       "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
       "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8=",
       "dev": true
+    },
+    "plur": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
+      "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
+      "dev": true,
+      "requires": {
+        "irregular-plurals": "1.4.0"
+      }
     },
     "pluralize": {
       "version": "7.0.0",
@@ -12087,19 +13230,7 @@
         "loader-utils": "1.1.0",
         "postcss": "6.0.17",
         "postcss-load-config": "1.2.0",
-        "schema-utils": "0.4.3"
-      },
-      "dependencies": {
-        "schema-utils": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.3.tgz",
-          "integrity": "sha512-sgv/iF/T4/SewJkaVpldKC4WjSkz0JsOh2eKtxCPpCO1oR05+7MOF+H476HVRbLArkgA7j5TRJJ4p2jdFkUGQQ==",
-          "dev": true,
-          "requires": {
-            "ajv": "5.5.2",
-            "ajv-keywords": "2.1.1"
-          }
-        }
+        "schema-utils": "0.4.5"
       }
     },
     "postcss-merge-idents": {
@@ -12926,9 +14057,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.10.2.tgz",
-      "integrity": "sha512-TcdNoQIWFoHblurqqU6d1ysopjq7UX0oRcT/hJ8qvBAELiYWn+Ugf0AXdnzISEJ7vuhNnQ98N8jR8Sh53x4IZg==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.9.2.tgz",
+      "integrity": "sha512-piXx9N2WT8hWb7PBbX1glAuJVIkEyUV9F5fMXFINpZ0x3otVOFKKeGmeuiclFJlP/UrgTckyV606VjH2rNK4bw==",
       "dev": true
     },
     "prettier-eslint": {
@@ -12944,7 +14075,7 @@
         "indent-string": "3.2.0",
         "lodash.merge": "4.6.1",
         "loglevel-colored-level-prefix": "1.0.0",
-        "prettier": "1.10.2",
+        "prettier": "1.9.2",
         "pretty-format": "22.1.0",
         "require-relative": "0.8.7",
         "typescript": "2.7.1",
@@ -13098,6 +14229,16 @@
         }
       }
     },
+    "pretty-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
+      "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
+      "dev": true,
+      "requires": {
+        "renderkid": "2.0.1",
+        "utila": "0.4.0"
+      }
+    },
     "pretty-format": {
       "version": "22.1.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.1.0.tgz",
@@ -13122,6 +14263,42 @@
           "requires": {
             "color-convert": "1.9.1"
           }
+        }
+      }
+    },
+    "prettylint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettylint/-/prettylint-1.0.0.tgz",
+      "integrity": "sha512-IjIAoGeIve8NQR6WbslnMs5rcnEVbJkZN/IXm302wNlSEo+3pIyxroy+3bkEFLP14prz1Aq1GGlKsX0UXHXuEQ==",
+      "dev": true,
+      "requires": {
+        "eslint-formatter-pretty": "1.3.0",
+        "eslint-plugin-prettier": "2.6.0",
+        "globby": "6.1.0",
+        "ignore": "3.3.7",
+        "lines-and-columns": "1.1.6",
+        "meow": "3.7.0",
+        "tslib": "1.9.0"
+      },
+      "dependencies": {
+        "globby": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+          "dev": true,
+          "requires": {
+            "array-union": "1.0.2",
+            "glob": "7.1.2",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
         }
       }
     },
@@ -13156,6 +14333,12 @@
         "asap": "2.0.6"
       }
     },
+    "promise-inflight": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
+      "dev": true
+    },
     "promise.prototype.finally": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/promise.prototype.finally/-/promise.prototype.finally-3.1.0.tgz",
@@ -13189,15 +14372,6 @@
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
         "object-assign": "4.1.1"
-      }
-    },
-    "prop-types-exact": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prop-types-exact/-/prop-types-exact-1.1.2.tgz",
-      "integrity": "sha512-3x4BWv7w2luSStiHwSzrhK9U1sm+vHwSyg9le2RfY41pZyJdiPKDOKh6TCQywwl++SCr7MMKu7POp4LU/L/eIA==",
-      "requires": {
-        "has": "1.0.1",
-        "object.assign": "4.1.0"
       }
     },
     "proto-list": {
@@ -13245,6 +14419,27 @@
         "create-hash": "1.1.3",
         "parse-asn1": "5.1.0",
         "randombytes": "2.0.6"
+      }
+    },
+    "pump": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "1.4.1",
+        "once": "1.4.0"
+      }
+    },
+    "pumpify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.4.0.tgz",
+      "integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
+      "dev": true,
+      "requires": {
+        "duplexify": "3.5.3",
+        "inherits": "2.0.3",
+        "pump": "2.0.1"
       }
     },
     "punycode": {
@@ -13307,6 +14502,12 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
+      "dev": true
+    },
+    "querystringify": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz",
+      "integrity": "sha1-DPf4T5Rj/wrlHExLFC2VvjdyTZw=",
       "dev": true
     },
     "quick-lru": {
@@ -13453,6 +14654,32 @@
       "integrity": "sha1-wStu/cIkfBDae4dw0YUICnsEcVY=",
       "dev": true
     },
+    "react-dev-utils": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-5.0.0.tgz",
+      "integrity": "sha512-j+Rmwct2aOGAbIk046PjBpQ5zxaLtSlTFwyt3yhVfpQgieqyQbtFwATKY4HSB3j+hSQ4UEBBxwjxjSJiGCP+ow==",
+      "dev": true,
+      "requires": {
+        "address": "1.0.3",
+        "babel-code-frame": "6.26.0",
+        "chalk": "1.1.3",
+        "cross-spawn": "5.1.0",
+        "detect-port-alt": "1.1.5",
+        "escape-string-regexp": "1.0.5",
+        "filesize": "3.5.11",
+        "global-modules": "1.0.0",
+        "gzip-size": "3.0.0",
+        "inquirer": "3.3.0",
+        "is-root": "1.0.0",
+        "opn": "5.2.0",
+        "react-error-overlay": "4.0.0",
+        "recursive-readdir": "2.2.1",
+        "shell-quote": "1.6.1",
+        "sockjs-client": "1.1.4",
+        "strip-ansi": "3.0.1",
+        "text-table": "0.2.0"
+      }
+    },
     "react-docgen": {
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-2.20.0.tgz",
@@ -13507,10 +14734,16 @@
         "traverse": "0.6.6"
       }
     },
+    "react-error-overlay": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-4.0.0.tgz",
+      "integrity": "sha512-FlsPxavEyMuR6TjVbSSywovXSEyOg6ZDj5+Z8nbsRl9EkOzAhEIcS+GLoQDC5fz/t9suhUXWmUrOBrgeUvrMxw==",
+      "dev": true
+    },
     "react-fuzzy": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/react-fuzzy/-/react-fuzzy-0.5.1.tgz",
-      "integrity": "sha512-m2QClpw+Z51m6oEpfznVr7CQ9zdUGQ7vvidv05+drt0c3UMkpOWqmB0fQhYJYP/5QNh7ojyMCgu99cxvFaya6Q==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/react-fuzzy/-/react-fuzzy-0.5.2.tgz",
+      "integrity": "sha512-qIZZxaCheb/HhcBi5fABbiCFg85+K5r1TCps1D4uaL0LAMMD/1zm/x1/kNR130Tx7nnY9V7mbFyY0DquPYeLAw==",
       "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
@@ -13610,22 +14843,20 @@
       "integrity": "sha512-p84kBqGaMoa7VYT0vZ/aOYRfJB+gw34yjpda1Z5KeLflg70HipZOT+MXQenEhdkPAABuE2Astq4zEPdMqUQxcg=="
     },
     "react-split-pane": {
-      "version": "0.1.76",
-      "resolved": "https://registry.npmjs.org/react-split-pane/-/react-split-pane-0.1.76.tgz",
-      "integrity": "sha512-b8/rIizOP+b4i8IXk4gIu7y9RxXnItn4tS0VzD+AsiIeWzBEJn6FHoL0lBXT7J64H7sUTASjMdTeZ4xov/0bCA==",
+      "version": "0.1.77",
+      "resolved": "https://registry.npmjs.org/react-split-pane/-/react-split-pane-0.1.77.tgz",
+      "integrity": "sha512-xq0PPsbkNI9xEd6yTrGPr7hzf6XfIgnsxuUEdRJELq+kLPHMsO3ymFCjhiYP35wlDPn9W46+rHDsJd7LFYteMw==",
       "dev": true,
       "requires": {
-        "@types/inline-style-prefixer": "3.0.1",
-        "@types/react": "16.0.36",
         "inline-style-prefixer": "3.0.8",
         "prop-types": "15.6.0",
-        "react-style-proptype": "3.1.0"
+        "react-style-proptype": "3.2.0"
       }
     },
     "react-style-proptype": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/react-style-proptype/-/react-style-proptype-3.1.0.tgz",
-      "integrity": "sha512-e4lOMjF4f8Pp/jdO9myNzDvSAx1aG5r0olziD64Bgk40LN8LxidRCgnKeI2RiKrqYD6j2Z8ByXoUbwV+/mwpwg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-style-proptype/-/react-style-proptype-3.2.0.tgz",
+      "integrity": "sha512-Mafmkzj3oNmLSJNOlH+WWWyGIdzVLhPj+d12fDxQMQdwDQ5sMX7vQKOLpry4U+zRWieTCx448AyRKK0NLWuXmg==",
       "dev": true,
       "requires": {
         "prop-types": "15.6.0"
@@ -13755,6 +14986,26 @@
         "resolve": "1.5.0"
       }
     },
+    "recursive-readdir": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.1.tgz",
+      "integrity": "sha1-kO8jHQd4xc4JPJpI105cVCLROpk=",
+      "dev": true,
+      "requires": {
+        "minimatch": "3.0.3"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+          "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        }
+      }
+    },
     "redent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
@@ -13865,11 +15116,92 @@
         "jsesc": "0.5.0"
       }
     },
+    "relateurl": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+      "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
+      "dev": true
+    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
+    },
+    "renderkid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.1.tgz",
+      "integrity": "sha1-iYyr/Ivt5Le5ETWj/9Mj5YwNsxk=",
+      "dev": true,
+      "requires": {
+        "css-select": "1.2.0",
+        "dom-converter": "0.1.4",
+        "htmlparser2": "3.3.0",
+        "strip-ansi": "3.0.1",
+        "utila": "0.3.3"
+      },
+      "dependencies": {
+        "domhandler": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
+          "integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
+          "dev": true,
+          "requires": {
+            "domelementtype": "1.3.0"
+          }
+        },
+        "domutils": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz",
+          "integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
+          "dev": true,
+          "requires": {
+            "domelementtype": "1.3.0"
+          }
+        },
+        "htmlparser2": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
+          "integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
+          "dev": true,
+          "requires": {
+            "domelementtype": "1.3.0",
+            "domhandler": "2.1.0",
+            "domutils": "1.1.6",
+            "readable-stream": "1.0.34"
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        },
+        "utila": {
+          "version": "0.3.3",
+          "resolved": "https://registry.npmjs.org/utila/-/utila-0.3.3.tgz",
+          "integrity": "sha1-1+jn1+MJEHCSsF+NloiCTWM6QiY=",
+          "dev": true
+        }
+      }
     },
     "repeat-element": {
       "version": "1.1.2",
@@ -13986,6 +15318,16 @@
         "path-parse": "1.0.5"
       }
     },
+    "resolve-dir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+      "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+      "dev": true,
+      "requires": {
+        "expand-tilde": "2.0.2",
+        "global-modules": "1.0.0"
+      }
+    },
     "resolve-from": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
@@ -14043,6 +15385,15 @@
       "dev": true,
       "requires": {
         "is-promise": "2.1.0"
+      }
+    },
+    "run-queue": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+      "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
+      "dev": true,
+      "requires": {
+        "aproba": "1.2.0"
       }
     },
     "rx-lite": {
@@ -14287,12 +15638,32 @@
       "dev": true
     },
     "schema-utils": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
-      "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.5.tgz",
+      "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2"
+        "ajv": "6.1.1",
+        "ajv-keywords": "3.1.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.1.1.tgz",
+          "integrity": "sha1-l41Zf7wrfQ5aXD3esUmmgvKr+g4=",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.1.0.tgz",
+          "integrity": "sha1-rCsnk5xUPpXSwG5/f1wnvkqlQ74=",
+          "dev": true
+        }
       }
     },
     "scss-tokenizer": {
@@ -14349,6 +15720,12 @@
           "dev": true
         }
       }
+    },
+    "serialize-javascript": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.4.0.tgz",
+      "integrity": "sha1-fJWFFNtqwkQ6irwGLcn3iGp/YAU=",
+      "dev": true
     },
     "serve-favicon": {
       "version": "2.4.5",
@@ -14432,10 +15809,22 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
+    "shell-quote": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+      "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+      "dev": true,
+      "requires": {
+        "array-filter": "0.0.1",
+        "array-map": "0.0.0",
+        "array-reduce": "0.0.0",
+        "jsonify": "0.0.0"
+      }
+    },
     "shelljs": {
-      "version": "0.7.8",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
-      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.1.tgz",
+      "integrity": "sha512-YA/iYtZpzFe5HyWVGrb02FjPxc4EMCfpoU/Phg9fQoyMC72u9598OUBrsU8IrtwAKG0tO8IYaqbaLIw+k3IRGA==",
       "dev": true,
       "requires": {
         "glob": "7.1.2",
@@ -14679,6 +16068,20 @@
         }
       }
     },
+    "sockjs-client": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz",
+      "integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "eventsource": "0.1.6",
+        "faye-websocket": "0.11.1",
+        "inherits": "2.0.3",
+        "json3": "3.3.2",
+        "url-parse": "1.2.0"
+      }
+    },
     "sort-keys": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
@@ -14769,6 +16172,15 @@
         "tweetnacl": "0.14.5"
       }
     },
+    "ssri": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.2.4.tgz",
+      "integrity": "sha512-UnEAgMZa15973iH7cUi0AHjJn1ACDIkaMyZILoqwN6yzt+4P81I8tBc5Hl+qwi5auMplZtPQsHrPBR5vJLcQtQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "stack-trace": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
@@ -14806,6 +16218,16 @@
         "readable-stream": "2.3.3"
       }
     },
+    "stream-each": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
+      "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "1.4.1",
+        "stream-shift": "1.0.0"
+      }
+    },
     "stream-http": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.0.tgz",
@@ -14818,6 +16240,12 @@
         "to-arraybuffer": "1.0.1",
         "xtend": "4.0.1"
       }
+    },
+    "stream-shift": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+      "dev": true
     },
     "stream-to-observable": {
       "version": "0.1.0",
@@ -15305,6 +16733,16 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
+    "through2": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "2.3.3",
+        "xtend": "4.0.1"
+      }
+    },
     "time-stamp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-2.0.0.tgz",
@@ -15360,6 +16798,12 @@
       "requires": {
         "hoek": "4.2.0"
       }
+    },
+    "toposort": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.6.tgz",
+      "integrity": "sha1-wxdI5V0hDv/AD9zcfW5o19e7nOw=",
+      "dev": true
     },
     "tough-cookie": {
       "version": "2.3.3",
@@ -15417,6 +16861,12 @@
           }
         }
       }
+    },
+    "tslib": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
+      "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
+      "dev": true
     },
     "tty-browserify": {
       "version": "0.0.0",
@@ -15584,6 +17034,24 @@
       "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
       "dev": true
     },
+    "unique-filename": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
+      "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
+      "dev": true,
+      "requires": {
+        "unique-slug": "2.0.0"
+      }
+    },
+    "unique-slug": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
+      "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
+      "dev": true,
+      "requires": {
+        "imurmurhash": "0.1.4"
+      }
+    },
     "unique-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
@@ -15603,6 +17071,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "dev": true
+    },
+    "upper-case": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
       "dev": true
     },
     "url": {
@@ -15632,6 +17106,35 @@
         "loader-utils": "1.1.0",
         "mime": "1.6.0",
         "schema-utils": "0.3.0"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
+          "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
+          "dev": true,
+          "requires": {
+            "ajv": "5.5.2"
+          }
+        }
+      }
+    },
+    "url-parse": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.2.0.tgz",
+      "integrity": "sha512-DT1XbYAfmQP65M/mE6OALxmXzZ/z1+e5zk2TcSKe/KiYbNGZxgtttzC0mR/sjopbpOXcbniq7eIKmocJnUWlEw==",
+      "dev": true,
+      "requires": {
+        "querystringify": "1.0.0",
+        "requires-port": "1.0.0"
+      },
+      "dependencies": {
+        "querystringify": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz",
+          "integrity": "sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs=",
+          "dev": true
+        }
       }
     },
     "user-home": {
@@ -15671,6 +17174,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "utila": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
+      "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
       "dev": true
     },
     "utile": {
@@ -15922,6 +17431,22 @@
         "source-map": "0.6.1"
       }
     },
+    "websocket-driver": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
+      "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
+      "dev": true,
+      "requires": {
+        "http-parser-js": "0.4.10",
+        "websocket-extensions": "0.1.3"
+      }
+    },
+    "websocket-extensions": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
+      "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
+      "dev": true
+    },
     "whatwg-encoding": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
@@ -16124,6 +17649,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+      "dev": true
+    },
+    "xml-char-classes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/xml-char-classes/-/xml-char-classes-1.0.0.tgz",
+      "integrity": "sha1-ZGV4SKIP/F31g6Qq2KJ3tFErvE0=",
       "dev": true
     },
     "xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -1,674 +1,668 @@
 {
-  "name": "design-system-react",
-  "version": "0.8.7",
-  "description": "Salesforce Lightning Design System for React",
-  "license": "SEE LICENSE IN README.md",
-  "engines": {
-    "node": "8.x",
-    "npm": "^5.5.1"
-  },
-  "scripts": {
-    "build-docs": "./node_modules/.bin/babel-node ./scripts/build-docs.js",
-    "build-storybook": "build-storybook -o ./storybook",
-    "build-storybook-for-tests": "build-storybook -o ./storybook-based-tests -c ./.storybook-based-tests",
-    "dist": "scripts/dist.sh",
-    "heroku-prebuild": "./scripts/heroku-prebuild.sh",
-    "heroku-postbuild": "./scripts/heroku-postbuild.sh",
-    "icons": "./node_modules/.bin/babel-node scripts/inline-icons.js",
-    "link": "./scripts/npm-link.sh",
-    "lint": "npm run lint:style && npm run lint:quality",
-    "lint:fix": "./node_modules/.bin/prettier-eslint --write \"**/*.{js,jsx}\" && ./node_modules/.bin/prettier --use-tabs=false --write \"*.{json,md}\"",
-    "lint:quality": "./node_modules/.bin/eslint \"**/*.{js,jsx}\" --max-warnings=0",
-    "lint:style": "./node_modules/.bin/prettier-eslint --list-different \"**/*.{js,jsx}\" && ./node_modules/.bin/prettier --use-tabs=false --list-different \"*.{json,md}\"",
-    "publish:origin": "./node_modules/.bin/babel-node scripts/publish-to-git.js",
-    "publish:edge": "./node_modules/.bin/babel-node scripts/publish-to-git.js --tag=edge",
-    "publish:upstream": "./node_modules/.bin/babel-node scripts/publish-to-git.js --remote=upstream",
-    "release:patch": "./node_modules/.bin/babel-node scripts/release.js --release=patch",
-    "release:minor": "./node_modules/.bin/babel-node scripts/release.js --release=minor",
-    "snapshot-test": "./node_modules/.bin/jest",
-    "start": "./node_modules/.bin/start-storybook -p 9001 -s ./node_modules & node tests/app",
-    "start:static": "node app",
-    "storybook": "start-storybook -p 9001 -s ./node_modules",
-    "test": "scripts/local-qa.sh --no-fix",
-    "test:fix": "scripts/local-qa.sh",
-    "travis-ci": "scripts/travis-ci.sh",
-    "validate": "npm ls",
-    "version": "git add package.json && git commit -m \"Bump package version\""
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+ssh://git@github.com/salesforce/design-system-react.git"
-  },
-  "jest": {
-    "testRegex": "/(components|tests)/.*\\.snapshot-test\\.jsx?$",
-    "testEnvironment": "node",
-    "testPathIgnorePatterns": [
-      "/node_modules/",
-      "/preset/",
-      "/.tmp-amd/",
-      "/.tmp-commonjs/",
-      "/.tmp-es/",
-      "/.tmp-npm/"
-    ],
-    "transformIgnorePatterns": [
-      "/node_modules/",
-      "/preset/",
-      "/.tmp-amd/",
-      "/.tmp-commonjs/",
-      "/.tmp-es/",
-      "/.tmp-npm/"
-    ]
-  },
-  "keywords": [
-    "react",
-    "slds",
-    "salesforce",
-    "salesforce-ux",
-    "lightning",
-    "design system",
-    "lightning design system",
-    "salesforce lightning design system",
-    "interactive components",
-    "interactive",
-    "components"
-  ],
-  "bugs": {
-    "url": "https://github.com/salesforce/design-system-react/issues"
-  },
-  "main": "components/index.js",
-  "module": "components/index.js",
-  "homepage": "https://react.lightningdesignsystem.com",
-  "dependencies": {
-    "@salesforce/babel-preset-design-system-react": "^1.0.0",
-    "airbnb-prop-types": "^2.5.3",
-    "babel-preset-es2015": "^6.24.1",
-    "classnames": "^2.2.5",
-    "create-react-class": "^15.6.0",
-    "lodash.assign": "^4.0.9",
-    "lodash.compact": "^3.0.0",
-    "lodash.escaperegexp": "^4.1.1",
-    "lodash.find": "^4.3.0",
-    "lodash.findindex": "^4.3.0",
-    "lodash.flatten": "^4.2.0",
-    "lodash.isboolean": "^3.0.3",
-    "lodash.isdate": "^4.0.1",
-    "lodash.isequal": "^4.2.0",
-    "lodash.isfunction": "^3.0.8",
-    "lodash.isnumber": "^3.0.3",
-    "lodash.memoize": "^4.1.1",
-    "lodash.omit": "^4.3.0",
-    "lodash.partial": "^4.1.3",
-    "lodash.reject": "^4.3.0",
-    "lodash.uniqueid": "^4.0.0",
-    "popper.js": "^1.10.8",
-    "prop-types": ">=15.5.8",
-    "react-highlighter": "^0.4.0",
-    "react-modal": "^1.7.7",
-    "react-onclickoutside": "^6.5.0",
-    "react-text-truncate": "^0.12.0",
-    "shortid": "^2.2.6",
-    "warning": "^3.0.0"
-  },
-  "peerDependencies": {
-    "@salesforce-ux/design-system": ">=2.4.x",
-    "react": ">=15.4.1 <16",
-    "react-dom": ">=15.4.1 <16"
-  },
-  "devDependencies": {
-    "@salesforce-ux/design-system": "2.4.3",
-    "@salesforce-ux/icons": "7.x",
-    "@storybook/addon-actions": "^3.2.12",
-    "@storybook/addon-info": "^3.2.10",
-    "@storybook/addon-storyshots": "^3.4.0-alpha.4",
-    "@storybook/addons": "^3.4.0-alpha.6",
-    "@storybook/react": "~3.2.0",
-    "async": "^2.0.0-rc.5",
-    "babel-cli": "^6.24.1",
-    "babel-core": "^6.26.0",
-    "babel-eslint": "^8.0.2",
-    "babel-jest": "^20.0.3",
-    "babel-loader": "^7.1.1",
-    "babel-plugin-import-noop": "^1.0.1",
-    "babel-plugin-istanbul": "^4.1.4",
-    "babel-plugin-root-import": "^5.1.0",
-    "babel-plugin-transform-class-properties": "^6.24.1",
-    "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
-    "babel-plugin-transform-es2015-modules-commonjs": "^6.24.0",
-    "babel-plugin-transform-export-extensions": "6.22.0",
-    "babel-polyfill": "^6.26.0",
-    "babel-preset-env": "^1.5.2",
-    "babel-preset-react": "^6.23.0",
-    "basic-auth": "^1.0.4",
-    "chai": "^4.0.1",
-    "chai-enzyme": "^0.8.0",
-    "compression": "^1.6.2",
-    "css-loader": "^0.28.0",
-    "enzyme": "^2.5.1",
-    "enzyme-to-json": "^1.5.0",
-    "eslint": "^4.12.0",
-    "eslint-config-airbnb": "16.1.0",
-    "eslint-loader": "^1.6.0",
-    "eslint-plugin-filenames": "^1.2.0",
-    "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-jsx-a11y": "^6.0.3",
-    "eslint-plugin-react": "^7.1.0",
-    "express": "^4.15.5",
-    "file-loader": "^0.11.0",
-    "find-remove": "^1.1.0",
-    "fs-extra": "^3.0.0",
-    "istanbul-instrumenter-loader": "^2.0.0",
-    "jest": "^21.2.1",
-    "js-beautify": "^1.6.8",
-    "json-loader": "^0.5.3",
-    "karma": "^1.7.0",
-    "karma-chai-sinon": "^0.1.5",
-    "karma-chrome-launcher": "^2.0.0",
-    "karma-cli": "^1.0.0",
-    "karma-coverage": "^1.0.0",
-    "karma-mocha": "^1.0.1",
-    "karma-phantomjs-launcher": "^1.0.4",
-    "karma-sourcemap-loader": "^0.3.5",
-    "karma-spec-reporter": "^0.0.31",
-    "karma-webpack": "^2.0.2",
-    "lint-staged": "^3.3.0",
-    "lodash.filter": "^4.6.0",
-    "lodash.isempty": "^4.2.1",
-    "lodash.kebabcase": "^4.0.1",
-    "lodash.trim": "^4.0.1",
-    "minimist": "^1.2.0",
-    "mocha": "^3.1.2",
-    "node-sass": "^4.5.0",
-    "object.entries": "^1.0.4",
-    "phantomjs-polyfill-find-index": "^1.0.1",
-    "phantomjs-polyfill-includes": "^1.0.2",
-    "phantomjs-prebuilt": "^2.1.15",
-    "prettier": "^1.9.2",
-    "prettier-eslint": "~8.8.1",
-    "prettier-eslint-cli": "^4.4.2",
-    "prompt": "^1.0.0",
-    "react": ">=15.4.1 <16",
-    "react-addons-test-utils": ">=15.4.1 <16",
-    "react-docgen": "^2.14.1",
-    "react-dom": ">=15.4.1 <16",
-    "react-hot-loader": "^1.2.7",
-    "react-test-renderer": ">=15.4.1 <16",
-    "sinon": "^2.3.5",
-    "sinon-chai": "^2.14.0",
-    "string-replace-webpack-plugin": "^0.1.2",
-    "style-loader": "^0.17.0",
-    "webpack": "^3.4.1",
-    "webpack-dev-middleware": "^1.12.0",
-    "webpack-hot-middleware": "^2.18.2",
-    "xml2json": "^0.11.0"
-  },
-  "prettier": {
-    "arrowParens": "always",
-    "bracketSpacing": true,
-    "jsxBracketSameLine": false,
-    "semi": true,
-    "singleQuote": true,
-    "trailingComma": "es5",
-    "useTabs": true
-  },
-  "components": [
-    {
-      "component": "accordion",
-      "status": "prod",
-      "display-name": "Accordions",
-      "last-accessibility-review": {
-        "date-iso-8601": "2018/01/18",
-        "commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
-      },
-      "SLDS-component-path": "/components/accordions",
-      "dependencies": [
-        {
-          "component": "panel"
-        }
-      ]
-    },
-    {
-      "component": "alert",
-      "status": "prod",
-      "display-name": "Alerts",
-      "last-accessibility-review": {
-        "date-iso-8601": "2018/01/18",
-        "commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
-      },
-      "SLDS-component-path": "/components/alerts",
-      "dependencies": [
-        {
-          "component": "container"
-        }
-      ]
-    },
-    {
-      "component": "app-launcher",
-      "status": "prototype",
-      "display-name": "App Launcher",
-      "SLDS-component-path": "/components/app-launcher/#flavor-default",
-      "dependencies": [
-        {
-          "component": "section"
-        },
-        {
-          "component": "tile"
-        }
-      ]
-    },
-    {
-      "component": "avatar",
-      "status": "prod",
-      "display-name": "Avatars",
-      "last-accessibility-review": {
-        "date-iso-8601": "2018/01/18",
-        "commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
-      },
-      "SLDS-component-path": "/components/avatars"
-    },
-    {
-      "component": "breadcrumb",
-      "status": "prod",
-      "display-name": "Breadcrumbs",
-      "last-accessibility-review": {
-        "date-iso-8601": "2018/01/18",
-        "commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
-      },
-      "SLDS-component-path": "/components/breadcrumbs"
-    },
-    {
-      "component": "button",
-      "status": "prod",
-      "display-name": "Buttons",
-      "last-accessibility-review": {
-        "date-iso-8601": "2018/01/18",
-        "commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
-      },
-      "SLDS-component-path": "/components/buttons"
-    },
-    {
-      "component": "button-stateful",
-      "status": "prod",
-      "display-name": "Stateful Buttons",
-      "SLDS-component-path": "/components/buttons/#flavor-stateful"
-    },
-    {
-      "component": "button-group",
-      "status": "prod",
-      "display-name": "Button Groups",
-      "SLDS-component-path": "/components/button-groups"
-    },
-    {
-      "component": "card",
-      "status": "prod",
-      "display-name": "Cards",
-      "last-accessibility-review": {
-        "date-iso-8601": "2018/01/18",
-        "commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
-      },
-      "SLDS-component-path": "/components/cards",
-      "dependencies": [
-        {
-          "component": "empty"
-        },
-        {
-          "component": "filter"
-        }
-      ]
-    },
-    {
-      "component": "forms/checkbox",
-      "status": "prod",
-      "display-name": "Checkboxes",
-      "last-accessibility-review": {
-        "date-iso-8601": "2018/01/18",
-        "commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
-      },
-      "SLDS-component-path": "/components/forms/#flavor-checkbox"
-    },
-    {
-      "component": "combobox",
-      "status": "prod",
-      "display-name": "Comboboxes",
-      "last-accessibility-review": {
-        "date-iso-8601": "2017/08/21",
-        "commit-sha": "295a4766f712a5f93743c4ecd3ba62d91c1fc153"
-      },
-      "SLDS-component-path": "/components/comboboxes"
-    },
-    {
-      "component": "data-table",
-      "status": "prod",
-      "display-name": "Data Tables",
-      "last-accessibility-review": {
-        "date-iso-8601": "2017/01/01",
-        "deprecated-accessibility": "true",
-        "commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
-      },
-      "SLDS-component-path": "/components/data-tables",
-      "dependencies": [
-        {
-          "component": "cell"
-        },
-        {
-          "component": "column"
-        },
-        {
-          "component": "highlight-cell"
-        },
-        {
-          "component": "row-actions"
-        }
-      ]
-    },
-    {
-      "component": "date-picker",
-      "status": "prod",
-      "display-name": "Datepickers",
-      "last-accessibility-review": {
-        "date-iso-8601": "2017/01/20",
-        "commit-sha": "568f503b19ddc039207e4b5c2636461de937f5f0"
-      },
-      "SLDS-component-path": "/components/datepickers"
-    },
-    {
-      "component": "filter",
-      "status": "prototype",
-      "display-name": "Filters",
-      "SLDS-component-path": "/components/filter"
-    },
-    {
-      "component": "forms/input/inline",
-      "status": "prod",
-      "display-name": "Inline Edit Inputs",
-      "last-accessibility-review": {
-        "date-iso-8601": "2017/08/21",
-        "commit-sha": "119f7033c17a8a0634a31c6eeef947ddd0ee876b"
-      },
-      "last-slds-markup-review": {
-        "date-iso-8601": "2017/08/21",
-        "commit-sha": "119f7033c17a8a0634a31c6eeef947ddd0ee876b"
-      },
-      "SLDS-component-path": "/components/forms#flavor-input"
-    },
-    {
-      "component": "forms/input",
-      "status": "prod",
-      "display-name": "Inputs",
-      "last-accessibility-review": {
-        "date-iso-8601": "2017/09/22",
-        "commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
-      },
-      "SLDS-component-path": "/components/forms#flavor-input"
-    },
-    {
-      "component": "forms/textarea",
-      "status": "prod",
-      "display-name": "Textareas",
-      "SLDS-component-path": "/components/forms#flavor-textarea"
-    },
-    {
-      "component": "global-header",
-      "status": "prototype",
-      "display-name": "Global Header",
-      "SLDS-component-path": "/components/global-header#flavor-base",
-      "dependencies": [
-        {
-          "component": "button"
-        },
-        {
-          "component": "dropdown"
-        },
-        {
-          "component": "profile"
-        },
-        {
-          "component": "search"
-        }
-      ]
-    },
-    {
-      "component": "global-navigation-bar",
-      "status": "prototype",
-      "display-name": "Global Navigation Bar",
-      "last-accessibility-review": {
-        "date-iso-8601": "2017/05/02",
-        "commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
-      },
-      "SLDS-component-path": "/components/global-navigation#flavor-navigation-bar",
-      "dependencies": [
-        {
-          "component": "button"
-        },
-        {
-          "component": "dropdown"
-        },
-        {
-          "component": "label"
-        },
-        {
-          "component": "link"
-        },
-        {
-          "component": "region"
-        }
-      ]
-    },
-    {
-      "component": "icon",
-      "status": "prod",
-      "display-name": "Icons",
-      "last-accessibility-review": {
-        "date-iso-8601": "2018/01/18",
-        "commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
-      },
-      "SLDS-component-path": "/components/icons"
-    },
-    {
-      "component": "icon-settings",
-      "status": "prod",
-      "display-name": "Icon Settings",
-      "SLDS-component-path": "/components/icons-settings"
-    },
-    {
-      "component": "media-object",
-      "status": "prod",
-      "display-name": "Media Objects",
-      "last-accessibility-review": {
-        "date-iso-8601": "2018/01/18",
-        "commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
-      },
-      "SLDS-component-path": "/components/utilities/media-objects/"
-    },
-    {
-      "component": "menu-dropdown",
-      "status": "prod",
-      "display-name": "Dropdown Menus",
-      "last-accessibility-review": {
-        "date-iso-8601": "2018/01/18",
-        "commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
-      },
-      "SLDS-component-path": "/components/menus#flavor-dropdown",
-      "dependencies": [
-        {
-          "component": "button-trigger"
-        }
-      ]
-    },
-    {
-      "component": "modal",
-      "status": "prod",
-      "display-name": "Modals",
-      "SLDS-component-path": "/components/modals"
-    },
-    {
-      "component": "navigation",
-      "status": "prod",
-      "display-name": "Navigation",
-      "SLDS-component-path": "/components/navigation"
-    },
-    {
-      "component": "panel",
-      "status": "prototype",
-      "display-name": "Panels",
-      "SLDS-component-path": "/components/panels",
-      "dependencies": [
-        {
-          "component": "filtering/group"
-        },
-        {
-          "component": "filtering/list-heading"
-        },
-        {
-          "component": "filtering/list"
-        }
-      ]
-    },
-    {
-      "component": "pill",
-      "status": "prototype",
-      "display-name": "Pills",
-      "SLDS-component-path": "/components/pills"
-    },
-    {
-      "component": "popover",
-      "status": "prod",
-      "display-name": "Popovers",
-      "last-accessibility-review": {
-        "date-iso-8601": "2018/01/18",
-        "commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
-      },
-      "SLDS-component-path": "/components/popovers"
-    },
-    {
-      "component": "page-header",
-      "status": "prod",
-      "display-name": "Page Headers",
-      "SLDS-component-path": "/components/page-headers"
-    },
-    {
-      "component": "progress-indicator",
-      "status": "prod",
-      "display-name": "Progress Indicators",
-      "SLDS-component-path": "/components/progress-indicator"
-    },
-    {
-      "component": "progress-ring",
-      "status": "prod",
-      "display-name": "Progress Rings",
-      "last-accessibility-review": {
-        "date-iso-8601": "2017/11/28",
-        "commit-sha": "1b7025689af65ff2b92ad359c809970f2afd8439"
-      },
-      "last-slds-markup-review": {
-        "date-iso-8601": "2017/11/28",
-        "commit-sha": "1b7025689af65ff2b92ad359c809970f2afd8439"
-      },
-      "SLDS-component-path": "/components/progress-ring"
-    },
-    {
-      "component": "forms/radio",
-      "status": "prod",
-      "display-name": "Radios",
-      "last-accessibility-review": {
-        "date-iso-8601": "2018/01/18",
-        "commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
-      },
-      "SLDS-component-path": "/components/forms/#flavor-radio"
-    },
-    {
-      "component": "split-view",
-      "status": "prod",
-      "display-name": "Split View",
-      "last-accessibility-review": {
-        "date-iso-8601": "2018/01/18",
-        "commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
-      },
-      "last-slds-markup-review": {
-        "date-iso-8601": "2018/01/18",
-        "commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
-      },
-      "SLDS-component-path": "/components/split-view",
-      "dependencies": [
-        {
-          "component": "header"
-        },
-        {
-          "component": "listbox"
-        }
-      ]
-    },
-    {
-      "component": "radio-group",
-      "status": "prod",
-      "display-name": "Radio Groups",
-      "last-accessibility-review": {
-        "date-iso-8601": "2018/01/18",
-        "commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
-      },
-      "SLDS-component-path": "/components/radio-group"
-    },
-    {
-      "component": "radio-button-group",
-      "status": "prod",
-      "display-name": "Radio Button Groups",
-      "last-accessibility-review": {
-        "date-iso-8601": "2018/01/18",
-        "commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
-      },
-      "SLDS-component-path": "/components/radio-button-group"
-    },
-    {
-      "component": "tooltip",
-      "status": "prod",
-      "display-name": "Tooltips",
-      "SLDS-component-path": "/components/tooltips"
-    },
-    {
-      "component": "tabs",
-      "status": "prod",
-      "display-name": "Tabs",
-      "last-accessibility-review": {
-        "date-iso-8601": "2018/01/18",
-        "commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
-      },
-      "SLDS-component-path": "/components/tabs",
-      "dependencies": [
-        {
-          "component": "panel"
-        }
-      ]
-    },
-    {
-      "component": "toast",
-      "status": "prod",
-      "display-name": "Toasts",
-      "last-accessibility-review": {
-        "date-iso-8601": "2018/01/18",
-        "commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
-      },
-      "SLDS-component-path": "/components/toasts",
-      "dependencies": [
-        {
-          "component": "container"
-        }
-      ]
-    },
-    {
-      "component": "tree",
-      "status": "prototype",
-      "display-name": "Tree",
-      "SLDS-component-path": "/components/tree"
-    },
-    {
-      "component": "time-picker",
-      "status": "prod",
-      "display-name": "Timepickers",
-      "SLDS-component-path": "/components/datepickers"
-    }
-  ],
-  "documentation": {
-    "prototype": {
-      "description": "The following components are prototypes. (a) Props may change within a minor release. (b) Web Content Accessibility Guidelines may not be met. (c) CSS imports may be required, since it is being added to SLDS."
-    }
-  }
+	"name": "design-system-react",
+	"version": "0.8.9",
+	"description": "Salesforce Lightning Design System for React",
+	"license": "SEE LICENSE IN README.md",
+	"engines": {
+		"node": "8.x",
+		"npm": "^5.5.1"
+	},
+	"scripts": {
+		"build-docs": "npx babel-node ./scripts/build-docs.js",
+		"build-and-test-docs": "npm run build-docs && npx babel-node ./tests/component-docs-test.js",
+		"build-storybook": "build-storybook -o ./storybook",
+		"build-storybook-for-tests": "build-storybook -o ./storybook-based-tests -c ./.storybook-based-tests",
+		"dist": "scripts/dist.sh",
+		"heroku-prebuild": "./scripts/heroku-prebuild.sh",
+		"heroku-postbuild": "./scripts/heroku-postbuild.sh",
+		"icons": "npx babel-node scripts/inline-icons.js",
+		"link": "./scripts/npm-link.sh",
+		"lint": "npm run lint:style && npm run lint:quality",
+		"lint:docs": "npx prettylint \"*.md\"",
+		"lint:fix": "npx eslint \"./tests/eslint-config-test.js\" && npx prettier-eslint --write \"**/*.{js,jsx}\" && npx prettylint \"*.json\" --fix",
+		"lint:quality": "npx eslint \"**/*.{js,jsx,json}\" --max-warnings=0",
+		"lint:style": "npx eslint \"./tests/eslint-config-test.js\" && npx prettier-eslint --list-different \"**/*.{js,jsx}\" && npx prettylint \"*.json\"",
+		"publish:origin": "npx babel-node scripts/publish-to-git.js",
+		"publish:edge": "npx babel-node scripts/publish-to-git.js --tag=edge",
+		"publish:upstream": "npx babel-node scripts/publish-to-git.js --remote=upstream",
+		"release:patch": "npx babel-node scripts/release.js --release=patch",
+		"release:minor": "npx babel-node scripts/release.js --release=minor",
+		"snapshot-test": "npx jest",
+		"start": "npx start-storybook -p 9001 -s ./node_modules & node tests/browser-tests-app",
+		"start:static": "node app",
+		"storybook": "start-storybook -p 9001 -s ./node_modules",
+		"test": "scripts/local-qa.sh --no-fix",
+		"test:fix": "scripts/local-qa.sh",
+		"travis-ci": "scripts/travis-ci.sh",
+		"validate": "npm ls",
+		"version": "git add package.json && git commit -m \"Bump package version\""
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+ssh://git@github.com/salesforce/design-system-react.git"
+	},
+	"jest": {
+		"testRegex": "/(components|tests)/.*\\.snapshot-test\\.jsx?$",
+		"testEnvironment": "node",
+		"testPathIgnorePatterns": [
+			"/node_modules/",
+			"/preset/",
+			"/.tmp-amd/",
+			"/.tmp-commonjs/",
+			"/.tmp-es/",
+			"/.tmp-npm/"
+		],
+		"transformIgnorePatterns": [
+			"/node_modules/",
+			"/preset/",
+			"/.tmp-amd/",
+			"/.tmp-commonjs/",
+			"/.tmp-es/",
+			"/.tmp-npm/"
+		]
+	},
+	"keywords": [
+		"react",
+		"slds",
+		"salesforce",
+		"salesforce-ux",
+		"lightning",
+		"design system",
+		"lightning design system",
+		"salesforce lightning design system",
+		"interactive components",
+		"interactive",
+		"components"
+	],
+	"bugs": {
+		"url": "https://github.com/salesforce/design-system-react/issues"
+	},
+	"main": "components/index.js",
+	"module": "components/index.js",
+	"homepage": "https://react.lightningdesignsystem.com",
+	"dependencies": {
+		"@salesforce/babel-preset-design-system-react": "^1.0.0",
+		"babel-preset-es2015": "^6.24.1",
+		"classnames": "^2.2.5",
+		"create-react-class": "^15.6.0",
+		"lodash.assign": "^4.0.9",
+		"lodash.compact": "^3.0.0",
+		"lodash.escaperegexp": "^4.1.1",
+		"lodash.find": "^4.3.0",
+		"lodash.findindex": "^4.3.0",
+		"lodash.flatten": "^4.2.0",
+		"lodash.isboolean": "^3.0.3",
+		"lodash.isdate": "^4.0.1",
+		"lodash.isequal": "^4.2.0",
+		"lodash.isfunction": "^3.0.8",
+		"lodash.isnumber": "^3.0.3",
+		"lodash.memoize": "^4.1.1",
+		"lodash.omit": "^4.3.0",
+		"lodash.partial": "^4.1.3",
+		"lodash.reject": "^4.3.0",
+		"lodash.uniqueid": "^4.0.0",
+		"popper.js": "^1.10.8",
+		"prop-types": ">=15.5.8",
+		"react-highlighter": "^0.4.0",
+		"react-modal": "^1.7.7",
+		"react-onclickoutside": "^6.5.0",
+		"react-text-truncate": "^0.12.0",
+		"shortid": "^2.2.6",
+		"warning": "^3.0.0"
+	},
+	"peerDependencies": {
+		"@salesforce-ux/design-system": "^2.4.0 || ^2.6.0-alpha",
+		"react": ">=15.4.1 <16",
+		"react-dom": ">=15.4.1 <16"
+	},
+	"devDependencies": {
+		"@salesforce-ux/design-system": "2.4.3",
+		"@salesforce-ux/icons": "7.x",
+		"@storybook/addon-actions": "^3.2.12",
+		"@storybook/addon-info": "^3.2.10",
+		"@storybook/addon-storyshots": "^3.4.0-alpha.4",
+		"@storybook/addons": "^3.4.0-alpha.8",
+		"@storybook/react": "^3.4.0-alpha.8",
+		"async": "^2.0.0-rc.5",
+		"babel-cli": "^6.24.1",
+		"babel-core": "^6.26.0",
+		"babel-eslint": "^8.0.2",
+		"babel-jest": "^20.0.3",
+		"babel-loader": "^7.1.1",
+		"babel-plugin-import-noop": "^1.0.1",
+		"babel-plugin-istanbul": "^4.1.4",
+		"babel-plugin-root-import": "^5.1.0",
+		"babel-plugin-transform-class-properties": "^6.24.1",
+		"babel-plugin-transform-es2015-modules-amd": "^6.24.0",
+		"babel-plugin-transform-es2015-modules-commonjs": "^6.24.0",
+		"babel-plugin-transform-export-extensions": "6.22.0",
+		"babel-polyfill": "^6.26.0",
+		"babel-preset-env": "^1.5.2",
+		"babel-preset-react": "^6.23.0",
+		"basic-auth": "^1.0.4",
+		"chai": "^4.0.1",
+		"chai-enzyme": "^0.8.0",
+		"compression": "^1.6.2",
+		"css-loader": "^0.28.0",
+		"enzyme": "^2.5.1",
+		"enzyme-to-json": "^1.5.0",
+		"eslint": "^4.12.0",
+		"eslint-config-airbnb": "16.1.0",
+		"eslint-loader": "^1.6.0",
+		"eslint-plugin-filenames": "^1.2.0",
+		"eslint-plugin-import": "^2.2.0",
+		"eslint-plugin-json": "^1.2.0",
+		"eslint-plugin-jsx-a11y": "^6.0.3",
+		"eslint-plugin-react": "^7.1.0",
+		"express": "^4.15.5",
+		"file-loader": "^0.11.0",
+		"find-remove": "^1.1.0",
+		"fs-extra": "^3.0.0",
+		"istanbul-instrumenter-loader": "^2.0.0",
+		"jest": "^21.2.1",
+		"js-beautify": "^1.6.8",
+		"json-loader": "^0.5.3",
+		"karma": "^1.7.0",
+		"karma-chai-sinon": "^0.1.5",
+		"karma-chrome-launcher": "^2.0.0",
+		"karma-cli": "^1.0.0",
+		"karma-coverage": "^1.0.0",
+		"karma-mocha": "^1.0.1",
+		"karma-phantomjs-launcher": "^1.0.4",
+		"karma-sourcemap-loader": "^0.3.5",
+		"karma-spec-reporter": "^0.0.31",
+		"karma-webpack": "^2.0.2",
+		"lint-staged": "^3.3.0",
+		"lodash.filter": "^4.6.0",
+		"lodash.isempty": "^4.2.1",
+		"lodash.kebabcase": "^4.0.1",
+		"lodash.trim": "^4.0.1",
+		"minimist": "^1.2.0",
+		"mocha": "^3.1.2",
+		"node-sass": "^4.5.0",
+		"object.entries": "^1.0.4",
+		"phantomjs-polyfill-find-index": "^1.0.1",
+		"phantomjs-polyfill-includes": "^1.0.2",
+		"phantomjs-prebuilt": "^2.1.15",
+		"prettier": "1.9.2",
+		"prettier-eslint": "~8.8.1",
+		"prettier-eslint-cli": "^4.4.2",
+		"prettylint": "^1.0.0",
+		"prompt": "^1.0.0",
+		"react": ">=15.4.1 <16",
+		"react-addons-test-utils": ">=15.4.1 <16",
+		"react-docgen": "^2.14.1",
+		"react-dom": ">=15.4.1 <16",
+		"react-hot-loader": "^1.2.7",
+		"react-test-renderer": ">=15.4.1 <16",
+		"sinon": "^2.3.5",
+		"sinon-chai": "^2.14.0",
+		"string-replace-webpack-plugin": "^0.1.2",
+		"style-loader": "^0.17.0",
+		"webpack": "^3.4.1",
+		"webpack-dev-middleware": "^1.12.0",
+		"webpack-hot-middleware": "^2.18.2",
+		"xml2json": "^0.11.0"
+	},
+	"components": [
+		{
+			"component": "accordion",
+			"status": "prod",
+			"display-name": "Accordions",
+			"last-accessibility-review": {
+				"date-iso-8601": "2018/01/18",
+				"commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
+			},
+			"SLDS-component-path": "/components/accordions",
+			"dependencies": [
+				{
+					"component": "panel"
+				}
+			]
+		},
+		{
+			"component": "alert",
+			"status": "prod",
+			"display-name": "Alerts",
+			"last-accessibility-review": {
+				"date-iso-8601": "2018/01/18",
+				"commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
+			},
+			"SLDS-component-path": "/components/alerts",
+			"dependencies": [
+				{
+					"component": "container"
+				}
+			]
+		},
+		{
+			"component": "app-launcher",
+			"status": "prototype",
+			"display-name": "App Launcher",
+			"SLDS-component-path": "/components/app-launcher/#flavor-default",
+			"dependencies": [
+				{
+					"component": "section"
+				},
+				{
+					"component": "tile"
+				}
+			]
+		},
+		{
+			"component": "avatar",
+			"status": "prod",
+			"display-name": "Avatars",
+			"last-accessibility-review": {
+				"date-iso-8601": "2018/01/18",
+				"commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
+			},
+			"SLDS-component-path": "/components/avatars"
+		},
+		{
+			"component": "breadcrumb",
+			"status": "prod",
+			"display-name": "Breadcrumbs",
+			"last-accessibility-review": {
+				"date-iso-8601": "2018/01/18",
+				"commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
+			},
+			"SLDS-component-path": "/components/breadcrumbs"
+		},
+		{
+			"component": "button",
+			"status": "prod",
+			"display-name": "Buttons",
+			"last-accessibility-review": {
+				"date-iso-8601": "2018/01/18",
+				"commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
+			},
+			"SLDS-component-path": "/components/buttons"
+		},
+		{
+			"component": "button-stateful",
+			"status": "prod",
+			"display-name": "Stateful Buttons",
+			"SLDS-component-path": "/components/buttons/#flavor-stateful"
+		},
+		{
+			"component": "button-group",
+			"status": "prod",
+			"display-name": "Button Groups",
+			"SLDS-component-path": "/components/button-groups"
+		},
+		{
+			"component": "card",
+			"status": "prod",
+			"display-name": "Cards",
+			"last-accessibility-review": {
+				"date-iso-8601": "2018/01/18",
+				"commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
+			},
+			"SLDS-component-path": "/components/cards",
+			"dependencies": [
+				{
+					"component": "empty"
+				},
+				{
+					"component": "filter"
+				}
+			]
+		},
+		{
+			"component": "forms/checkbox",
+			"status": "prod",
+			"display-name": "Checkboxes",
+			"last-accessibility-review": {
+				"date-iso-8601": "2018/01/18",
+				"commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
+			},
+			"SLDS-component-path": "/components/forms/#flavor-checkbox"
+		},
+		{
+			"component": "combobox",
+			"status": "prod",
+			"display-name": "Comboboxes",
+			"last-accessibility-review": {
+				"date-iso-8601": "2017/08/21",
+				"commit-sha": "295a4766f712a5f93743c4ecd3ba62d91c1fc153"
+			},
+			"SLDS-component-path": "/components/comboboxes"
+		},
+		{
+			"component": "data-table",
+			"status": "prod",
+			"display-name": "Data Tables",
+			"last-accessibility-review": {
+				"date-iso-8601": "2017/01/01",
+				"deprecated-accessibility": "true",
+				"commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
+			},
+			"SLDS-component-path": "/components/data-tables",
+			"dependencies": [
+				{
+					"component": "cell"
+				},
+				{
+					"component": "column"
+				},
+				{
+					"component": "highlight-cell"
+				},
+				{
+					"component": "row-actions"
+				}
+			]
+		},
+		{
+			"component": "date-picker",
+			"status": "prod",
+			"display-name": "Datepickers",
+			"last-accessibility-review": {
+				"date-iso-8601": "2017/01/20",
+				"commit-sha": "568f503b19ddc039207e4b5c2636461de937f5f0"
+			},
+			"SLDS-component-path": "/components/datepickers"
+		},
+		{
+			"component": "filter",
+			"status": "prototype",
+			"display-name": "Filters",
+			"SLDS-component-path": "/components/filter"
+		},
+		{
+			"component": "forms/input/inline",
+			"status": "prod",
+			"display-name": "Inline Edit Inputs",
+			"last-accessibility-review": {
+				"date-iso-8601": "2017/08/21",
+				"commit-sha": "119f7033c17a8a0634a31c6eeef947ddd0ee876b"
+			},
+			"last-slds-markup-review": {
+				"date-iso-8601": "2017/08/21",
+				"commit-sha": "119f7033c17a8a0634a31c6eeef947ddd0ee876b"
+			},
+			"SLDS-component-path": "/components/forms#flavor-input"
+		},
+		{
+			"component": "forms/input",
+			"status": "prod",
+			"display-name": "Inputs",
+			"last-accessibility-review": {
+				"date-iso-8601": "2017/09/22",
+				"commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
+			},
+			"SLDS-component-path": "/components/forms#flavor-input"
+		},
+		{
+			"component": "forms/textarea",
+			"status": "prod",
+			"display-name": "Textareas",
+			"SLDS-component-path": "/components/forms#flavor-textarea"
+		},
+		{
+			"component": "global-header",
+			"status": "prototype",
+			"display-name": "Global Header",
+			"SLDS-component-path": "/components/global-header#flavor-base",
+			"dependencies": [
+				{
+					"component": "button"
+				},
+				{
+					"component": "dropdown"
+				},
+				{
+					"component": "profile"
+				},
+				{
+					"component": "search"
+				}
+			]
+		},
+		{
+			"component": "global-navigation-bar",
+			"status": "prototype",
+			"display-name": "Global Navigation Bar",
+			"last-accessibility-review": {
+				"date-iso-8601": "2017/05/02",
+				"commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
+			},
+			"SLDS-component-path": "/components/global-navigation#flavor-navigation-bar",
+			"dependencies": [
+				{
+					"component": "button"
+				},
+				{
+					"component": "dropdown"
+				},
+				{
+					"component": "label"
+				},
+				{
+					"component": "link"
+				},
+				{
+					"component": "region"
+				}
+			]
+		},
+		{
+			"component": "icon",
+			"status": "prod",
+			"display-name": "Icons",
+			"last-accessibility-review": {
+				"date-iso-8601": "2018/01/18",
+				"commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
+			},
+			"SLDS-component-path": "/components/icons"
+		},
+		{
+			"component": "icon-settings",
+			"status": "prod",
+			"display-name": "Icon Settings",
+			"SLDS-component-path": "/components/icons-settings"
+		},
+		{
+			"component": "media-object",
+			"status": "prod",
+			"display-name": "Media Objects",
+			"last-accessibility-review": {
+				"date-iso-8601": "2018/01/18",
+				"commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
+			},
+			"SLDS-component-path": "/components/utilities/media-objects/"
+		},
+		{
+			"component": "menu-dropdown",
+			"status": "prod",
+			"display-name": "Dropdown Menus",
+			"last-accessibility-review": {
+				"date-iso-8601": "2018/01/18",
+				"commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
+			},
+			"SLDS-component-path": "/components/menus#flavor-dropdown",
+			"dependencies": [
+				{
+					"component": "button-trigger"
+				}
+			]
+		},
+		{
+			"component": "modal",
+			"status": "prod",
+			"display-name": "Modals",
+			"SLDS-component-path": "/components/modals"
+		},
+		{
+			"component": "navigation",
+			"status": "prod",
+			"display-name": "Navigation",
+			"SLDS-component-path": "/components/navigation"
+		},
+		{
+			"component": "panel",
+			"status": "prototype",
+			"display-name": "Panels",
+			"SLDS-component-path": "/components/panels",
+			"dependencies": [
+				{
+					"component": "filtering/group"
+				},
+				{
+					"component": "filtering/list-heading"
+				},
+				{
+					"component": "filtering/list"
+				}
+			]
+		},
+		{
+			"component": "pill",
+			"status": "prototype",
+			"display-name": "Pills",
+			"SLDS-component-path": "/components/pills"
+		},
+		{
+			"component": "popover",
+			"status": "prod",
+			"display-name": "Popovers",
+			"last-accessibility-review": {
+				"date-iso-8601": "2018/01/18",
+				"commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
+			},
+			"SLDS-component-path": "/components/popovers"
+		},
+		{
+			"component": "page-header",
+			"status": "prod",
+			"display-name": "Page Headers",
+			"SLDS-component-path": "/components/page-headers"
+		},
+		{
+			"component": "progress-indicator",
+			"status": "prod",
+			"display-name": "Progress Indicators",
+			"SLDS-component-path": "/components/progress-indicator"
+		},
+		{
+			"component": "progress-ring",
+			"status": "prod",
+			"display-name": "Progress Rings",
+			"last-accessibility-review": {
+				"date-iso-8601": "2017/11/28",
+				"commit-sha": "1b7025689af65ff2b92ad359c809970f2afd8439"
+			},
+			"last-slds-markup-review": {
+				"date-iso-8601": "2017/11/28",
+				"commit-sha": "1b7025689af65ff2b92ad359c809970f2afd8439"
+			},
+			"SLDS-component-path": "/components/progress-ring"
+		},
+		{
+			"component": "forms/radio",
+			"status": "prod",
+			"display-name": "Radios",
+			"last-accessibility-review": {
+				"date-iso-8601": "2018/01/18",
+				"commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
+			},
+			"SLDS-component-path": "/components/forms/#flavor-radio"
+		},
+		{
+			"component": "split-view",
+			"status": "prod",
+			"display-name": "Split View",
+			"last-accessibility-review": {
+				"date-iso-8601": "2018/01/18",
+				"commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
+			},
+			"last-slds-markup-review": {
+				"date-iso-8601": "2018/01/18",
+				"commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
+			},
+			"SLDS-component-path": "/components/split-view",
+			"dependencies": [
+				{
+					"component": "header"
+				},
+				{
+					"component": "listbox"
+				}
+			]
+		},
+		{
+			"component": "radio-group",
+			"status": "prod",
+			"display-name": "Radio Groups",
+			"last-accessibility-review": {
+				"date-iso-8601": "2018/01/18",
+				"commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
+			},
+			"SLDS-component-path": "/components/radio-group"
+		},
+		{
+			"component": "radio-button-group",
+			"status": "prod",
+			"display-name": "Radio Button Groups",
+			"last-accessibility-review": {
+				"date-iso-8601": "2018/01/18",
+				"commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
+			},
+			"SLDS-component-path": "/components/radio-button-group"
+		},
+		{
+			"component": "tooltip",
+			"status": "prod",
+			"display-name": "Tooltips",
+			"SLDS-component-path": "/components/tooltips"
+		},
+		{
+			"component": "tabs",
+			"status": "prod",
+			"display-name": "Tabs",
+			"last-accessibility-review": {
+				"date-iso-8601": "2018/01/18",
+				"commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
+			},
+			"SLDS-component-path": "/components/tabs",
+			"dependencies": [
+				{
+					"component": "panel"
+				}
+			]
+		},
+		{
+			"component": "toast",
+			"status": "prod",
+			"display-name": "Toasts",
+			"last-accessibility-review": {
+				"date-iso-8601": "2018/01/18",
+				"commit-sha": "ad6b6c6523ee21cada11be5f7ea4d99abc530726"
+			},
+			"SLDS-component-path": "/components/toasts",
+			"dependencies": [
+				{
+					"component": "container"
+				}
+			]
+		},
+		{
+			"component": "tree",
+			"status": "prototype",
+			"display-name": "Tree",
+			"SLDS-component-path": "/components/tree"
+		},
+		{
+			"component": "time-picker",
+			"status": "prod",
+			"display-name": "Timepickers",
+			"SLDS-component-path": "/components/datepickers"
+		}
+	],
+	"documentation": {
+		"prototype": {
+			"description": "The following components are prototypes. (a) Props may change within a minor release. (b) Web Content Accessibility Guidelines may not be met. (c) CSS imports may be required, since it is being added to SLDS."
+		}
+	}
 }


### PR DESCRIPTION
Fixes #1211.

Allows the nubbin to change position when a popover flips

Before

[![https://gyazo.com/d4a444546e61100ef2b532cd7e1eb255](https://i.gyazo.com/d4a444546e61100ef2b532cd7e1eb255.gif)](https://gyazo.com/d4a444546e61100ef2b532cd7e1eb255)

After:

[![https://gyazo.com/d419d7f31b8bb6c628722a326a233d75](https://i.gyazo.com/d419d7f31b8bb6c628722a326a233d75.gif)](https://gyazo.com/d419d7f31b8bb6c628722a326a233d75)
---

### Pull Request Review checklist (do not remove)

* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at snapshot strings.
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
