### PR TITLE
Change the year pick init focus to current selected year

### DIFF
--- a/components/date-picker/private/year-picklist.jsx
+++ b/components/date-picker/private/year-picklist.jsx
@@ -49,6 +49,7 @@ const DatepickerYearSelector = createReactClass({
 	},
 
 	getSelectedValueIndex () {
+		const now = new Date();
 		const selectedYear = this.props.initialDateForCalendarRender.getFullYear();
 		const fromYear = now.getFullYear() + this.props.relativeYearFrom;
 		return selectYear - fromYear;

--- a/components/date-picker/private/year-picklist.jsx
+++ b/components/date-picker/private/year-picklist.jsx
@@ -48,6 +48,12 @@ const DatepickerYearSelector = createReactClass({
 		return opts;
 	},
 
+	getSelectedValueIndex () {
+		const selectedYear = this.props.initialDateForCalendarRender.getFullYear();
+		const fromYear = now.getFullYear() + this.props.relativeYearFrom;
+		return selectYear - fromYear;
+	}
+
 	handleSelect (selectedValue) {
 		if (selectedValue) {
 			this.props.onChangeMonth(
@@ -74,6 +80,7 @@ const DatepickerYearSelector = createReactClass({
 					options={this.getOptions()}
 					placeholder="Year"
 					value={this.props.initialDateForCalendarRender.getFullYear()}
+					valueIndex = {this.getSelectedValueIndex()}
 				/>
 			</div>
 		);

--- a/components/date-picker/private/year-picklist.jsx
+++ b/components/date-picker/private/year-picklist.jsx
@@ -52,7 +52,7 @@ const DatepickerYearSelector = createReactClass({
 		const selectedYear = this.props.initialDateForCalendarRender.getFullYear();
 		const fromYear = now.getFullYear() + this.props.relativeYearFrom;
 		return selectYear - fromYear;
-	}
+	},
 
 	handleSelect (selectedValue) {
 		if (selectedValue) {

--- a/components/menu-picklist/index.jsx
+++ b/components/menu-picklist/index.jsx
@@ -124,6 +124,11 @@ const MenuPicklist = createReactClass({
 		 * Current selected item.
 		 */
 		value: PropTypes.node,
+		/**
+		 * Current selected item index.
+		 */
+		valueIndex: PropTypes.number,
+
 	},
 
 	mixins: [KeyboardNavigable],
@@ -142,8 +147,8 @@ const MenuPicklist = createReactClass({
 
 	getInitialState () {
 		return {
-			focusedIndex: -1,
-			selectedIndex: -1,
+			focusedIndex: valueIndex,
+			selectedIndex: valueIndex,
 			selectedIndices: [],
 			currentPillLabel: '',
 		};

--- a/components/menu-picklist/index.jsx
+++ b/components/menu-picklist/index.jsx
@@ -147,8 +147,8 @@ const MenuPicklist = createReactClass({
 
 	getInitialState () {
 		return {
-			focusedIndex: valueIndex,
-			selectedIndex: valueIndex,
+			focusedIndex: this.props.valueIndex,
+			selectedIndex: this.props.valueIndex,
 			selectedIndices: [],
 			currentPillLabel: '',
 		};


### PR DESCRIPTION
Change the behavior when opening the year pick list in datepicker. Before it starts with the start year, this PR changes the init focus/selection to the current selected year.

---

### Pull Request Review checklist (do not remove)

* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at snapshot strings.
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
