### PR TITLE
Use Fetch for url-exists, if available

### DIFF
--- a/utilities/warning/url-exists.js
+++ b/utilities/warning/url-exists.js
@@ -13,32 +13,43 @@ if (process.env.NODE_ENV !== 'production') {
 	const hasWarned = {};
 	let hasExecuted;
 
-	// Using XMLHttpRequest can cause problems in non-browser environments. This should be completely removed in production environment and should not execute in a testing environment.
-	urlExists = function (control, url, comment) {
-		if (
-			!hasExecuted &&
-			!hasWarned[`${control}-path`] &&
-			typeof window !== 'undefined' &&
-			XMLHttpRequest &&
-			process.env.NODE_ENV !== 'test'
-		) {
-			const http = new XMLHttpRequest();
-			http.open('GET', url, false);
-			http.send();
-			hasExecuted = true;
-
-			if (http.status === 404) {
-				const additionalComment = comment ? ` ${comment}` : '';
-				/* eslint-disable max-len */
-				warning(
-					!url,
-					`The icon asset was not found at ${url}. Make sure the path to the icon asset is correct. You can set the icon path by importing the IconSettings component, \`<IconSettings iconPath=[/assets/icons]>\` from \`components/iconSettings\`, and wrap that component around your entire app or around individual components using icons. If you are using the \`<Icon>\` component, you can also pass the url to \`this.props.path\`.${additionalComment}`
-				);
-				/* eslint-enable max-len */
-				hasWarned[`${control}-path`] = !!url;
-			}
+	const warn = (control, url, comment) => (res) => {
+		hasExecuted = true;
+		if (res.status === 404) {
+			const additionalComment = comment ? ` ${comment}` : '';
+			/* eslint-disable max-len */
+			warning(
+				!url,
+				`The icon asset was not found at ${url}. Make sure the path to the icon asset is correct. You can set the icon path by importing the IconSettings component, \`<IconSettings iconPath=[/assets/icons]>\` from \`components/iconSettings\`, and wrap that component around your entire app or around individual components using icons. If you are using the \`<Icon>\` component, you can also pass the url to \`this.props.path\`.${additionalComment}`
+			);
+			/* eslint-enable max-len */
+			hasWarned[`${control}-path`] = !!url;
 		}
 	};
+
+	const shouldWarn = (control) =>
+		!hasExecuted &&
+		!hasWarned[`${control}-path`] &&
+		typeof window !== 'undefined' &&
+		process.env.NODE_ENV !== 'test';
+
+	if (typeof fetch === 'function') {
+		urlExists = function (control, url, comment) {
+			if (shouldWarn(control)) {
+				fetch(url).then(warn(control, url, comment));
+			}
+		};
+	} else {
+		// Using XMLHttpRequest can cause problems in non-browser environments. This should be completely removed in production environment and should not execute in a testing environment.
+		urlExists = function (control, url, comment) {
+			if (shouldWarn(control) && XMLHttpRequest) {
+				const http = new XMLHttpRequest();
+				http.open('GET', url, false);
+				http.send();
+				warn(control, url, comment)(http);
+			}
+		};
+	}
 }
 
 export default urlExists;


### PR DESCRIPTION
Fixes #1423 

### Additional description

When checking to see if an icon exists, url-exists is using the standard xmlHttpRequest, which is synchronous, and is deprecated.  I added a check to see if `fetch` is available to the browser, in which case it will use fetch, which is async and standard in modern browsers.

### Pull Request Review checklist (do not remove)

* [ ] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
