### PR TITLE
Added dropdown option to DataTableRowActions

### DIFF
--- a/components/data-table/__examples__/advanced.jsx
+++ b/components/data-table/__examples__/advanced.jsx
@@ -199,7 +199,7 @@ const Example = createReactClass({
 									id: 6,
 									label: 'Seventh of Seven',
 									value: '7',
-								}
+								},
 							]}
 							onAction={this.handleRowAction}
 							dropdown={<Dropdown length="7" />}

--- a/components/data-table/__examples__/advanced.jsx
+++ b/components/data-table/__examples__/advanced.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
+import Dropdown from '~/components/menu-dropdown';
 import DataTable from '~/components/data-table'; // `~` is replaced with design-system-react at runtime
 import DataTableColumn from '~/components/data-table/column';
 import DataTableCell from '~/components/data-table/cell';
@@ -174,8 +175,34 @@ const Example = createReactClass({
 									label: 'Publish',
 									value: '2',
 								},
+								{
+									id: 2,
+									label: 'Third of Seven',
+									value: '3',
+								},
+								{
+									id: 3,
+									label: 'Fourth of Seven',
+									value: '4',
+								},
+								{
+									id: 4,
+									label: 'Fifth of Seven',
+									value: '5',
+								},
+								{
+									id: 5,
+									label: 'Sixth of Seven',
+									value: '6',
+								},
+								{
+									id: 6,
+									label: 'Seventh of Seven',
+									value: '7',
+								}
 							]}
 							onAction={this.handleRowAction}
+							dropdown={<Dropdown length="7" />}
 						/>
 					</DataTable>
 				</IconSettings>

--- a/components/data-table/__tests__/data-table.browser-test.jsx
+++ b/components/data-table/__tests__/data-table.browser-test.jsx
@@ -336,20 +336,22 @@ describe('DataTable: ', function () {
 						<DataTableColumn {...columnProps} key={columnProps.property} />
 					))}
 					<DataTableRowActions
-						dropdown={<Dropdown
-							options={[
-								{
-									id: 0,
-									label: 'Add to Group',
-									value: '1',
-								},
-								{
-									id: 1,
-									label: 'Publish',
-									value: '2',
-								},
-							]}
-						/>}
+						dropdown={
+							<Dropdown
+								options={[
+									{
+										id: 0,
+										label: 'Add to Group',
+										value: '1',
+									},
+									{
+										id: 1,
+										label: 'Publish',
+										value: '2',
+									},
+								]}
+							/>
+						}
 					/>
 				</DataTable>
 			).call(this);

--- a/components/data-table/__tests__/data-table.browser-test.jsx
+++ b/components/data-table/__tests__/data-table.browser-test.jsx
@@ -4,6 +4,7 @@ import TestUtils from 'react-addons-test-utils';
 
 import chai from 'chai';
 
+import Dropdown from '../../menu-dropdown';
 import DataTable from '../../data-table';
 import DataTableColumn from '../../data-table/column';
 import DataTableRowActions from '../../data-table/row-actions';
