### PR TITLE
Tree bug fixes introduced by keyboard navigation

### DIFF
--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -6748,29 +6748,8 @@
             },
             "iconCategory": {
                 "type": {
-                    "name": "enum",
-                    "value": [
-                        {
-                            "value": "'action'",
-                            "computed": false
-                        },
-                        {
-                            "value": "'custom'",
-                            "computed": false
-                        },
-                        {
-                            "value": "'doctype'",
-                            "computed": false
-                        },
-                        {
-                            "value": "'standard'",
-                            "computed": false
-                        },
-                        {
-                            "value": "'utility'",
-                            "computed": false
-                        }
-                    ]
+                    "name": "custom",
+                    "raw": "requiredIf(\n    PropTypes.oneOf(['action', 'custom', 'doctype', 'standard', 'utility']),\n    (props) => !!props.iconName\n)"
                 },
                 "required": false,
                 "description": "Name of the icon category. Visit <a href=\"http://www.lightningdesignsystem.com/resources/icons\">Lightning Design System Icons</a> to reference icon categories."
@@ -7442,6 +7421,23 @@
                 "description": "Vertical alignment of Modal.",
                 "defaultValue": {
                     "value": "'center'",
+                    "computed": false
+                }
+            },
+            "assistiveText": {
+                "type": {
+                    "name": "shape",
+                    "value": {
+                        "dialogLabel": {
+                            "name": "string",
+                            "required": false
+                        }
+                    }
+                },
+                "required": false,
+                "description": "Assistive text for the modal.",
+                "defaultValue": {
+                    "value": "{}",
                     "computed": false
                 }
             },
