### PR TITLE
Consolidate assistiveText props under one object [DataTable, Icon, Search, PanelFilterGroup, Spinner, Tree, Textarea]

### DIFF
--- a/components/app-launcher/__docs__/storybook-stories.jsx
+++ b/components/app-launcher/__docs__/storybook-stories.jsx
@@ -280,7 +280,7 @@ const DemoAppLauncher = createReactClass({
 				onChange={this.onSearch}
 				onClear={this.onClear}
 				placeholder="Find an app"
-				assistiveText="Find an app"
+				assistiveText={{ label: 'Find an app' }}
 				value={this.state.search}
 			/>
 		);
@@ -368,7 +368,7 @@ const DemoAppLauncherNoHeaderButton = createReactClass({
 			<Search
 				onChange={this.onSearch}
 				placeholder="Find an app"
-				assistiveText="Find an app"
+				assistiveText={{ label: 'Find an app' }}
 			/>
 		);
 
@@ -457,7 +457,7 @@ const DemoAppLauncherWithSeveralSections = createReactClass({
 			<Search
 				onChange={this.onSearch}
 				placeholder="Find an app"
-				assistiveText="Find an app"
+				assistiveText={{ label: 'Find an app' }}
 			/>
 		);
 		const modalHeaderButton = (

--- a/components/avatar/index.jsx
+++ b/components/avatar/index.jsx
@@ -139,7 +139,7 @@ class Avatar extends React.Component {
 				}.icon;
 		return (
 			<UtilityIcon
-				assistiveText={iconAssistiveText}
+				assistiveText={{ label: iconAssistiveText }}
 				category="standard"
 				name={variant === 'entity' ? 'account' : 'user'}
 			/>

--- a/components/combobox/__examples__/base-custom-menu-item.jsx
+++ b/components/combobox/__examples__/base-custom-menu-item.jsx
@@ -56,7 +56,7 @@ const accountsWithIcon = accounts.map((elem) => ({
 	...{
 		icon: (
 			<Icon
-				assistiveText="Account"
+				assistiveText={{ label: 'Account' }}
 				category="standard"
 				size="x-small"
 				name={elem.type}

--- a/components/combobox/__examples__/base-inherit-menu-width.jsx
+++ b/components/combobox/__examples__/base-inherit-menu-width.jsx
@@ -49,7 +49,13 @@ const accounts = [
 const accountsWithIcon = accounts.map((elem) => ({
 	...elem,
 	...{
-		icon: <Icon assistiveText="Account" category="standard" name={elem.type} />,
+		icon: (
+			<Icon
+				assistiveText={{ label: 'Account' }}
+				category="standard"
+				name={elem.type}
+			/>
+		),
 	},
 }));
 

--- a/components/combobox/__examples__/base-menu-separator.jsx
+++ b/components/combobox/__examples__/base-menu-separator.jsx
@@ -56,7 +56,13 @@ const accounts = [
 const accountsWithIcon = accounts.map((elem) => ({
 	...elem,
 	...{
-		icon: <Icon assistiveText="Account" category="standard" name={elem.type} />,
+		icon: (
+			<Icon
+				assistiveText={{ label: 'Account' }}
+				category="standard"
+				name={elem.type}
+			/>
+		),
 	},
 }));
 

--- a/components/combobox/__examples__/base-menu-subheader.jsx
+++ b/components/combobox/__examples__/base-menu-subheader.jsx
@@ -62,7 +62,13 @@ const accounts = [
 const accountsWithIcon = accounts.map((elem) => ({
 	...elem,
 	...{
-		icon: <Icon assistiveText="Account" category="standard" name={elem.type} />,
+		icon: (
+			<Icon
+				assistiveText={{ label: 'Account' }}
+				category="standard"
+				name={elem.type}
+			/>
+		),
 	},
 }));
 

--- a/components/combobox/__examples__/base-predefined-options-only.jsx
+++ b/components/combobox/__examples__/base-predefined-options-only.jsx
@@ -55,7 +55,13 @@ const accounts = [
 const accountsWithIcon = accounts.map((elem) => ({
 	...elem,
 	...{
-		icon: <Icon assistiveText="Account" category="standard" name={elem.type} />,
+		icon: (
+			<Icon
+				assistiveText={{ label: 'Account' }}
+				category="standard"
+				name={elem.type}
+			/>
+		),
 	},
 }));
 

--- a/components/combobox/__examples__/base.jsx
+++ b/components/combobox/__examples__/base.jsx
@@ -54,7 +54,13 @@ const accounts = [
 const accountsWithIcon = accounts.map((elem) => ({
 	...elem,
 	...{
-		icon: <Icon assistiveText="Account" category="standard" name={elem.type} />,
+		icon: (
+			<Icon
+				assistiveText={{ label: 'Account' }}
+				category="standard"
+				name={elem.type}
+			/>
+		),
 	},
 }));
 

--- a/components/combobox/__examples__/inline-multiple.jsx
+++ b/components/combobox/__examples__/inline-multiple.jsx
@@ -54,7 +54,13 @@ const accounts = [
 const accountsWithIcon = accounts.map((elem) => ({
 	...elem,
 	...{
-		icon: <Icon assistiveText="Account" category="standard" name={elem.type} />,
+		icon: (
+			<Icon
+				assistiveText={{ label: 'Account' }}
+				category="standard"
+				name={elem.type}
+			/>
+		),
 	},
 }));
 

--- a/components/combobox/__examples__/inline-single.jsx
+++ b/components/combobox/__examples__/inline-single.jsx
@@ -54,7 +54,13 @@ const accounts = [
 const accountsWithIcon = accounts.map((elem) => ({
 	...elem,
 	...{
-		icon: <Icon assistiveText="Account" category="standard" name={elem.type} />,
+		icon: (
+			<Icon
+				assistiveText={{ label: 'Account' }}
+				category="standard"
+				name={elem.type}
+			/>
+		),
 	},
 }));
 

--- a/components/combobox/__examples__/readonly-single-selection-custom-menu-item.jsx
+++ b/components/combobox/__examples__/readonly-single-selection-custom-menu-item.jsx
@@ -56,7 +56,7 @@ const accountsWithIcon = accounts.map((elem) => ({
 	...{
 		icon: (
 			<Icon
-				assistiveText="Account"
+				assistiveText={{ label: 'Account' }}
 				category="standard"
 				size="x-small"
 				name={elem.type}

--- a/components/combobox/__examples__/required-input-error-state.jsx
+++ b/components/combobox/__examples__/required-input-error-state.jsx
@@ -54,7 +54,13 @@ const accounts = [
 const accountsWithIcon = accounts.map((elem) => ({
 	...elem,
 	...{
-		icon: <Icon assistiveText="Account" category="standard" name={elem.type} />,
+		icon: (
+			<Icon
+				assistiveText={{ label: 'Account' }}
+				category="standard"
+				name={elem.type}
+			/>
+		),
 	},
 }));
 

--- a/components/combobox/__examples__/snapshot/base-open-class-name.jsx
+++ b/components/combobox/__examples__/snapshot/base-open-class-name.jsx
@@ -28,7 +28,13 @@ const accounts = [
 const accountsWithIcon = accounts.map((elem) => ({
 	...elem,
 	...{
-		icon: <Icon assistiveText="Account" category="standard" name={elem.type} />,
+		icon: (
+			<Icon
+				assistiveText={{ label: 'Account' }}
+				category="standard"
+				name={elem.type}
+			/>
+		),
 	},
 }));
 

--- a/components/combobox/__examples__/snapshot/base-open.jsx
+++ b/components/combobox/__examples__/snapshot/base-open.jsx
@@ -23,7 +23,13 @@ const accounts = [
 const accountsWithIcon = accounts.map((elem) => ({
 	...elem,
 	...{
-		icon: <Icon assistiveText="Account" category="standard" name={elem.type} />,
+		icon: (
+			<Icon
+				assistiveText={{ label: 'Account' }}
+				category="standard"
+				name={elem.type}
+			/>
+		),
 	},
 }));
 

--- a/components/combobox/__examples__/snapshot/base-selected.jsx
+++ b/components/combobox/__examples__/snapshot/base-selected.jsx
@@ -23,7 +23,13 @@ const accounts = [
 const accountsWithIcon = accounts.map((elem) => ({
 	...elem,
 	...{
-		icon: <Icon assistiveText="Account" category="standard" name={elem.type} />,
+		icon: (
+			<Icon
+				assistiveText={{ label: 'Account' }}
+				category="standard"
+				name={elem.type}
+			/>
+		),
 	},
 }));
 

--- a/components/combobox/__examples__/snapshot/inline-multiple-selection-selected.jsx
+++ b/components/combobox/__examples__/snapshot/inline-multiple-selection-selected.jsx
@@ -54,7 +54,13 @@ const accounts = [
 const accountsWithIcon = accounts.map((elem) => ({
 	...elem,
 	...{
-		icon: <Icon assistiveText="Account" category="standard" name={elem.type} />,
+		icon: (
+			<Icon
+				assistiveText={{ label: 'Account' }}
+				category="standard"
+				name={elem.type}
+			/>
+		),
 	},
 }));
 

--- a/components/combobox/__examples__/snapshot/inline-multiple-selection.jsx
+++ b/components/combobox/__examples__/snapshot/inline-multiple-selection.jsx
@@ -54,7 +54,13 @@ const accounts = [
 const accountsWithIcon = accounts.map((elem) => ({
 	...elem,
 	...{
-		icon: <Icon assistiveText="Account" category="standard" name={elem.type} />,
+		icon: (
+			<Icon
+				assistiveText={{ label: 'Account' }}
+				category="standard"
+				name={elem.type}
+			/>
+		),
 	},
 }));
 

--- a/components/combobox/__examples__/snapshot/inline-single-selection-selected.jsx
+++ b/components/combobox/__examples__/snapshot/inline-single-selection-selected.jsx
@@ -54,7 +54,13 @@ const accounts = [
 const accountsWithIcon = accounts.map((elem) => ({
 	...elem,
 	...{
-		icon: <Icon assistiveText="Account" category="standard" name={elem.type} />,
+		icon: (
+			<Icon
+				assistiveText={{ label: 'Account' }}
+				category="standard"
+				name={elem.type}
+			/>
+		),
 	},
 }));
 

--- a/components/combobox/__examples__/snapshot/inline-single-selection.jsx
+++ b/components/combobox/__examples__/snapshot/inline-single-selection.jsx
@@ -54,7 +54,13 @@ const accounts = [
 const accountsWithIcon = accounts.map((elem) => ({
 	...elem,
 	...{
-		icon: <Icon assistiveText="Account" category="standard" name={elem.type} />,
+		icon: (
+			<Icon
+				assistiveText={{ label: 'Account' }}
+				category="standard"
+				name={elem.type}
+			/>
+		),
 	},
 }));
 

--- a/components/combobox/__tests__/combobox.browser-test.jsx
+++ b/components/combobox/__tests__/combobox.browser-test.jsx
@@ -79,7 +79,13 @@ const accounts = [
 
 const accountsWithIcon = accounts.map((elem) =>
 	assign(elem, {
-		icon: <Icon assistiveText="Account" category="standard" name={elem.type} />,
+		icon: (
+			<Icon
+				assistiveText={{ label: 'Account' }}
+				category="standard"
+				name={elem.type}
+			/>
+		),
 	})
 );
 

--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -3090,69 +3090,40 @@
             }
         ],
         "props": {
-            "assistiveTextForActionsHeader": {
+            "assistiveText": {
                 "type": {
-                    "name": "string"
+                    "name": "shape",
+                    "value": {
+                        "actionsHeader": {
+                            "name": "string",
+                            "required": false
+                        },
+                        "columnSort": {
+                            "name": "string",
+                            "required": false
+                        },
+                        "columnSortedAscending": {
+                            "name": "string",
+                            "required": false
+                        },
+                        "columnSortedDescending": {
+                            "name": "string",
+                            "required": false
+                        },
+                        "selectAllRows": {
+                            "name": "string",
+                            "required": false
+                        },
+                        "selectRow": {
+                            "name": "string",
+                            "required": false
+                        }
+                    }
                 },
                 "required": false,
-                "description": "Text for heading of actions column",
+                "description": "**Assistive text for accessibility.**\nThis object is merged with the default props object on every render.\n* `actionsHeader`: Text for heading of actions column\n* `columnSort`: Text for sort action on table column header\n* `columnSortedAscending`: Text announced once a column is sorted in ascending order\n* `columnSortedDescending`: Text announced once a column is sorted in descending order\n* `selectAllRows`: Text for select all checkbox within the table header\n* `selectRow`: Text for select row",
                 "defaultValue": {
-                    "value": "'Actions'",
-                    "computed": false
-                }
-            },
-            "assistiveTextForColumnSort": {
-                "type": {
-                    "name": "string"
-                },
-                "required": false,
-                "description": "Text for sort action on table column header",
-                "defaultValue": {
-                    "value": "'Sort by: '",
-                    "computed": false
-                }
-            },
-            "assistiveTextForColumnSortedAscending": {
-                "type": {
-                    "name": "string"
-                },
-                "required": false,
-                "description": "Text announced once a column is sorted in ascending order",
-                "defaultValue": {
-                    "value": "'Sorted Ascending'",
-                    "computed": false
-                }
-            },
-            "assistiveTextForColumnSortedDescending": {
-                "type": {
-                    "name": "string"
-                },
-                "required": false,
-                "description": "Text announced once a column is sorted in descending order",
-                "defaultValue": {
-                    "value": "'Sorted Descending'",
-                    "computed": false
-                }
-            },
-            "assistiveTextForSelectAllRows": {
-                "type": {
-                    "name": "string"
-                },
-                "required": false,
-                "description": "Text for select all checkbox within the table header",
-                "defaultValue": {
-                    "value": "'Select all rows'",
-                    "computed": false
-                }
-            },
-            "assistiveTextForSelectRow": {
-                "type": {
-                    "name": "string"
-                },
-                "required": false,
-                "description": "Text for select row",
-                "defaultValue": {
-                    "value": "'Select row'",
+                    "value": "{\n    actionsHeader: 'Actions',\n    columnSort: 'Sort by: ',\n    columnSortedAscending: 'Sorted Ascending',\n    columnSortedDescending: 'Sorted Descending',\n    selectAllRows: 'Select all rows',\n    selectRow: 'Select row',\n}",
                     "computed": false
                 }
             },
@@ -5760,10 +5731,20 @@
         "props": {
             "assistiveText": {
                 "type": {
-                    "name": "string"
+                    "name": "shape",
+                    "value": {
+                        "label": {
+                            "name": "string",
+                            "required": false
+                        }
+                    }
                 },
                 "required": false,
-                "description": "Text that is visually hidden but read aloud by screenreaders to tell the user what the icon means.\nNaked icons must have assistive text, however, if you also have visible descriptive text with the icon,\ndeclare this prop as <code>assistiveText=''</code>."
+                "description": "**Assistive text for accessibility.**\nThis object is merged with the default props object on every render.\n* `label`: Text that is visually hidden but read aloud by screenreaders to tell the user what the icon means. Naked icons must have assistive text, however, if you also have visible descriptive text with the icon, declare this prop as <code>assistiveText=''</code>.",
+                "defaultValue": {
+                    "value": "{}",
+                    "computed": false
+                }
             },
             "category": {
                 "type": {
@@ -7721,6 +7702,23 @@
                     "description": "A filtering panel contextual filtering options.",
                     "methods": [],
                     "props": {
+                        "assistiveText": {
+                            "type": {
+                                "name": "shape",
+                                "value": {
+                                    "closeButton": {
+                                        "name": "string",
+                                        "required": false
+                                    }
+                                }
+                            },
+                            "required": false,
+                            "description": "**Assistive text for accessibility.**\nThis object is merged with the default props object on every render.\n* `closeButton`: Localized description of the close button for the panel for screen readers",
+                            "defaultValue": {
+                                "value": "{\n    closeButton: 'Close Filter Panel',\n}",
+                                "computed": false
+                            }
+                        },
                         "addFilterLabel": {
                             "type": {
                                 "name": "node"
@@ -7729,17 +7727,6 @@
                             "description": "Localized description of the \"Add Filter\" button in the footer",
                             "defaultValue": {
                                 "value": "'Add Filter'",
-                                "computed": false
-                            }
-                        },
-                        "assistiveTextCloseFilterPanel": {
-                            "type": {
-                                "name": "node"
-                            },
-                            "required": false,
-                            "description": "Localized description of the close button for the panel for screen readers",
-                            "defaultValue": {
-                                "value": "'Close Filter Panel'",
                                 "computed": false
                             }
                         },
@@ -11810,10 +11797,20 @@
         "props": {
             "assistiveText": {
                 "type": {
-                    "name": "string"
+                    "name": "shape",
+                    "value": {
+                        "label": {
+                            "name": "string",
+                            "required": false
+                        }
+                    }
                 },
                 "required": false,
-                "description": "For users of assistive technology, if set the heading will be hidden. One of `heading` or `assistiveText` must be set in order to label the tree."
+                "description": "**Assistive text for accessibility.**\nThis object is merged with the default props object on every render.\n* `label`: For users of assistive technology, if set the heading will be hidden. One of `heading` or `assistiveText.label` must be set in order to label the tree.",
+                "defaultValue": {
+                    "value": "{}",
+                    "computed": false
+                }
             },
             "className": {
                 "type": {

--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -10772,10 +10772,16 @@
             },
             "assistiveText": {
                 "type": {
-                    "name": "string"
+                    "name": "shape",
+                    "value": {
+                        "label": {
+                            "name": "string",
+                            "required": false
+                        }
+                    }
                 },
                 "required": false,
-                "description": "If present, the label associated with this `textarea` is overwritten\nby this text and is visually not shown."
+                "description": "**Assistive text for accessibility.**\n* `label`: If present, the label associated with this `textarea` is overwritten by this text and is visually not shown."
             },
             "children": {
                 "type": {

--- a/components/data-table/__examples__/advanced.jsx
+++ b/components/data-table/__examples__/advanced.jsx
@@ -126,6 +126,14 @@ const Example = createReactClass({
 			<div>
 				<IconSettings iconPath="/assets/icons">
 					<DataTable
+						assistiveText={{
+							actionsHeader: 'actions',
+							columnSort: 'sort this column',
+							columnSortedAscending: 'asc',
+							columnSortedDescending: 'desc',
+							selectAllRows: 'all rows',
+							selectRow: 'select this row',
+						}}
 						fixedLayout
 						items={this.state.items}
 						id="DataTableExample-2"

--- a/components/data-table/__tests__/__snapshots__/data-table.snapshot-test.jsx.snap
+++ b/components/data-table/__tests__/__snapshots__/data-table.snapshot-test.jsx.snap
@@ -10,14 +10,14 @@ exports[`DataTable Advanced HTML Snapshot 1`] = `
             <div class=\\"slds-form-element\\">
               <div class=\\"slds-form-element__control\\"><span class=\\"slds-checkbox\\"><input type=\\"checkbox\\" id=\\"DataTableExample-2-SLDSDataTableHead-SelectAll\\" name=\\"SelectAll\\"/><label class=\\"slds-checkbox__label\\" for=\\"DataTableExample-2-SLDSDataTableHead-SelectAll\\"><span class=\\"slds-checkbox--faux\\"></span>
                 <span
-                  class=\\"slds-assistive-text\\">Select all rows</span>
+                  class=\\"slds-assistive-text\\">all rows</span>
                   </label>
                   </span>
               </div>
             </div>
           </div>
         </th>
-        <th aria-label=\\"Name\\" aria-sort=\\"ascending\\" class=\\"slds-is-sortable slds-is-sorted slds-text-title_caps\\" scope=\\"col\\" style=\\"width:[object Object];\\"><a href=\\"javascript:void(0)\\" class=\\"slds-th__action slds-text-link_reset\\" role=\\"button\\" tabindex=\\"0\\"><span class=\\"slds-assistive-text\\">Sort by:  </span><span class=\\"slds-truncate\\" title=\\"Name\\">Name</span><span><svg aria-hidden=\\"true\\" class=\\"slds-is-sortable__icon slds-icon slds-icon--x-small slds-icon-text-default\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#arrowup\\"></use></svg></span><span class=\\"slds-assistive-text\\" aria-live=\\"assertive\\" aria-atomic=\\"true\\">Sorted Ascending</span></a></th>
+        <th aria-label=\\"Name\\" aria-sort=\\"ascending\\" class=\\"slds-is-sortable slds-is-sorted slds-text-title_caps\\" scope=\\"col\\" style=\\"width:[object Object];\\"><a href=\\"javascript:void(0)\\" class=\\"slds-th__action slds-text-link_reset\\" role=\\"button\\" tabindex=\\"0\\"><span class=\\"slds-assistive-text\\">sort this column </span><span class=\\"slds-truncate\\" title=\\"Name\\">Name</span><span><svg aria-hidden=\\"true\\" class=\\"slds-is-sortable__icon slds-icon slds-icon--x-small slds-icon-text-default\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#arrowup\\"></use></svg></span><span class=\\"slds-assistive-text\\" aria-live=\\"assertive\\" aria-atomic=\\"true\\">asc</span></a></th>
         <th
           aria-label=\\"Account Name\\" aria-sort=\\"none\\" class=\\"slds-text-title_caps\\" scope=\\"col\\" style=\\"width:[object Object];\\"><span class=\\"slds-p-horizontal_x-small\\" style=\\"display:flex;\\"><span class=\\"slds-truncate\\" title=\\"Account Name\\">Account Name</span></span>
           </th>
@@ -25,14 +25,14 @@ exports[`DataTable Advanced HTML Snapshot 1`] = `
           </th>
           <th aria-label=\\"Stage\\" aria-sort=\\"none\\" class=\\"slds-text-title_caps\\" scope=\\"col\\"><span class=\\"slds-p-horizontal_x-small\\" style=\\"display:flex;\\"><span class=\\"slds-truncate\\" title=\\"Stage\\">Stage</span></span>
           </th>
-          <th aria-label=\\"Confidence\\" aria-sort=\\"none\\" class=\\"slds-is-sortable slds-text-title_caps\\" scope=\\"col\\"><a href=\\"javascript:void(0)\\" class=\\"slds-th__action slds-text-link_reset\\" role=\\"button\\" tabindex=\\"0\\"><span class=\\"slds-assistive-text\\">Sort by:  </span><span class=\\"slds-truncate\\" title=\\"Confidence\\">Confidence</span><span><svg aria-hidden=\\"true\\" class=\\"slds-is-sortable__icon slds-icon slds-icon--x-small slds-icon-text-default\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#arrowup\\"></use></svg></span></a></th>
+          <th aria-label=\\"Confidence\\" aria-sort=\\"none\\" class=\\"slds-is-sortable slds-text-title_caps\\" scope=\\"col\\"><a href=\\"javascript:void(0)\\" class=\\"slds-th__action slds-text-link_reset\\" role=\\"button\\" tabindex=\\"0\\"><span class=\\"slds-assistive-text\\">sort this column </span><span class=\\"slds-truncate\\" title=\\"Confidence\\">Confidence</span><span><svg aria-hidden=\\"true\\" class=\\"slds-is-sortable__icon slds-icon slds-icon--x-small slds-icon-text-default\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#arrowup\\"></use></svg></span></a></th>
           <th
             aria-label=\\"Amount\\" aria-sort=\\"none\\" class=\\"slds-text-title_caps\\" scope=\\"col\\"><span class=\\"slds-p-horizontal_x-small\\" style=\\"display:flex;\\"><span class=\\"slds-truncate\\" title=\\"Amount\\">Amount</span></span>
             </th>
             <th aria-label=\\"Contact\\" aria-sort=\\"none\\" class=\\"slds-text-title_caps\\" scope=\\"col\\"><span class=\\"slds-p-horizontal_x-small\\" style=\\"display:flex;\\"><span class=\\"slds-truncate\\" title=\\"Contact\\">Contact</span></span>
             </th>
             <th scope=\\"col\\" style=\\"width:3.25rem;\\">
-              <div class=\\"slds-th__action\\"><span class=\\"slds-assistive-text\\">Actions</span></div>
+              <div class=\\"slds-th__action\\"><span class=\\"slds-assistive-text\\">actions</span></div>
             </th>
       </tr>
     </thead>
@@ -42,7 +42,7 @@ exports[`DataTable Advanced HTML Snapshot 1`] = `
           <div class=\\"slds-form-element\\">
             <div class=\\"slds-form-element__control\\"><span class=\\"slds-checkbox\\"><input type=\\"checkbox\\" id=\\"DataTableExample-2-SLDSDataTableRow-8IKZHZZV80-SelectRow\\" name=\\"SelectRow\\"/><label class=\\"slds-checkbox__label\\" for=\\"DataTableExample-2-SLDSDataTableRow-8IKZHZZV80-SelectRow\\"><span class=\\"slds-checkbox--faux\\"></span>
               <span
-                class=\\"slds-assistive-text\\">Select row</span>
+                class=\\"slds-assistive-text\\">select this row</span>
                 </label>
                 </span>
             </div>
@@ -79,7 +79,7 @@ exports[`DataTable Advanced HTML Snapshot 1`] = `
           <div class=\\"slds-form-element\\">
             <div class=\\"slds-form-element__control\\"><span class=\\"slds-checkbox\\"><input type=\\"checkbox\\" id=\\"DataTableExample-2-SLDSDataTableRow-5GJOOOPWU7-SelectRow\\" name=\\"SelectRow\\"/><label class=\\"slds-checkbox__label\\" for=\\"DataTableExample-2-SLDSDataTableRow-5GJOOOPWU7-SelectRow\\"><span class=\\"slds-checkbox--faux\\"></span>
               <span
-                class=\\"slds-assistive-text\\">Select row</span>
+                class=\\"slds-assistive-text\\">select this row</span>
                 </label>
                 </span>
             </div>
@@ -116,7 +116,7 @@ exports[`DataTable Advanced HTML Snapshot 1`] = `
           <div class=\\"slds-form-element\\">
             <div class=\\"slds-form-element__control\\"><span class=\\"slds-checkbox\\"><input type=\\"checkbox\\" checked=\\"\\" id=\\"DataTableExample-2-SLDSDataTableRow-8IKZHZZV81-SelectRow\\" name=\\"SelectRow\\"/><label class=\\"slds-checkbox__label\\" for=\\"DataTableExample-2-SLDSDataTableRow-8IKZHZZV81-SelectRow\\"><span class=\\"slds-checkbox--faux\\"></span>
               <span
-                class=\\"slds-assistive-text\\">Select row</span>
+                class=\\"slds-assistive-text\\">select this row</span>
                 </label>
                 </span>
             </div>

--- a/components/data-table/check-props.js
+++ b/components/data-table/check-props.js
@@ -44,6 +44,43 @@ if (process.env.NODE_ENV !== 'production') {
 			'All SLDS DataTables have row borders by default now. If you do not want row borders, please use `unborderedRow`'
 		);
 		/* eslint-enable max-len */
+
+		deprecatedProperty(
+			COMPONENT,
+			props.assistiveTextForActionsHeader,
+			'assistiveTextForActionsHeader',
+			"assistiveText['actionsHeader']"
+		);
+		deprecatedProperty(
+			COMPONENT,
+			props.assistiveTextForColumnSort,
+			'assistiveTextForColumnSort',
+			"assistiveText['columnSort']"
+		);
+		deprecatedProperty(
+			COMPONENT,
+			props.assistiveTextForColumnSortedAscending,
+			'assistiveTextForColumnSortedAscending',
+			"assistiveText['columnSortedAscending']"
+		);
+		deprecatedProperty(
+			COMPONENT,
+			props.assistiveTextForColumnSortedDescending,
+			'assistiveTextForColumnSortedDescending',
+			"assistiveText['columnSortedDescending']"
+		);
+		deprecatedProperty(
+			COMPONENT,
+			props.assistiveTextForSelectAllRows,
+			'assistiveTextForSelectAllRows',
+			"assistiveText['selectAllRows']"
+		);
+		deprecatedProperty(
+			COMPONENT,
+			props.assistiveTextForSelectRow,
+			'assistiveTextForSelectRow',
+			"assistiveText['selectRow']"
+		);
 	};
 }
 

--- a/components/data-table/index.jsx
+++ b/components/data-table/index.jsx
@@ -47,6 +47,19 @@ import {
 // Safely get the length of an array, returning 0 for invalid input.
 const count = (array) => (Array.isArray(array) ? array.length : 0);
 
+const defaultProps = {
+	assistiveText: {
+		actionsHeader: 'Actions',
+		columnSort: 'Sort by: ',
+		columnSortedAscending: 'Sorted Ascending',
+		columnSortedDescending: 'Sorted Descending',
+		selectAllRows: 'Select all rows',
+		selectRow: 'Select row',
+	},
+	id: shortid.generate(),
+	selection: [],
+};
+
 /**
  * DataTables support the display of structured data in rows and columns with an HTML table. To sort, filter or paginate the table, simply update the data passed in the items to the table and it will re-render itself appropriately. The table will throw a sort event as needed, and helper components for paging and filtering are coming soon.
  *
@@ -59,29 +72,23 @@ const DataTable = createReactClass({
 	// ### Prop Types
 	propTypes: {
 		/**
-		 * Text for heading of actions column
+		 * **Assistive text for accessibility.**
+		 * This object is merged with the default props object on every render.
+		 * * `actionsHeader`: Text for heading of actions column
+		 * * `columnSort`: Text for sort action on table column header
+		 * * `columnSortedAscending`: Text announced once a column is sorted in ascending order
+		 * * `columnSortedDescending`: Text announced once a column is sorted in descending order
+		 * * `selectAllRows`: Text for select all checkbox within the table header
+		 * * `selectRow`: Text for select row
 		 */
-		assistiveTextForActionsHeader: PropTypes.string,
-		/**
-		 * Text for sort action on table column header
-		 */
-		assistiveTextForColumnSort: PropTypes.string,
-		/**
-		 * Text announced once a column is sorted in ascending order
-		 */
-		assistiveTextForColumnSortedAscending: PropTypes.string,
-		/**
-		 * Text announced once a column is sorted in descending order
-		 */
-		assistiveTextForColumnSortedDescending: PropTypes.string,
-		/**
-		 * Text for select all checkbox within the table header
-		 */
-		assistiveTextForSelectAllRows: PropTypes.string,
-		/**
-		 * Text for select row
-		 */
-		assistiveTextForSelectRow: PropTypes.string,
+		assistiveText: PropTypes.shape({
+			actionsHeader: PropTypes.string,
+			columnSort: PropTypes.string,
+			columnSortedAscending: PropTypes.string,
+			columnSortedDescending: PropTypes.string,
+			selectAllRows: PropTypes.string,
+			selectRow: PropTypes.string,
+		}),
 		/**
 		 * Provide children of the type `<DataTableColumn />` to define the structure of the data being represented and children of the type `<DataTableRowActions />` to define a menu which will be rendered for each item in the grid. Use a _higher-order component_ to customize a data table cell that will override the default cell rendering. `CustomDataTableCell` must have the same `displayName` as `DataTableCell` or it will be ignored. If you want complete control of the HTML, including the wrapping `td`, you don't have to use `DataTableCell`.
 		 * ```
@@ -170,16 +177,7 @@ const DataTable = createReactClass({
 	},
 
 	getDefaultProps () {
-		return {
-			assistiveTextForActionsHeader: 'Actions',
-			assistiveTextForColumnSort: 'Sort by: ',
-			assistiveTextForColumnSortedAscending: 'Sorted Ascending',
-			assistiveTextForColumnSortedDescending: 'Sorted Descending',
-			assistiveTextForSelectAllRows: 'Select all rows',
-			assistiveTextForSelectRow: 'Select row',
-			id: shortid.generate(),
-			selection: [],
-		};
+		return defaultProps;
 	},
 
 	componentWillMount () {
@@ -249,6 +247,29 @@ const DataTable = createReactClass({
 			}
 		});
 
+		const assistiveText = {
+			...defaultProps.assistiveText,
+			...this.props.assistiveText,
+		};
+		if (this.props.assistiveTextForActionsHeader) {
+			assistiveText.actionsHeader = this.props.assistiveTextForActionsHeader;
+		}
+		if (this.props.assistiveTextForSelectAllRows) {
+			assistiveText.selectAllRows = this.props.assistiveTextForSelectAllRows;
+		}
+		if (this.props.assistiveTextForColumnSortedAscending) {
+			assistiveText.columnSortedAscending = this.props.assistiveTextForColumnSortedAscending;
+		}
+		if (this.props.assistiveTextForColumnSortedDescending) {
+			assistiveText.columnSortedDescending = this.props.assistiveTextForColumnSortedDescending;
+		}
+		if (this.props.assistiveTextForColumnSort) {
+			assistiveText.columnSort = this.props.assistiveTextForColumnSort;
+		}
+		if (this.props.assistiveTextForSelectRow) {
+			assistiveText.selectRow = this.props.assistiveTextForSelectRow;
+		}
+
 		return (
 			<table
 				className={classNames(
@@ -272,19 +293,7 @@ const DataTable = createReactClass({
 				role={this.props.fixedLayout ? 'grid' : null}
 			>
 				<DataTableHead
-					assistiveTextForActionsHeader={
-						this.props.assistiveTextForActionsHeader
-					}
-					assistiveTextForSelectAllRows={
-						this.props.assistiveTextForSelectAllRows
-					}
-					assistiveTextForColumnSortedAscending={
-						this.props.assistiveTextForColumnSortedAscending
-					}
-					assistiveTextForColumnSortedDescending={
-						this.props.assistiveTextForColumnSortedDescending
-					}
-					assistiveTextForColumnSort={this.props.assistiveTextForColumnSort}
+					assistiveText={assistiveText}
 					allSelected={allSelected}
 					indeterminateSelected={indeterminateSelected}
 					canSelectRows={canSelectRows}
@@ -302,9 +311,7 @@ const DataTable = createReactClass({
 									shortid.generate();
 							return (
 								<DataTableRow
-									assistiveTextForSelectRow={
-										this.props.assistiveTextForSelectRow
-									}
+									assistiveText={assistiveText}
 									canSelectRows={canSelectRows}
 									columns={columns}
 									fixedLayout={this.props.fixedLayout}

--- a/components/data-table/private/head.jsx
+++ b/components/data-table/private/head.jsx
@@ -23,18 +23,14 @@ const DataTableHead = createReactClass({
 
 	// ### Prop Types
 	propTypes: {
-		/**
-		 * Text for heading of actions column
-		 */
-		assistiveTextForActionsHeader: PropTypes.string,
-		/**
-		 * Text for sort action on table column header
-		 */
-		assistiveTextForColumnSort: PropTypes.string,
-		/**
-		 * Text for select all checkbox within the table header
-		 */
-		assistiveTextForSelectAllRows: PropTypes.string,
+		assistiveText: PropTypes.shape({
+			actionsHeader: PropTypes.string,
+			columnSort: PropTypes.string,
+			columnSortedAscending: PropTypes.string,
+			columnSortedDescending: PropTypes.string,
+			selectAllRows: PropTypes.string,
+			selectRow: PropTypes.string,
+		}),
 		allSelected: PropTypes.bool,
 		indeterminateSelected: PropTypes.bool,
 		canSelectRows: PropTypes.bool,
@@ -66,7 +62,7 @@ const DataTableHead = createReactClass({
 							<div className="slds-th__action slds-th__action--form">
 								<Checkbox
 									assistiveText={{
-										label: this.props.assistiveTextForSelectAllRows,
+										label: this.props.assistiveText.selectAllRows,
 									}}
 									checked={this.props.allSelected}
 									indeterminate={this.props.indeterminateSelected}
@@ -79,7 +75,7 @@ const DataTableHead = createReactClass({
 					) : null}
 					{this.props.columns.map((column) => (
 						<HeaderCell
-							assistiveTextForColumnSort={this.props.assistiveTextForColumnSort}
+							assistiveText={this.props.assistiveText}
 							id={`${this.props.id}-${column.props.property}`}
 							key={`${this.props.id}-${column.props.property}`}
 							onSort={this.props.onSort}
@@ -90,7 +86,7 @@ const DataTableHead = createReactClass({
 						<th scope="col" style={{ width: '3.25rem' }}>
 							<div className="slds-th__action">
 								<span className="slds-assistive-text">
-									{this.props.assistiveTextForActionsHeader}
+									{this.props.assistiveText.actionsHeader}
 								</span>
 							</div>
 						</th>

--- a/components/data-table/private/header-cell.jsx
+++ b/components/data-table/private/header-cell.jsx
@@ -34,19 +34,14 @@ const DataTableHeaderCell = createReactClass({
 
 	// ### Prop Types
 	propTypes: {
-		/**
-		 * Text for sort action on table column header
-		 *
-		 */
-		assistiveTextForColumnSort: PropTypes.string,
-		/**
-		 * Text announced once a column is sorted in ascending order
-		 */
-		assistiveTextForColumnSortedAscending: PropTypes.string,
-		/**
-		 * Text announced once a column is sorted in descending order
-		 */
-		assistiveTextForColumnSortedDescending: PropTypes.string,
+		assistiveText: PropTypes.shape({
+			actionsHeader: PropTypes.string,
+			columnSort: PropTypes.string,
+			columnSortedAscending: PropTypes.string,
+			columnSortedDescending: PropTypes.string,
+			selectAllRows: PropTypes.string,
+			selectRow: PropTypes.string,
+		}),
 		id: PropTypes.string.isRequired,
 		/**
 		 * Indicates if column is sorted.
@@ -132,7 +127,8 @@ const DataTableHeaderCell = createReactClass({
 					tabIndex="0"
 				>
 					<span className="slds-assistive-text">
-						{this.props.assistiveTextForColumnSort}{' '}
+						{this.props.assistiveTextForColumnSort ||
+							this.props.assistiveText.columnSort}{' '}
 					</span>
 					<span
 						className="slds-truncate"
@@ -153,8 +149,10 @@ const DataTableHeaderCell = createReactClass({
 							aria-atomic="true"
 						>
 							{sortDirection === 'asc'
-								? this.props.assistiveTextForColumnSortedAscending
-								: this.props.assistiveTextForColumnSortedDescending}
+								? this.props.assistiveTextForColumnSortedAscending ||
+									this.props.assistiveText.columnSortedAscending
+								: this.props.assistiveTextForColumnSortedDescending ||
+									this.props.assistiveText.columnSortedDescending}
 						</span>
 					) : null}
 				</a>

--- a/components/data-table/private/row.jsx
+++ b/components/data-table/private/row.jsx
@@ -32,10 +32,14 @@ const DataTableRow = createReactClass({
 
 	// ### Prop Types
 	propTypes: {
-		/**
-		 * Text for select row
-		 */
-		assistiveTextForSelectRow: PropTypes.string,
+		assistiveText: PropTypes.shape({
+			actionsHeader: PropTypes.string,
+			columnSort: PropTypes.string,
+			columnSortedAscending: PropTypes.string,
+			columnSortedDescending: PropTypes.string,
+			selectAllRows: PropTypes.string,
+			selectRow: PropTypes.string,
+		}),
 		canSelectRows: PropTypes.bool,
 		columns: PropTypes.arrayOf(
 			PropTypes.shape({
@@ -83,7 +87,7 @@ const DataTableRow = createReactClass({
 					>
 						<Checkbox
 							assistiveText={{
-								label: this.props.assistiveTextForSelectRow,
+								label: this.props.assistiveText.selectRow,
 							}}
 							checked={isSelected}
 							id={`${this.props.id}-SelectRow`}

--- a/components/icon-settings/__examples__/icon-path.jsx
+++ b/components/icon-settings/__examples__/icon-path.jsx
@@ -12,7 +12,7 @@ const Example = createReactClass({
 				<div className="slds-grid slds-grid--pull-padded slds-grid--vertical-align-center">
 					<div className="slds-col--padded">
 						<Icon
-							assistiveText="Account"
+							assistiveText={{ label: 'Account' }}
 							category="standard"
 							name="account"
 							size="small"
@@ -20,7 +20,7 @@ const Example = createReactClass({
 					</div>
 					<div className="slds-col--padded">
 						<Icon
-							assistiveText="Announcement"
+							assistiveText={{ label: 'Announcement' }}
 							category="utility"
 							name="announcement"
 							size="small"
@@ -28,7 +28,7 @@ const Example = createReactClass({
 					</div>
 					<div className="slds-col--padded">
 						<Icon
-							assistiveText="Description"
+							assistiveText={{ label: 'Description' }}
 							category="action"
 							name="description"
 							size="small"
@@ -36,7 +36,7 @@ const Example = createReactClass({
 					</div>
 					<div className="slds-col--padded">
 						<Icon
-							assistiveText="XML"
+							assistiveText={{ label: 'XML' }}
 							category="doctype"
 							name="xml"
 							size="small"
@@ -44,7 +44,7 @@ const Example = createReactClass({
 					</div>
 					<div className="slds-col--padded">
 						<Icon
-							assistiveText="custom5"
+							assistiveText={{ label: 'custom5' }}
 							category="custom"
 							name="custom5"
 							size="small"

--- a/components/icon-settings/__examples__/sprite.jsx
+++ b/components/icon-settings/__examples__/sprite.jsx
@@ -24,7 +24,7 @@ const Example = createReactClass({
 				<div className="slds-grid slds-grid--pull-padded slds-grid--vertical-align-center">
 					<div className="slds-col--padded">
 						<Icon
-							assistiveText="Account"
+							assistiveText={{ label: 'Account' }}
 							category="standard"
 							name="account"
 							size="small"
@@ -32,7 +32,7 @@ const Example = createReactClass({
 					</div>
 					<div className="slds-col--padded">
 						<Icon
-							assistiveText="Announcement"
+							assistiveText={{ label: 'Announcement' }}
 							category="utility"
 							name="announcement"
 							size="small"
@@ -40,7 +40,7 @@ const Example = createReactClass({
 					</div>
 					<div className="slds-col--padded">
 						<Icon
-							assistiveText="Description"
+							assistiveText={{ label: 'Description' }}
 							category="action"
 							name="description"
 							size="small"
@@ -48,7 +48,7 @@ const Example = createReactClass({
 					</div>
 					<div className="slds-col--padded">
 						<Icon
-							assistiveText="XML"
+							assistiveText={{ label: 'XML' }}
 							category="doctype"
 							name="xml"
 							size="small"
@@ -56,7 +56,7 @@ const Example = createReactClass({
 					</div>
 					<div className="slds-col--padded">
 						<Icon
-							assistiveText="custom5"
+							assistiveText={{ label: 'custom5' }}
 							category="custom"
 							name="custom5"
 							size="small"

--- a/components/icon/__docs__/storybook-stories.jsx
+++ b/components/icon/__docs__/storybook-stories.jsx
@@ -49,7 +49,7 @@ storiesOf(ICON, module)
 	.add('Color: Default', () => <ColorDefault />)
 	.add('Base: Standard (custom styles)', () => (
 		<Icon
-			assistiveText="Account"
+			assistiveText={{ label: 'Account' }}
 			category="standard"
 			name="account"
 			style={{ backgroundColor: '#aceace', fill: 'orangered' }}
@@ -57,5 +57,5 @@ storiesOf(ICON, module)
 		/>
 	))
 	.add('Base: Imported', () => (
-		<Icon assistiveText="Download" category="utility" icon={download} />
+		<Icon assistiveText={{ label: 'Download' }} category="utility" icon={download} />
 	));

--- a/components/icon/__examples__/action.jsx
+++ b/components/icon/__examples__/action.jsx
@@ -10,7 +10,7 @@ const Example = createReactClass({
 		return (
 			<IconSettings iconPath="/assets/icons">
 				<Icon
-					assistiveText="Description of icon"
+					assistiveText={{ label: 'Description of icon' }}
 					category="action"
 					name="description"
 					size="small"

--- a/components/icon/__examples__/categories.jsx
+++ b/components/icon/__examples__/categories.jsx
@@ -12,7 +12,7 @@ const Example = createReactClass({
 				<div className="slds-grid slds-grid--pull-padded slds-grid--vertical-align-center">
 					<div className="slds-col--padded">
 						<Icon
-							assistiveText="Account"
+							assistiveText={{ label: 'Account' }}
 							category="standard"
 							name="account"
 							size="small"
@@ -20,7 +20,7 @@ const Example = createReactClass({
 					</div>
 					<div className="slds-col--padded">
 						<Icon
-							assistiveText="Announcement"
+							assistiveText={{ label: 'Announcement' }}
 							category="utility"
 							name="announcement"
 							size="small"
@@ -28,7 +28,7 @@ const Example = createReactClass({
 					</div>
 					<div className="slds-col--padded">
 						<Icon
-							assistiveText="Description"
+							assistiveText={{ label: 'Description' }}
 							category="action"
 							name="description"
 							size="small"
@@ -36,7 +36,7 @@ const Example = createReactClass({
 					</div>
 					<div className="slds-col--padded">
 						<Icon
-							assistiveText="XML"
+							assistiveText={{ label: 'XML' }}
 							category="doctype"
 							name="xml"
 							size="small"
@@ -44,7 +44,7 @@ const Example = createReactClass({
 					</div>
 					<div className="slds-col--padded">
 						<Icon
-							assistiveText="custom5"
+							assistiveText={{ label: 'custom5' }}
 							category="custom"
 							name="custom5"
 							size="small"

--- a/components/icon/__examples__/color-base.jsx
+++ b/components/icon/__examples__/color-base.jsx
@@ -10,7 +10,7 @@ const Example = createReactClass({
 		return (
 			<IconSettings iconPath="/assets/icons">
 				<Icon
-					assistiveText="Description of icon"
+					assistiveText={{ label: 'Description of icon' }}
 					category="utility"
 					name="announcement"
 					title="description of icon when needed"

--- a/components/icon/__examples__/color-default.jsx
+++ b/components/icon/__examples__/color-default.jsx
@@ -10,7 +10,7 @@ const Example = createReactClass({
 		return (
 			<IconSettings iconPath="/assets/icons">
 				<Icon
-					assistiveText="Description of icon"
+					assistiveText={{ label: 'Description of icon' }}
 					category="standard"
 					name="account"
 					title="This is a title"

--- a/components/icon/__examples__/color-error.jsx
+++ b/components/icon/__examples__/color-error.jsx
@@ -10,7 +10,7 @@ const Example = createReactClass({
 		return (
 			<IconSettings iconPath="/assets/icons">
 				<Icon
-					assistiveText="Description of icon"
+					assistiveText={{ label: 'Description of icon' }}
 					category="standard"
 					name="account"
 					title="description of icon"

--- a/components/icon/__examples__/color-warning.jsx
+++ b/components/icon/__examples__/color-warning.jsx
@@ -10,7 +10,7 @@ const Example = createReactClass({
 		return (
 			<IconSettings iconPath="/assets/icons">
 				<Icon
-					assistiveText="Description of icon"
+					assistiveText={{ label: 'Description of icon' }}
 					category="standard"
 					name="account"
 					title="description of icon"

--- a/components/icon/__examples__/colors.jsx
+++ b/components/icon/__examples__/colors.jsx
@@ -12,7 +12,7 @@ const Example = createReactClass({
 				<div className="slds-grid slds-grid--pull-padded slds-grid--vertical-align-center">
 					<div className="slds-col--padded">
 						<Icon
-							assistiveText="Lead"
+							assistiveText={{ label: 'Lead' }}
 							category="standard"
 							colorVariant="base"
 							name="lead"
@@ -20,7 +20,7 @@ const Example = createReactClass({
 					</div>
 					<div className="slds-col--padded">
 						<Icon
-							assistiveText="Lock"
+							assistiveText={{ label: 'Lock' }}
 							category="utility"
 							colorVariant="default"
 							name="lock"
@@ -28,7 +28,7 @@ const Example = createReactClass({
 					</div>
 					<div className="slds-col--padded">
 						<Icon
-							assistiveText="Warning"
+							assistiveText={{ label: 'Warning' }}
 							category="utility"
 							colorVariant="warning"
 							name="warning"
@@ -36,7 +36,7 @@ const Example = createReactClass({
 					</div>
 					<div className="slds-col--padded">
 						<Icon
-							assistiveText="Warning"
+							assistiveText={{ lable: 'Warning' }}
 							category="utility"
 							colorVariant="error"
 							name="warning"

--- a/components/icon/__examples__/custom.jsx
+++ b/components/icon/__examples__/custom.jsx
@@ -10,7 +10,7 @@ const Example = createReactClass({
 		return (
 			<IconSettings iconPath="/assets/icons">
 				<Icon
-					assistiveText="Description of icon"
+					assistiveText={{ label: 'Description of icon' }}
 					category="custom"
 					name="custom5"
 					title="description of icon when needed"

--- a/components/icon/__examples__/doctype.jsx
+++ b/components/icon/__examples__/doctype.jsx
@@ -10,7 +10,7 @@ const Example = createReactClass({
 		return (
 			<IconSettings iconPath="/assets/icons">
 				<Icon
-					assistiveText="Description of icon"
+					assistiveText={{ label: 'Description of icon' }}
 					category="doctype"
 					name="xml"
 				/>

--- a/components/icon/__examples__/external-path.jsx
+++ b/components/icon/__examples__/external-path.jsx
@@ -10,7 +10,7 @@ const Example = createReactClass({
 		return (
 			<IconSettings iconPath="/assets/icons">
 				<Icon
-					assistiveText="We got news!"
+					assistiveText={{ label: 'We got news!' }}
 					inverse
 					path="/assets/icons/utility-sprite/svg/symbols.svg#announcement"
 					size="medium"

--- a/components/icon/__examples__/sizes-extra-small.jsx
+++ b/components/icon/__examples__/sizes-extra-small.jsx
@@ -10,7 +10,7 @@ const Example = createReactClass({
 		return (
 			<IconSettings iconPath="/assets/icons">
 				<Icon
-					assistiveText="Description of icon"
+					assistiveText={{ label: 'Description of icon' }}
 					category="utility"
 					name="warning"
 					size="x-small"

--- a/components/icon/__examples__/sizes-large.jsx
+++ b/components/icon/__examples__/sizes-large.jsx
@@ -10,7 +10,7 @@ const Example = createReactClass({
 		return (
 			<IconSettings iconPath="/assets/icons">
 				<Icon
-					assistiveText="Description of icon"
+					assistiveText={{ label: 'Description of icon' }}
 					category="standard"
 					name="case"
 					size="large"

--- a/components/icon/__examples__/sizes-medium.jsx
+++ b/components/icon/__examples__/sizes-medium.jsx
@@ -10,7 +10,7 @@ const Example = createReactClass({
 		return (
 			<IconSettings iconPath="/assets/icons">
 				<Icon
-					assistiveText="Description of icon"
+					assistiveText={{ label: 'Description of icon' }}
 					category="standard"
 					name="case"
 				/>

--- a/components/icon/__examples__/sizes-small.jsx
+++ b/components/icon/__examples__/sizes-small.jsx
@@ -10,7 +10,7 @@ const Example = createReactClass({
 		return (
 			<IconSettings iconPath="/assets/icons">
 				<Icon
-					assistiveText="Description of icon"
+					assistiveText={{ label: 'Description of icon' }}
 					category="standard"
 					name="case"
 					size="small"

--- a/components/icon/__examples__/sizes.jsx
+++ b/components/icon/__examples__/sizes.jsx
@@ -12,7 +12,7 @@ const Example = createReactClass({
 				<div className="slds-grid slds-grid--pull-padded slds-grid--vertical-align-center">
 					<div className="slds-col--padded">
 						<Icon
-							assistiveText="Warning"
+							assistiveText={{ label: 'Warning' }}
 							category="utility"
 							color="warning"
 							name="warning"
@@ -21,7 +21,7 @@ const Example = createReactClass({
 					</div>
 					<div className="slds-col--padded">
 						<Icon
-							assistiveText="Case"
+							assistiveText={{ label: 'Case' }}
 							category="standard"
 							name="case"
 							size="small"
@@ -29,7 +29,7 @@ const Example = createReactClass({
 					</div>
 					<div className="slds-col--padded">
 						<Icon
-							assistiveText="Case"
+							assistiveText={{ label: 'Case' }}
 							category="standard"
 							name="case"
 							size="medium"
@@ -37,7 +37,7 @@ const Example = createReactClass({
 					</div>
 					<div className="slds-col--padded">
 						<Icon
-							assistiveText="Case"
+							assistiveText={{ label: 'Case' }}
 							category="standard"
 							name="case"
 							size="large"

--- a/components/icon/__examples__/standard.jsx
+++ b/components/icon/__examples__/standard.jsx
@@ -10,7 +10,7 @@ const Example = createReactClass({
 		return (
 			<IconSettings iconPath="/assets/icons">
 				<Icon
-					assistiveText="Description of icon"
+					assistiveText={{ label: 'Description of icon' }}
 					category="standard"
 					name="account"
 					title="description of icon"

--- a/components/icon/__examples__/utility.jsx
+++ b/components/icon/__examples__/utility.jsx
@@ -10,7 +10,7 @@ const Example = createReactClass({
 		return (
 			<IconSettings iconPath="/assets/icons">
 				<Icon
-					assistiveText="Description of icon"
+					assistiveText={{ label: 'Description of icon' }}
 					category="utility"
 					colorVariant="default"
 					name="announcement"

--- a/components/icon/__tests__/icon.browser-test.jsx
+++ b/components/icon/__tests__/icon.browser-test.jsx
@@ -39,7 +39,7 @@ describe('SLDSIcon: ', function () {
 			mountComponent(
 				<IconSettings iconPath="/assets/icons">
 					<DemoIcon
-						assistiveText="Log a Call"
+						assistiveText={{ label: 'Log a Call' }}
 						category="standard"
 						name="log_a_call"
 						style={{ backgroundColor: 'rgb(218, 165, 32)' }}
@@ -86,7 +86,7 @@ describe('SLDSIcon: ', function () {
 			mountComponent(
 				<IconSettings iconPath="/assets/icons">
 					<DemoIcon
-						assistiveText="Heart"
+						assistiveText={{ label: 'Heart' }}
 						category="custom"
 						name="custom1"
 						size="small"
@@ -127,7 +127,7 @@ describe('SLDSIcon: ', function () {
 			mountComponent(
 				<IconSettings iconPath="/assets/icons">
 					<DemoIcon
-						assistiveText="Announcements"
+						assistiveText={{ label: 'Announcements' }}
 						category="action"
 						name="announcement"
 						size="large"
@@ -209,7 +209,7 @@ describe('SLDSIcon: ', function () {
 			mountComponent(
 				<IconSettings iconPath="/assets/icons">
 					<DemoIcon
-						assistiveText="New stuff!"
+						assistiveText={{ label: 'New stuff!' }}
 						inverse
 						path="/assets/icons/utility-sprite/svg/symbols.svg#announcement"
 						size="medium"

--- a/components/icon/check-props.js
+++ b/components/icon/check-props.js
@@ -1,0 +1,22 @@
+/* Copyright (c) 2015-present, salesforce.com, inc. All rights reserved */
+/* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
+/* eslint-disable import/no-mutable-exports */
+
+import sunsetProperty from '../../utilities/warning/sunset-property';
+
+let checkProps = function () { };
+
+if (process.env.NODE_ENV !== 'production') {
+    checkProps = function (COMPONENT, props) {
+        if (typeof props.assistiveText === 'string') {
+            sunsetProperty(
+                COMPONENT,
+                props.assistiveText,
+                'assistiveText',
+                '`assistiveText` as a string has been deprecated and is now an object to allow for multiple uses in the component. Please use `assistiveText.label` instead.'
+            );
+        }
+    };
+}
+
+export default checkProps;

--- a/components/icon/index.jsx
+++ b/components/icon/index.jsx
@@ -11,6 +11,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import checkProps from './check-props';
+
 // ### classNames
 // [github.com/JedWatson/classnames](https://github.com/JedWatson/classnames)
 // A simple javascript utility for conditionally joining classNames together.
@@ -22,22 +24,36 @@ import UtilityIcon from '../utilities/utility-icon';
 // ## Constants
 import { ICON } from '../../utilities/constants';
 
+const defaultProps = {
+	assistiveText: {},
+	category: 'standard',
+	size: 'medium'
+};
+
 /**
  * The Icon component is the Lightning Design System Icon component and should be used for naked icons. For icons that are buttons, use the <a href='/components/buttons/'>Button component</a> component with <code>variant='icon'</code>.
  */
-const Icon = ({
-	assistiveText,
-	category,
-	className,
-	containerClassName,
-	icon,
-	inverse,
-	name,
-	path,
-	size,
-	style,
-	title
-}) => {
+const Icon = (props) => {
+	checkProps(ICON, props);
+	const {
+		category,
+		className,
+		containerClassName,
+		icon,
+		inverse,
+		name,
+		path,
+		size,
+		style,
+		title
+	} = props;
+	const assistiveText = typeof props.assistiveText === 'string'
+		? props.assistiveText
+		: {
+			...defaultProps.assistiveText,
+			...props.assistiveText,
+		}.label;
+
 	const kababCaseName = name ? name.replace(/_/g, '-') : '';
 
 	return (
@@ -89,11 +105,13 @@ Icon.displayName = ICON;
 // ### Prop Types
 Icon.propTypes = {
 	/**
-	 * Text that is visually hidden but read aloud by screenreaders to tell the user what the icon means.
-	 * Naked icons must have assistive text, however, if you also have visible descriptive text with the icon,
-	 * declare this prop as <code>assistiveText=''</code>.
+	 * **Assistive text for accessibility.**
+	 * This object is merged with the default props object on every render.
+	 * * `label`: Text that is visually hidden but read aloud by screenreaders to tell the user what the icon means. Naked icons must have assistive text, however, if you also have visible descriptive text with the icon, declare this prop as <code>assistiveText=''</code>.
 	 */
-	assistiveText: PropTypes.string,
+	assistiveText: PropTypes.shape({
+		label: PropTypes.string,
+	}),
 	/**
 	 * Icon category from [lightningdesignsystem.com/icons/](https://www.lightningdesignsystem.com/icons/)
 	 */
@@ -154,9 +172,6 @@ Icon.propTypes = {
 	title: PropTypes.string
 };
 
-Icon.defaultProps = {
-	category: 'standard',
-	size: 'medium'
-};
+Icon.defaultProps = defaultProps;
 
 export default Icon;

--- a/components/input/__docs__/search/storybook-stories.jsx
+++ b/components/input/__docs__/search/storybook-stories.jsx
@@ -13,7 +13,7 @@ storiesOf(FORMS_SEARCH, module)
 	))
 	.add('Standard', () => (
 		<Search
-			assistiveText="Search"
+			assistiveText={{ label: 'Search' }}
 			placeholder="Search"
 			name="search-input"
 			onChange={action('change')}

--- a/components/input/check-props.js
+++ b/components/input/check-props.js
@@ -8,76 +8,89 @@ import sunsetProperty from '../../utilities/warning/sunset-property';
 // import oneOfRequiredProperty from '../../../utilities/warning/one-of-required-property';
 import onlyOneOfProperties from '../../utilities/warning/only-one-of-properties';
 
+import { FORMS_INPUT, FORMS_SEARCH } from '../../utilities/constants';
+
 let checkProps = function () {};
 
 if (process.env.NODE_ENV !== 'production') {
 	checkProps = function (COMPONENT, props) {
-		// Deprecated and changed to another property
-		deprecatedProperty(
-			COMPONENT,
-			props.iconCategory,
-			'iconCategory',
-			undefined,
-			'Please use `iconLeft` and `iconRight` to pass in a customized <Icon> component.'
-		);
-		deprecatedProperty(
-			COMPONENT,
-			props.iconName,
-			'iconName',
-			undefined,
-			'Please use `iconLeft` and `iconRight` to pass in a customized <Icon> component'
-		);
-		deprecatedProperty(
-			COMPONENT,
-			props.iconPosition,
-			'iconPosition',
-			undefined,
-			'Please use `iconLeft` and `iconRight` to pass in a customized <Icon> component'
-		);
-		deprecatedProperty(
-			COMPONENT,
-			props.iconAssistiveText,
-			'iconAssistiveText',
-			undefined,
-			'Please use `iconLeft` and `iconRight` to pass in a customized <Icon> component'
-		);
-		deprecatedProperty(
-			COMPONENT,
-			props.onIconClick,
-			'onIconClick',
-			undefined,
-			'Please use `iconLeft` and `iconRight` to pass in a customized <Icon> component'
-		);
-
-		if (typeof props.assistiveText === 'string') {
-			sunsetProperty(
+		if (COMPONENT === FORMS_INPUT) {
+			// Deprecated and changed to another property
+			deprecatedProperty(
 				COMPONENT,
-				props.assistiveText,
-				'assistiveText',
-				'AssistiveText as a string has been deprecated and is now an object to allow for multiple uses in the component. Please use either assistiveText.label or assistiveText.spinner'
+				props.iconCategory,
+				'iconCategory',
+				undefined,
+				'Please use `iconLeft` and `iconRight` to pass in a customized <Icon> component.'
 			);
-		}
+			deprecatedProperty(
+				COMPONENT,
+				props.iconName,
+				'iconName',
+				undefined,
+				'Please use `iconLeft` and `iconRight` to pass in a customized <Icon> component'
+			);
+			deprecatedProperty(
+				COMPONENT,
+				props.iconPosition,
+				'iconPosition',
+				undefined,
+				'Please use `iconLeft` and `iconRight` to pass in a customized <Icon> component'
+			);
+			deprecatedProperty(
+				COMPONENT,
+				props.iconAssistiveText,
+				'iconAssistiveText',
+				undefined,
+				'Please use `iconLeft` and `iconRight` to pass in a customized <Icon> component'
+			);
+			deprecatedProperty(
+				COMPONENT,
+				props.onIconClick,
+				'onIconClick',
+				undefined,
+				'Please use `iconLeft` and `iconRight` to pass in a customized <Icon> component'
+			);
 
-		onlyOneOfProperties(COMPONENT, {
-			assistiveText: props.assistiveText,
-			label: props.label,
-		});
+			if (typeof props.assistiveText === 'string') {
+				sunsetProperty(
+					COMPONENT,
+					props.assistiveText,
+					'assistiveText',
+					'AssistiveText as a string has been deprecated and is now an object to allow for multiple uses in the component. Please use either assistiveText.label or assistiveText.spinner'
+				);
+			}
 
-		onlyOneOfProperties(COMPONENT, {
-			fixedTextLeft: props.fixedTextLeft,
-			fixedTextRight: props.fixedTextRight,
-		});
-
-		/*
-		 * Once we support horizontal labels, then I think we can enable this check
-		 *
-		if (!props.inlineEditTrigger) {
-			oneOfRequiredProperty(COMPONENT, {
+			onlyOneOfProperties(COMPONENT, {
 				assistiveText: props.assistiveText,
-				label: props.label
+				label: props.label,
 			});
+
+			onlyOneOfProperties(COMPONENT, {
+				fixedTextLeft: props.fixedTextLeft,
+				fixedTextRight: props.fixedTextRight,
+			});
+
+			/*
+			* Once we support horizontal labels, then I think we can enable this check
+			*
+			if (!props.inlineEditTrigger) {
+				oneOfRequiredProperty(COMPONENT, {
+					assistiveText: props.assistiveText,
+					label: props.label
+				});
+			}
+			*/
+		} else if (COMPONENT === FORMS_SEARCH) {
+			if (typeof props.assistiveText === 'string') {
+				sunsetProperty(
+					COMPONENT,
+					props.assistiveText,
+					'assistiveText',
+					'`assistiveText` as a string has been deprecated and is now an object to allow for multiple uses in the component. Please use `assistiveText.label` instead.'
+				);
+			}
 		}
-		*/
 	};
 }
 

--- a/components/input/index.jsx
+++ b/components/input/index.jsx
@@ -392,9 +392,7 @@ const Input = createReactClass({
 					readOnly={this.props.readOnly}
 					required={this.props.required}
 					role={this.props.role}
-					spinnerAssistiveText={
-						this.props.assistiveText && this.props.assistiveText.spinner
-					}
+					assistiveText={this.props.assistiveText}
 					type={this.props.type}
 					value={this.props.value}
 				/>

--- a/components/input/private/inner-input.jsx
+++ b/components/input/private/inner-input.jsx
@@ -33,6 +33,14 @@ const propTypes = {
 	'aria-owns': PropTypes.string,
 	'aria-required': PropTypes.bool,
 	/**
+	 * **Assistive text for accessibility.**
+	 * This object is merged with the default props object on every render.
+	 * * `spinner`: Assistive text on the spinner.
+	 */
+	assistiveText: PropTypes.shape({
+		spinner: PropTypes.string,
+	}),
+	/**
 	 * Disabled brower's autocomplete when "off" is used.
 	 */
 	autoComplete: PropTypes.string,
@@ -136,10 +144,6 @@ const propTypes = {
 	 */
 	role: PropTypes.string,
 	/**
-	 * Assistive text on the spinner
-	 */
-	spinnerAssistiveText: PropTypes.string,
-	/**
 	 * Style object to be added to `input` node
 	 */
 	style: PropTypes.object,
@@ -181,7 +185,9 @@ const propTypes = {
 };
 
 const defaultProps = {
-	spinnerAssistiveText: 'Loading ...',
+	assistiveText: {
+		spinner: 'Loading ...',
+	},
 	type: 'text',
 };
 
@@ -193,6 +199,11 @@ const InnerInput = (props) => {
 		className: containerClassName,
 		...containerProps
 	} = props.containerProps;
+
+	const assistiveText = {
+		...defaultProps.assistiveText,
+		...props.assistiveText,
+	};
 
 	return (
 		<div
@@ -261,7 +272,7 @@ const InnerInput = (props) => {
 				<div className="slds-input__icon-group slds-input__icon-group_right">
 					{props.hasSpinner && (
 						<Spinner
-							assistiveText={props.spinnerAssistiveText}
+							assistiveText={{ label: assistiveText.spinner }}
 							id="loading-status-icon"
 							isInput
 							size="x-small"

--- a/components/input/search.jsx
+++ b/components/input/search.jsx
@@ -15,6 +15,8 @@ import PropTypes from 'prop-types';
 import Input from './index';
 import InputIcon from '../icon/input-icon';
 
+import checkProps from './check-props';
+
 // ### Event Helpers
 import KEYS from '../../utilities/key-code';
 import EventUtil from '../../utilities/event';
@@ -29,50 +31,61 @@ const handleKeyDown = (event, onSearch) => {
 	}
 };
 
+const defaultProps = {
+	assistiveText: {},
+};
+
 /**
  * A `Search` is an `Input` which renders the search icon by default. It can be cleared, too. All `Input` props not specified as props already may be used with this component and will override defaults.
  */
-const Search = ({
-	assistiveText,
-	clearable,
-	onClear,
-	onSearch,
-	placeholder,
-	...props
-}) => (
-	<Input
-		assistiveText={{ label: assistiveText }}
-		iconLeft={
-			<InputIcon
-				assistiveText={{ icon: 'Search' }}
-				category="utility"
-				name="search"
-				onClick={onSearch}
-			/>
-		}
-		iconRight={
-			clearable ? (
+const Search = ({ clearable, onClear, onSearch, placeholder, ...props }) => {
+	checkProps(FORMS_SEARCH, props);
+	const assistiveText =
+		typeof props.assistiveText === 'string'
+			? props.assistiveText
+			: {
+				...defaultProps.assistiveText,
+				...props.assistiveText,
+			}.label;
+	return (
+		<Input
+			assistiveText={{ label: assistiveText }}
+			iconLeft={
 				<InputIcon
-					assistiveText={{ icon: 'Clear' }}
+					assistiveText={{ icon: 'Search' }}
 					category="utility"
-					name="clear"
-					onClick={onClear}
+					name="search"
+					onClick={onSearch}
 				/>
-			) : null
-		}
-		onKeyDown={onSearch ? (event) => handleKeyDown(event, onSearch) : null}
-		placeholder={placeholder}
-		{...props}
-	/>
-);
+			}
+			iconRight={
+				clearable ? (
+					<InputIcon
+						assistiveText={{ icon: 'Clear' }}
+						category="utility"
+						name="clear"
+						onClick={onClear}
+					/>
+				) : null
+			}
+			onKeyDown={onSearch ? (event) => handleKeyDown(event, onSearch) : null}
+			placeholder={placeholder}
+			{...props}
+		/>
+	);
+};
 
 Search.displayName = FORMS_SEARCH;
 
 Search.propTypes = {
 	/**
-	 * Assistive text to search input
+	 * **Assistive text for accessibility.**
+	 * This object is merged with the default props object on every render.
+	 * * `label`: Assistive text to search input
 	 */
-	assistiveText: PropTypes.string,
+	assistiveText: PropTypes.shape({
+		icon: PropTypes.string,
+	}),
 	/**
 	 * Adds a clear button to right side of the input
 	 */
@@ -90,5 +103,7 @@ Search.propTypes = {
 	 */
 	placeholder: PropTypes.string,
 };
+
+Search.defaultProps = defaultProps;
 
 export default Search;

--- a/components/input/search.jsx
+++ b/components/input/search.jsx
@@ -84,7 +84,7 @@ Search.propTypes = {
 	 * * `label`: Assistive text to search input
 	 */
 	assistiveText: PropTypes.shape({
-		icon: PropTypes.string,
+		label: PropTypes.string,
 	}),
 	/**
 	 * Adds a clear button to right side of the input

--- a/components/panel/__examples__/filtering.jsx
+++ b/components/panel/__examples__/filtering.jsx
@@ -94,6 +94,7 @@ const Example = createReactClass({
 			<IconSettings iconPath="/assets/icons">
 				<Panel variant="filters">
 					<PanelFilterGroup
+						assistiveText={{ closeButton: 'Close Panel' }}
 						modified={this.state.modifiedPanel}
 						onClickAdd={() => {
 							this.setState({

--- a/components/panel/__tests__/__snapshots__/filtering.snapshot-test.jsx.snap
+++ b/components/panel/__tests__/__snapshots__/filtering.snapshot-test.jsx.snap
@@ -5,7 +5,7 @@ exports[`Panel Filtering Default HTML Snapshot 1`] = `
   <div class=\\"slds-form--stacked slds-grow slds-scrollable--y slds-grid slds-grid--vertical\\">
     <div class=\\"slds-filters\\">
       <div class=\\"slds-filters__header slds-grid slds-has-divider--bottom-space\\">
-        <h2 class=\\"slds-align-middle slds-text-heading--small\\">Filter</h2><button class=\\"slds-button slds-button--icon slds-button--icon-bare slds-button--icon-small slds-col--bump-left\\" title=\\"Close Filter Panel\\" type=\\"button\\"><svg aria-hidden=\\"true\\" class=\\"slds-button__icon\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#forward\\"></use></svg><span class=\\"slds-assistive-text\\">Close Filter Panel</span></button></div>
+        <h2 class=\\"slds-align-middle slds-text-heading--small\\">Filter</h2><button class=\\"slds-button slds-button--icon slds-button--icon-bare slds-button--icon-small slds-col--bump-left\\" title=\\"Close Panel\\" type=\\"button\\"><svg aria-hidden=\\"true\\" class=\\"slds-button__icon\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#forward\\"></use></svg><span class=\\"slds-assistive-text\\">Close Panel</span></button></div>
       <div
         class=\\"slds-filters__body\\">
         <ol class=\\"slds-list--vertical slds-list--vertical-space\\">
@@ -48,7 +48,11 @@ exports[`Panel Filtering Default Snapshot 1`] = `
   >
     <SLDSFilterGroup
       addFilterLabel="Add Filter"
-      assistiveTextCloseFilterPanel="Close Filter Panel"
+      assistiveText={
+        Object {
+          "closeButton": "Close Panel",
+        }
+      }
       cancelLabel="Cancel"
       heading="Filter"
       modified={false}

--- a/components/panel/filtering/check-props.js
+++ b/components/panel/filtering/check-props.js
@@ -1,0 +1,20 @@
+/* Copyright (c) 2015-present, salesforce.com, inc. All rights reserved */
+/* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
+/* eslint-disable import/no-mutable-exports */
+
+import deprecatedProperty from '../../../utilities/warning/deprecated-property';
+
+let checkProps = function () {};
+
+if (process.env.NODE_ENV !== 'production') {
+	checkProps = function (COMPONENT, props) {
+		deprecatedProperty(
+			COMPONENT,
+			props.assistiveTextCloseFilterPanel,
+			'assistiveTextCloseFilterPanel',
+			"assistiveText['closeButton']"
+		);
+	};
+}
+
+export default checkProps;

--- a/components/panel/filtering/group.jsx
+++ b/components/panel/filtering/group.jsx
@@ -12,88 +12,115 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import checkProps from './check-props';
+
 import PanelFilteringFooter from './private/panel-footer';
 import PanelHeader from './private/panel-header';
 
 // ## Constants
 import { PANEL_FILTER_GROUP } from '../../../utilities/constants';
 
+const defaultProps = {
+	addFilterLabel: 'Add Filter',
+	cancelLabel: 'Cancel',
+	assistiveText: {
+		closeButton: 'Close Filter Panel',
+	},
+	heading: 'Filter',
+	saveLabel: 'Save',
+	removeAllLabel: 'Remove All',
+};
+
 /**
  * A filtering panel contextual filtering options.
  */
-const PanelFilterGroup = ({
-	children,
-	errorLabel,
-	footer,
-	header,
-	variant,
+const PanelFilterGroup = (props) => {
+	checkProps(PANEL_FILTER_GROUP, props);
+	const {
+		children,
+		errorLabel,
+		footer,
+		header,
+		variant,
 
-	// footer
-	addFilterLabel,
-	onClickAdd,
-	onClickRemoveAll,
-	removeAllLabel,
+		// footer
+		addFilterLabel,
+		onClickAdd,
+		onClickRemoveAll,
+		removeAllLabel,
 
-	// header
-	assistiveTextCloseFilterPanel,
-	cancelLabel,
-	heading,
-	modified,
-	onRequestCancel,
-	onRequestClose,
-	onRequestSave,
-	saveLabel,
-}) => (
-	<div className="slds-filters">
-		{variant === 'panel' ? (
-			<PanelHeader
-				assistiveTextCloseFilterPanel={assistiveTextCloseFilterPanel}
-				cancelLabel={cancelLabel}
-				heading={heading}
-				modified={modified}
-				onRequestCancel={onRequestCancel}
-				onRequestClose={onRequestClose}
-				onRequestSave={onRequestSave}
-				saveLabel={saveLabel}
-			/>
-		) : (
-			header || null
-		)}
-		<div className="slds-filters__body">
-			{errorLabel ? (
-				<div
-					className="slds-text-color--error slds-m-bottom--x-small"
-					role="alert"
-				>
-					{errorLabel}
-				</div>
-			) : null}
-			{children}
+		// header
+		cancelLabel,
+		heading,
+		modified,
+		onRequestCancel,
+		onRequestClose,
+		onRequestSave,
+		saveLabel,
+	} = props;
+	const assistiveText = {
+		...defaultProps.assistiveText,
+		...props.assistiveText,
+	};
+	if (props.assistiveTextCloseFilterPanel) {
+		assistiveText.closeButton = props.assistiveTextCloseFilterPanel;
+	}
+	return (
+		<div className="slds-filters">
+			{variant === 'panel' ? (
+				<PanelHeader
+					assistiveText={assistiveText}
+					cancelLabel={cancelLabel}
+					heading={heading}
+					modified={modified}
+					onRequestCancel={onRequestCancel}
+					onRequestClose={onRequestClose}
+					onRequestSave={onRequestSave}
+					saveLabel={saveLabel}
+				/>
+			) : (
+				header || null
+			)}
+			<div className="slds-filters__body">
+				{errorLabel ? (
+					<div
+						className="slds-text-color--error slds-m-bottom--x-small"
+						role="alert"
+					>
+						{errorLabel}
+					</div>
+				) : null}
+				{children}
+			</div>
+			{variant === 'panel' ? (
+				<PanelFilteringFooter
+					addFilterLabel={addFilterLabel}
+					onClickAdd={onClickAdd}
+					onClickRemoveAll={onClickRemoveAll}
+					removeAllLabel={removeAllLabel}
+				/>
+			) : (
+				footer || null
+			)}
 		</div>
-		{variant === 'panel' ? (
-			<PanelFilteringFooter
-				addFilterLabel={addFilterLabel}
-				onClickAdd={onClickAdd}
-				onClickRemoveAll={onClickRemoveAll}
-				removeAllLabel={removeAllLabel}
-			/>
-		) : (
-			footer || null
-		)}
-	</div>
-);
+	);
+};
 
 PanelFilterGroup.displayName = PANEL_FILTER_GROUP;
 
 PanelFilterGroup.propTypes = {
 	/**
+	 * **Assistive text for accessibility.**
+	 * This object is merged with the default props object on every render.
+	 * * `closeButton`: Localized description of the close button for the panel for screen readers
+	 */
+	assistiveText: PropTypes.shape({
+		closeButton: PropTypes.string,
+	}),
+	/**
 	 * Localized description of the "Add Filter" button in the footer
 	 */
 	addFilterLabel: PropTypes.node,
-	/**
-	 * Localized description of the close button for the panel for screen readers
-	 */
-	assistiveTextCloseFilterPanel: PropTypes.node,
 	/**
 	 * Label for button that cancels modified filters
 	 */
@@ -171,13 +198,6 @@ PanelFilterGroup.propTypes = {
 	variant: PropTypes.oneOf(['panel']),
 };
 
-PanelFilterGroup.defaultProps = {
-	addFilterLabel: 'Add Filter',
-	cancelLabel: 'Cancel',
-	assistiveTextCloseFilterPanel: 'Close Filter Panel',
-	heading: 'Filter',
-	saveLabel: 'Save',
-	removeAllLabel: 'Remove All',
-};
+PanelFilterGroup.defaultProps = defaultProps;
 
 export default PanelFilterGroup;

--- a/components/panel/filtering/list-heading.jsx
+++ b/components/panel/filtering/list-heading.jsx
@@ -33,7 +33,7 @@ const PanelFilterListHeading = ({ heading, isLocked, lockedHeading }) => (
 		{isLocked ? (
 			<Icon
 				className="slds-m-left--x-small"
-				assistiveText="locked"
+				assistiveText={{ label: 'locked' }}
 				category="utility"
 				name="lock"
 				size="x-small"

--- a/components/panel/filtering/private/panel-header.jsx
+++ b/components/panel/filtering/private/panel-header.jsx
@@ -18,7 +18,7 @@ import Button from '../../../button';
  * Header for a Filter Group within a Panel.
  */
 const PanelFilterHeader = ({
-	assistiveTextCloseFilterPanel,
+	assistiveText,
 	cancelLabel,
 	heading,
 	modified,
@@ -37,13 +37,13 @@ const PanelFilterHeader = ({
 			<h2 className="slds-align-middle slds-text-heading--small">{heading}</h2>
 			<Button
 				className="slds-col--bump-left"
-				assistiveText={{ icon: assistiveTextCloseFilterPanel }}
+				assistiveText={{ icon: assistiveText.closeButton }}
 				iconCategory="utility"
 				iconName="forward"
 				iconVariant="bare"
 				iconSize="small"
 				onClick={onRequestClose}
-				title={assistiveTextCloseFilterPanel}
+				title={assistiveText.closeButton}
 				variant="icon"
 			/>
 		</div>
@@ -53,9 +53,13 @@ PanelFilterHeader.displayName = 'SLDSPanelFilterHeader';
 
 PanelFilterHeader.propTypes = {
 	/**
-	 * Localized description of the close button for the panel for screen readers
+	 * **Assistive text for accessibility.**
+	 * This object is merged with the default props object on every render.
+	 * * `closeButton`: Localized description of the close button for the panel for screen readers
 	 */
-	assistiveTextCloseFilterPanel: PropTypes.node,
+	assistiveText: PropTypes.shape({
+		closeButton: PropTypes.string,
+	}),
 	/**
 	 * Label for button that cancels modified filters
 	 */

--- a/components/popover/__examples__/alternative-header.jsx
+++ b/components/popover/__examples__/alternative-header.jsx
@@ -12,7 +12,7 @@ const panelContent = (
 				<div className="slds-media slds-media--center">
 					<div className="slds-media__figure">
 						<Icon
-							assistiveText="Opportunity Icon"
+							assistiveText={{ label: 'Opportunity Icon' }}
 							category="standard"
 							name="opportunity"
 							size="small"

--- a/components/spinner/__docs__/storybook-stories.jsx
+++ b/components/spinner/__docs__/storybook-stories.jsx
@@ -22,7 +22,13 @@ storiesOf(SPINNER, module)
 			<IconSettings iconPath="/assets/icons">{getStory()}</IconSettings>
 		</div>
 	))
-	.add('Small', () => getSpinner({ size: 'small', variant: 'base' }))
+	.add('Small', () =>
+		getSpinner({
+			size: 'small',
+			variant: 'base',
+			assistiveText: { label: 'Small spinner' },
+		})
+	)
 	.add('Medium', () => getSpinner({ size: 'medium', variant: 'base' }))
 	.add('Large', () => getSpinner({ size: 'large', variant: 'base' }))
 	.add('Brand Small', () => getSpinner({ size: 'small', variant: 'brand' }))

--- a/components/spinner/check-props.js
+++ b/components/spinner/check-props.js
@@ -2,20 +2,12 @@
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 /* eslint-disable import/no-mutable-exports */
 
-import oneOfRequiredProperty from '../../utilities/warning/one-of-required-property';
 import sunsetProperty from '../../utilities/warning/sunset-property';
 
 let checkProps = function () {};
 
 if (process.env.NODE_ENV !== 'production') {
 	checkProps = function (COMPONENT, props) {
-		/* eslint-disable max-len */
-		oneOfRequiredProperty(COMPONENT, {
-			assistiveText: props.assistiveText,
-			heading: props.heading,
-		});
-		/* eslint-enable max-len */
-
 		if (typeof props.assistiveText === 'string') {
 			sunsetProperty(
 				COMPONENT,

--- a/components/spinner/index.jsx
+++ b/components/spinner/index.jsx
@@ -11,15 +11,21 @@ import PropTypes from 'prop-types';
 
 import classNames from 'classnames';
 
+import checkProps from './check-props';
+
 // ## Constants
 import { SPINNER } from '../../utilities/constants';
 
 // ### Prop Types
 const PROP_TYPES = {
 	/**
-	 * Assistive text that is read out loud to screen readers.
+	 * **Assistive text for accessibility.**
+	 * This object is merged with the default props object on every render.
+	 * * `label`: Assistive text that is read out loud to screen readers.
 	 */
-	assistiveText: PropTypes.string,
+	assistiveText: PropTypes.shape({
+		label: PropTypes.string,
+	}),
 	/**
 	 * Custom css classes applied to Spinner container
 	 */
@@ -43,21 +49,22 @@ const PROP_TYPES = {
 };
 
 const DEFAULT_PROPS = {
-	assistiveText: 'Loading...',
+	assistiveText: { label: 'Loading...' },
 	size: 'medium',
 	variant: 'base',
 };
 
 // ## Spinner
 const Spinner = (props) => {
-	const {
-		assistiveText,
-		containerClassName,
-		id,
-		isInput,
-		size,
-		variant,
-	} = props;
+	checkProps(SPINNER, props);
+	const { containerClassName, id, isInput, size, variant } = props;
+	const assistiveText =
+		typeof props.assistiveText === 'string'
+			? props.assistiveText
+			: {
+				...DEFAULT_PROPS.assistiveText,
+				...props.assistiveText,
+			}.label;
 
 	const spinnerClassName = classNames('slds-spinner', {
 		'slds-input__spinner': isInput,

--- a/components/textarea/__docs__/storybook-stories.jsx
+++ b/components/textarea/__docs__/storybook-stories.jsx
@@ -30,7 +30,7 @@ storiesOf(FORMS_TEXTAREA, module)
 		<Textarea
 			aria-describedby="required-1"
 			name="required-textarea"
-			label="Textarea Label"
+			assistiveText={{ label: 'Textarea Label' }}
 			required
 			placeholder="Placeholder Text"
 		/>

--- a/components/textarea/__tests__/textarea.browser-test.jsx
+++ b/components/textarea/__tests__/textarea.browser-test.jsx
@@ -88,7 +88,7 @@ describe('SLDS TEXTAREA **************************************************', () 
 		let label;
 
 		beforeEach(() => {
-			component = getTextarea({ assistiveText: 'Assistive Label' });
+			component = getTextarea({ assistiveText: { label: 'Assistive Label' } });
 			label = findRenderedDOMComponentWithClass(
 				component,
 				'slds-form-element__label'

--- a/components/textarea/check-props.js
+++ b/components/textarea/check-props.js
@@ -4,6 +4,7 @@
 /* eslint-disable max-len */
 
 import onlyOneOfProperties from '../../utilities/warning/only-one-of-properties';
+import sunsetProperty from '../../utilities/warning/sunset-property';
 
 let checkProps = function () {};
 
@@ -13,6 +14,15 @@ if (process.env.NODE_ENV !== 'production') {
 			assistiveText: props.assistiveText,
 			label: props.label,
 		});
+
+		if (typeof props.assistiveText === 'string') {
+			sunsetProperty(
+				COMPONENT,
+				props.assistiveText,
+				'assistiveText',
+				'`assistiveText` as a string has been deprecated and is now an object to allow for multiple uses in the component. Please use `assistiveText.label` instead.'
+			);
+		}
 	};
 }
 

--- a/components/textarea/index.jsx
+++ b/components/textarea/index.jsx
@@ -85,10 +85,12 @@ const Textarea = createReactClass({
 		 */
 		autoFocus: PropTypes.bool,
 		/**
-		 * If present, the label associated with this `textarea` is overwritten
-		 * by this text and is visually not shown.
+		 * **Assistive text for accessibility.**
+		 * * `label`: If present, the label associated with this `textarea` is overwritten by this text and is visually not shown.
 		 */
-		assistiveText: PropTypes.string,
+		assistiveText: PropTypes.shape({
+			label: PropTypes.string,
+		}),
 		/**
 		 * Elements are added after the `textarea`.
 		 */
@@ -224,7 +226,6 @@ const Textarea = createReactClass({
 	render () {
 		const {
 			autoFocus,
-			assistiveText,
 			children,
 			className,
 			classNameContainer,
@@ -256,6 +257,13 @@ const Textarea = createReactClass({
 			// Using [object destructuring](https://facebook.github.io/react/docs/transferring-props.html#transferring-with-...-in-jsx) to pass on any properties which are not explicitly defined.
 			// ...props // Uncomment this if you actually need to send the rest of the props to other elements
 		} = this.props;
+
+		const assistiveText =
+			typeof this.props.assistiveText === 'string'
+				? this.props.assistiveText
+				: {
+					...this.props.assistiveText,
+				}.label;
 
 		const labelText = label || assistiveText; // One of these is required to pass accessibility tests
 

--- a/components/tooltip/__docs__/storybook-stories.jsx
+++ b/components/tooltip/__docs__/storybook-stories.jsx
@@ -117,7 +117,7 @@ storiesOf(POPOVER_TOOLTIP, module)
 			), // react/no-unescaped-entities
 			trigger: (
 				<Icon
-					assistiveText="Case Icon"
+					assistiveText={{ label: 'Case Icon' }}
 					category="standard"
 					name="case"
 					size="small"

--- a/components/tooltip/__examples__/base.jsx
+++ b/components/tooltip/__examples__/base.jsx
@@ -16,7 +16,7 @@ const Example = createReactClass({
 				>
 					<a href="javascript:void(0)">
 						<Icon
-							assistiveText="Tooltip with icon"
+							assistiveText={{ label: 'Tooltip with icon' }}
 							category="utility"
 							name="info"
 							size="x-small"

--- a/components/tooltip/index.jsx
+++ b/components/tooltip/index.jsx
@@ -171,7 +171,9 @@ class Tooltip extends React.Component {
 					<Icon
 						category="utility"
 						name="info"
-						assistiveText={this.props.assistiveText.triggerLearnMoreIcon}
+						assistiveText={{
+							label: this.props.assistiveText.triggerLearnMoreIcon,
+						}}
 						size="x-small"
 					/>
 				</a>,
@@ -249,7 +251,9 @@ class Tooltip extends React.Component {
 					<div className="slds-m-top_x-small">
 						{this.props.labels.learnMoreBefore}{' '}
 						<Icon
-							assistiveText={this.props.assistiveText.tooltipTipLearnMoreIcon}
+							assistiveText={{
+								label: this.props.assistiveText.tooltipTipLearnMoreIcon,
+							}}
 							category="utility"
 							inverse
 							name="info"

--- a/components/tree/__docs__/storybook-stories.jsx
+++ b/components/tree/__docs__/storybook-stories.jsx
@@ -48,7 +48,7 @@ storiesOf(TREE, module)
 		<DefaultExample
 			action={action}
 			noHeading
-			assistiveText="Miscellaneous Foods"
+			assistiveText={{ label: 'Miscellaneous Foods' }}
 		/>
 	))
 	.add('Overflow Hidden', () => (

--- a/components/tree/__examples__/default.jsx
+++ b/components/tree/__examples__/default.jsx
@@ -369,7 +369,7 @@ class Example extends React.Component {
 					{this.props.searchable ? (
 						<div>
 							<Search
-								assistiveText="Search Tree"
+								assistiveText={{ label: 'Search Tree' }}
 								id="example-search"
 								value={this.state.searchTerm}
 								onChange={this.handleSearchChange}

--- a/components/tree/index.jsx
+++ b/components/tree/index.jsx
@@ -17,6 +17,11 @@ import checkProps from './check-props';
 // ## Constants
 import { TREE } from '../../utilities/constants';
 
+const defaultProps = {
+	assistiveText: {},
+	getNodes: (node) => node.nodes,
+};
+
 /**
  * A tree is visualization of a structure hierarchy. A branch can be expanded or collapsed. This is a controlled component, since visual state is present in the `nodes` data.
  */
@@ -144,7 +149,14 @@ class Tree extends React.Component {
 
 	render () {
 		// One of these is required to pass accessibility tests
-		const headingText = this.props.assistiveText || this.props.heading;
+		const assistiveText =
+			typeof this.props.assistiveText === 'string'
+				? this.props.assistiveText
+				: {
+					...defaultProps.assistiveText,
+					...this.props.assistiveText,
+				}.label;
+		const headingText = assistiveText || this.props.heading;
 
 		// Start the zero level branch--that is the tree root. There is no label for
 		// the tree root, but is required by all other nodes
@@ -158,7 +170,7 @@ class Tree extends React.Component {
 			>
 				<h4
 					className={classNames('slds-text-title--caps', {
-						'slds-assistive-text': this.props.assistiveText,
+						'slds-assistive-text': assistiveText,
 					})}
 					id={`${this.props.id}__heading`}
 				>
@@ -187,9 +199,7 @@ class Tree extends React.Component {
 	}
 }
 
-Tree.defaultProps = {
-	getNodes: (node) => node.nodes,
-};
+Tree.defaultProps = defaultProps;
 
 // ### Display Name
 // Always use the canonical component name as the React display name.
@@ -198,9 +208,13 @@ Tree.displayName = TREE;
 // ### Prop Types
 Tree.propTypes = {
 	/**
-	 * For users of assistive technology, if set the heading will be hidden. One of `heading` or `assistiveText` must be set in order to label the tree.
+	 * **Assistive text for accessibility.**
+	 * This object is merged with the default props object on every render.
+	 * * `label`: For users of assistive technology, if set the heading will be hidden. One of `heading` or `assistiveText.label` must be set in order to label the tree.
 	 */
-	assistiveText: PropTypes.string,
+	assistiveText: PropTypes.shape({
+		label: PropTypes.string,
+	}),
 	/**
 	 * Class names to be added to the container element which has the heading and the `ul.slds-tree` element as children.
 	 */

--- a/tests/__snapshots__/story-based-tests.snapshot-test.js.snap
+++ b/tests/__snapshots__/story-based-tests.snapshot-test.js.snap
@@ -307,7 +307,7 @@ exports[`DOM snapshots SLDSDataTable Advanced (Fixed Layout) 1`] = `
                       <span
                         className="slds-assistive-text"
                       >
-                        Select all rows
+                        all rows
                       </span>
                     </label>
                   </span>
@@ -338,7 +338,7 @@ exports[`DOM snapshots SLDSDataTable Advanced (Fixed Layout) 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Sort by: 
+                sort this column
                  
               </span>
               <span
@@ -363,7 +363,7 @@ exports[`DOM snapshots SLDSDataTable Advanced (Fixed Layout) 1`] = `
                 aria-live="assertive"
                 className="slds-assistive-text"
               >
-                Sorted Ascending
+                asc
               </span>
             </a>
           </th>
@@ -471,7 +471,7 @@ exports[`DOM snapshots SLDSDataTable Advanced (Fixed Layout) 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Sort by: 
+                sort this column
                  
               </span>
               <span
@@ -561,7 +561,7 @@ exports[`DOM snapshots SLDSDataTable Advanced (Fixed Layout) 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Actions
+                actions
               </span>
             </div>
           </th>
@@ -607,7 +607,7 @@ exports[`DOM snapshots SLDSDataTable Advanced (Fixed Layout) 1`] = `
                     <span
                       className="slds-assistive-text"
                     >
-                      Select row
+                      select this row
                     </span>
                   </label>
                 </span>
@@ -800,7 +800,7 @@ exports[`DOM snapshots SLDSDataTable Advanced (Fixed Layout) 1`] = `
                     <span
                       className="slds-assistive-text"
                     >
-                      Select row
+                      select this row
                     </span>
                   </label>
                 </span>
@@ -993,7 +993,7 @@ exports[`DOM snapshots SLDSDataTable Advanced (Fixed Layout) 1`] = `
                     <span
                       className="slds-assistive-text"
                     >
-                      Select row
+                      select this row
                     </span>
                   </label>
                 </span>


### PR DESCRIPTION
This PR consolidates assistive text props under one `assistiveText` prop for the following components:
- `DataTable`
- `Icon`
- `Search`
- `PanelFilterGroup`
- `Spinner`
- `Tree`
- `Textarea`

This completes our assistive text cleanup work!  Fixes https://github.com/salesforce/design-system-react/issues/901
- I left `Lookup` unchanged because it's deprecated.

### Additional description

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [ ] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [ ] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [x] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [x] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [x] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [x] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.