### PR TITLE
add "offset" prop to combobox and update doc

### DIFF
--- a/components/combobox/combobox.jsx
+++ b/components/combobox/combobox.jsx
@@ -189,6 +189,7 @@ const propTypes = {
 	multiple: PropTypes.bool,
 	/**
 	 *  Offset adds pixels to the absolutely positioned dropdown menu in the format: ([vertical]px [horizontal]px).
+	 *  This is an undocumented prop and its usage is discouraged.
 	 */
 	offset: PropTypes.string,
 	/**

--- a/components/combobox/combobox.jsx
+++ b/components/combobox/combobox.jsx
@@ -188,6 +188,10 @@ const propTypes = {
 	 */
 	multiple: PropTypes.bool,
 	/**
+	 *  Offset adds pixels to the absolutely positioned dropdown menu in the format: ([vertical]px [horizontal]px).
+	 */
+	offset: PropTypes.string,
+	/**
 	 * Item added to the dropdown menu.
 	 * To add an item as a separator, set item `type` as `separator`. Note: At the moment, we don't support two consecutive separators. _Tested with snapshot testing._
 	 */
@@ -323,6 +327,7 @@ class Combobox extends React.Component {
 				context={this.context}
 				hasStaticAlignment={this.props.hasStaticAlignment}
 				inheritWidthOf={this.props.inheritWidthOf}
+				offset={this.props.offset}
 				onClose={this.handleClose}
 				onOpen={this.handleOpen}
 				onRequestTargetElement={this.getTargetElement}

--- a/components/combobox/combobox.jsx
+++ b/components/combobox/combobox.jsx
@@ -188,11 +188,6 @@ const propTypes = {
 	 */
 	multiple: PropTypes.bool,
 	/**
-	 *  Offset adds pixels to the absolutely positioned dropdown menu in the format: ([vertical]px [horizontal]px).
-	 *  This is an undocumented prop and its usage is discouraged.
-	 */
-	offset: PropTypes.string,
-	/**
 	 * Item added to the dropdown menu.
 	 * To add an item as a separator, set item `type` as `separator`. Note: At the moment, we don't support two consecutive separators. _Tested with snapshot testing._
 	 */
@@ -322,7 +317,9 @@ class Combobox extends React.Component {
 			? 'relative'
 			: this.props.menuPosition; // eslint-disable-line react/prop-types
 
+
 		return !this.props.disabled && this.getIsOpen() ? (
+			// offset is an undocumented prop and its usage is discouraged.
 			<Dialog
 				align="bottom left"
 				context={this.context}

--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -2908,6 +2908,13 @@
                 "required": false,
                 "description": "Allows multiple selections _Tested with mocha testing._"
             },
+            "offset": {
+                "type": {
+                    "name": "string"
+                },
+                "required": false,
+                "description": "Offset adds pixels to the absolutely positioned dropdown menu in the format: ([vertical]px [horizontal]px)."
+            },
             "options": {
                 "type": {
                     "name": "array"

--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -2908,13 +2908,6 @@
                 "required": false,
                 "description": "Allows multiple selections _Tested with mocha testing._"
             },
-            "offset": {
-                "type": {
-                    "name": "string"
-                },
-                "required": false,
-                "description": "Offset adds pixels to the absolutely positioned dropdown menu in the format: ([vertical]px [horizontal]px)."
-            },
             "options": {
                 "type": {
                     "name": "array"


### PR DESCRIPTION
Fixes #1451 

### Additional description
Same as menu-dropdown and any other component that uses dialog component, I would like to pass an "offset" prop down to dialog. This fix is needed to fix an SFX internal bug related to combobox.
---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [ ] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [x] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [x] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.