### PR TITLE
Make hint an optional field for data table actions

### DIFF
--- a/components/data-table/row-actions.jsx
+++ b/components/data-table/row-actions.jsx
@@ -47,6 +47,10 @@ const DataTableRowActions = createReactClass({
 		 */
 		item: PropTypes.object,
 		/**
+		 * Disable hint styling which changes the color of the dropdown svg on hover over.
+		 */
+		noHint: PropTypes.bool,
+		/**
 		 * Triggered when an item is selected.
 		 */
 		onAction: PropTypes.func,
@@ -59,6 +63,7 @@ const DataTableRowActions = createReactClass({
 	getDefaultProps () {
 		return {
 			assistiveText: 'Actions',
+			noHint: false,
 		};
 	},
 
@@ -91,7 +96,7 @@ const DataTableRowActions = createReactClass({
 					buttonVariant="icon"
 					className={this.props.className}
 					options={this.props.options}
-					hint
+					hint={!this.props.noHint}
 					iconName="down"
 					iconSize="small"
 					iconVariant="border-filled"


### PR DESCRIPTION
Still have no idea what a hint is. Couldn't really find anything about hints at https://www.lightningdesignsystem.com/components/buttons/#hint as specified across multiple locations in docs and code. Is this a deprecated thing?

Either way it's messing with the styling of the dropdown icon for me, and there's no way to override it.