### PR TITLE
Attach disabled attribute to combobox inputs

### DIFF
--- a/components/combobox/__docs__/storybook-stories.jsx
+++ b/components/combobox/__docs__/storybook-stories.jsx
@@ -108,6 +108,4 @@ storiesOf(COMBOBOX, module)
 	.add('Snapshot Readonly Single Selection Custom Menu Item', () => (
 		<SnapshotReadonlySingleSelectionCustomMenuItemOpen action={action} />
 	))
-	.add('Disabled', () => (
-		<Disabled action={action} />
-	));
+	.add('Disabled', () => <Disabled action={action} />);

--- a/components/combobox/__docs__/storybook-stories.jsx
+++ b/components/combobox/__docs__/storybook-stories.jsx
@@ -32,6 +32,7 @@ import SnapshotReadonlyMultipleSelectionSingleItemSelected from '../__examples__
 import SnapshotReadonlyMultipleSelectionMultipleItemsSelected from '../__examples__/snapshot/readonly-multiple-selection-multiple-items-selected';
 import SnapshotReadonlySingleSelectionCustomMenuItemOpen from '../__examples__/snapshot/readonly-single-selection-custom-menu-item';
 import SnapshotBaseLabelRequired from '../__examples__/snapshot/base-label-required';
+import Disabled from '../__examples__/snapshot/disabled';
 
 storiesOf(COMBOBOX, module)
 	.addDecorator((getStory) => (
@@ -106,4 +107,7 @@ storiesOf(COMBOBOX, module)
 	))
 	.add('Snapshot Readonly Single Selection Custom Menu Item', () => (
 		<SnapshotReadonlySingleSelectionCustomMenuItemOpen action={action} />
+	))
+	.add('Disabled', () => (
+		<Disabled action={action} />
 	));

--- a/components/combobox/__examples__/snapshot/disabled.jsx
+++ b/components/combobox/__examples__/snapshot/disabled.jsx
@@ -3,25 +3,18 @@ import Combobox from '~/components/combobox/combobox';
 import IconSettings from '~/components/icon-settings';
 
 class Example extends React.Component {
-  constructor (props) {
-    super(props);
-  }
-
-  render () {
-    return (
-      <section>
-        <h1 className="slds-text-title_caps slds-p-vertical--medium">
-          Disabled Combobox
-        </h1>
-        <IconSettings iconPath="/assets/icons">
-          <Combobox
-            id="combobox-unique-id"
-            disabled
-          />
-        </IconSettings>
-      </section>
-      );
-  }
+	render () {
+		return (
+			<section>
+				<h1 className="slds-text-title_caps slds-p-vertical--medium">
+					Disabled Combobox
+				</h1>
+				<IconSettings iconPath="/assets/icons">
+					<Combobox id="combobox-unique-id" disabled />
+				</IconSettings>
+			</section>
+		);
+	}
 }
 
 Example.displayName = 'ComboboxExample';

--- a/components/combobox/__examples__/snapshot/disabled.jsx
+++ b/components/combobox/__examples__/snapshot/disabled.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import Combobox from '~/components/combobox/combobox';
+import IconSettings from '~/components/icon-settings';
+
+class Example extends React.Component {
+  constructor (props) {
+    super(props);
+  }
+
+  render () {
+    return (
+      <section>
+        <h1 className="slds-text-title_caps slds-p-vertical--medium">
+          Disabled Combobox
+        </h1>
+        <IconSettings iconPath="/assets/icons">
+          <Combobox
+            id="combobox-unique-id"
+            disabled
+          />
+        </IconSettings>
+      </section>
+      );
+  }
+}
+
+Example.displayName = 'ComboboxExample';
+export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/combobox/__tests__/combobox.browser-test.jsx
+++ b/components/combobox/__tests__/combobox.browser-test.jsx
@@ -453,7 +453,7 @@ describe('SLDSCombobox', function () {
 			destroyMountNode({ wrapper, mountNode });
 		});
 
-		it('has attribute "disabled"', function() {
+		it('has attribute "disabled"', function () {
 			wrapper = mount(<DemoComponent disabled />, {
 				attachTo: mountNode,
 			});
@@ -461,6 +461,5 @@ describe('SLDSCombobox', function () {
 			const nodes = getNodes({ wrapper });
 			expect(nodes.input.node.getAttribute('disabled')).to.equal('');
 		});
-
-	})
+	});
 });

--- a/components/combobox/__tests__/combobox.browser-test.jsx
+++ b/components/combobox/__tests__/combobox.browser-test.jsx
@@ -443,4 +443,24 @@ describe('SLDSCombobox', function () {
 			expect(onOpenCallback.callCount).to.equal(1);
 		});
 	});
+
+	describe('Disabled', () => {
+		beforeEach(() => {
+			mountNode = createMountNode({ context: this });
+		});
+
+		afterEach(() => {
+			destroyMountNode({ wrapper, mountNode });
+		});
+
+		it('has attribute "disabled"', function() {
+			wrapper = mount(<DemoComponent disabled />, {
+				attachTo: mountNode,
+			});
+
+			const nodes = getNodes({ wrapper });
+			expect(nodes.input.node.getAttribute('disabled')).to.equal('');
+		});
+
+	})
 });

--- a/components/combobox/combobox.jsx
+++ b/components/combobox/combobox.jsx
@@ -755,6 +755,7 @@ class Combobox extends React.Component {
 									props.value
 								: props.value
 						}
+						disabled={props.disabled}
 					/>
 					{this.getDialog({
 						menuRenderer: this.renderMenu({ assistiveText, labels }),
@@ -880,6 +881,7 @@ class Combobox extends React.Component {
 									props.value
 								: props.value
 						}
+						disabled={props.disabled}
 					/>
 					{this.getDialog({
 						menuRenderer: this.renderMenu({ assistiveText, labels }),
@@ -998,6 +1000,7 @@ class Combobox extends React.Component {
 										props.value
 									: value
 							}
+							disabled={props.disabled}
 						/>
 						{this.getDialog({
 							menuRenderer: this.renderMenu({ assistiveText, labels }),
@@ -1117,6 +1120,7 @@ class Combobox extends React.Component {
 							required={props.required}
 							role="textbox"
 							value={value}
+							disabled={props.disabled}
 						/>
 						{this.getDialog({
 							menuRenderer: this.renderMenu({ assistiveText, labels }),
@@ -1224,6 +1228,7 @@ class Combobox extends React.Component {
 								(this.state.activeOption && this.state.activeOption.label) ||
 								value
 							}
+							disabled={props.disabled}
 						/>
 						{this.getDialog({
 							menuRenderer: this.renderMenu({ assistiveText, labels }),


### PR DESCRIPTION
Passing the disabled attribute to a combobox was not attaching the attribute to the input. You would not actually be able to select anything (so it was truly disabled) although the browser was not setting it to a disabled state so it would _appear_ to be editable until you tried to interact with it.

I'm (very) new to React so please let me know if I need to fix anything!

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [x] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
^ Unfortunately it appears that there are quite a few accessibility violations but it does not appear to be anything I added
* [x] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [x] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
