### PR TITLE
Switch xml2json to xml2js in tooling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7559,6 +7559,15 @@
 						}
 					}
 				},
+				"string_decoder": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+					"integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+					"dev": true,
+					"requires": {
+						"safe-buffer": "5.0.1"
+					}
+				},
 				"string-width": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -7568,15 +7577,6 @@
 						"code-point-at": "1.1.0",
 						"is-fullwidth-code-point": "1.0.0",
 						"strip-ansi": "3.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-					"integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-					"dev": true,
-					"requires": {
-						"safe-buffer": "5.0.1"
 					}
 				},
 				"stringstream": {
@@ -16853,6 +16853,15 @@
 			"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
 			"dev": true
 		},
+		"string_decoder": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
 		"string-length": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -17015,15 +17024,6 @@
 				"define-properties": "1.1.2",
 				"es-abstract": "1.10.0",
 				"function-bind": "1.1.1"
-			}
-		},
-		"string_decoder": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "5.1.1"
 			}
 		},
 		"stringify-object": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3258,12 +3258,6 @@
 			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
 			"dev": true
 		},
-		"bindings": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
-			"integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw==",
-			"dev": true
-		},
 		"blacklist": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/blacklist/-/blacklist-1.1.4.tgz",
@@ -8935,12 +8929,6 @@
 			"integrity": "sha1-Sj6XTsDLqQBNP8bN5yCeppNopiE=",
 			"dev": true
 		},
-		"isemail": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
-			"integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY=",
-			"dev": true
-		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -9221,12 +9209,6 @@
 			"requires": {
 				"handlebars": "4.0.11"
 			}
-		},
-		"items": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/items/-/items-2.1.1.tgz",
-			"integrity": "sha1-i9FtnIOxlSneWuoyGsqtp4NkoZg=",
-			"dev": true
 		},
 		"jest": {
 			"version": "21.2.1",
@@ -10388,19 +10370,6 @@
 						"has-flag": "2.0.0"
 					}
 				}
-			}
-		},
-		"joi": {
-			"version": "9.2.0",
-			"resolved": "https://registry.npmjs.org/joi/-/joi-9.2.0.tgz",
-			"integrity": "sha1-M4WseQGSEwy+Iw6ALsAskhW7/to=",
-			"dev": true,
-			"requires": {
-				"hoek": "4.2.0",
-				"isemail": "2.2.1",
-				"items": "2.1.1",
-				"moment": "2.20.1",
-				"topo": "2.0.2"
 			}
 		},
 		"js-base64": {
@@ -12175,12 +12144,6 @@
 				}
 			}
 		},
-		"moment": {
-			"version": "2.20.1",
-			"resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
-			"integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg==",
-			"dev": true
-		},
 		"move-concurrently": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -12258,16 +12221,6 @@
 			"dev": true,
 			"requires": {
 				"minimatch": "3.0.4"
-			}
-		},
-		"node-expat": {
-			"version": "2.3.16",
-			"resolved": "https://registry.npmjs.org/node-expat/-/node-expat-2.3.16.tgz",
-			"integrity": "sha512-e3HyQI0lk5CXyYQ4RsDYGiWdY5LJxNMlNCzo4/gwqY8lhYIeTf5VwGirGDa1EPrcZROmOR37wHuFVnoHmOWnOw==",
-			"dev": true,
-			"requires": {
-				"bindings": "1.3.0",
-				"nan": "2.8.0"
 			}
 		},
 		"node-fetch": {
@@ -17437,15 +17390,6 @@
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
 			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
 		},
-		"topo": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
-			"integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
-			"dev": true,
-			"requires": {
-				"hoek": "4.2.0"
-			}
-		},
 		"toposort": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.7.tgz",
@@ -18298,16 +18242,21 @@
 			"integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
 			"dev": true
 		},
