### PR TITLE
Focus input if menu was actually open and not just requested to close

### DIFF
--- a/components/combobox/__tests__/combobox.browser-test.jsx
+++ b/components/combobox/__tests__/combobox.browser-test.jsx
@@ -160,7 +160,7 @@ class DemoComponent extends React.Component {
 						},
 						onOpen: (event) => {
 							this.props.onOpen();
-						}
+						},
 					}}
 					options={filter({
 						inputValue: this.state.inputValue,
@@ -435,7 +435,9 @@ describe('SLDSCombobox', function () {
 		});
 
 		it('onOpen callback is called', function () {
-			wrapper = mount(<DemoComponent onOpen={onOpenCallback} />, { attachTo: mountNode });
+			wrapper = mount(<DemoComponent onOpen={onOpenCallback} />, {
+				attachTo: mountNode,
+			});
 			const nodes = getNodes({ wrapper });
 			nodes.input.simulate('click', {});
 			expect(onOpenCallback.callCount).to.equal(1);


### PR DESCRIPTION
Replacement for #1187 with updated master branch pull down 
Fixes #1340

### Additional description
This limits input focus to not just when `onRequestFocus` is made, but limits the focus call to just the change in internal menu open state or prop `isOpen`. This is helpful for when Datepicker menu is a controlled with prop `isOpen`.

---

### Pull Request Review checklist (do not remove)

* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at snapshot strings.
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