@@ -328,25 +329,27 @@ describe('DataTable: ', function () {
 	describe('w/ RowActions', function () {
 		afterEach(removeTable);
 
-		it('renders the RowActions', function () {
+		it('renders the RowActions and uses dropdown override property', function () {
 			renderTable(
 				<DataTable {...defaultProps}>
 					{columns.map((columnProps) => (
 						<DataTableColumn {...columnProps} key={columnProps.property} />
 					))}
 					<DataTableRowActions
-						options={[
-							{
-								id: 0,
-								label: 'Add to Group',
-								value: '1',
-							},
-							{
-								id: 1,
-								label: 'Publish',
-								value: '2',
-							},
-						]}
+						dropdown={<Dropdown
+							options={[
+								{
+									id: 0,
+									label: 'Add to Group',
+									value: '1',
+								},
+								{
+									id: 1,
+									label: 'Publish',
+									value: '2',
+								},
+							]}
+						/>}
 					/>
 				</DataTable>
 			).call(this);
@@ -371,6 +374,7 @@ describe('DataTable: ', function () {
 						<DataTableColumn {...columnProps} key={columnProps.property} />
 					))}
 					<DataTableRowActions
+						onAction={this.onAction}
 						options={[
 							{
 								id: 0,
@@ -383,7 +387,6 @@ describe('DataTable: ', function () {
 								value: '2',
 							},
 						]}
-						onAction={this.onAction}
 					/>
 				</DataTable>
 			).call(this);

--- a/components/data-table/__tests__/data-table.browser-test.jsx
+++ b/components/data-table/__tests__/data-table.browser-test.jsx
@@ -363,11 +363,18 @@ describe('DataTable: ', function () {
 			rowActionMenus.should.have.length(6);
 		});
 
-		it('calls onAction when an action is clicked', function (done) {
+		it('calls onAction & onSelect when an action is clicked', function (done) {
+			let expectedCalbacks = 2;
+
 			this.onAction = (item, action) => {
 				item.id.should.equal('8IKZHZZV80');
 				action.value.should.equal('1');
-				done();
+				if (!--expectedCalbacks) done();
+			};
+
+			this.onSelect = (action) => {
+				action.value.should.equal('1');
+				if (!--expectedCalbacks) done();
 			};
 
 			renderTable(
@@ -389,6 +396,7 @@ describe('DataTable: ', function () {
 								value: '2',
 							},
 						]}
+						dropdown={<Dropdown onSelect={this.onSelect} />}
 					/>
 				</DataTable>
 			).call(this);

--- a/components/data-table/row-actions.jsx
+++ b/components/data-table/row-actions.jsx
@@ -60,7 +60,7 @@ const DataTableRowActions = createReactClass({
 		options: PropTypes.array,
 		/**
 		 * A [Dropdown](http://react.lightningdesignsystem.com/components/dropdown-menus/) component. The props from this drop will be merged and override any default props.
-		 * **Note:** onAction will not be overridden, both `DropDown`'s onSelect and onAction will be called with appropriate parameters
+		 * **Note:** onAction will not be overridden, both `DropDown`'s onSelect(dropDownActionOption) and onAction(rowItem, dropdownActionOption) will be called with appropriate parameters
 		 */
 		dropdown: PropTypes.node,
 	},

--- a/components/data-table/row-actions.jsx
+++ b/components/data-table/row-actions.jsx
@@ -60,7 +60,7 @@ const DataTableRowActions = createReactClass({
 		/**
 		 * `Dropdown` options. See `Dropdown`.
 		 */
-		options: PropTypes.array.isRequired,
+		options: PropTypes.array,
 		/**
 		 * A `Dropdown` component. The props from this drop will be merged and override any default props.
 		 * **Note:** onAction will not be overridden, both `DropDown`'s onSelect and onAction will be called with appropriate parameters
@@ -72,6 +72,7 @@ const DataTableRowActions = createReactClass({
 		return {
 			assistiveText: 'Actions',
 			noHint: false,
+			options: [],
 		};
 	},
 

--- a/components/data-table/row-actions.jsx
+++ b/components/data-table/row-actions.jsx
@@ -59,7 +59,7 @@ const DataTableRowActions = createReactClass({
 		 */
 		options: PropTypes.array,
 		/**
-		 * A `Dropdown` component. The props from this drop will be merged and override any default props.
+		 * A [Dropdown](http://react.lightningdesignsystem.com/components/dropdown-menus/) component. The props from this drop will be merged and override any default props.
 		 * **Note:** onAction will not be overridden, both `DropDown`'s onSelect and onAction will be called with appropriate parameters
 		 */
 		dropdown: PropTypes.node,

--- a/components/data-table/row-actions.jsx
+++ b/components/data-table/row-actions.jsx
@@ -11,6 +11,9 @@ import PropTypes from 'prop-types';
 // ### isFunction
 import isFunction from 'lodash.isfunction';
 
+// ### merge
+import assign from 'lodash.assign';
+
 // ## Children
 import Dropdown from '../menu-dropdown';
 
@@ -58,12 +61,17 @@ const DataTableRowActions = createReactClass({
 		 * `Dropdown` options. See `Dropdown`.
 		 */
 		options: PropTypes.array.isRequired,
+		/**
+		 * A `Dropdown` component. The props from this drop will be merged and override any default props.
+		 * **Note:** onAction will not be overridden, both `DropDown`'s onSelect and onAction will be called with appropriate parameters
+		 */
+		dropdown: PropTypes.node
 	},
 
 	getDefaultProps () {
 		return {
 			assistiveText: 'Actions',
-			noHint: false,
+			noHint: false
 		};
 	},
 
@@ -75,11 +83,36 @@ const DataTableRowActions = createReactClass({
 		if (isFunction(this.props.onAction)) {
 			this.props.onAction(this.props.item, selection);
 		}
+		if (this.props.dropdown && isFunction(this.props.dropdown.onSelect)) {
+			this.props.dropdown.onSelect(selection);
+		}
 	},
 
 	// ### Render
 	render () {
 		// i18n
+		const defaultDropdownProps = {
+			align: 'right',
+			buttonClassName: 'slds-button--icon-x-small',
+			buttonVariant: 'icon',
+			iconCategory: 'utility',
+			iconName: 'down',
+			iconSize: 'small',
+			iconVariant: 'border-filled',
+			assistiveText: this.props.assistiveText,
+			className: this.props.className,
+			options: this.props.options,
+			hint: !this.props.noHint,
+			id: this.props.id
+		};
+
+		const dropdownProps = assign(
+			defaultDropdownProps,
+			this.props.dropdown ? this.props.dropdown.props : {}
+		);
+
+		dropdownProps.onAction = this.handleSelect;
+
 		return (
 			/* eslint-disable jsx-a11y/no-static-element-interactions */
 			<td
@@ -89,21 +122,7 @@ const DataTableRowActions = createReactClass({
 				style={{ width: '3.25rem' }}
 			>
 				{/* eslint-enable jsx-a11y/no-static-element-interactions */}
-				<Dropdown
-					align="right"
-					assistiveText={this.props.assistiveText}
-					buttonClassName="slds-button--icon-x-small"
-					buttonVariant="icon"
-					className={this.props.className}
-					options={this.props.options}
-					hint={!this.props.noHint}
-					iconCategory="utility"
-					iconName="down"
-					iconSize="small"
-					iconVariant="border-filled"
-					id={this.props.id}
-					onSelect={this.handleSelect}
-				/>
+				<Dropdown {...dropdownProps} />
 			</td>
 		);
 	},

--- a/components/data-table/row-actions.jsx
+++ b/components/data-table/row-actions.jsx
@@ -84,8 +84,8 @@ const DataTableRowActions = createReactClass({
 		if (isFunction(this.props.onAction)) {
 			this.props.onAction(this.props.item, selection);
 		}
-		if (this.props.dropdown && isFunction(this.props.dropdown.onSelect)) {
-			this.props.dropdown.onSelect(selection);
+		if (this.props.dropdown && isFunction(this.props.dropdown.props.onSelect)) {
+			this.props.dropdown.props.onSelect(selection);
 		}
 	},
 
@@ -112,7 +112,7 @@ const DataTableRowActions = createReactClass({
 			this.props.dropdown ? this.props.dropdown.props : {}
 		);
 
-		dropdownProps.onAction = this.handleSelect;
+		dropdownProps.onSelect = this.handleSelect;
 
 		return (
 			/* eslint-disable jsx-a11y/no-static-element-interactions */

--- a/components/data-table/row-actions.jsx
+++ b/components/data-table/row-actions.jsx
@@ -65,13 +65,13 @@ const DataTableRowActions = createReactClass({
 		 * A `Dropdown` component. The props from this drop will be merged and override any default props.
 		 * **Note:** onAction will not be overridden, both `DropDown`'s onSelect and onAction will be called with appropriate parameters
 		 */
-		dropdown: PropTypes.node
+		dropdown: PropTypes.node,
 	},
 
 	getDefaultProps () {
 		return {
 			assistiveText: 'Actions',
-			noHint: false
+			noHint: false,
 		};
 	},
 
@@ -103,7 +103,7 @@ const DataTableRowActions = createReactClass({
 			className: this.props.className,
 			options: this.props.options,
 			hint: !this.props.noHint,
-			id: this.props.id
+			id: this.props.id,
 		};
 
 		const dropdownProps = assign(

--- a/components/data-table/row-actions.jsx
+++ b/components/data-table/row-actions.jsx
@@ -11,9 +11,6 @@ import PropTypes from 'prop-types';
 // ### isFunction
 import isFunction from 'lodash.isfunction';
 
-// ### merge
-import assign from 'lodash.assign';
-
 // ## Children
 import Dropdown from '../menu-dropdown';
 
@@ -107,12 +104,12 @@ const DataTableRowActions = createReactClass({
 			id: this.props.id,
 		};
 
-		const dropdownProps = assign(
-			defaultDropdownProps,
-			this.props.dropdown ? this.props.dropdown.props : {}
-		);
-
-		dropdownProps.onSelect = this.handleSelect;
+		const props = this.props.dropdown ? this.props.dropdown.props : {};
+		const dropdownProps = {
+			...defaultDropdownProps,
+			...props,
+			onSelect: this.handleSelect,
+		};
 
 		return (
 			/* eslint-disable jsx-a11y/no-static-element-interactions */


### PR DESCRIPTION
Fixes https://github.com/salesforce/design-system-react/issues/1403
Added dropdown option to DataTableRowActions that takes MenuDropdown component as a property to allow support for all dropdown properties by overriding defaults

---

### Pull Request Review checklist (do not remove)

* [ ] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