-		"xml2json": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/xml2json/-/xml2json-0.11.0.tgz",
-			"integrity": "sha1-HVTx2GjbvQSJK4RdfLrZTFKOFuQ=",
+		"xml2js": {
+			"version": "0.4.19",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+			"integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
 			"dev": true,
 			"requires": {
-				"hoek": "4.2.0",
-				"joi": "9.2.0",
-				"node-expat": "2.3.16"
+				"sax": "1.2.4",
+				"xmlbuilder": "9.0.7"
 			}
+		},
+		"xmlbuilder": {
+			"version": "9.0.7",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+			"integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+			"dev": true
 		},
 		"xmlhttprequest-ssl": {
 			"version": "1.5.3",

--- a/package.json
+++ b/package.json
@@ -204,7 +204,7 @@
 		"webpack": "^3.4.1",
 		"webpack-dev-middleware": "^1.12.0",
 		"webpack-hot-middleware": "^2.18.2",
-		"xml2json": "^0.11.0"
+		"xml2js": "^0.4.19"
 	},
 	"components": [
 		{

--- a/scripts/inline-icons.js
+++ b/scripts/inline-icons.js
@@ -3,7 +3,7 @@
 import async from 'async';
 import fs from 'fs-extra';
 import path from 'path';
-import parser from 'xml2json';
+import xml2js from 'xml2js';
 import omit from 'lodash.omit';
 
 console.log('# Building the inline SVG icons');
@@ -12,6 +12,18 @@ const outputFile = (filename, data, done) => {
 	const outputPath = path.join(__dirname, '../icons/', `${filename}.js`);
 
 	fs.outputFile(outputPath, data.join('\n'), done);
+};
+
+const parseXml = (string, done) => {
+	xml2js.parseString(
+		string,
+		{
+			emptyTag: {},
+			explicitArray: false,
+			mergeAttrs: true
+		},
+		done
+	);
 };
 
 const inlineIcons = (spriteType, done) => {
@@ -35,32 +47,34 @@ const inlineIcons = (spriteType, done) => {
 		"let icons = {}; if ('__EXCLUDE_SLDS_ICONS__' === '__INCLUDE_SLDS_ICONS__') { icons = {",
 	];
 
-	const sprite = JSON.parse(parser.toJson(text));
+	parseXml(text, (error, sprite) => {
+		if (error) throw error;
 
-	let viewBox;
-	async.each(
-		sprite.svg.symbol,
-		(symbol, iconDone) => {
-			let data = omit(symbol, ['id']);
-			const iconName = symbol.id.toLowerCase();
+		let viewBox;
+		async.each(
+			sprite.svg.symbol,
+			(symbol, iconDone) => {
+				let data = omit(symbol, ['id']);
+				const iconName = symbol.id.toLowerCase();
 
-			const icon = [license, `export default ${JSON.stringify(data)};`, ''];
+				const icon = [license, `export default ${JSON.stringify(data)};`, ''];
 
-			outputFile(`${spriteType}/${iconName}`, icon, iconDone);
+				outputFile(`${spriteType}/${iconName}`, icon, iconDone);
 
-			if (!viewBox) viewBox = data.viewBox;
-			data = omit(data, ['viewBox']);
-			index.push(`${iconName}:${JSON.stringify(data)},`);
-		},
-		(err) => {
-			if (err) console.error(err);
-		}
-	);
+				if (!viewBox) viewBox = data.viewBox;
+				data = omit(data, ['viewBox']);
+				index.push(`${iconName}:${JSON.stringify(data)},`);
+			},
+			(err) => {
+				if (err) console.error(err);
+			}
+		);
 
-	index.push(`viewBox:'${viewBox}'`);
-	index.push('}; } export default icons;');
-	index.push('');
-	outputFile(`${spriteType}/index`, index, done);
+		index.push(`viewBox:'${viewBox}'`);
+		index.push('}; } export default icons;');
+		index.push('');
+		outputFile(`${spriteType}/index`, index, done);
+	});
 };
 
 async.each(

--- a/scripts/inline-icons.js
+++ b/scripts/inline-icons.js
@@ -20,7 +20,7 @@ const parseXml = (string, done) => {
 		{
 			emptyTag: {},
 			explicitArray: false,
-			mergeAttrs: true
+			mergeAttrs: true,
 		},
 		done
 	);


### PR DESCRIPTION
### Additional description

So this is related to (but not the final fix for) #1366 . Typically Windows users will not have python and a g++ compiler tool chain installed in order to compile native addons. A lot of modules work-around this issue by offering pre-compiled addons (like node-sass), but `node-expat` (a dependency of `xml2json`) does not.

Since this is just in some tooling and I was able to use the popular `xml2js` to fill in with the same functionality, I thought this may be another way to help improve the Windows contributor experience.

### Pull Request Review checklist (do not remove)

* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [x] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [x] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
