### PR TITLE
Set flip.enabled based on hasStaticAlignment prop

### DIFF
--- a/components/combobox/combobox.jsx
+++ b/components/combobox/combobox.jsx
@@ -121,7 +121,7 @@ const propTypes = {
 	 */
 	errorText: PropTypes.string,
 	/**
-	 * By default, dialogs will flip their alignment (such as bottom to top) if they extend beyond a boundary element such as a scrolling parent or a window/viewpoint. This is the opposite of "flippable."
+	 * By default, dialogs will flip their alignment (such as bottom to top) if they extend beyond a boundary element such as a scrolling parent or a window/viewpoint. `hasStaticAlignment` disables this behavior and allows this component to extend beyond boundary elements. _Not tested._
 	 */
 	hasStaticAlignment: PropTypes.bool,
 	/**

--- a/components/date-picker/date-picker.jsx
+++ b/components/date-picker/date-picker.jsx
@@ -80,7 +80,7 @@ const propTypes = {
 	 */
 	formattedValue: PropTypes.string,
 	/**
-	 * Prevents the dropdown from changing position based on the viewport/window. If set to true your dropdowns can extend outside the viewport _and_ overflow outside of a scrolling parent. If this happens, you might want to consider making the dropdowns contents scrollable to fit the menu on the screen. _Not tested._
+	 * Prevents the dropdown from changing position based on the viewport/window. If set to true your dropdowns can extend outside the viewport _and_ overflow outside of a scrolling parent. If this happens, you might want to consider making the dropdowns contents scrollable to fit the menu on the screen. `hasStaticAlignment` disables this behavior and allows this component to extend beyond boundary elements. _Not tested._
 	 */
 	hasStaticAlignment: PropTypes.bool,
 	/**

--- a/components/menu-dropdown/menu-dropdown.jsx
+++ b/components/menu-dropdown/menu-dropdown.jsx
@@ -170,7 +170,7 @@ const MenuDropdown = createReactClass({
 		 */
 		disabled: PropTypes.bool,
 		/**
-		 * Prevents the dropdown from changing position based on the viewport/window. If set to true your dropdowns can extend outside the viewport _and_ overflow outside of a scrolling parent. If this happens, you might want to consider making the dropdowns contents scrollable to fit the menu on the screen.
+		 * Prevents the dropdown from changing position based on the viewport/window. If set to true your dropdowns can extend outside the viewport _and_ overflow outside of a scrolling parent. If this happens, you might want to consider making the dropdowns contents scrollable to fit the menu on the screen. `hasStaticAlignment` disables this behavior and allows this component to extend beyond boundary elements. _Not tested._
 		 */
 		hasStaticAlignment: PropTypes.bool,
 		/**

--- a/components/popover/popover.jsx
+++ b/components/popover/popover.jsx
@@ -129,7 +129,7 @@ const Popover = createReactClass({
 		 */
 		footer: PropTypes.node,
 		/**
-		 * Prevents the Popover from changing position based on the viewport/window. If set to true your popover can extend outside the viewport _and_ overflow outside of a scrolling parent. If this happens, you might want to consider making the popover contents scrollable to fit the menu on the screen.
+		 * Prevents the Popover from changing position based on the viewport/window. If set to true your popover can extend outside the viewport _and_ overflow outside of a scrolling parent. If this happens, you might want to consider making the popover contents scrollable to fit the menu on the screen. When enabled, `position` `absolute` is used.
 		 */
 		hasStaticAlignment: PropTypes.bool,
 		/**

--- a/components/tooltip/index.jsx
+++ b/components/tooltip/index.jsx
@@ -59,7 +59,7 @@ const propTypes = {
 	 */
 	content: PropTypes.node.isRequired,
 	/**
-	 * By default, dialogs will flip their alignment (such as bottom to top) if they extend beyond a boundary element such as a scrolling parent or a window/viewpoint. This is the opposite of "flippable."
+	 * By default, dialogs will flip their alignment (such as bottom to top) if they extend beyond a boundary element such as a scrolling parent or a window/viewpoint. `hasStaticAlignment` disables this behavior and allows this component to extend beyond boundary elements. _Not tested._
 	 */
 	hasStaticAlignment: PropTypes.bool,
 	/**

--- a/components/utilities/dialog/index.jsx
+++ b/components/utilities/dialog/index.jsx
@@ -323,7 +323,7 @@ const Dialog = createReactClass({
 			applyStyle: { enabled: false },
 			// moves dialog in order to not extend a boundary element such as a scrolling parent or a window/viewpoint.
 			preventOverflow: {
-				enabled: true,
+				enabled: !this.props.hasStaticAlignment,
 				boundariesElement:
 					this.props.position === 'absolute' ? 'scrollParent' : 'viewport',
 			},

--- a/components/utilities/dialog/index.jsx
+++ b/components/utilities/dialog/index.jsx
@@ -99,7 +99,7 @@ const Dialog = createReactClass({
 		 */
 		inheritWidthOf: PropTypes.oneOf(['target', 'menu', 'none']),
 		/**
-		 * By default, dialogs will flip their alignment (such as bottom to top) if they extend beyond a boundary element such as a scrolling parent or a window/viewpoint. This is the opposite of "flippable."
+		 * By default, dialogs will flip their alignment (such as bottom to top) if they extend beyond a boundary element such as a scrolling parent or a window/viewpoint. `hasStaticAlignment` disables this behavior and allows this component to extend beyond boundary elements.
 		 */
 		hasStaticAlignment: PropTypes.bool,
 		/**
@@ -329,7 +329,7 @@ const Dialog = createReactClass({
 			},
 			// By default, dialogs will flip their alignment if they extend beyond a boundary element such as a scrolling parent or a window/viewpoint
 			flip: {
-				enabled: !this.props.hasStaticAlignment
+				enabled: !this.props.hasStaticAlignment,
 			},
 			removeOnDestroy: true,
 			updateState: {

--- a/components/utilities/dialog/index.jsx
+++ b/components/utilities/dialog/index.jsx
@@ -328,6 +328,9 @@ const Dialog = createReactClass({
 					this.props.position === 'absolute' ? 'scrollParent' : 'viewport',
 			},
 			// By default, dialogs will flip their alignment if they extend beyond a boundary element such as a scrolling parent or a window/viewpoint
+			flip: {
+				enabled: !this.props.hasStaticAlignment
+			},
 			removeOnDestroy: true,
 			updateState: {
 				enabled: true,


### PR DESCRIPTION
This sets `flip.enabled` based on the `hasStaticAlignment` prop.

Fixes https://github.com/salesforce/design-system-react/issues/1312

@interactivellama could you take a look?  Thanks!

---

### Pull Request Review checklist (do not remove)

* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at snapshot strings.
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.