### PR TITLE
Fixing JS errors in tree accessibility

### DIFF
--- a/components/tree/private/branch.jsx
+++ b/components/tree/private/branch.jsx
@@ -115,8 +115,8 @@ const handleKeyDownUp = (event, props) => {
 const handleKeyDownRight = (event, props) => {
 	if (props.node.expanded) {
 		if (
-			this.props.getNodes(props.node) &&
-			this.props.getNodes(props.node).length > 0
+			props.getNodes(props.node) &&
+			props.getNodes(props.node).length > 0
 		) {
 			handleKeyDownDown(event, props);
 		}
@@ -134,11 +134,14 @@ const handleKeyDownLeft = (event, props) => {
 		);
 		const index = nodes.indexOf(props.parent);
 		if (index !== -1) {
-			props.onExpand(event, {
-				node: props.parent,
-				select: true,
-				expand: !props.parent.expanded,
-				treeIndex: props.flattenedNodes[index].treeIndex,
+			const expand = !props.parent.expanded;
+			props.onExpand({event,
+				data: {
+					node: props.parent,
+					select: true,
+					expand: !props.parent.expanded,
+					treeIndex: props.flattenedNodes[index].treeIndex,
+				}
 			});
 		}
 	}

--- a/components/tree/private/branch.jsx
+++ b/components/tree/private/branch.jsx
@@ -131,7 +131,6 @@ const handleKeyDownLeft = (event, props) => {
 		);
 		const index = nodes.indexOf(props.parent);
 		if (index !== -1) {
-			const expand = !props.parent.expanded;
 			props.onExpand({
 				event,
 				data: {

--- a/components/tree/private/branch.jsx
+++ b/components/tree/private/branch.jsx
@@ -114,10 +114,7 @@ const handleKeyDownUp = (event, props) => {
 
 const handleKeyDownRight = (event, props) => {
 	if (props.node.expanded) {
-		if (
-			props.getNodes(props.node) &&
-			props.getNodes(props.node).length > 0
-		) {
+		if (props.getNodes(props.node) && props.getNodes(props.node).length > 0) {
 			handleKeyDownDown(event, props);
 		}
 	} else {
@@ -135,13 +132,14 @@ const handleKeyDownLeft = (event, props) => {
 		const index = nodes.indexOf(props.parent);
 		if (index !== -1) {
 			const expand = !props.parent.expanded;
-			props.onExpand({event,
+			props.onExpand({
+				event,
 				data: {
 					node: props.parent,
 					select: true,
 					expand: !props.parent.expanded,
 					treeIndex: props.flattenedNodes[index].treeIndex,
-				}
+				},
 			});
 		}
 	}


### PR DESCRIPTION
Fixes #1427 

Fixing JS errors on tree accessibility.

### Additional description

---

### Pull Request Review checklist (do not remove)

* [ ] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
