### PR TITLE
Fix bug with sortable causing focusable attribute to throw an error

### DIFF
--- a/components/data-table/__tests__/__snapshots__/data-table.snapshot-test.jsx.snap
+++ b/components/data-table/__tests__/__snapshots__/data-table.snapshot-test.jsx.snap
@@ -19,21 +19,21 @@ exports[`DataTable Advanced HTML Snapshot 1`] = `
         </th>
         <th aria-sort=\\"ascending\\" class=\\"slds-is-sortable slds-is-sorted\\" focusable=\\"true\\" scope=\\"col\\" style=\\"width:10rem;\\"><a href=\\"javascript:void(0)\\" class=\\"slds-th__action slds-text-link--reset\\" tabindex=\\"0\\"><span class=\\"slds-assistive-text\\">Sort </span><span class=\\"slds-truncate\\" title=\\"Name\\">Name</span><span><svg aria-hidden=\\"true\\" class=\\"slds-is-sortable__icon slds-icon slds-icon--x-small slds-icon-text-default\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#arrowup\\"></use></svg></span><span class=\\"slds-assistive-text\\" aria-live=\\"assertive\\" aria-atomic=\\"true\\">Sorted Ascending</span></a></th>
         <th
-          class=\\"\\" scope=\\"col\\" style=\\"width:8rem;\\">
+          class=\\"\\" focusable=\\"false\\" scope=\\"col\\" style=\\"width:8rem;\\">
           <div class=\\"slds-truncate\\">Account Name</div>
           </th>
-          <th class=\\"\\" scope=\\"col\\">
+          <th class=\\"\\" focusable=\\"false\\" scope=\\"col\\">
             <div class=\\"slds-truncate\\">Close Date</div>
           </th>
-          <th class=\\"\\" scope=\\"col\\">
+          <th class=\\"\\" focusable=\\"false\\" scope=\\"col\\">
             <div class=\\"slds-truncate\\">Stage</div>
           </th>
           <th class=\\"slds-is-sortable\\" focusable=\\"true\\" scope=\\"col\\"><a href=\\"javascript:void(0)\\" class=\\"slds-th__action slds-text-link--reset\\" tabindex=\\"0\\"><span class=\\"slds-assistive-text\\">Sort </span><span class=\\"slds-truncate\\" title=\\"Confidence\\">Confidence</span><span><svg aria-hidden=\\"true\\" class=\\"slds-is-sortable__icon slds-icon slds-icon--x-small slds-icon-text-default\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#arrowup\\"></use></svg></span></a></th>
           <th
-            class=\\"\\" scope=\\"col\\">
+            class=\\"\\" focusable=\\"false\\" scope=\\"col\\">
             <div class=\\"slds-truncate\\">Amount</div>
             </th>
-            <th class=\\"\\" scope=\\"col\\">
+            <th class=\\"\\" focusable=\\"false\\" scope=\\"col\\">
               <div class=\\"slds-truncate\\">Contact</div>
             </th>
             <th scope=\\"col\\" style=\\"width:3.25rem;\\">
@@ -164,25 +164,25 @@ exports[`DataTable Basic HTML Snapshot 1`] = `
   <table class=\\"slds-table slds-table--bordered slds-table--cell-buffer\\" id=\\"DataTableExample-1-default\\">
     <thead>
       <tr class=\\"slds-text-title--caps\\">
-        <th class=\\"\\" scope=\\"col\\">
+        <th class=\\"\\" focusable=\\"false\\" scope=\\"col\\">
           <div class=\\"slds-truncate\\">Opportunity Name</div>
         </th>
-        <th class=\\"\\" scope=\\"col\\">
+        <th class=\\"\\" focusable=\\"false\\" scope=\\"col\\">
           <div class=\\"slds-truncate\\">Account Name</div>
         </th>
-        <th class=\\"\\" scope=\\"col\\">
+        <th class=\\"\\" focusable=\\"false\\" scope=\\"col\\">
           <div class=\\"slds-truncate\\">Close Date</div>
         </th>
-        <th class=\\"\\" scope=\\"col\\">
+        <th class=\\"\\" focusable=\\"false\\" scope=\\"col\\">
           <div class=\\"slds-truncate\\">Stage</div>
         </th>
-        <th class=\\"\\" scope=\\"col\\">
+        <th class=\\"\\" focusable=\\"false\\" scope=\\"col\\">
           <div class=\\"slds-truncate\\">Confidence</div>
         </th>
-        <th class=\\"\\" scope=\\"col\\">
+        <th class=\\"\\" focusable=\\"false\\" scope=\\"col\\">
           <div class=\\"slds-truncate\\">Amount</div>
         </th>
