### PR TITLE
Align button group example with SLDS example

### DIFF
--- a/components/button-group/__examples__/icon-group.jsx
+++ b/components/button-group/__examples__/icon-group.jsx
@@ -20,16 +20,16 @@ const Example = createReactClass({
 						variant="icon"
 					/>
 					<ButtonStateful
-						assistiveText="Filter"
-						iconName="filter"
+						assistiveText="Filter List"
+						iconName="filterList"
 						iconVariant="border"
 						variant="icon"
 					/>
 					<Dropdown
-						assistiveText="Sort"
+						assistiveText="Settings"
 						checkmark
 						iconCategory="utility"
-						iconName="sort"
+						iconName="settings"
 						iconVariant="more"
 						id="icon-dropdown-example"
 						onSelect={(item) => {
@@ -37,8 +37,8 @@ const Example = createReactClass({
 						}}
 						openOn="click"
 						options={[
-							{ label: 'Sort ascending', value: 'A0' },
-							{ label: 'Sort descending', value: 'B0' },
+							{ label: 'Bring left panel to front', value: 'A0' },
+							{ label: 'Bring right panel to front', value: 'B0' },
 						]}
 						value="A0"
 						variant="icon"

--- a/components/button-group/__tests__/__snapshots__/button-group.snapshot-test.jsx.snap
+++ b/components/button-group/__tests__/__snapshots__/button-group.snapshot-test.jsx.snap
@@ -472,13 +472,13 @@ exports[`Button Group IconGroup DOM Snapshot 1`] = `
       className="slds-button__icon slds-button__icon--stateful"
     >
       <use
-        xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#filter"
+        xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#filterList"
       />
     </svg>
     <span
       className="slds-assistive-text"
     >
-      Filter
+      Filter List
     </span>
   </button>
   <div
@@ -518,7 +518,7 @@ exports[`Button Group IconGroup DOM Snapshot 1`] = `
         className="slds-button__icon"
       >
         <use
-          xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#sort"
+          xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#settings"
         />
       </svg>
       <svg
@@ -532,7 +532,7 @@ exports[`Button Group IconGroup DOM Snapshot 1`] = `
       <span
         className="slds-assistive-text"
       >
-        Sort
+        Settings
       </span>
     </button>
   </div>
@@ -542,9 +542,9 @@ exports[`Button Group IconGroup DOM Snapshot 1`] = `
 exports[`Button Group IconGroup HTML Snapshot 1`] = `
 "<div class=\\"slds-button-group\\" role=\\"group\\"><button aria-live=\\"polite\\" class=\\"slds-button slds-not-selected slds-button--icon-border\\"><svg aria-hidden=\\"true\\" class=\\"slds-button__icon slds-button__icon--stateful\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#chart\\"></use></svg><span class=\\"slds-assistive-text\\">Show Chart</span></button>
   <button
-    aria-live=\\"polite\\" class=\\"slds-button slds-not-selected slds-button--icon-border\\"><svg aria-hidden=\\"true\\" class=\\"slds-button__icon slds-button__icon--stateful\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#filter\\"></use></svg><span class=\\"slds-assistive-text\\">Filter</span></button>
+    aria-live=\\"polite\\" class=\\"slds-button slds-not-selected slds-button--icon-border\\"><svg aria-hidden=\\"true\\" class=\\"slds-button__icon slds-button__icon--stateful\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#filterList\\"></use></svg><span class=\\"slds-assistive-text\\">Filter List</span></button>
     <div class=\\"slds-dropdown-trigger slds-dropdown-trigger--click slds-button--last\\"
-      id=\\"icon-dropdown-example\\"><button aria-expanded=\\"false\\" aria-haspopup=\\"true\\" class=\\"slds-button slds-button--icon-more ignore-click-icon-dropdown-example\\" tabindex=\\"0\\" type=\\"button\\"><svg aria-hidden=\\"true\\" class=\\"slds-button__icon\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#sort\\"></use></svg><svg aria-hidden=\\"true\\" class=\\"slds-button__icon slds-button__icon--x-small\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#down\\"></use></svg><span class=\\"slds-assistive-text\\">Sort</span></button></div>
+      id=\\"icon-dropdown-example\\"><button aria-expanded=\\"false\\" aria-haspopup=\\"true\\" class=\\"slds-button slds-button--icon-more ignore-click-icon-dropdown-example\\" tabindex=\\"0\\" type=\\"button\\"><svg aria-hidden=\\"true\\" class=\\"slds-button__icon\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#settings\\"></use></svg><svg aria-hidden=\\"true\\" class=\\"slds-button__icon slds-button__icon--x-small\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#down\\"></use></svg><span class=\\"slds-assistive-text\\">Settings</span></button></div>
 </div>"
 `;
 


### PR DESCRIPTION
- Aligning button group example with SLDS example, that is, changing icons and assistive text.

Button group will now look like this:

![screen shot 2018-05-20 at 11 33 47 pm](https://user-images.githubusercontent.com/1821787/40293754-3c974d2a-5c87-11e8-8327-8a6c74f5673b.png)


Fixes #1229 

### Additional description

---

### Pull Request Review checklist (do not remove)

* [x] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
