### PR TITLE
Consolidate assistiveText props under one object [App Launcher, Popover, Modal]

### DIFF
--- a/components/app-launcher/__docs__/storybook-stories.jsx
+++ b/components/app-launcher/__docs__/storybook-stories.jsx
@@ -291,6 +291,7 @@ const DemoAppLauncher = createReactClass({
 			<GlobalNavigationBar>
 				<GlobalNavigationBarRegion region="primary">
 					<AppLauncher
+						assistiveText={{ trigger: 'Open App Launcher' }}
 						triggerName="App Name"
 						search={search}
 						modalClassName="custom-modal-class"

--- a/components/app-launcher/__tests__/app-launcher.browser-test.jsx
+++ b/components/app-launcher/__tests__/app-launcher.browser-test.jsx
@@ -168,7 +168,7 @@ describe('SLDS APP LAUNCHER *******************************************', () => 
 			triggerOnClick = sinon.spy();
 
 			mountAppLauncher({
-				triggerAssistiveText: 'Custom Icon Assistive Text',
+				assistiveText: { trigger: 'Custom Icon Assistive Text' },
 				triggerOnClick,
 			});
 		});

--- a/components/app-launcher/check-props.js
+++ b/components/app-launcher/check-props.js
@@ -17,7 +17,7 @@ if (process.env.NODE_ENV !== 'production') {
 			COMPONENT,
 			props.triggerAssistiveText,
 			'triggerAssistiveText',
-			'assistiveText[\'trigger\']',
+			"assistiveText['trigger']"
 		);
 	};
 }

--- a/components/app-launcher/check-props.js
+++ b/components/app-launcher/check-props.js
@@ -2,6 +2,7 @@
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 /* eslint-disable import/no-mutable-exports */
 
+import deprecatedProperty from '../../utilities/warning/deprecated-property';
 import oneOfComponent from '../../utilities/warning/one-of-component';
 
 let checkProps = function () {};
@@ -11,6 +12,13 @@ if (process.env.NODE_ENV !== 'production') {
 		if (props.modalHeaderButton !== undefined) {
 			oneOfComponent(COMPONENT, props, 'modalHeaderButton', ['SLDSButton']);
 		}
+
+		deprecatedProperty(
+			COMPONENT,
+			props.triggerAssistiveText,
+			'triggerAssistiveText',
+			'assistiveText[\'trigger\']',
+		);
 	};
 }
 