@@ -11110,7 +11106,51 @@
     },
     "tree": {
         "description": "A tree is visualization of a structure hierarchy. A branch can be expanded or collapsed. This is a controlled component, since visual state is present in the `nodes` data.",
-        "methods": [],
+        "methods": [
+            {
+                "name": "handleSelect",
+                "docblock": null,
+                "modifiers": [],
+                "params": [
+                    {
+                        "name": "event",
+                        "type": null
+                    },
+                    {
+                        "name": "data",
+                        "type": null
+                    },
+                    {
+                        "name": "clearSelectedNodes",
+                        "type": null
+                    }
+                ],
+                "returns": null
+            },
+            {
+                "name": "handleNodeBlur",
+                "docblock": null,
+                "modifiers": [],
+                "params": [],
+                "returns": null
+            },
+            {
+                "name": "handleExpand",
+                "docblock": null,
+                "modifiers": [],
+                "params": [
+                    {
+                        "name": "event",
+                        "type": null
+                    },
+                    {
+                        "name": "data",
+                        "type": null
+                    }
+                ],
+                "returns": null
+            }
+        ],
         "props": {
             "assistiveText": {
                 "type": {
@@ -11185,21 +11225,21 @@
                     "name": "array"
                 },
                 "required": false,
-                "description": "Array of items starting at the top of the tree. The required shape is: `{expanded: string, id: string, label: string, selected: string, type: string, nodes: array}`, but only `id` and `label` are required. Use `type: 'branch'` for folder and categories."
+                "description": "Array of items starting at the top of the tree. The shape each node in the array is:\n```\n{\n  expanded: string,\n  id: string,\n  label: string or node,\n  selected: string,\n  type: string,\n  nodes: array\n}\n```\n`assistiveText: string` is optional and helpful if the label is not a string. Only `id` and `label` are required. Use `type: 'branch'` for folder and categories."
             },
             "onClick": {
                 "type": {
                     "name": "func"
                 },
                 "required": true,
-                "description": "Function that will run whenever an item or branch is clicked."
+                "description": "Function that will run whenever an item or branch is selected due to click or keyboard navigation."
             },
             "onExpandClick": {
                 "type": {
                     "name": "func"
                 },
                 "required": true,
-                "description": "This function triggers when the expand or collapse icon is clicked."
+                "description": "This function triggers when the expand or collapse icon is clicked or due to keyboard navigation."
             },
             "onScroll": {
                 "type": {

--- a/components/tree/__docs__/storybook-stories.jsx
+++ b/components/tree/__docs__/storybook-stories.jsx
@@ -74,7 +74,7 @@ const DemoTree = createReactClass({
 
 				return { selectedNode: data.node };
 			});
-			itemClicked('Node Clicked')(event, data);
+			itemClicked('Node Selected')(event, data);
 		} else if (
 			!this.props.noBranchSelection ||
 			(this.props.noBranchSelection && data.node.type !== 'branch')
@@ -82,7 +82,7 @@ const DemoTree = createReactClass({
 			data.node.selected = data.select;
 			// trigger render
 			this.setState((prevState) => ({ ...prevState }));
-			itemClicked('Node Clicked')(event, data);
+			itemClicked('Node Selected')(event, data);
 		}
 	},
 

--- a/components/tree/__docs__/storybook-stories.jsx
+++ b/components/tree/__docs__/storybook-stories.jsx
@@ -2,10 +2,12 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import { storiesOf, action } from '@storybook/react';
+import cloneDeep from 'lodash.clonedeep';
 import IconSettings from '../../icon-settings';
 
 import { TREE } from '../../../utilities/constants';
 import sampleNodes from '../../../utilities/sample-data/tree';
+
 
 import Tree from '../../tree';
 import Search from '../../forms/input/search';
@@ -38,7 +40,7 @@ const DemoTree = createReactClass({
 			? sampleNodes[this.props.exampleNodesIndex]
 			: sampleNodes.sampleNodesDefault;
 		return {
-			nodes: initalNodes,
+			nodes: cloneDeep(initalNodes),
 			selectedNode: undefined,
 			searchTerm: this.props.searchable ? 'fruit' : undefined,
 		};

--- a/components/tree/__docs__/storybook-stories.jsx
+++ b/components/tree/__docs__/storybook-stories.jsx
@@ -8,7 +8,6 @@ import IconSettings from '../../icon-settings';
 import { TREE } from '../../../utilities/constants';
 import sampleNodes from '../../../utilities/sample-data/tree';
 
-
 import Tree from '../../tree';
 import Search from '../../forms/input/search';
 

--- a/components/tree/__examples__/default.jsx
+++ b/components/tree/__examples__/default.jsx
@@ -19,7 +19,8 @@ const sampleNodes = {
 			expanded: true,
 			nodes: [
 				{
-					label: 'Ground Fruits',
+					assistiveText: 'Ground Fruits',
+					label: <span>Ground Fruits</span>,
 					type: 'branch',
 					id: 4,
 					nodes: [

--- a/components/tree/__examples__/default.jsx
+++ b/components/tree/__examples__/default.jsx
@@ -13,8 +13,7 @@ const sampleNodes = {
 			selected: true,
 		},
 		{
-			assistiveText: 'Fruits',
-			label: <span>Fruits</span>,
+			label: 'Fruits',
 			type: 'branch',
 			id: 2,
 			expanded: true,

--- a/components/tree/__examples__/default.jsx
+++ b/components/tree/__examples__/default.jsx
@@ -13,7 +13,8 @@ const sampleNodes = {
 			selected: true,
 		},
 		{
-			label: 'Fruits',
+			assistiveText: 'Fruits',
+			label: <span>Fruits</span>,
 			type: 'branch',
 			id: 2,
 			expanded: true,

--- a/components/tree/__tests__/tree.browser-test.jsx
+++ b/components/tree/__tests__/tree.browser-test.jsx
@@ -313,9 +313,10 @@ describe('Tree: ', () => {
 
 		it('has initial selection', function () {
 			let selectedNode = this.wrapper
-				.find('#example-tree-1')
+				.find('#example-tree-2')
 				.find('.slds-is-selected');
-			expect(selectedNode).to.have.length(1);
+			// Fruits, Watermelon, Tree Fruits
+			expect(selectedNode).to.have.length(3);
 			selectedNode = this.wrapper
 				.find('#example-tree-5')
 				.find('.slds-is-selected');

--- a/components/tree/__tests__/tree.browser-test.jsx
+++ b/components/tree/__tests__/tree.browser-test.jsx
@@ -8,6 +8,7 @@ import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 
 import isFunction from 'lodash.isfunction';
+import cloneDeep from 'lodash.clonedeep';
 
 import chai, { expect } from 'chai';
 import chaiEnzyme from 'chai-enzyme';
@@ -60,7 +61,7 @@ const DemoTree = createReactClass({
 			? sampleNodes[this.props.exampleNodesIndex]
 			: sampleNodes.sampleNodesDefault;
 		return {
-			nodes: initalNodes,
+			nodes: cloneDeep(initalNodes),
 			searchTerm: this.props.searchable ? 'fruit' : undefined,
 		};
 	},

--- a/components/tree/index.jsx
+++ b/components/tree/index.jsx
@@ -29,9 +29,9 @@ import { TREE } from '../../utilities/constants';
 class Tree extends React.Component {
 	constructor (props) {
 		super(props);
-		this.handleClick = this.handleClick.bind(this);
+		this.handleSelect = this.handleSelect.bind(this);
 		this.handleNodeBlur = this.handleNodeBlur.bind(this);
-		this.handleExpandClick = this.handleExpandClick.bind(this);
+		this.handleExpand = this.handleExpand.bind(this);
 		this.state = {
 			flattenedNodes: this.flattenTree({
 				nodes: this.props.nodes,
@@ -74,7 +74,7 @@ class Tree extends React.Component {
 		return nodes;
 	}
 
-	handleClick (event, data, clearSelectedNodes) {
+	handleSelect (event, data, clearSelectedNodes) {
 		// When triggered by a key event, other nodes should be deselected.
 		if (clearSelectedNodes) {
 			this.state.flattenedNodes.forEach((flattenedNode) => {
@@ -112,7 +112,7 @@ class Tree extends React.Component {
 		this.treeHasFocus = false;
 	}
 
-	handleExpandClick (event, data) {
+	handleExpand (event, data) {
 		this.treeHasFocus = true;
 		this.props.onExpandClick(event, data);
 	}
@@ -151,8 +151,8 @@ class Tree extends React.Component {
 					focusedNodeIndex={this.state.focusedNodeIndex}
 					treeHasFocus={this.treeHasFocus}
 					onNodeBlur={this.handleNodeBlur}
-					onClick={this.handleClick}
-					onExpandClick={this.handleExpandClick}
+					onSelect={this.handleSelect}
+					onExpand={this.handleExpand}
 					onScroll={this.props.onScroll}
 					searchTerm={this.props.searchTerm}
 					treeId={this.props.id}
@@ -209,11 +209,11 @@ Tree.propTypes = {
 	 */
 	nodes: PropTypes.array,
 	/**
-	 * Function that will run whenever an item or branch is clicked.
+	 * Function that will run whenever an item or branch is selected due to click or keyboard navigation.
 	 */
 	onClick: PropTypes.func.isRequired,
 	/**
-	 * This function triggers when the expand or collapse icon is clicked.
+	 * This function triggers when the expand or collapse icon is clicked or due to keyboard navigation.
 	 */
 	onExpandClick: PropTypes.func.isRequired,
 	/**

--- a/components/tree/index.jsx
+++ b/components/tree/index.jsx
@@ -14,6 +14,8 @@ import PropTypes from 'prop-types';
 // ### classNames
 import classNames from 'classnames';
 
+import find from 'lodash.find';
+
 // Child components
 import Branch from './private/branch';
 
@@ -29,15 +31,27 @@ import { TREE } from '../../utilities/constants';
 class Tree extends React.Component {
 	constructor (props) {
 		super(props);
+		const flattenedNodes = this.flattenTree({
+			nodes: this.props.nodes,
+			expanded: true,
+		}).slice(1);
+		const selectedNode = find(
+			flattenedNodes,
+			(curNode) => curNode.node.selected
+		);
+		const selectedNodeIndexes = [];
+		let focusedNodeIndex;
+		if (selectedNode) {
+			selectedNodeIndexes.push(selectedNode.treeIndex);
+			focusedNodeIndex = selectedNode.treeIndex;
+		}
 		this.handleSelect = this.handleSelect.bind(this);
 		this.handleNodeBlur = this.handleNodeBlur.bind(this);
 		this.handleExpand = this.handleExpand.bind(this);
 		this.state = {
-			flattenedNodes: this.flattenTree({
-				nodes: this.props.nodes,
-				expanded: true,
-			}).slice(1),
-			selectedNodeIndexes: [],
+			flattenedNodes,
+			selectedNodeIndexes,
+			focusedNodeIndex,
 		};
 	}
 

--- a/components/tree/index.jsx
+++ b/components/tree/index.jsx
@@ -38,10 +38,7 @@ const flattenTree = (root, treeIndex = '') => {
 		for (let index = 0; index < root.nodes.length; index++) {
 			const curNode = root.nodes[index];
 			nodes = nodes.concat(
-				flattenTree(
-					curNode,
-					treeIndex ? `${treeIndex}-${index}` : `${index}`
-				)
+				flattenTree(curNode, treeIndex ? `${treeIndex}-${index}` : `${index}`)
 			);
 		}
 	}
@@ -121,19 +118,19 @@ class Tree extends React.Component {
 			focusedNodeIndex: data.treeIndex,
 			selectedNodeIndexes,
 		});
-	}
+	};
 
 	handleNodeBlur = () => {
 		// There is no need to render when blurring a node because focus is either:
 		//  - outside of the tree, or
 		//  - focused on another node in the tree, which triggers its own render
 		this.treeHasFocus = false;
-	}
+	};
 
 	handleExpand = (event, data) => {
 		this.treeHasFocus = true;
 		this.props.onExpandClick(event, data);
-	}
+	};
 
 	render () {
 		// One of these is required to pass accessibility tests

--- a/components/tree/index.jsx
+++ b/components/tree/index.jsx
@@ -54,16 +54,6 @@ class Tree extends React.Component {
 		});
 	}
 
-	shouldComponentUpdate (nextProps, nextState) {
-		// There is no need to render when blurring a node because focus is either:
-		//  - outside of the tree, or
-		//  - focused on another node in the tree, which triggers its own render
-		if (!nextState.treeHasFocus) {
-			return false;
-		}
-		return true;
-	}
-
 	// Flattens hierarchical tree structure into a flat array.
 	flattenTree (root, treeIndex = '') {
 		if (!root.nodes) {
@@ -108,20 +98,23 @@ class Tree extends React.Component {
 				(treeIndex) => treeIndex !== data.treeIndex
 			);
 		}
+		this.treeHasFocus = true;
 		this.setState({
 			focusedNodeIndex: data.treeIndex,
 			selectedNodeIndexes,
-			treeHasFocus: true,
 		});
 	}
 
 	handleNodeBlur () {
-		this.setState({ treeHasFocus: false });
+		// There is no need to render when blurring a node because focus is either:
+		//  - outside of the tree, or
+		//  - focused on another node in the tree, which triggers its own render
+		this.treeHasFocus = false;
 	}
 
 	handleExpandClick (event, data) {
+		this.treeHasFocus = true;
 		this.props.onExpandClick(event, data);
-		this.setState({ treeHasFocus: true });
 	}
 
 	render () {
@@ -156,7 +149,7 @@ class Tree extends React.Component {
 					flattenedNodes={this.state.flattenedNodes}
 					selectedNodeIndexes={this.state.selectedNodeIndexes}
 					focusedNodeIndex={this.state.focusedNodeIndex}
-					treeHasFocus={this.state.treeHasFocus}
+					treeHasFocus={this.treeHasFocus}
 					onNodeBlur={this.handleNodeBlur}
 					onClick={this.handleClick}
 					onExpandClick={this.handleExpandClick}
@@ -212,7 +205,7 @@ Tree.propTypes = {
 	 */
 	id: PropTypes.string.isRequired,
 	/**
-	 * Array of items starting at the top of the tree. The required shape is: `{expanded: string, id: string, label: string, selected: string, type: string, nodes: array}`, but only `id` and `label` are required. Use `type: 'branch'` for folder and categories.
+	 * Array of items starting at the top of the tree. The required shape is: `{expanded: string, id: string, label: string or node, assistiveText: string, selected: string, type: string, nodes: array}`, but only `id` and `label` are required. Use `type: 'branch'` for folder and categories.
 	 */
 	nodes: PropTypes.array,
 	/**

--- a/components/tree/private/branch.jsx
+++ b/components/tree/private/branch.jsx
@@ -276,7 +276,9 @@ const renderBranch = (children, props) => {
 		</div>
 	);
 
-	const label = props.node.assistiveText || (typeof props.node.label === 'string' ? props.node.label : null);
+	const label =
+		props.node.assistiveText ||
+		(typeof props.node.label === 'string' ? props.node.label : null);
 	return (
 		<li
 			id={props.htmlId}
@@ -284,9 +286,7 @@ const renderBranch = (children, props) => {
 			aria-level={props.level}
 			aria-expanded={isExpanded ? 'true' : 'false'}
 			aria-label={
-				props.node.nodes && props.node.nodes.length > 0
-					? label
-					: null
+				props.node.nodes && props.node.nodes.length > 0 ? label : null
 			}
 			tabIndex={getTabIndex(props)}
 			onKeyDown={(event) => handleKeyDown(event, props)}

--- a/components/tree/private/branch.jsx
+++ b/components/tree/private/branch.jsx
@@ -276,6 +276,7 @@ const renderBranch = (children, props) => {
 		</div>
 	);
 
+	const label = props.node.assistiveText || (typeof props.node.label === 'string' ? props.node.label : null);
 	return (
 		<li
 			id={props.htmlId}
@@ -284,7 +285,7 @@ const renderBranch = (children, props) => {
 			aria-expanded={isExpanded ? 'true' : 'false'}
 			aria-label={
 				props.node.nodes && props.node.nodes.length > 0
-					? props.node.label
+					? label
 					: null
 			}
 			tabIndex={getTabIndex(props)}

--- a/components/tree/private/branch.jsx
+++ b/components/tree/private/branch.jsx
@@ -38,7 +38,6 @@ import { TREE_BRANCH } from '../../../utilities/constants';
 
 const handleExpand = (event, props) => {
 	EventUtil.trap(event);
-
 	if (isFunction(props.onExpand)) {
 		props.onExpand(event, {
 			node: props.node,
@@ -173,7 +172,7 @@ const handleKeyDown = (event, props) => {
 };
 
 const handleFocus = (event, props) => {
-	if (!props.focusedNodeIndex) {
+	if (!props.focusedNodeIndex && event.target === event.currentTarget) {
 		handleSelect(event, props);
 	}
 };

--- a/components/tree/private/branch.jsx
+++ b/components/tree/private/branch.jsx
@@ -36,11 +36,11 @@ import mapKeyEventCallbacks from '../../../utilities/key-callbacks';
 // ## Constants
 import { TREE_BRANCH } from '../../../utilities/constants';
 
-const handleExpandClick = (event, props) => {
+const handleExpand = (event, props) => {
 	EventUtil.trap(event);
 
-	if (isFunction(props.onExpandClick)) {
-		props.onExpandClick(event, {
+	if (isFunction(props.onExpand)) {
+		props.onExpand(event, {
 			node: props.node,
 			expand: !props.node.expanded,
 			treeIndex: props.treeIndex,
@@ -48,10 +48,10 @@ const handleExpandClick = (event, props) => {
 	}
 };
 
-const handleClick = (event, props) => {
+const handleSelect = (event, props) => {
 	EventUtil.trap(event);
-	if (isFunction(props.onClick)) {
-		props.onClick(event, {
+	if (isFunction(props.onSelect)) {
+		props.onSelect(event, {
 			node: props.node,
 			select: !props.node.selected,
 			treeIndex: props.treeIndex,
@@ -91,7 +91,7 @@ const handleKeyDownDown = (event, props) => {
 	if (props.focusedNodeIndex === props.treeIndex) {
 		// Select the next visible node
 		const flattenedNode = findNextNode(props.flattenedNodes, props.node);
-		props.onClick(
+		props.onSelect(
 			event,
 			{
 				node: flattenedNode.node,
@@ -107,7 +107,7 @@ const handleKeyDownUp = (event, props) => {
 	if (props.focusedNodeIndex === props.treeIndex) {
 		// Go to the previous visible node
 		const flattenedNode = findPreviousNode(props.flattenedNodes, props.node);
-		props.onClick(
+		props.onSelect(
 			event,
 			{
 				node: flattenedNode.node,
@@ -125,25 +125,25 @@ const handleKeyDownRight = (event, props) => {
 			handleKeyDownDown(event, props);
 		}
 	} else {
-		handleExpandClick(event, props);
+		handleExpand(event, props);
 	}
 };
 
 const handleKeyDownLeft = (event, props) => {
 	if (props.node.expanded) {
-		handleExpandClick(event, props);
+		handleExpand(event, props);
 	} else {
 		const nodes = props.flattenedNodes.map(
 			(flattenedNode) => flattenedNode.node
 		);
 		const index = nodes.indexOf(props.parent);
 		if (index !== -1) {
-			props.onExpandClick(event, {
+			props.onExpand(event, {
 				node: props.parent,
 				expand: !props.parent.expanded,
 				treeIndex: props.flattenedNodes[index].treeIndex,
 			});
-			props.onClick(
+			props.onSelect(
 				event,
 				{
 					node: props.parent,
@@ -157,7 +157,7 @@ const handleKeyDownLeft = (event, props) => {
 };
 
 const handleKeyDownEnter = (event, props) => {
-	handleClick(event, props);
+	handleSelect(event, props);
 };
 
 const handleKeyDown = (event, props) => {
@@ -174,7 +174,7 @@ const handleKeyDown = (event, props) => {
 
 const handleFocus = (event, props) => {
 	if (!props.focusedNodeIndex) {
-		handleClick(event, props);
+		handleSelect(event, props);
 	}
 };
 
@@ -304,7 +304,7 @@ const renderBranch = (children, props) => {
 					'slds-is-selected': isSelected,
 				})}
 				onClick={(event) => {
-					handleClick(event, props);
+					handleSelect(event, props);
 				}}
 			>
 				{/* eslint-enable jsx-a11y/no-static-element-interactions */}
@@ -318,7 +318,7 @@ const renderBranch = (children, props) => {
 					role="presentation"
 					aria-controls={props.htmlId}
 					onClick={(event) => {
-						handleExpandClick(event, props);
+						handleExpand(event, props);
 					}}
 					tabIndex="-1"
 				/>
@@ -370,13 +370,13 @@ renderBranch.propTypes = {
 	 */
 	node: PropTypes.object.isRequired,
 	/**
+	 * This function triggers when the expand or collapse icon is clicked or due to keyboard navigation.
+	 */
+	onExpand: PropTypes.func.isRequired,
+	/**
 	 * Function that will run whenever an item or branch is clicked.
 	 */
-	onClick: PropTypes.func,
-	/**
-	 * This function triggers when the expand or collapse icon is clicked.
-	 */
-	onExpandClick: PropTypes.func.isRequired,
+	onSelect: PropTypes.func,
 	/**
 	 * Highlights term if found in node label
 	 */
@@ -418,7 +418,7 @@ const Branch = (props) => {
 	let treeIndex = '';
 	let children;
 
-	const { treeId, level, onExpandClick, searchTerm } = props;
+	const { treeId, level, onExpand, searchTerm } = props;
 
 	if (Array.isArray(props.getNodes(props.node))) {
 		children = props.node.nodes.map((node, index) => {
@@ -444,8 +444,8 @@ const Branch = (props) => {
 						treeHasFocus={props.treeHasFocus}
 						onNodeBlur={props.onNodeBlur}
 						nodes={node.nodes}
-						onClick={props.onClick}
-						onExpandClick={onExpandClick}
+						onSelect={props.onSelect}
+						onExpand={onExpand}
 						searchTerm={searchTerm}
 						treeId={treeId}
 						treeIndex={treeIndex}
@@ -465,8 +465,8 @@ const Branch = (props) => {
 						focusedNodeIndex={props.focusedNodeIndex}
 						treeHasFocus={props.treeHasFocus}
 						onNodeBlur={props.onNodeBlur}
-						onClick={props.onClick}
-						onExpandClick={onExpandClick}
+						onSelect={props.onSelect}
+						onExpand={onExpand}
 						searchTerm={searchTerm}
 						treeIndex={treeIndex}
 						treeId={treeId}
@@ -529,13 +529,13 @@ Branch.propTypes = {
 	 */
 	node: PropTypes.object.isRequired,
 	/**
-	 * Function that will run whenever an item or branch is clicked.
+	 * Function that will run whenever an item or branch is selected (click or keyboard).
 	 */
-	onClick: PropTypes.func,
+	onSelect: PropTypes.func,
 	/**
 	 * This function triggers when the expand or collapse icon is clicked.
 	 */
-	onExpandClick: PropTypes.func.isRequired,
+	onExpand: PropTypes.func.isRequired,
 	/**
 	 * Highlights term if found in node label
 	 */

--- a/components/tree/private/item.jsx
+++ b/components/tree/private/item.jsx
@@ -130,7 +130,7 @@ const handleKeyDown = (event, props) => {
 };
 
 const handleFocus = (event, props) => {
-	if (!props.focusedNodeIndex) {
+	if (!props.focusedNodeIndex && event.target === event.currentTarget) {
 		handleSelect(event, props);
 	}
 };

--- a/components/tree/private/item.jsx
+++ b/components/tree/private/item.jsx
@@ -30,11 +30,11 @@ import mapKeyEventCallbacks from '../../../utilities/key-callbacks';
 // ## Constants
 import { TREE_ITEM } from '../../../utilities/constants';
 
-const handleClick = (event, props) => {
+const handleSelect = (event, props) => {
 	EventUtil.trap(event);
 
-	if (isFunction(props.onClick)) {
-		props.onClick(event, {
+	if (isFunction(props.onSelect)) {
+		props.onSelect(event, {
 			node: props.node,
 			select: !props.node.selected,
 			treeIndex: props.treeIndex,
@@ -61,7 +61,7 @@ const handleKeyDownDown = (event, props) => {
 	if (props.focusedNodeIndex === props.treeIndex) {
 		// Select the next visible node
 		const flattenedNode = findNextNode(props.flattenedNodes, props.node);
-		props.onClick(
+		props.onSelect(
 			event,
 			{
 				node: flattenedNode.node,
@@ -77,7 +77,7 @@ const handleKeyDownUp = (event, props) => {
 	if (props.focusedNodeIndex === props.treeIndex) {
 		// Go to the previous visible node
 		const flattenedNode = findPreviousNode(props.flattenedNodes, props.node);
-		props.onClick(
+		props.onSelect(
 			event,
 			{
 				node: flattenedNode.node,
@@ -93,12 +93,12 @@ const handleKeyDownLeft = (event, props) => {
 	const nodes = props.flattenedNodes.map((flattenedNode) => flattenedNode.node);
 	const index = nodes.indexOf(props.parent);
 	if (index !== -1) {
-		props.onExpandClick(event, {
+		props.onExpand(event, {
 			node: props.parent,
 			expand: !props.parent.expanded,
 			treeIndex: props.flattenedNodes[index].treeIndex,
 		});
-		props.onClick(
+		props.onSelect(
 			event,
 			{
 				node: props.parent,
@@ -111,7 +111,7 @@ const handleKeyDownLeft = (event, props) => {
 };
 
 const handleKeyDownEnter = (event, props) => {
-	handleClick(event, props);
+	handleSelect(event, props);
 };
 
 const handleKeyDown = (event, props) => {
@@ -131,7 +131,7 @@ const handleKeyDown = (event, props) => {
 
 const handleFocus = (event, props) => {
 	if (!props.focusedNodeIndex) {
-		handleClick(event, props);
+		handleSelect(event, props);
 	}
 };
 
@@ -175,7 +175,7 @@ const Item = (props) => {
 					'slds-is-selected': isSelected,
 				})}
 				onClick={(event) => {
-					handleClick(event, props);
+					handleSelect(event, props);
 				}}
 			>
 				{/* eslint-enable jsx-a11y/no-static-element-interactions */}
@@ -229,13 +229,13 @@ Item.propTypes = {
 	 */
 	node: PropTypes.object.isRequired,
 	/**
-	 * Function that will run whenever an item or branch is clicked.
+	 * This function triggers when the expand or collapse icon is clicked or due to keyboard navigation.
 	 */
-	onClick: PropTypes.func,
+	onExpand: PropTypes.func.isRequired,
 	/**
-	 * This function triggers when the expand or collapse icon is clicked.
+	 * Function that will run whenever an item or branch is selected (click or keyboard).
 	 */
-	onExpandClick: PropTypes.func.isRequired,
+	onSelect: PropTypes.func,
 	/**
 	 * Highlights term if found in node label
 	 */

--- a/utilities/sample-data/tree/index.jsx
+++ b/utilities/sample-data/tree/index.jsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import sampleNodesWithLargeDataset from './sample-nodes-with-large-dataset';
 import sampleNodesWithInitialState from './sample-nodes-with-initial-state';
 
@@ -13,7 +14,8 @@ const sampleNodesDefault = [
 		id: 2,
 		nodes: [
 			{
-				label: 'Ground Fruits',
+				assistiveText: 'Ground Fruits',
+				label: <span>Ground Fruits</span>,
 				type: 'branch',
 				id: 4,
 				nodes: [

--- a/utilities/sample-data/tree/index.jsx
+++ b/utilities/sample-data/tree/index.jsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import sampleNodesWithLargeDataset from './sample-nodes-with-large-dataset';
 import sampleNodesWithInitialState from './sample-nodes-with-initial-state';
 
@@ -8,7 +9,8 @@ const sampleNodesDefault = [
 		id: 1,
 	},
 	{
-		label: 'Fruits',
+		assistiveText: 'Fruits',
+		label: <span>Fruits</span>,
 		type: 'branch',
 		id: 2,
 		nodes: [

--- a/utilities/sample-data/tree/index.jsx
+++ b/utilities/sample-data/tree/index.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import sampleNodesWithLargeDataset from './sample-nodes-with-large-dataset';
 import sampleNodesWithInitialState from './sample-nodes-with-initial-state';
 
@@ -9,8 +8,7 @@ const sampleNodesDefault = [
 		id: 1,
 	},
 	{
-		assistiveText: 'Fruits',
-		label: <span>Fruits</span>,
+		label: 'Fruits',
 		type: 'branch',
 		id: 2,
 		nodes: [

--- a/utilities/sample-data/tree/sample-nodes-with-initial-state.jsx
+++ b/utilities/sample-data/tree/sample-nodes-with-initial-state.jsx
@@ -3,23 +3,25 @@ const treeNodesWithInitialState = [
 		label: 'Grains',
 		type: 'item',
 		id: 1,
-		selected: true,
 	},
 	{
 		label: 'Fruits',
 		type: 'branch',
 		id: 2,
 		expanded: true,
+		selected: true,
 		nodes: [
 			{
 				label: 'Ground Fruits',
 				type: 'branch',
 				id: 4,
+				expanded: true,
 				nodes: [
 					{
 						label: 'Watermelon',
 						type: 'item',
 						id: 12,
+						selected: true,
 					},
 					{
 						label: 'Canteloupe',


### PR DESCRIPTION
This fixes two Tree bugs: 
- Tree is not rendered on props changes https://github.com/salesforce/design-system-react/issues/1377
- Show proper aria-label value when label is a node https://github.com/salesforce/design-system-react/issues/1378

---

### Pull Request Review checklist (do not remove)

* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [x] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.