### PR TITLE
Trigger onOpen callback in Combobox

### DIFF
--- a/components/combobox/__tests__/combobox.browser-test.jsx
+++ b/components/combobox/__tests__/combobox.browser-test.jsx
@@ -90,6 +90,7 @@ const defaultProps = {
 		placeholder: 'Search Salesforce',
 	},
 	menuPosition: 'relative',
+	onOpen: () => {},
 };
 
 const propTypes = {
@@ -157,6 +158,9 @@ class DemoComponent extends React.Component {
 								selection: data.selection,
 							});
 						},
+						onOpen: (event) => {
+							this.props.onOpen();
+						}
 					}}
 					options={filter({
 						inputValue: this.state.inputValue,
@@ -417,6 +421,24 @@ describe('SLDSCombobox', function () {
 					.find('.slds-listbox__item.slds-listbox__status')
 					.text()
 			).to.equal('No matches found.');
+		});
+	});
+
+	describe('Input Onclick', () => {
+		const onOpenCallback = sinon.spy();
+		beforeEach(() => {
+			mountNode = createMountNode({ context: this });
+		});
+
+		afterEach(() => {
+			destroyMountNode({ wrapper, mountNode });
+		});
+
+		it('onOpen callback is called', function () {
+			wrapper = mount(<DemoComponent onOpen={onOpenCallback} />, { attachTo: mountNode });
+			const nodes = getNodes({ wrapper });
+			nodes.input.simulate('click', {});
+			expect(onOpenCallback.callCount).to.equal(1);
 		});
 	});
 });

--- a/components/combobox/combobox.jsx
+++ b/components/combobox/combobox.jsx
@@ -549,7 +549,7 @@ class Combobox extends React.Component {
 			if (currentOpenDropdown && isFunction(currentOpenDropdown.handleClose)) {
 				currentOpenDropdown.handleClose();
 			}
-
+		} else {
 			currentOpenDropdown = this;
 
 			this.setState({


### PR DESCRIPTION
Fixes #1338 

### Additional description

I found an issue in combobox.jsx where the passed-in onOpen callback is never triggered in handleOpen function.
Added a test for this change as well. Note that more component tests can be added to test the event trigger, but maybe not in this PR.
FYI - The three test failures below are not related to this PR, they occur without the changes.

![screen shot 2018-04-25 at 4 32 33 pm](https://user-images.githubusercontent.com/4957585/39278132-5590f082-48a6-11e8-892f-0b92fa3ef315.png)


### Pull Request Review checklist (do not remove)

* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [x] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at snapshot strings.
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.