### PR TITLE
Tree keyboard navigation

### DIFF
--- a/components/tree/index.jsx
+++ b/components/tree/index.jsx
@@ -137,7 +137,7 @@ class Tree extends React.Component {
 					level={0}
 					node={{ nodes: this.props.nodes }}
 					flattenedNodes={this.state.flattenedNodes}
-					selectedNodeIndexes={this.state.selecselectedNodeIndexestedNodes}
+					selectedNodeIndexes={this.state.selectedNodeIndexes}
 					focusedNodeIndex={this.state.focusedNodeIndex}
 					onNodeFocus={this.handleNodeFocus}
 					onClick={this.handleClick}

--- a/components/tree/index.jsx
+++ b/components/tree/index.jsx
@@ -32,8 +32,11 @@ class Tree extends React.Component {
 		this.handleClick = this.handleClick.bind(this);
 		this.handleNodeFocus = this.handleNodeFocus.bind(this);
 		this.state = {
-			flattenedNodes: this.flattenTree({ nodes: this.props.nodes, expanded: true }).slice(1),
-			selectedNodeIndexes: []
+			flattenedNodes: this.flattenTree({
+				nodes: this.props.nodes,
+				expanded: true,
+			}).slice(1),
+			selectedNodeIndexes: [],
 		};
 	}
 
@@ -43,7 +46,10 @@ class Tree extends React.Component {
 
 	componentWillReceiveProps (nextProps) {
 		this.setState({
-			flattenedNodes: this.flattenTree({ nodes: nextProps.nodes, expanded: true }).slice(1)
+			flattenedNodes: this.flattenTree({
+				nodes: nextProps.nodes,
+				expanded: true,
+			}).slice(1),
 		});
 	}
 
@@ -56,7 +62,12 @@ class Tree extends React.Component {
 		if (root.expanded) {
 			for (let index = 0; index < root.nodes.length; index++) {
 				const curNode = root.nodes[index];
-				nodes = nodes.concat(this.flattenTree(curNode, treeIndex ? `${treeIndex}-${index}` : `${index}`));
+				nodes = nodes.concat(
+					this.flattenTree(
+						curNode,
+						treeIndex ? `${treeIndex}-${index}` : `${index}`
+					)
+				);
 			}
 		}
 		return nodes;
@@ -78,13 +89,17 @@ class Tree extends React.Component {
 		// Keep track of the currently selected and focused nodes.
 		let selectedNodeIndexes;
 		if (data.select) {
-			selectedNodeIndexes = this.state.selectedNodeIndexes.concat([data.treeIndex]);
+			selectedNodeIndexes = this.state.selectedNodeIndexes.concat([
+				data.treeIndex,
+			]);
 		} else {
-			selectedNodeIndexes = this.state.selectedNodeIndexes.filter((treeIndex) => treeIndex !== data.treeIndex);
+			selectedNodeIndexes = this.state.selectedNodeIndexes.filter(
+				(treeIndex) => treeIndex !== data.treeIndex
+			);
 		}
 		this.setState({
 			focusedNodeIndex: data.treeIndex,
-			selectedNodeIndexes
+			selectedNodeIndexes,
 		});
 	}
 

--- a/components/tree/index.jsx
+++ b/components/tree/index.jsx
@@ -29,8 +29,11 @@ import { TREE } from '../../utilities/constants';
 class Tree extends React.Component {
 	constructor (props) {
 		super(props);
+		this.handleClick = this.handleClick.bind(this);
+		this.handleNodeFocus = this.handleNodeFocus.bind(this);
 		this.state = {
-			flattenedNodes: this.flattenTree({ nodes: this.props.nodes, expanded: true }).slice(1)
+			flattenedNodes: this.flattenTree({ nodes: this.props.nodes, expanded: true }).slice(1),
+			selectedNodeIndexes: []
 		};
 	}
 
@@ -39,9 +42,9 @@ class Tree extends React.Component {
 	}
 
 	componentWillReceiveProps (nextProps) {
-		this.state = {
+		this.setState({
 			flattenedNodes: this.flattenTree({ nodes: nextProps.nodes, expanded: true }).slice(1)
-		};
+		});
 	}
 
 	// Flattens hierarchical tree structure into a flat array.
@@ -57,6 +60,36 @@ class Tree extends React.Component {
 			}
 		}
 		return nodes;
+	}
+
+	handleClick (event, data, clearSelectedNodes) {
+		// When triggered by a key event, other nodes should be deselected.
+		if (clearSelectedNodes) {
+			this.state.flattenedNodes.forEach((flattenedNode) => {
+				if (flattenedNode.node.selected) {
+					flattenedNode.node.selected = false;
+				}
+			});
+		}
+
+		// Do the click.
+		this.props.onClick(event, data);
+
+		// Keep track of the currently selected and focused nodes.
+		let selectedNodeIndexes;
+		if (data.select) {
+			selectedNodeIndexes = this.state.selectedNodeIndexes.concat([data.treeIndex]);
+		} else {
+			selectedNodeIndexes = this.state.selectedNodeIndexes.filter((treeIndex) => treeIndex !== data.treeIndex);
+		}
+		this.setState({
+			focusedNodeIndex: data.treeIndex,
+			selectedNodeIndexes
+		});
+	}
+
+	handleNodeFocus (event, data) {
+		this.setState({ focusedNodeIndex: data.treeIndex });
 	}
 
 	render () {
@@ -89,7 +122,10 @@ class Tree extends React.Component {
 					level={0}
 					node={{ nodes: this.props.nodes }}
 					flattenedNodes={this.state.flattenedNodes}
-					onClick={this.props.onClick}
+					selectedNodeIndexes={this.state.selecselectedNodeIndexestedNodes}
+					focusedNodeIndex={this.state.focusedNodeIndex}
+					onNodeFocus={this.handleNodeFocus}
+					onClick={this.handleClick}
 					onExpandClick={this.props.onExpandClick}
 					onScroll={this.props.onScroll}
 					searchTerm={this.props.searchTerm}

--- a/components/tree/index.jsx
+++ b/components/tree/index.jsx
@@ -38,7 +38,7 @@ class Tree extends React.Component {
 		checkProps(TREE, this.props);
 	}
 
-	componentWillReceiveProps(nextProps) {
+	componentWillReceiveProps (nextProps) {
 		this.state = {
 			flattenedNodes: this.flattenTree({ nodes: nextProps.nodes, expanded: true }).slice(1)
 		};

--- a/components/tree/index.jsx
+++ b/components/tree/index.jsx
@@ -38,9 +38,9 @@ class Tree extends React.Component {
 		checkProps(TREE, this.props);
 	}
 
-	componentWillReceiveProps () {
+	componentWillReceiveProps(nextProps) {
 		this.state = {
-			flattenedNodes: this.flattenTree({ nodes: this.props.nodes, expanded: true }).slice(1)
+			flattenedNodes: this.flattenTree({ nodes: nextProps.nodes, expanded: true }).slice(1)
 		};
 	}
 

--- a/components/tree/index.jsx
+++ b/components/tree/index.jsx
@@ -27,8 +27,40 @@ import { TREE } from '../../utilities/constants';
  * A tree is visualization of a structure hierarchy. A branch can be expanded or collapsed. This is a controlled component, since visual state is present in the `nodes` data.
  */
 class Tree extends React.Component {
+	constructor (props) {
+		super(props);
+		this.state = {
+			flattenedNodes: this.flattenTree({ nodes: this.props.nodes, expanded: true }).slice(1)
+		 };
+	}
+
 	componentWillMount () {
 		checkProps(TREE, this.props);
+	}
+
+	componentWillReceiveProps () {
+		this.state = {
+			flattenedNodes: this.flattenTree({ nodes: this.props.nodes, expanded: true }).slice(1)
+		};
+	}
+
+	/**
+	 * Flattens hierarchical tree structure into a flat array. Stops when we encounter node, because that's all we need.
+	 * @param {*} root
+	 * @param {*} node
+	 */
+	flattenTree (root, treeIndex = '') {
+		if (!root.nodes) {
+			return [{ node: root, treeIndex }];
+		}
+		let nodes = [{ node: root, treeIndex }];
+		if (root.expanded) {
+			for (let index = 0; index < root.nodes.length; index++) {
+				const curNode = root.nodes[index];
+				nodes = nodes.concat(this.flattenTree(curNode, treeIndex ? `${treeIndex}-${index}` : `${index}`));
+			}
+		}
+		return nodes;
 	}
 
 	render () {
@@ -59,7 +91,8 @@ class Tree extends React.Component {
 					htmlId={this.props.id}
 					initialStyle={this.props.listStyle}
 					level={0}
-					node={{ nodes: this.props.nodes }}
+					node={{ nodes: this.props.nodes, expanded: true }}
+					flattenedNodes={this.state.flattenedNodes}
 					onClick={this.props.onClick}
 					onExpandClick={this.props.onExpandClick}
 					onScroll={this.props.onScroll}

--- a/components/tree/index.jsx
+++ b/components/tree/index.jsx
@@ -30,7 +30,7 @@ class Tree extends React.Component {
 	constructor (props) {
 		super(props);
 		this.handleClick = this.handleClick.bind(this);
-		this.handleNodeFocus = this.handleNodeFocus.bind(this);
+		this.handleNodeBlur = this.handleNodeBlur.bind(this);
 		this.state = {
 			flattenedNodes: this.flattenTree({
 				nodes: this.props.nodes,
@@ -51,6 +51,16 @@ class Tree extends React.Component {
 				expanded: true,
 			}).slice(1),
 		});
+	}
+
+	shouldComponentUpdate (nextProps, nextState) {
+		// There is no need to render when blurring a node because focus is either:
+		//  - outside of the tree, or
+		//  - focused on another node in the tree, which triggers its own render
+		if (this.state.treeHasFocus && !nextState.treeHasFocus) {
+			return false;
+		}
+		return true;
 	}
 
 	// Flattens hierarchical tree structure into a flat array.
@@ -100,11 +110,12 @@ class Tree extends React.Component {
 		this.setState({
 			focusedNodeIndex: data.treeIndex,
 			selectedNodeIndexes,
+			treeHasFocus: true,
 		});
 	}
 
-	handleNodeFocus (event, data) {
-		this.setState({ focusedNodeIndex: data.treeIndex });
+	handleNodeBlur () {
+		this.setState({ treeHasFocus: false });
 	}
 
 	render () {
@@ -139,7 +150,8 @@ class Tree extends React.Component {
 					flattenedNodes={this.state.flattenedNodes}
 					selectedNodeIndexes={this.state.selectedNodeIndexes}
 					focusedNodeIndex={this.state.focusedNodeIndex}
-					onNodeFocus={this.handleNodeFocus}
+					treeHasFocus={this.state.treeHasFocus}
+					onNodeBlur={this.handleNodeBlur}
 					onClick={this.handleClick}
 					onExpandClick={this.props.onExpandClick}
 					onScroll={this.props.onScroll}

--- a/components/tree/index.jsx
+++ b/components/tree/index.jsx
@@ -31,7 +31,7 @@ class Tree extends React.Component {
 		super(props);
 		this.state = {
 			flattenedNodes: this.flattenTree({ nodes: this.props.nodes, expanded: true }).slice(1)
-		 };
+		};
 	}
 
 	componentWillMount () {
@@ -44,11 +44,7 @@ class Tree extends React.Component {
 		};
 	}
 
-	/**
-	 * Flattens hierarchical tree structure into a flat array. Stops when we encounter node, because that's all we need.
-	 * @param {*} root
-	 * @param {*} node
-	 */
+	// Flattens hierarchical tree structure into a flat array.
 	flattenTree (root, treeIndex = '') {
 		if (!root.nodes) {
 			return [{ node: root, treeIndex }];
@@ -91,7 +87,7 @@ class Tree extends React.Component {
 					htmlId={this.props.id}
 					initialStyle={this.props.listStyle}
 					level={0}
-					node={{ nodes: this.props.nodes, expanded: true }}
+					node={{ nodes: this.props.nodes }}
 					flattenedNodes={this.state.flattenedNodes}
 					onClick={this.props.onClick}
 					onExpandClick={this.props.onExpandClick}

--- a/components/tree/private/branch.jsx
+++ b/components/tree/private/branch.jsx
@@ -182,12 +182,12 @@ const handleKeyDownEnter = (event, props) => {
 const handleKeyDown = (event, props) => {
 	mapKeyEventCallbacks(event, {
 		callbacks: {
-			[KEYS.DOWN]: { callback: (event) => handleKeyDownDown(event, props) },
-			[KEYS.UP]: { callback: (event) => handleKeyDownUp(event, props) },
-			[KEYS.RIGHT]: { callback: (event) => handleKeyDownRight(event, props) },
-			[KEYS.LEFT]: { callback: (event) => handleKeyDownLeft(event, props) },
-			[KEYS.SPACE]: { callback: (event) => handleKeyDownSpace(event, props) },
-			[KEYS.ENTER]: { callback: (event) => handleKeyDownEnter(event, props) },
+			[KEYS.DOWN]: { callback: (evt) => handleKeyDownDown(evt, props) },
+			[KEYS.UP]: { callback: (evt) => handleKeyDownUp(evt, props) },
+			[KEYS.RIGHT]: { callback: (evt) => handleKeyDownRight(evt, props) },
+			[KEYS.LEFT]: { callback: (evt) => handleKeyDownLeft(evt, props) },
+			[KEYS.SPACE]: { callback: (evt) => handleKeyDownSpace(evt, props) },
+			[KEYS.ENTER]: { callback: (evt) => handleKeyDownEnter(evt, props) },
 		},
 	});
 };

--- a/components/tree/private/branch.jsx
+++ b/components/tree/private/branch.jsx
@@ -459,6 +459,7 @@ const Branch = (props) => {
 						treeHasFocus={props.treeHasFocus}
 						onNodeBlur={props.onNodeBlur}
 						onClick={props.onClick}
+						onExpandClick={onExpandClick}
 						searchTerm={searchTerm}
 						treeIndex={treeIndex}
 						treeId={treeId}

--- a/components/tree/private/branch.jsx
+++ b/components/tree/private/branch.jsx
@@ -33,7 +33,6 @@ import EventUtil from '../../../utilities/event';
 import KEYS from '../../../utilities/key-code';
 import mapKeyEventCallbacks from '../../../utilities/key-callbacks';
 
-
 // ## Constants
 import { TREE_BRANCH } from '../../../utilities/constants';
 
@@ -74,13 +73,13 @@ const handleScroll = (event, props) => {
 };
 
 const findNextNode = (flattenedNodes, node) => {
-	const nodes = flattenedNodes.map(((flattenedNode) => flattenedNode.node));
+	const nodes = flattenedNodes.map((flattenedNode) => flattenedNode.node);
 	const index = nodes.indexOf(node);
 	return flattenedNodes[(index + 1) % flattenedNodes.length];
 };
 
 const findPreviousNode = (flattenedNodes, node) => {
-	const nodes = flattenedNodes.map(((flattenedNode) => flattenedNode.node));
+	const nodes = flattenedNodes.map((flattenedNode) => flattenedNode.node);
 	let index = nodes.indexOf(node) - 1;
 	if (index < 0) {
 		index += flattenedNodes.length;
@@ -95,16 +94,20 @@ const handleKeyDownDown = (event, props) => {
 			const flattenedNode = findNextNode(props.flattenedNodes, props.node);
 			props.onNodeFocus(event, {
 				node: flattenedNode.node,
-				treeIndex: flattenedNode.treeIndex
+				treeIndex: flattenedNode.treeIndex,
 			});
 		} else {
 			// Select the next visible node
 			const flattenedNode = findNextNode(props.flattenedNodes, props.node);
-			props.onClick(event, {
-				node: flattenedNode.node,
-				select: true,
-				treeIndex: flattenedNode.treeIndex,
-			}, true);
+			props.onClick(
+				event,
+				{
+					node: flattenedNode.node,
+					select: true,
+					treeIndex: flattenedNode.treeIndex,
+				},
+				true
+			);
 		}
 	}
 };
@@ -116,16 +119,20 @@ const handleKeyDownUp = (event, props) => {
 			const flattenedNode = findPreviousNode(props.flattenedNodes, props.node);
 			props.onNodeFocus(event, {
 				node: flattenedNode.node,
-				treeIndex: flattenedNode.treeIndex
+				treeIndex: flattenedNode.treeIndex,
 			});
 		} else {
 			// Go to the previous visible node
 			const flattenedNode = findPreviousNode(props.flattenedNodes, props.node);
-			props.onClick(event, {
-				node: flattenedNode.node,
-				select: true,
-				treeIndex: flattenedNode.treeIndex,
-			}, true);
+			props.onClick(
+				event,
+				{
+					node: flattenedNode.node,
+					select: true,
+					treeIndex: flattenedNode.treeIndex,
+				},
+				true
+			);
 		}
 	}
 };
@@ -144,14 +151,20 @@ const handleKeyDownLeft = (event, props) => {
 	if (props.node.expanded) {
 		handleExpandClick(event, props);
 	} else {
-		const nodes = props.flattenedNodes.map(((flattenedNode) => flattenedNode.node));
+		const nodes = props.flattenedNodes.map(
+			(flattenedNode) => flattenedNode.node
+		);
 		const index = nodes.indexOf(props.parent);
 		if (index !== -1) {
-			props.onClick(event, {
-				node: props.parent,
-				select: true,
-				treeIndex: props.flattenedNodes[index].treeIndex,
-			}, true);
+			props.onClick(
+				event,
+				{
+					node: props.parent,
+					select: true,
+					treeIndex: props.flattenedNodes[index].treeIndex,
+				},
+				true
+			);
 		}
 	}
 };
@@ -186,8 +199,11 @@ const handleFocus = (event, props) => {
 };
 
 const getTabIndex = (props) => {
-	if (props.treeIndex === props.focusedNodeIndex ||
-		(props.selectedNodeIndexes.length === 0 && props.treeIndex === props.flattenedNodes[0].treeIndex)) {
+	if (
+		props.treeIndex === props.focusedNodeIndex ||
+		(props.selectedNodeIndexes.length === 0 &&
+			props.treeIndex === props.flattenedNodes[0].treeIndex)
+	) {
 		return 0;
 	}
 	return -1;
@@ -286,7 +302,11 @@ const renderBranch = (children, props) => {
 			role="treeitem"
 			aria-level={props.level}
 			aria-expanded={isExpanded ? 'true' : 'false'}
-			aria-label={props.node.nodes && props.node.nodes.length > 0 ? props.node.label : null}
+			aria-label={
+				props.node.nodes && props.node.nodes.length > 0
+					? props.node.label
+					: null
+			}
 			tabIndex={getTabIndex(props)}
 			onKeyDown={(event) => handleKeyDown(event, props)}
 			onFocus={(event) => handleFocus(event, props)}
@@ -402,7 +422,6 @@ renderBranch.propTypes = {
 	 * This node's parent.
 	 */
 	parent: PropTypes.object,
-
 };
 
 /**

--- a/components/tree/private/branch.jsx
+++ b/components/tree/private/branch.jsx
@@ -89,51 +89,33 @@ const findPreviousNode = (flattenedNodes, node) => {
 
 const handleKeyDownDown = (event, props) => {
 	if (props.focusedNodeIndex === props.treeIndex) {
-		if (event.ctrlKey) {
-			// Focus the next visible node
-			const flattenedNode = findNextNode(props.flattenedNodes, props.node);
-			props.onNodeFocus(event, {
+		// Select the next visible node
+		const flattenedNode = findNextNode(props.flattenedNodes, props.node);
+		props.onClick(
+			event,
+			{
 				node: flattenedNode.node,
+				select: true,
 				treeIndex: flattenedNode.treeIndex,
-			});
-		} else {
-			// Select the next visible node
-			const flattenedNode = findNextNode(props.flattenedNodes, props.node);
-			props.onClick(
-				event,
-				{
-					node: flattenedNode.node,
-					select: true,
-					treeIndex: flattenedNode.treeIndex,
-				},
-				true
-			);
-		}
+			},
+			true
+		);
 	}
 };
 
 const handleKeyDownUp = (event, props) => {
 	if (props.focusedNodeIndex === props.treeIndex) {
-		if (event.ctrlKey) {
-			// Focus the previous visible node
-			const flattenedNode = findPreviousNode(props.flattenedNodes, props.node);
-			props.onNodeFocus(event, {
+		// Go to the previous visible node
+		const flattenedNode = findPreviousNode(props.flattenedNodes, props.node);
+		props.onClick(
+			event,
+			{
 				node: flattenedNode.node,
+				select: true,
 				treeIndex: flattenedNode.treeIndex,
-			});
-		} else {
-			// Go to the previous visible node
-			const flattenedNode = findPreviousNode(props.flattenedNodes, props.node);
-			props.onClick(
-				event,
-				{
-					node: flattenedNode.node,
-					select: true,
-					treeIndex: flattenedNode.treeIndex,
-				},
-				true
-			);
-		}
+			},
+			true
+		);
 	}
 };
 
@@ -169,12 +151,6 @@ const handleKeyDownLeft = (event, props) => {
 	}
 };
 
-const handleKeyDownSpace = (event, props) => {
-	if (event.ctrlKey) {
-		handleClick(event, props);
-	}
-};
-
 const handleKeyDownEnter = (event, props) => {
 	handleClick(event, props);
 };
@@ -186,7 +162,6 @@ const handleKeyDown = (event, props) => {
 			[KEYS.UP]: { callback: (evt) => handleKeyDownUp(evt, props) },
 			[KEYS.RIGHT]: { callback: (evt) => handleKeyDownRight(evt, props) },
 			[KEYS.LEFT]: { callback: (evt) => handleKeyDownLeft(evt, props) },
-			[KEYS.SPACE]: { callback: (evt) => handleKeyDownSpace(evt, props) },
 			[KEYS.ENTER]: { callback: (evt) => handleKeyDownEnter(evt, props) },
 		},
 	});
@@ -310,8 +285,9 @@ const renderBranch = (children, props) => {
 			tabIndex={getTabIndex(props)}
 			onKeyDown={(event) => handleKeyDown(event, props)}
 			onFocus={(event) => handleFocus(event, props)}
+			onBlur={props.onNodeBlur}
 			ref={(component) => {
-				if (component && isFocused) {
+				if (props.treeHasFocus && component && isFocused) {
 					component.focus();
 				}
 			}}
@@ -415,9 +391,13 @@ renderBranch.propTypes = {
 	 */
 	focusedNodeIndex: PropTypes.string,
 	/**
-	 * Callback for when a node is focused.
+	 * Callback for when a node is blurred.
 	 */
-	onNodeFocus: PropTypes.func,
+	onNodeBlur: PropTypes.func,
+	/**
+	 * Sets focus on render.
+	 */
+	treeHasFocus: PropTypes.bool,
 	/**
 	 * This node's parent.
 	 */
@@ -454,7 +434,8 @@ const Branch = (props) => {
 						flattenedNodes={props.flattenedNodes}
 						selectedNodeIndexes={props.selectedNodeIndexes}
 						focusedNodeIndex={props.focusedNodeIndex}
-						onNodeFocus={props.onNodeFocus}
+						treeHasFocus={props.treeHasFocus}
+						onNodeBlur={props.onNodeBlur}
 						nodes={node.nodes}
 						onClick={props.onClick}
 						onExpandClick={onExpandClick}
@@ -475,7 +456,8 @@ const Branch = (props) => {
 						flattenedNodes={props.flattenedNodes}
 						selectedNodeIndexes={props.selectedNodeIndexes}
 						focusedNodeIndex={props.focusedNodeIndex}
-						onNodeFocus={props.onNodeFocus}
+						treeHasFocus={props.treeHasFocus}
+						onNodeBlur={props.onNodeBlur}
 						onClick={props.onClick}
 						searchTerm={searchTerm}
 						treeIndex={treeIndex}
@@ -571,9 +553,13 @@ Branch.propTypes = {
 	 */
 	focusedNodeIndex: PropTypes.string,
 	/**
-	 * Callback for when a node is focused.
+	 * Callback for when a node is blurred.
 	 */
-	onNodeFocus: PropTypes.func,
+	onNodeBlur: PropTypes.func,
+	/**
+	 * Sets focus on render.
+	 */
+	treeHasFocus: PropTypes.bool,
 	/**
 	 * This node's parent.
 	 */

--- a/components/tree/private/branch.jsx
+++ b/components/tree/private/branch.jsx
@@ -129,6 +129,17 @@ const handleKeyDownRight = (event, props) => {
 const handleKeyDownLeft = (event, props) => {
 	if (props.node.expanded) {
 		handleExpandClick(event, props);
+	} else {
+		const nodes = props.flattenedNodes.map(((flattenedNode) => flattenedNode.node));
+		const index = nodes.indexOf(props.parent);
+		if (index !== -1) {
+			handleClick(event, props);
+			props.onClick(event, {
+				node: props.parent,
+				select: true,
+				treeIndex: props.flattenedNodes[index].treeIndex,
+			});
+		}
 	}
 };
 
@@ -331,10 +342,14 @@ renderBranch.propTypes = {
 	 */
 	treeIndex: PropTypes.string,
 	/**
-	 * Key down on the branch is triggered.
+	 * Flattened tree structure.
 	 */
-	onKeyDown: PropTypes.func,
-	root: PropTypes.object,
+	flattenedNodes: PropTypes.arrayOf(PropTypes.object),
+	/**
+	 * This node's parent.
+	 */
+	parent: PropTypes.object,
+
 };
 
 /**
@@ -466,10 +481,13 @@ Branch.propTypes = {
 	 */
 	treeIndex: PropTypes.string,
 	/**
-	 * Key down on the branch is triggered.
+	 * Flattened tree structure.
 	 */
-	onKeyDown: PropTypes.func,
-	flattenedNodes: PropTypes.object,
+	flattenedNodes: PropTypes.arrayOf(PropTypes.object),
+	/**
+	 * This node's parent.
+	 */
+	parent: PropTypes.object,
 };
 
 Branch.defaultProps = {

--- a/components/tree/private/item.jsx
+++ b/components/tree/private/item.jsx
@@ -43,13 +43,13 @@ const handleClick = (event, props) => {
 };
 
 const findNextNode = (flattenedNodes, node) => {
-	const nodes = flattenedNodes.map(((flattenedNode) => flattenedNode.node));
+	const nodes = flattenedNodes.map((flattenedNode) => flattenedNode.node);
 	const index = nodes.indexOf(node);
 	return flattenedNodes[(index + 1) % flattenedNodes.length];
 };
 
 const findPreviousNode = (flattenedNodes, node) => {
-	const nodes = flattenedNodes.map(((flattenedNode) => flattenedNode.node));
+	const nodes = flattenedNodes.map((flattenedNode) => flattenedNode.node);
 	let index = nodes.indexOf(node) - 1;
 	if (index < 0) {
 		index += flattenedNodes.length;
@@ -64,16 +64,20 @@ const handleKeyDownDown = (event, props) => {
 			const flattenedNode = findNextNode(props.flattenedNodes, props.node);
 			props.onNodeFocus(event, {
 				node: flattenedNode.node,
-				treeIndex: flattenedNode.treeIndex
+				treeIndex: flattenedNode.treeIndex,
 			});
 		} else {
 			// Select the next visible node
 			const flattenedNode = findNextNode(props.flattenedNodes, props.node);
-			props.onClick(event, {
-				node: flattenedNode.node,
-				select: true,
-				treeIndex: flattenedNode.treeIndex,
-			}, true);
+			props.onClick(
+				event,
+				{
+					node: flattenedNode.node,
+					select: true,
+					treeIndex: flattenedNode.treeIndex,
+				},
+				true
+			);
 		}
 	}
 };
@@ -85,28 +89,36 @@ const handleKeyDownUp = (event, props) => {
 			const flattenedNode = findPreviousNode(props.flattenedNodes, props.node);
 			props.onNodeFocus(event, {
 				node: flattenedNode.node,
-				treeIndex: flattenedNode.treeIndex
+				treeIndex: flattenedNode.treeIndex,
 			});
 		} else {
 			// Go to the previous visible node
 			const flattenedNode = findPreviousNode(props.flattenedNodes, props.node);
-			props.onClick(event, {
-				node: flattenedNode.node,
-				select: true,
-				treeIndex: flattenedNode.treeIndex,
-			}, true);
+			props.onClick(
+				event,
+				{
+					node: flattenedNode.node,
+					select: true,
+					treeIndex: flattenedNode.treeIndex,
+				},
+				true
+			);
 		}
 	}
 };
 
 const handleKeyDownLeft = (event, props) => {
-	const nodes = props.flattenedNodes.map(((flattenedNode) => flattenedNode.node));
+	const nodes = props.flattenedNodes.map((flattenedNode) => flattenedNode.node);
 	const index = nodes.indexOf(props.parent);
-	props.onClick(event, {
-		node: props.parent,
-		select: true,
-		treeIndex: props.flattenedNodes[index].treeIndex,
-	}, true);
+	props.onClick(
+		event,
+		{
+			node: props.parent,
+			select: true,
+			treeIndex: props.flattenedNodes[index].treeIndex,
+		},
+		true
+	);
 };
 
 const handleKeyDownSpace = (event, props) => {
@@ -120,15 +132,19 @@ const handleKeyDownEnter = (event, props) => {
 };
 
 const handleKeyDown = (event, props) => {
-	mapKeyEventCallbacks(event, {
-		callbacks: {
-			[KEYS.DOWN]: { callback: (event) => handleKeyDownDown(event, props) },
-			[KEYS.UP]: { callback: (event) => handleKeyDownUp(event, props) },
-			[KEYS.LEFT]: { callback: (event) => handleKeyDownLeft(event, props) },
-			[KEYS.SPACE]: { callback: (event) => handleKeyDownSpace(event, props) },
-			[KEYS.ENTER]: { callback: (event) => handleKeyDownEnter(event, props) },
+	mapKeyEventCallbacks(
+		event,
+		{
+			callbacks: {
+				[KEYS.DOWN]: { callback: (event) => handleKeyDownDown(event, props) },
+				[KEYS.UP]: { callback: (event) => handleKeyDownUp(event, props) },
+				[KEYS.LEFT]: { callback: (event) => handleKeyDownLeft(event, props) },
+				[KEYS.SPACE]: { callback: (event) => handleKeyDownSpace(event, props) },
+				[KEYS.ENTER]: { callback: (event) => handleKeyDownEnter(event, props) },
+			},
 		},
-	}, true);
+		true
+	);
 };
 
 const handleFocus = (event, props) => {
@@ -138,8 +154,11 @@ const handleFocus = (event, props) => {
 };
 
 const getTabIndex = (props) => {
-	if (props.treeIndex === props.focusedNodeIndex ||
-		(props.selectedNodeIndexes.length === 0 && props.treeIndex === props.flattenedNodes[0].treeIndex)) {
+	if (
+		props.treeIndex === props.focusedNodeIndex ||
+		(props.selectedNodeIndexes.length === 0 &&
+			props.treeIndex === props.flattenedNodes[0].treeIndex)
+	) {
 		return 0;
 	}
 	return -1;
@@ -265,7 +284,7 @@ Item.propTypes = {
 
 Item.defaultProps = {
 	selected: false,
-	selectedNodeIndexes: []
+	selectedNodeIndexes: [],
 };
 
 export default Item;

--- a/components/tree/private/item.jsx
+++ b/components/tree/private/item.jsx
@@ -136,11 +136,11 @@ const handleKeyDown = (event, props) => {
 		event,
 		{
 			callbacks: {
-				[KEYS.DOWN]: { callback: (event) => handleKeyDownDown(event, props) },
-				[KEYS.UP]: { callback: (event) => handleKeyDownUp(event, props) },
-				[KEYS.LEFT]: { callback: (event) => handleKeyDownLeft(event, props) },
-				[KEYS.SPACE]: { callback: (event) => handleKeyDownSpace(event, props) },
-				[KEYS.ENTER]: { callback: (event) => handleKeyDownEnter(event, props) },
+				[KEYS.DOWN]: { callback: (evt) => handleKeyDownDown(evt, props) },
+				[KEYS.UP]: { callback: (evt) => handleKeyDownUp(evt, props) },
+				[KEYS.LEFT]: { callback: (evt) => handleKeyDownLeft(evt, props) },
+				[KEYS.SPACE]: { callback: (evt) => handleKeyDownSpace(evt, props) },
+				[KEYS.ENTER]: { callback: (evt) => handleKeyDownEnter(evt, props) },
 			},
 		},
 		true

--- a/components/tree/private/item.jsx
+++ b/components/tree/private/item.jsx
@@ -59,51 +59,33 @@ const findPreviousNode = (flattenedNodes, node) => {
 
 const handleKeyDownDown = (event, props) => {
 	if (props.focusedNodeIndex === props.treeIndex) {
-		if (event.ctrlKey) {
-			// Focus the next visible node
-			const flattenedNode = findNextNode(props.flattenedNodes, props.node);
-			props.onNodeFocus(event, {
+		// Select the next visible node
+		const flattenedNode = findNextNode(props.flattenedNodes, props.node);
+		props.onClick(
+			event,
+			{
 				node: flattenedNode.node,
+				select: true,
 				treeIndex: flattenedNode.treeIndex,
-			});
-		} else {
-			// Select the next visible node
-			const flattenedNode = findNextNode(props.flattenedNodes, props.node);
-			props.onClick(
-				event,
-				{
-					node: flattenedNode.node,
-					select: true,
-					treeIndex: flattenedNode.treeIndex,
-				},
-				true
-			);
-		}
+			},
+			true
+		);
 	}
 };
 
 const handleKeyDownUp = (event, props) => {
 	if (props.focusedNodeIndex === props.treeIndex) {
-		if (event.ctrlKey) {
-			// Focus the previous visible node
-			const flattenedNode = findPreviousNode(props.flattenedNodes, props.node);
-			props.onNodeFocus(event, {
+		// Go to the previous visible node
+		const flattenedNode = findPreviousNode(props.flattenedNodes, props.node);
+		props.onClick(
+			event,
+			{
 				node: flattenedNode.node,
+				select: true,
 				treeIndex: flattenedNode.treeIndex,
-			});
-		} else {
-			// Go to the previous visible node
-			const flattenedNode = findPreviousNode(props.flattenedNodes, props.node);
-			props.onClick(
-				event,
-				{
-					node: flattenedNode.node,
-					select: true,
-					treeIndex: flattenedNode.treeIndex,
-				},
-				true
-			);
-		}
+			},
+			true
+		);
 	}
 };
 
@@ -121,12 +103,6 @@ const handleKeyDownLeft = (event, props) => {
 	);
 };
 
-const handleKeyDownSpace = (event, props) => {
-	if (event.ctrlKey) {
-		handleClick(event, props);
-	}
-};
-
 const handleKeyDownEnter = (event, props) => {
 	handleClick(event, props);
 };
@@ -139,7 +115,6 @@ const handleKeyDown = (event, props) => {
 				[KEYS.DOWN]: { callback: (evt) => handleKeyDownDown(evt, props) },
 				[KEYS.UP]: { callback: (evt) => handleKeyDownUp(evt, props) },
 				[KEYS.LEFT]: { callback: (evt) => handleKeyDownLeft(evt, props) },
-				[KEYS.SPACE]: { callback: (evt) => handleKeyDownSpace(evt, props) },
 				[KEYS.ENTER]: { callback: (evt) => handleKeyDownEnter(evt, props) },
 			},
 		},
@@ -176,11 +151,13 @@ const Item = (props) => {
 			id={`${props.treeId}-${props.node.id}`}
 			role="treeitem"
 			aria-level={props.level}
+			aria-selected={isSelected ? 'true' : 'false'}
 			tabIndex={getTabIndex(props)}
 			onKeyDown={(event) => handleKeyDown(event, props)}
 			onFocus={(event) => handleFocus(event, props)}
+			onBlur={props.onNodeBlur}
 			ref={(component) => {
-				if (component && isFocused) {
+				if (props.treeHasFocus && component && isFocused) {
 					component.focus();
 				}
 			}}
@@ -190,7 +167,6 @@ const Item = (props) => {
 				className={classNames('slds-tree__item', {
 					'slds-is-selected': isSelected,
 				})}
-				aria-selected={isSelected ? 'true' : 'false'}
 				onClick={(event) => {
 					handleClick(event, props);
 				}}
@@ -273,9 +249,13 @@ Item.propTypes = {
 	 */
 	focusedNodeIndex: PropTypes.string,
 	/**
-	 * Callback for when a node is focused.
+	 * Callback for when a node is blurred.
 	 */
-	onNodeFocus: PropTypes.func,
+	onNodeBlur: PropTypes.func,
+	/**
+	 * Sets focus on render.
+	 */
+	treeHasFocus: PropTypes.bool,
 	/**
 	 * This node's parent.
 	 */

--- a/components/tree/private/item.jsx
+++ b/components/tree/private/item.jsx
@@ -92,15 +92,22 @@ const handleKeyDownUp = (event, props) => {
 const handleKeyDownLeft = (event, props) => {
 	const nodes = props.flattenedNodes.map((flattenedNode) => flattenedNode.node);
 	const index = nodes.indexOf(props.parent);
-	props.onClick(
-		event,
-		{
+	if (index !== -1) {
+		props.onExpandClick(event, {
 			node: props.parent,
-			select: true,
+			expand: !props.parent.expanded,
 			treeIndex: props.flattenedNodes[index].treeIndex,
-		},
-		true
-	);
+		});
+		props.onClick(
+			event,
+			{
+				node: props.parent,
+				select: true,
+				treeIndex: props.flattenedNodes[index].treeIndex,
+			},
+			true
+		);
+	}
 };
 
 const handleKeyDownEnter = (event, props) => {
@@ -224,6 +231,10 @@ Item.propTypes = {
 	 * Function that will run whenever an item or branch is clicked.
 	 */
 	onClick: PropTypes.func,
+	/**
+	 * This function triggers when the expand or collapse icon is clicked.
+	 */
+	onExpandClick: PropTypes.func.isRequired,
 	/**
 	 * Highlights term if found in node label
 	 */

--- a/components/tree/private/item.jsx
+++ b/components/tree/private/item.jsx
@@ -91,10 +91,12 @@ const handleKeyDownUp = (event, props) => {
 
 const handleKeyDownLeft = (event, props) => {
 	handleClick(event, props);
+	const nodes = props.flattenedNodes.map(((flattenedNode) => flattenedNode.node));
+	const index = nodes.indexOf(props.parent);
 	props.onClick(event, {
 		node: props.parent,
 		select: true,
-		treeIndex: '', // TODO
+		treeIndex: props.flattenedNodes[index].treeIndex,
 	});
 };
 
@@ -203,10 +205,13 @@ Item.propTypes = {
 	 */
 	treeIndex: PropTypes.string,
 	/**
-	 * Key down on the item is triggered.
+	 * Flattened tree structure.
 	 */
-	onKeyDown: PropTypes.func,
-	flattenedNodes: PropTypes.object,
+	flattenedNodes: PropTypes.arrayOf(PropTypes.object),
+	/**
+	 * This node's parent.
+	 */
+	parent: PropTypes.object,
 };
 
 Item.defaultProps = {

--- a/components/tree/private/item.jsx
+++ b/components/tree/private/item.jsx
@@ -58,46 +58,65 @@ const findPreviousNode = (flattenedNodes, node) => {
 };
 
 const handleKeyDownDown = (event, props) => {
-	if (props.node.selected) {
-		// Go to the next visible node
-		handleClick(event, props);
-		const flattenedNode = findNextNode(props.flattenedNodes, props.node);
-		props.onClick(event, {
-			node: flattenedNode.node,
-			select: true,
-			treeIndex: flattenedNode.treeIndex,
-		});
-	} else {
-		// Focus is on this node but it's not selected, so select it
-		handleClick(event, props);
+	if (props.focusedNodeIndex === props.treeIndex) {
+		if (event.ctrlKey) {
+			// Focus the next visible node
+			const flattenedNode = findNextNode(props.flattenedNodes, props.node);
+			props.onNodeFocus(event, {
+				node: flattenedNode.node,
+				treeIndex: flattenedNode.treeIndex
+			});
+		} else {
+			// Select the next visible node
+			const flattenedNode = findNextNode(props.flattenedNodes, props.node);
+			props.onClick(event, {
+				node: flattenedNode.node,
+				select: true,
+				treeIndex: flattenedNode.treeIndex,
+			}, true);
+		}
 	}
 };
 
 const handleKeyDownUp = (event, props) => {
-	if (props.node.selected) {
-		// Go to the next visible node
-		handleClick(event, props);
-		const flattenedNode = findPreviousNode(props.flattenedNodes, props.node);
-		props.onClick(event, {
-			node: flattenedNode.node,
-			select: true,
-			treeIndex: flattenedNode.treeIndex,
-		});
-	} else {
-		// Focus is on this node but it's not selected, so select it
-		handleClick(event, props);
+	if (props.focusedNodeIndex === props.treeIndex) {
+		if (event.ctrlKey) {
+			// Focus the previous visible node
+			const flattenedNode = findPreviousNode(props.flattenedNodes, props.node);
+			props.onNodeFocus(event, {
+				node: flattenedNode.node,
+				treeIndex: flattenedNode.treeIndex
+			});
+		} else {
+			// Go to the previous visible node
+			const flattenedNode = findPreviousNode(props.flattenedNodes, props.node);
+			props.onClick(event, {
+				node: flattenedNode.node,
+				select: true,
+				treeIndex: flattenedNode.treeIndex,
+			}, true);
+		}
 	}
 };
 
 const handleKeyDownLeft = (event, props) => {
-	handleClick(event, props);
 	const nodes = props.flattenedNodes.map(((flattenedNode) => flattenedNode.node));
 	const index = nodes.indexOf(props.parent);
 	props.onClick(event, {
 		node: props.parent,
 		select: true,
 		treeIndex: props.flattenedNodes[index].treeIndex,
-	});
+	}, true);
+};
+
+const handleKeyDownSpace = (event, props) => {
+	if (event.ctrlKey) {
+		handleClick(event, props);
+	}
+};
+
+const handleKeyDownEnter = (event, props) => {
+	handleClick(event, props);
 };
 
 const handleKeyDown = (event, props) => {
@@ -106,8 +125,24 @@ const handleKeyDown = (event, props) => {
 			[KEYS.DOWN]: { callback: (event) => handleKeyDownDown(event, props) },
 			[KEYS.UP]: { callback: (event) => handleKeyDownUp(event, props) },
 			[KEYS.LEFT]: { callback: (event) => handleKeyDownLeft(event, props) },
+			[KEYS.SPACE]: { callback: (event) => handleKeyDownSpace(event, props) },
+			[KEYS.ENTER]: { callback: (event) => handleKeyDownEnter(event, props) },
 		},
-	});
+	}, true);
+};
+
+const handleFocus = (event, props) => {
+	if (!props.focusedNodeIndex) {
+		handleClick(event, props);
+	}
+};
+
+const getTabIndex = (props) => {
+	if (props.treeIndex === props.focusedNodeIndex ||
+		(props.selectedNodeIndexes.length === 0 && props.treeIndex === props.flattenedNodes[0].treeIndex)) {
+		return 0;
+	}
+	return -1;
 };
 
 /**
@@ -115,16 +150,18 @@ const handleKeyDown = (event, props) => {
  */
 const Item = (props) => {
 	const isSelected = props.node.selected;
+	const isFocused = props.treeIndex === props.focusedNodeIndex;
 
 	return (
 		<li
 			id={`${props.treeId}-${props.node.id}`}
 			role="treeitem"
 			aria-level={props.level}
-			tabIndex="0"
+			tabIndex={getTabIndex(props)}
 			onKeyDown={(event) => handleKeyDown(event, props)}
+			onFocus={(event) => handleFocus(event, props)}
 			ref={(component) => {
-				if (component && isSelected) {
+				if (component && isFocused) {
 					component.focus();
 				}
 			}}
@@ -209,6 +246,18 @@ Item.propTypes = {
 	 */
 	flattenedNodes: PropTypes.arrayOf(PropTypes.object),
 	/**
+	 * Tree indexes of nodes that are currently selected.
+	 */
+	selectedNodeIndexes: PropTypes.arrayOf(PropTypes.string),
+	/**
+	 * Tree index of the node that is currently focused.
+	 */
+	focusedNodeIndex: PropTypes.string,
+	/**
+	 * Callback for when a node is focused.
+	 */
+	onNodeFocus: PropTypes.func,
+	/**
 	 * This node's parent.
 	 */
 	parent: PropTypes.object,
@@ -216,6 +265,7 @@ Item.propTypes = {
 
 Item.defaultProps = {
 	selected: false,
+	selectedNodeIndexes: []
 };
 
 export default Item;

--- a/package.json
+++ b/package.json
@@ -648,7 +648,7 @@
 		},
 		{
 			"component": "tree",
-			"status": "prototype",
+			"status": "prod",
 			"display-name": "Tree",
 			"SLDS-component-path": "/components/tree"
 		},

--- a/package.json
+++ b/package.json
@@ -650,6 +650,14 @@
 			"component": "tree",
 			"status": "prod",
 			"display-name": "Tree",
+			"last-accessibility-review": {
+				"date-iso-8601": "2018/05/04",
+				"commit-sha": "5fdeb31982a42cbd37a70d96d6257142cd7eec72"
+			},
+			"last-slds-markup-review": {
+				"date-iso-8601": "2018/05/04",
+				"commit-sha": "5fdeb31982a42cbd37a70d96d6257142cd7eec72"
+			},
 			"SLDS-component-path": "/components/tree"
 		},
 		{


### PR DESCRIPTION
This includes accessibility changes for the Tree component.
- Add role=”presentation” to buttons and anchors
- Add keyboard navigation: up/down to navigate, left/right to open/close
- Add aria-label=”{the label for that node}”

@interactivellama I'd like to get initial impressions on this approach.  Can you let me know what you think?

Fixes https://github.com/salesforce/design-system-react/issues/609

---

### Pull Request Review checklist (do not remove)

* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [x] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [x] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at snapshot strings.
* [x] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [x] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.