--- a/components/app-launcher/index.jsx
+++ b/components/app-launcher/index.jsx
@@ -69,6 +69,12 @@ const AppLauncher = createReactClass({
 	// ### Prop Types
 	propTypes: {
 		/**
+		 * Assistive text for the app launcher.
+		 */
+		assistiveText: PropTypes.shape({
+			trigger: PropTypes.string, // Assistive text for app launcher icon
+		}),
+		/**
 		 * One or more `<AppLauncherSection />`s each containing one or more `<AppLauncherTile />`s
 		 */
 		children: PropTypes.node.isRequired,
@@ -105,10 +111,6 @@ const AppLauncher = createReactClass({
 		 */
 		title: PropTypes.string,
 		/**
-		 * Assistive text for app launcher icon
-		 */
-		triggerAssistiveText: PropTypes.string,
-		/**
 		 * This is typically the name of the cloud or application
 		 */
 		triggerName: PropTypes.node,
@@ -120,7 +122,7 @@ const AppLauncher = createReactClass({
 
 	getDefaultProps () {
 		return {
-			triggerAssistiveText: 'Open App Launcher',
+			assistiveText: {},
 			title: 'App Launcher',
 		};
 	},
@@ -208,6 +210,7 @@ const AppLauncher = createReactClass({
 		// Not present in SLDS, but is consistent with other implementations of App Launcher. This also prevents resizing/jumping around when filtering. It will start clipping the modal close button at 600px viewport height.
 		const modalContentStaticHeight = '90%';
 
+		const triggerAssistiveText = this.props.assistiveText.trigger || this.props.triggerAssistiveText || 'Open App Launcher';
 		return (
 			<div className="slds-context-bar__item slds-no-hover" style={style}>
 				<div className="slds-context-bar__icon-action">
@@ -227,9 +230,9 @@ const AppLauncher = createReactClass({
 							<span className="slds-r8" />
 							<span className="slds-r9" />
 						</span>
-						{this.props.triggerAssistiveText && (
+						{triggerAssistiveText && (
 							<span className="slds-assistive-text">
-								{this.props.triggerAssistiveText}
+								{triggerAssistiveText}
 							</span>
 						)}
 					</button>

--- a/components/app-launcher/index.jsx
+++ b/components/app-launcher/index.jsx
@@ -15,6 +15,9 @@ import PropTypes from 'prop-types';
 // ### classNames
 import classNames from 'classnames';
 
+// ### assign
+import assign from 'lodash.assign';
+
 // ### isFunction
 import isFunction from 'lodash.isfunction';
 
@@ -26,6 +29,13 @@ import Modal from '../modal';
 
 // ## Constants
 import { APP_LAUNCHER } from '../../utilities/constants';
+
+const defaultProps = {
+	assistiveText: {
+		// Need to add `trigger` here after we remove `triggerAssistiveText`.
+	},
+	title: 'App Launcher',
+};
 
 /**
  * The App Launcher allows the user to quickly access all the apps and functionality with their organization.
@@ -60,7 +70,6 @@ import { APP_LAUNCHER } from '../../utilities/constants';
  * settings.setAppElement('#mount');
  * ```
  */
-
 const AppLauncher = createReactClass({
 	// ### Display Name
 	// Always use the canonical component name as the React display name.
@@ -69,10 +78,12 @@ const AppLauncher = createReactClass({
 	// ### Prop Types
 	propTypes: {
 		/**
-		 * Assistive text for the app launcher.
+		 * **Assistive text for accessibility.**
+		 * This object is merged with the default props object on every render.
+		 * * `trigger`: This is a visually hidden label for the app launcher icon.
 		 */
 		assistiveText: PropTypes.shape({
-			trigger: PropTypes.string, // Assistive text for app launcher icon
+			trigger: PropTypes.string,
 		}),
 		/**
 		 * One or more `<AppLauncherSection />`s each containing one or more `<AppLauncherTile />`s
@@ -121,10 +132,7 @@ const AppLauncher = createReactClass({
 	},
 
 	getDefaultProps () {
-		return {
-			assistiveText: {},
-			title: 'App Launcher',
-		};
+		return defaultProps;
 	},
 
 	getInitialState () {
@@ -210,10 +218,15 @@ const AppLauncher = createReactClass({
 		// Not present in SLDS, but is consistent with other implementations of App Launcher. This also prevents resizing/jumping around when filtering. It will start clipping the modal close button at 600px viewport height.
 		const modalContentStaticHeight = '90%';
 
+		const assistiveText = assign(
+			{},
+			defaultProps.assistiveText,
+			this.props.assistiveText
+		);
+		const deprecatedTriggerAssitiveText =
+			this.props.triggerAssistiveText || 'Open App Launcher';
 		const triggerAssistiveText =
-			this.props.assistiveText.trigger ||
-			this.props.triggerAssistiveText ||
-			'Open App Launcher';
+			assistiveText.trigger || deprecatedTriggerAssitiveText;
 		return (
 			<div className="slds-context-bar__item slds-no-hover" style={style}>
 				<div className="slds-context-bar__icon-action">

--- a/components/app-launcher/index.jsx
+++ b/components/app-launcher/index.jsx
@@ -210,7 +210,10 @@ const AppLauncher = createReactClass({
 		// Not present in SLDS, but is consistent with other implementations of App Launcher. This also prevents resizing/jumping around when filtering. It will start clipping the modal close button at 600px viewport height.
 		const modalContentStaticHeight = '90%';
 
-		const triggerAssistiveText = this.props.assistiveText.trigger || this.props.triggerAssistiveText || 'Open App Launcher';
+		const triggerAssistiveText =
+			this.props.assistiveText.trigger ||
+			this.props.triggerAssistiveText ||
+			'Open App Launcher';
 		return (
 			<div className="slds-context-bar__item slds-no-hover" style={style}>
 				<div className="slds-context-bar__icon-action">

--- a/components/app-launcher/index.jsx
+++ b/components/app-launcher/index.jsx
@@ -15,9 +15,6 @@ import PropTypes from 'prop-types';
 // ### classNames
 import classNames from 'classnames';
 
-// ### assign
-import assign from 'lodash.assign';
-
 // ### isFunction
 import isFunction from 'lodash.isfunction';
 
@@ -32,7 +29,7 @@ import { APP_LAUNCHER } from '../../utilities/constants';
 
 const defaultProps = {
 	assistiveText: {
-		// Need to add `trigger` here after we remove `triggerAssistiveText`.
+		trigger: 'Open App Launcher',
 	},
 	title: 'App Launcher',
 };
@@ -218,15 +215,12 @@ const AppLauncher = createReactClass({
 		// Not present in SLDS, but is consistent with other implementations of App Launcher. This also prevents resizing/jumping around when filtering. It will start clipping the modal close button at 600px viewport height.
 		const modalContentStaticHeight = '90%';
 
-		const assistiveText = assign(
-			{},
-			defaultProps.assistiveText,
-			this.props.assistiveText
-		);
-		const deprecatedTriggerAssitiveText =
-			this.props.triggerAssistiveText || 'Open App Launcher';
+		const assistiveText = {
+			...defaultProps.assistiveText,
+			...this.props.assistiveText,
+		};
 		const triggerAssistiveText =
-			assistiveText.trigger || deprecatedTriggerAssitiveText;
+			this.props.triggerAssistiveText || assistiveText.trigger;
 		return (
 			<div className="slds-context-bar__item slds-no-hover" style={style}>
 				<div className="slds-context-bar__icon-action">

--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -368,7 +368,7 @@
                     }
                 },
                 "required": false,
-                "description": "Assistive text for the app launcher.",
+                "description": "**Assistive text for accessibility.**\nThis object is merged with the default props object on every render.\n* `trigger`: This is a visually hidden label for the app launcher icon.",
                 "defaultValue": {
                     "value": "{}",
                     "computed": false
@@ -7437,9 +7437,9 @@
                     }
                 },
                 "required": false,
-                "description": "Assistive text for the modal.",
+                "description": "**Assistive text for accessibility.**\nThis object is merged with the default props object on every render.\n* `dialogLabel`: This is a visually hidden label for the dialog. If not provided, `title` is used.\n* `closeButton`: This is a visually hidden label for the close button.",
                 "defaultValue": {
-                    "value": "{}",
+                    "value": "{\n    dialogLabel: '',\n    // Need to add `closeButton` here after we remove `closeButtonAssistiveText`.\n}",
                     "computed": false
                 }
             },
@@ -8567,7 +8567,7 @@
                     }
                 },
                 "required": false,
-                "description": "Assistive text for the popover.",
+                "description": "**Assistive text for accessibility.**\nThis object is merged with the default props object on every render.\n* `closeButton`: This is a visually hidden label for the close button.",
                 "defaultValue": {
                     "value": "{}",
                     "computed": false

--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -357,6 +357,23 @@
             }
         ],
         "props": {
+            "assistiveText": {
+                "type": {
+                    "name": "shape",
+                    "value": {
+                        "trigger": {
+                            "name": "string",
+                            "required": false
+                        }
+                    }
+                },
+                "required": false,
+                "description": "Assistive text for the app launcher.",
+                "defaultValue": {
+                    "value": "{}",
+                    "computed": false
+                }
+            },
             "children": {
                 "type": {
                     "name": "node"
@@ -425,17 +442,6 @@
                 "description": "Set the App Launcher's title text (for localization)",
                 "defaultValue": {
                     "value": "'App Launcher'",
-                    "computed": false
-                }
-            },
-            "triggerAssistiveText": {
-                "type": {
-                    "name": "string"
-                },
-                "required": false,
-                "description": "Assistive text for app launcher icon",
-                "defaultValue": {
-                    "value": "'Open App Launcher'",
                     "computed": false
                 }
             },
@@ -7296,7 +7302,6 @@
     },
     "modal": {
         "description": "The Modal component is used for the Lightning Design System Modal and Notification > Prompt components. The Modal opens from a state change outside of the component itself (pass this state to the <code>isOpen</code> prop). For more details on the Prompt markup, please review the <a href=\"http://www.lightningdesignsystem.com/components/notifications#prompt\">Notifications > Prompt</a>.\n\nBy default, `Modal` will add `aria-hidden=true` to the `body` tag, but this disables some assistive technologies. To prevent this you can add the following to your application with `#mount` being the root node of your application that you would like to hide from assistive technologies when the `Modal` is open.\n```\nimport settings from 'design-system-react/components/settings';\nsettings.setAppElement('#mount');\n```\nThis component uses a portalMount (a disconnected React subtree mount) to create a modal as a child of `body`.",
-        "displayName": "Modal",
         "methods": [
             {
                 "name": "getId",
@@ -7424,6 +7429,10 @@
                         "dialogLabel": {
                             "name": "string",
                             "required": false
+                        },
+                        "closeButton": {
+                            "name": "string",
+                            "required": false
                         }
                     }
                 },
@@ -7440,13 +7449,6 @@
                 },
                 "required": true,
                 "description": "Modal content."
-            },
-            "closeButtonAssistiveText": {
-                "type": {
-                    "name": "string"
-                },
-                "required": false,
-                "description": "Text read aloud by screen readers when the user focuses on the Close Button."
             },
             "containerClassName": {
                 "type": {
@@ -8554,6 +8556,23 @@
                     "computed": false
                 }
             },
+            "assistiveText": {
+                "type": {
+                    "name": "shape",
+                    "value": {
+                        "closeButton": {
+                            "name": "string",
+                            "required": false
+                        }
+                    }
+                },
+                "required": false,
+                "description": "Assistive text for the popover.",
+                "defaultValue": {
+                    "value": "{}",
+                    "computed": false
+                }
+            },
             "ariaLabelledby": {
                 "type": {
                     "name": "string"
@@ -8600,22 +8619,6 @@
                 },
                 "required": false,
                 "description": "CSS classes to be added to the popover. That is the element with `.slds-popover` on it."
-            },
-            "closeButtonAssistiveText": {
-                "type": {
-                    "name": "union",
-                    "value": [
-                        {
-                            "name": "string"
-                        }
-                    ]
-                },
-                "required": false,
-                "description": "All popovers require a close button.",
-                "defaultValue": {
-                    "value": "'Close dialog'",
-                    "computed": false
-                }
             },
             "disabled": {
                 "type": {

--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -370,7 +370,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility.**\nThis object is merged with the default props object on every render.\n* `trigger`: This is a visually hidden label for the app launcher icon.",
                 "defaultValue": {
-                    "value": "{}",
+                    "value": "{\n    trigger: 'Open App Launcher',\n}",
                     "computed": false
                 }
             },
@@ -7439,7 +7439,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility.**\nThis object is merged with the default props object on every render.\n* `dialogLabel`: This is a visually hidden label for the dialog. If not provided, `title` is used.\n* `closeButton`: This is a visually hidden label for the close button.",
                 "defaultValue": {
-                    "value": "{\n    dialogLabel: '',\n    // Need to add `closeButton` here after we remove `closeButtonAssistiveText`.\n}",
+                    "value": "{\n    dialogLabel: '',\n    closeButton: 'Close',\n}",
                     "computed": false
                 }
             },
@@ -8569,7 +8569,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility.**\nThis object is merged with the default props object on every render.\n* `closeButton`: This is a visually hidden label for the close button.",
                 "defaultValue": {
-                    "value": "{}",
+                    "value": "{\n    closeButton: 'Close dialog',\n}",
                     "computed": false
                 }
             },

--- a/components/modal/__docs__/storybook-stories.jsx
+++ b/components/modal/__docs__/storybook-stories.jsx
@@ -195,7 +195,9 @@ storiesOf(MODAL, module)
 	.add('Modal with Custom Parent Node', () => <ModalCustomParentNode />)
 	.add('Small', () =>
 		getModal({
-			closeButtonAssistiveText: 'Exit',
+			assistiveText: {
+				closeButton: 'Exit',
+			},
 			isOpen: true,
 			tagline: 'Enter in details below',
 			title: 'New Opportunity',

--- a/components/modal/__tests__/modal.browser-test.jsx
+++ b/components/modal/__tests__/modal.browser-test.jsx
@@ -95,7 +95,9 @@ describe('SLDSModal: ', function () {
 		beforeEach(() => {
 			closed = false;
 			cmp = getModal({
-				closeButtonAssistiveText: 'Exit',
+				assistiveText: {
+					closeButton: 'Exit',
+				},
 				isOpen: true,
 				size: 'large',
 				containerClassName: 'my-custom-class',

--- a/components/modal/check-props.js
+++ b/components/modal/check-props.js
@@ -1,0 +1,21 @@
+/* Copyright (c) 2015-present, salesforce.com, inc. All rights reserved */
+/* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
+/* eslint-disable import/no-mutable-exports */
+/* eslint-disable max-len */
+
+import deprecatedProperty from '../../utilities/warning/deprecated-property';
+
+let checkProps = function () { };
+
+if (process.env.NODE_ENV !== 'production') {
+	checkProps = function (COMPONENT, props) {
+		deprecatedProperty(
+			COMPONENT,
+			props.closeButtonAssistiveText,
+			'closeButtonAssistiveText',
+			'assistiveText[\'closeButton\']',
+		);
+	};
+}
+
+export default checkProps;

--- a/components/modal/check-props.js
+++ b/components/modal/check-props.js
@@ -5,7 +5,7 @@
 
 import deprecatedProperty from '../../utilities/warning/deprecated-property';
 
-let checkProps = function () { };
+let checkProps = function () {};
 
 if (process.env.NODE_ENV !== 'production') {
 	checkProps = function (COMPONENT, props) {
@@ -13,7 +13,7 @@ if (process.env.NODE_ENV !== 'production') {
 			COMPONENT,
 			props.closeButtonAssistiveText,
 			'closeButtonAssistiveText',
-			'assistiveText[\'closeButton\']',
+			"assistiveText['closeButton']"
 		);
 	};
 }

--- a/components/modal/index.jsx
+++ b/components/modal/index.jsx
@@ -21,9 +21,13 @@ import isBoolean from 'lodash.isboolean';
 // shortid is a short, non-sequential, url-friendly, unique id generator
 import shortid from 'shortid';
 
+// This component's `checkProps` which issues warnings to developers about properties when in development mode (similar to React's built in development tools)
+import checkProps from './check-props';
+
 import Button from '../button';
 
-const displayName = 'Modal';
+import { MODAL } from '../../utilities/constants';
+
 const propTypes = {
 	/**
 	 * Vertical alignment of Modal.
@@ -34,15 +38,12 @@ const propTypes = {
 	 */
 	assistiveText: PropTypes.shape({
 		dialogLabel: PropTypes.string, // If not provided, `title` is used.
+		closeButton: PropTypes.string, // Text read aloud by screen readers when the user focuses on the Close Button.
 	}),
 	/**
 	 * Modal content.
 	 */
 	children: PropTypes.node.isRequired,
-	/**
-	 * Text read aloud by screen readers when the user focuses on the Close Button.
-	 */
-	closeButtonAssistiveText: PropTypes.string,
 	/**
 	 * Custom CSS classes for the modal's container. This is the element with `.slds-modal__container`. Use `classNames` [API](https://github.com/JedWatson/classnames).
 	 */
@@ -173,6 +174,7 @@ class Modal extends React.Component {
 
 	componentWillMount () {
 		this.generatedId = shortid.generate();
+		checkProps(MODAL, this.props);
 	}
 
 	componentDidMount () {
@@ -339,7 +341,7 @@ class Modal extends React.Component {
 		const headerEmpty =
 			!headerContent && !this.props.title && !this.props.tagline;
 		const closeButtonAssistiveText =
-			this.props.closeButtonAssistiveText || 'Close';
+			this.props.assistiveText.closeButton || this.props.closeButtonAssistiveText || 'Close';
 		const closeButton = (
 			<Button
 				assistiveText={closeButtonAssistiveText}
@@ -449,7 +451,7 @@ class Modal extends React.Component {
 	}
 }
 
-Modal.displayName = displayName;
+Modal.displayName = MODAL;
 Modal.propTypes = propTypes;
 Modal.defaultProps = defaultProps;
 

--- a/components/modal/index.jsx
+++ b/components/modal/index.jsx
@@ -13,9 +13,6 @@ import ReactDOM from 'react-dom';
 import classNames from 'classnames';
 import ReactModal from 'react-modal';
 
-// ### assign
-import assign from 'lodash.assign';
-
 // ### isBoolean
 import isBoolean from 'lodash.isboolean';
 
@@ -150,7 +147,7 @@ const propTypes = {
 const defaultProps = {
 	assistiveText: {
 		dialogLabel: '',
-		// Need to add `closeButton` here after we remove `closeButtonAssistiveText`.
+		closeButton: 'Close',
 	},
 	align: 'center',
 	dismissible: true,
@@ -349,15 +346,12 @@ class Modal extends React.Component {
 		let headerContent = this.props.header;
 		const headerEmpty =
 			!headerContent && !this.props.title && !this.props.tagline;
-		const assistiveText = assign(
-			{},
-			defaultProps.assistiveText,
-			this.props.assistiveText
-		);
-		const deprecatedCloseButtonAssistiveText =
-			this.props.closeButtonAssistiveText || 'Close';
+		const assistiveText = {
+			...defaultProps.assistiveText,
+			...this.props.assistiveText,
+		};
 		const closeButtonAssistiveText =
-			assistiveText.closeButton || deprecatedCloseButtonAssistiveText;
+			this.props.closeButtonAssistiveText || assistiveText.closeButton;
 		const closeButton = (
 			<Button
 				assistiveText={closeButtonAssistiveText}

--- a/components/modal/index.jsx
+++ b/components/modal/index.jsx
@@ -13,6 +13,9 @@ import ReactDOM from 'react-dom';
 import classNames from 'classnames';
 import ReactModal from 'react-modal';
 
+// ### assign
+import assign from 'lodash.assign';
+
 // ### isBoolean
 import isBoolean from 'lodash.isboolean';
 
@@ -34,11 +37,14 @@ const propTypes = {
 	 */
 	align: PropTypes.oneOf(['top', 'center']),
 	/**
-	 * Assistive text for the modal.
+	 * **Assistive text for accessibility.**
+	 * This object is merged with the default props object on every render.
+	 * * `dialogLabel`: This is a visually hidden label for the dialog. If not provided, `title` is used.
+	 * * `closeButton`: This is a visually hidden label for the close button.
 	 */
 	assistiveText: PropTypes.shape({
-		dialogLabel: PropTypes.string, // If not provided, `title` is used.
-		closeButton: PropTypes.string, // Text read aloud by screen readers when the user focuses on the Close Button.
+		dialogLabel: PropTypes.string,
+		closeButton: PropTypes.string,
 	}),
 	/**
 	 * Modal content.
@@ -142,7 +148,10 @@ const propTypes = {
 };
 
 const defaultProps = {
-	assistiveText: {},
+	assistiveText: {
+		dialogLabel: '',
+		// Need to add `closeButton` here after we remove `closeButtonAssistiveText`.
+	},
 	align: 'center',
 	dismissible: true,
 };
@@ -340,10 +349,15 @@ class Modal extends React.Component {
 		let headerContent = this.props.header;
 		const headerEmpty =
 			!headerContent && !this.props.title && !this.props.tagline;
+		const assistiveText = assign(
+			{},
+			defaultProps.assistiveText,
+			this.props.assistiveText
+		);
+		const deprecatedCloseButtonAssistiveText =
+			this.props.closeButtonAssistiveText || 'Close';
 		const closeButtonAssistiveText =
-			this.props.assistiveText.closeButton ||
-			this.props.closeButtonAssistiveText ||
-			'Close';
+			assistiveText.closeButton || deprecatedCloseButtonAssistiveText;
 		const closeButton = (
 			<Button
 				assistiveText={closeButtonAssistiveText}

--- a/components/modal/index.jsx
+++ b/components/modal/index.jsx
@@ -341,7 +341,9 @@ class Modal extends React.Component {
 		const headerEmpty =
 			!headerContent && !this.props.title && !this.props.tagline;
 		const closeButtonAssistiveText =
-			this.props.assistiveText.closeButton || this.props.closeButtonAssistiveText || 'Close';
+			this.props.assistiveText.closeButton ||
+			this.props.closeButtonAssistiveText ||
+			'Close';
 		const closeButton = (
 			<Button
 				assistiveText={closeButtonAssistiveText}

--- a/components/popover/__docs__/storybook-stories.jsx
+++ b/components/popover/__docs__/storybook-stories.jsx
@@ -112,7 +112,9 @@ storiesOf(POPOVER, module)
 			id: 'myPopoverId',
 			isOpen: true,
 			className: 'sample-classname',
-			closeButtonAssistiveText: 'Shut it now!',
+			assistiveText: {
+				closeButton: 'Shut it now!',
+			},
 			containerClassName: 'sample-container-classname',
 			containerStyle: { background: containerBackgroundColor },
 			style: { background: popoverBackgroundColor },

--- a/components/popover/__tests__/popover.browser-test.jsx
+++ b/components/popover/__tests__/popover.browser-test.jsx
@@ -145,7 +145,9 @@ describe('SLDSPopover', function () {
 		// What should be present in the DOM when style and className are applied?
 		const optionalProps = {
 			className: 'sample-classname',
-			closeButtonAssistiveText: 'Shut it now!',
+			assistiveText: {
+				closeButton: 'Shut it now!',
+			},
 			containerClassName: 'sample-container-classname',
 			containerStyle: { background: containerBackgroundColor },
 			footer: <p id="footer">Footer</p>,
@@ -160,7 +162,7 @@ describe('SLDSPopover', function () {
 			destroyMountNode({ wrapper, mountNode });
 		});
 
-		it('has correct className, closeButtonAssistiveText, style, and footer', function () {
+		it('has correct className, assistiveText, style, and footer', function () {
 			wrapper = mount(<DemoComponent {...optionalProps} isOpen />, {
 				attachTo: mountNode,
 			});
@@ -170,7 +172,7 @@ describe('SLDSPopover', function () {
 			expect(popover.node.classList.contains(optionalProps.className)).to.be
 				.true;
 			expect(popover.find('.slds-popover__close').node.textContent).to.equal(
-				optionalProps.closeButtonAssistiveText
+				optionalProps.assistiveText.closeButton
 			);
 			expect(popover.find('#footer')).to.exist;
 			expect(popover.node.style.background).to.equal(popoverBackgroundColor);

--- a/components/popover/check-props.js
+++ b/components/popover/check-props.js
@@ -35,7 +35,7 @@ if (process.env.NODE_ENV !== 'production') {
 			COMPONENT,
 			props.closeButtonAssistiveText,
 			'closeButtonAssistiveText',
-			'assistiveText[\'closeButton\']',
+			"assistiveText['closeButton']"
 		);
 	};
 }

--- a/components/popover/check-props.js
+++ b/components/popover/check-props.js
@@ -30,6 +30,13 @@ if (process.env.NODE_ENV !== 'production') {
 			'isInline',
 			'position="relative"'
 		);
+
+		deprecatedProperty(
+			COMPONENT,
+			props.closeButtonAssistiveText,
+			'closeButtonAssistiveText',
+			'assistiveText[\'closeButton\']',
+		);
 	};
 }
 

--- a/components/popover/popover.jsx
+++ b/components/popover/popover.jsx
@@ -76,7 +76,7 @@ const PopoverNubbinPositions = [
 const defaultProps = {
 	align: 'right',
 	assistiveText: {
-		// Need to add `closeButton` here after we remove `closeButtonAssistiveText`.
+		closeButton: 'Close dialog',
 	},
 	hoverCloseDelay: 300,
 	openOn: 'click',
@@ -435,15 +435,12 @@ const Popover = createReactClass({
 		const props = this.props;
 		const offset = props.offset;
 		const style = this.props.style || {};
-		const assistiveText = assign(
-			{},
-			defaultProps.assistiveText,
-			this.props.assistiveText
-		);
-		const deprecatedCloseButtonAssistiveText =
-			props.closeButtonAssistiveText || 'Close dialog';
+		const assistiveText = {
+			...defaultProps.assistiveText,
+			...this.props.assistiveText,
+		};
 		const closeButtonAssistiveText =
-			assistiveText.closeButton || deprecatedCloseButtonAssistiveText;
+			props.closeButtonAssistiveText || assistiveText.closeButton;
 
 		return isOpen ? (
 			<Dialog

--- a/components/popover/popover.jsx
+++ b/components/popover/popover.jsx
@@ -476,7 +476,11 @@ const Popover = createReactClass({
 					ref={this.setMenuRef}
 				>
 					<Button
-						assistiveText={props.assistiveText.closeButton || props.closeButtonAssistiveText || 'Close dialog'}
+						assistiveText={
+							props.assistiveText.closeButton ||
+							props.closeButtonAssistiveText ||
+							'Close dialog'
+						}
 						iconCategory="utility"
 						iconName="close"
 						iconSize="small"

--- a/components/popover/popover.jsx
+++ b/components/popover/popover.jsx
@@ -97,6 +97,12 @@ const Popover = createReactClass({
 			'left',
 		]),
 		/**
+		 * Assistive text for the popover.
+		 */
+		assistiveText: PropTypes.shape({
+			closeButton: PropTypes.string, // All popovers require a close button.
+		}),
+		/**
 		 * HTML `id` of heading for popover. Only use if your header is within your popover body.
 		 */
 		ariaLabelledby: PropTypes.string,
@@ -116,10 +122,6 @@ const Popover = createReactClass({
 			PropTypes.object,
 			PropTypes.string,
 		]),
-		/**
-		 * All popovers require a close button.
-		 */
-		closeButtonAssistiveText: PropTypes.oneOfType([PropTypes.string]),
 		/**
 		 * This prop is passed onto the triggering `Button`. Prevent popover from opening. Also applies disabled styling to trigger button.
 		 */
@@ -204,7 +206,7 @@ const Popover = createReactClass({
 	getDefaultProps () {
 		return {
 			align: 'right',
-			closeButtonAssistiveText: 'Close dialog',
+			assistiveText: {},
 			hoverCloseDelay: 300,
 			openOn: 'click',
 			position: 'absolute',
@@ -474,7 +476,7 @@ const Popover = createReactClass({
 					ref={this.setMenuRef}
 				>
 					<Button
-						assistiveText={props.closeButtonAssistiveText}
+						assistiveText={props.assistiveText.closeButton || props.closeButtonAssistiveText || 'Close dialog'}
 						iconCategory="utility"
 						iconName="close"
 						iconSize="small"

--- a/components/popover/popover.jsx
+++ b/components/popover/popover.jsx
@@ -73,6 +73,16 @@ const PopoverNubbinPositions = [
 	'bottom right',
 ];
 
+const defaultProps = {
+	align: 'right',
+	assistiveText: {
+		// Need to add `closeButton` here after we remove `closeButtonAssistiveText`.
+	},
+	hoverCloseDelay: 300,
+	openOn: 'click',
+	position: 'absolute',
+};
+
 /**
  * The Popover component is a non-modal dialog. It should be paired with a clickable trigger such as a `Button`. It traps focus from the page and must be exited if focus needs to be outside the Popover. Use a `Tooltip` if there are no call to actions within the dialog. A `Tooltip` does not need to be clicked. Multiple popovers open at the same time, each with focus trap is not supported.
  */
@@ -97,10 +107,12 @@ const Popover = createReactClass({
 			'left',
 		]),
 		/**
-		 * Assistive text for the popover.
+		 * **Assistive text for accessibility.**
+		 * This object is merged with the default props object on every render.
+		 * * `closeButton`: This is a visually hidden label for the close button.
 		 */
 		assistiveText: PropTypes.shape({
-			closeButton: PropTypes.string, // All popovers require a close button.
+			closeButton: PropTypes.string,
 		}),
 		/**
 		 * HTML `id` of heading for popover. Only use if your header is within your popover body.
@@ -204,13 +216,7 @@ const Popover = createReactClass({
 	},
 
 	getDefaultProps () {
-		return {
-			align: 'right',
-			assistiveText: {},
-			hoverCloseDelay: 300,
-			openOn: 'click',
-			position: 'absolute',
-		};
+		return defaultProps;
 	},
 
 	getInitialState () {
@@ -429,6 +435,15 @@ const Popover = createReactClass({
 		const props = this.props;
 		const offset = props.offset;
 		const style = this.props.style || {};
+		const assistiveText = assign(
+			{},
+			defaultProps.assistiveText,
+			this.props.assistiveText
+		);
+		const deprecatedCloseButtonAssistiveText =
+			props.closeButtonAssistiveText || 'Close dialog';
+		const closeButtonAssistiveText =
+			assistiveText.closeButton || deprecatedCloseButtonAssistiveText;
 
 		return isOpen ? (
 			<Dialog
@@ -476,11 +491,7 @@ const Popover = createReactClass({
 					ref={this.setMenuRef}
 				>
 					<Button
-						assistiveText={
-							props.assistiveText.closeButton ||
-							props.closeButtonAssistiveText ||
-							'Close dialog'
-						}
+						assistiveText={closeButtonAssistiveText}
 						iconCategory="utility"
 						iconName="close"
 						iconSize="small"


### PR DESCRIPTION
This PR consolidate assistive text props under one `assistiveText` prop for the following components:

- App Launcher
- Popover
- Modal

More components to come!

---

### Pull Request Review checklist (do not remove)

* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [x] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.