-        <th class=\\"\\" scope=\\"col\\">
+        <th class=\\"\\" focusable=\\"false\\" scope=\\"col\\">
           <div class=\\"slds-truncate\\">Contact</div>
         </th>
       </tr>
@@ -263,25 +263,25 @@ exports[`DataTable Basic HTML Snapshot 1`] = `
   <table class=\\"slds-table slds-table--bordered slds-table--cell-buffer slds-table--striped\\" id=\\"DataTableExample-1-striped\\">
     <thead>
       <tr class=\\"slds-text-title--caps\\">
-        <th class=\\"\\" scope=\\"col\\">
+        <th class=\\"\\" focusable=\\"false\\" scope=\\"col\\">
           <div class=\\"slds-truncate\\">Opportunity Name</div>
         </th>
-        <th class=\\"\\" scope=\\"col\\">
+        <th class=\\"\\" focusable=\\"false\\" scope=\\"col\\">
           <div class=\\"slds-truncate\\">Account Name</div>
         </th>
-        <th class=\\"\\" scope=\\"col\\">
+        <th class=\\"\\" focusable=\\"false\\" scope=\\"col\\">
           <div class=\\"slds-truncate\\">Close Date</div>
         </th>
-        <th class=\\"\\" scope=\\"col\\">
+        <th class=\\"\\" focusable=\\"false\\" scope=\\"col\\">
           <div class=\\"slds-truncate\\">Stage</div>
         </th>
-        <th class=\\"\\" scope=\\"col\\">
+        <th class=\\"\\" focusable=\\"false\\" scope=\\"col\\">
           <div class=\\"slds-truncate\\">Confidence</div>
         </th>
-        <th class=\\"\\" scope=\\"col\\">
+        <th class=\\"\\" focusable=\\"false\\" scope=\\"col\\">
           <div class=\\"slds-truncate\\">Amount</div>
         </th>
-        <th class=\\"\\" scope=\\"col\\">
+        <th class=\\"\\" focusable=\\"false\\" scope=\\"col\\">
           <div class=\\"slds-truncate\\">Contact</div>
         </th>
       </tr>
@@ -362,25 +362,25 @@ exports[`DataTable Basic HTML Snapshot 1`] = `
   <table class=\\"slds-table slds-table--bordered slds-table--cell-buffer slds-no-row-hover\\" id=\\"DataTableExample-noRowHover\\">
     <thead>
       <tr class=\\"slds-text-title--caps\\">
-        <th class=\\"\\" scope=\\"col\\">
+        <th class=\\"\\" focusable=\\"false\\" scope=\\"col\\">
           <div class=\\"slds-truncate\\">Opportunity Name</div>
         </th>
-        <th class=\\"\\" scope=\\"col\\">
+        <th class=\\"\\" focusable=\\"false\\" scope=\\"col\\">
           <div class=\\"slds-truncate\\">Account Name</div>
         </th>
-        <th class=\\"\\" scope=\\"col\\">
+        <th class=\\"\\" focusable=\\"false\\" scope=\\"col\\">
           <div class=\\"slds-truncate\\">Close Date</div>
         </th>
-        <th class=\\"\\" scope=\\"col\\">
+        <th class=\\"\\" focusable=\\"false\\" scope=\\"col\\">
           <div class=\\"slds-truncate\\">Stage</div>
         </th>
-        <th class=\\"\\" scope=\\"col\\">
+        <th class=\\"\\" focusable=\\"false\\" scope=\\"col\\">
           <div class=\\"slds-truncate\\">Confidence</div>
         </th>
-        <th class=\\"\\" scope=\\"col\\">
+        <th class=\\"\\" focusable=\\"false\\" scope=\\"col\\">
           <div class=\\"slds-truncate\\">Amount</div>
         </th>
-        <th class=\\"\\" scope=\\"col\\">
+        <th class=\\"\\" focusable=\\"false\\" scope=\\"col\\">
           <div class=\\"slds-truncate\\">Contact</div>
         </th>
       </tr>
