### PR TITLE
Fixing issue where modal jumps when opened

### DIFF
--- a/components/modal/index.jsx
+++ b/components/modal/index.jsx
@@ -425,7 +425,7 @@ class Modal extends React.Component {
 				padding: 'default',
 			},
 			overlay: {
-				position: 'static',
+				zIndex: 8000, // following SLDS guideline for z-index overlay
 				backgroundColor: 'default',
 			},
 		};


### PR DESCRIPTION
- Removing static positioning on modal overlay.
- Adding z-index to modal overlay as per SLDS guidelines.

This should fix the modal jump issue that consumers are experiencing, including `design-system-react-site` consumer - manually tested in repo.

This should also not regress [#200](https://github.com/salesforce/design-system-react/issues/200) - also manually tested.

Fixes #963 

### Additional description ###
---

### Pull Request Review checklist (do not remove)

* [ ] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
