### PR TITLE
add key to svg icon (re-render icon when changes are made)

### DIFF
--- a/components/utilities/utility-icon/index.jsx
+++ b/components/utilities/utility-icon/index.jsx
@@ -68,7 +68,7 @@ const UtilityIcon = (
 	return inlineData ? (
 		<Svg data={inlineData} name={name} {...rest} />
 	) : (
-		<svg {...rest}>
+		<svg key={`${name}_${category}`} {...rest}>
 			<use xlinkHref={modifiedPath} />
 		</svg>
 	);


### PR DESCRIPTION
### Additional description

We are seeing a problem when we try to update an `Icon` component. 

Our code looks like below, where the `name` and `category` are dyanmic and update frequently. After the initial render, we update these and are not seeing the SVG icon update. We have seen that url used in the `svg > use` is updated, but the icon disappears. 

Adding a `key` attribute to this SVG element seems to re-render the icon correctly, but we do get a bit of a flash.

```js

  const Test = ({ name, category }) => (
    <div className="slds-box--border">
      <Icon
        category={category}
        name={name}
        style={iconStyles}
      />
    </div>
  );
```

**Not working**
https://drive.google.com/open?id=10NjYbVF3foqqx-puufXsKdVaVzCHPA8s

**Working**
https://drive.google.com/open?id=1uK5EoZb-K-LiCpSN70daLgfXbnhTYrLZ



---

### Pull Request Review checklist (do not remove)

* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [x] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