@@ -461,25 +461,25 @@ exports[`DataTable Basic HTML Snapshot 1`] = `
   <table class=\\"slds-table slds-table--bordered slds-table--cell-buffer slds-table--col-bordered\\" id=\\"DataTableExample-columnBordered\\">
     <thead>
       <tr class=\\"slds-text-title--caps\\">
-        <th class=\\"\\" scope=\\"col\\">
+        <th class=\\"\\" focusable=\\"false\\" scope=\\"col\\">
           <div class=\\"slds-truncate\\">Opportunity Name</div>
         </th>
-        <th class=\\"\\" scope=\\"col\\">
+        <th class=\\"\\" focusable=\\"false\\" scope=\\"col\\">
           <div class=\\"slds-truncate\\">Account Name</div>
         </th>
-        <th class=\\"\\" scope=\\"col\\">
+        <th class=\\"\\" focusable=\\"false\\" scope=\\"col\\">
           <div class=\\"slds-truncate\\">Close Date</div>
         </th>
-        <th class=\\"\\" scope=\\"col\\">
+        <th class=\\"\\" focusable=\\"false\\" scope=\\"col\\">
           <div class=\\"slds-truncate\\">Stage</div>
         </th>
-        <th class=\\"\\" scope=\\"col\\">
+        <th class=\\"\\" focusable=\\"false\\" scope=\\"col\\">
           <div class=\\"slds-truncate\\">Confidence</div>
         </th>
-        <th class=\\"\\" scope=\\"col\\">
+        <th class=\\"\\" focusable=\\"false\\" scope=\\"col\\">
           <div class=\\"slds-truncate\\">Amount</div>
         </th>
-        <th class=\\"\\" scope=\\"col\\">
+        <th class=\\"\\" focusable=\\"false\\" scope=\\"col\\">
           <div class=\\"slds-truncate\\">Contact</div>
         </th>
       </tr>
@@ -560,25 +560,25 @@ exports[`DataTable Basic HTML Snapshot 1`] = `
   <table class=\\"slds-table slds-table--compact slds-table--bordered slds-table--cell-buffer\\" id=\\"DataTableExample-compact\\">
     <thead>
       <tr class=\\"slds-text-title--caps\\">
-        <th class=\\"\\" scope=\\"col\\">
+        <th class=\\"\\" focusable=\\"false\\" scope=\\"col\\">
           <div class=\\"slds-truncate\\">Opportunity Name</div>
         </th>
-        <th class=\\"\\" scope=\\"col\\">
+        <th class=\\"\\" focusable=\\"false\\" scope=\\"col\\">
           <div class=\\"slds-truncate\\">Account Name</div>
         </th>
-        <th class=\\"\\" scope=\\"col\\">
+        <th class=\\"\\" focusable=\\"false\\" scope=\\"col\\">
           <div class=\\"slds-truncate\\">Close Date</div>
         </th>
-        <th class=\\"\\" scope=\\"col\\">
+        <th class=\\"\\" focusable=\\"false\\" scope=\\"col\\">
           <div class=\\"slds-truncate\\">Stage</div>
         </th>
-        <th class=\\"\\" scope=\\"col\\">
+        <th class=\\"\\" focusable=\\"false\\" scope=\\"col\\">
           <div class=\\"slds-truncate\\">Confidence</div>
         </th>
-        <th class=\\"\\" scope=\\"col\\">
+        <th class=\\"\\" focusable=\\"false\\" scope=\\"col\\">
           <div class=\\"slds-truncate\\">Amount</div>
         </th>
-        <th class=\\"\\" scope=\\"col\\">
+        <th class=\\"\\" focusable=\\"false\\" scope=\\"col\\">
           <div class=\\"slds-truncate\\">Contact</div>
         </th>
       </tr>

--- a/components/data-table/private/header-cell.jsx
+++ b/components/data-table/private/header-cell.jsx
@@ -133,7 +133,7 @@ const DataTableHeaderCell = createReactClass({
 					[`slds-is-sorted--${sortDirection}`]: sortDirection,
 					'slds-is-sorted--asc': isSorted && !sortDirection, // default for hover, up arrow is ascending which means A is at the top of the table, and Z is at the bottom. You have to think about row numbers abstracting, and not the visual order on the table.
 				})}
-				focusable={sortable ? true : false}
+				focusable={!!sortable}
 				scope="col"
 				style={width ? { width } : null}
 			>

--- a/components/data-table/private/header-cell.jsx
+++ b/components/data-table/private/header-cell.jsx
@@ -133,7 +133,7 @@ const DataTableHeaderCell = createReactClass({
 					[`slds-is-sorted--${sortDirection}`]: sortDirection,
 					'slds-is-sorted--asc': isSorted && !sortDirection, // default for hover, up arrow is ascending which means A is at the top of the table, and Z is at the bottom. You have to think about row numbers abstracting, and not the visual order on the table.
 				})}
-				focusable={sortable ? true : null}
+				focusable={sortable ? true : false}
 				scope="col"
 				style={width ? { width } : null}
 			>


### PR DESCRIPTION
Fixes #1328
focusable attribute on the `th` of `header-cell.js` must be a boolean, cannot be null

### Additional description

---

### Pull Request Review checklist (do not remove)

* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at snapshot strings.
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
