### PR TITLE
fixes broken link to source of Inline Edit Inputs in docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -370,7 +370,7 @@
 			"SLDS-component-path": "/components/filter"
 		},
 		{
-			"component": "forms/input/inline",
+			"component": "forms/input",
 			"status": "prod",
 			"display-name": "Inline Edit Inputs",
 			"last-accessibility-review": {


### PR DESCRIPTION
Fixes #1302

### Additional description

new url points to the /input folder instead of broken /input/inline.
---

### Pull Request Review checklist (do not remove)

* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
