### PR TITLE
Use npm ci for travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 node_js:
-  - "6"
+  - "8"
 install:
   - npm install npm -g
-  - npm install
+  - npm ci
 script:
   - npm run travis-ci
 cache:

--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -3499,6 +3499,17 @@
                             "required": false,
                             "description": "`DataTable` row item"
                         },
+                        "noHint": {
+                            "type": {
+                                "name": "bool"
+                            },
+                            "required": false,
+                            "description": "Disable hint styling which changes the color of the dropdown svg on hover over.",
+                            "defaultValue": {
+                                "value": "false",
+                                "computed": false
+                            }
+                        },
                         "onAction": {
                             "type": {
                                 "name": "func"


### PR DESCRIPTION
### Additional description
Replaces `npm install` with `npm ci`. The main difference is that `package.json`'s versions are ignored and `package-lock.json` is used.

I'm not 100% sure folks know to update `package-lock.json`.

---
