### PR TITLE
Allow importing lookup DefaultSectionDivider

### DIFF
--- a/components/index.js
+++ b/components/index.js
@@ -126,6 +126,12 @@ export InputIcon from './icon/input-icon';
 
 export SLDSLookup from './lookup';
 export Lookup from './lookup';
+export SLDSLookupDefaultFooter from './lookup/menu/default-footer';
+export LookupDefaultFooter from './lookup/menu/default-footer';
+export SLDSLookupDefaultHeader from './lookup/menu/default-header';
+export LookupDefaultHeader from './lookup/menu/default-header';
+export SLDSLookupDefaultSectionDivider from './lookup/menu/default-section-divider';
+export LookupDefaultSectionDivider from './lookup/menu/default-section-divider';
 
 export SLDSMediaObject from './media-object';
 export MediaObject from './media-object';


### PR DESCRIPTION
I do know that lookup is currently deprecated, but we still use it and I've spent a full day trying to migrate one lookup to a combobox.

In the meantime this DefaultSectionDivider used to be exposed in es6 modules, but not in commonjs. It'd be a whole world easier if we just exposed it in both until the lookup component is actually killed. Refactoring is not part of the scope of upgrading DSR for me.