### PR TITLE
Add warning when Settings.setAppElement is not set.

### DIFF
--- a/components/app-launcher/index.jsx
+++ b/components/app-launcher/index.jsx
@@ -31,6 +31,7 @@ const defaultProps = {
 	assistiveText: {
 		trigger: 'Open App Launcher',
 	},
+	ariaHideApp: true,
 	title: 'App Launcher',
 };
 
@@ -82,6 +83,10 @@ const AppLauncher = createReactClass({
 		assistiveText: PropTypes.shape({
 			trigger: PropTypes.string,
 		}),
+		/**
+		 * Boolean indicating if the appElement should be hidden.
+		 */
+		ariaHideApp: PropTypes.bool,
 		/**
 		 * One or more `<AppLauncherSection />`s each containing one or more `<AppLauncherTile />`s
 		 */
@@ -248,6 +253,7 @@ const AppLauncher = createReactClass({
 					</button>
 				</div>
 				<Modal
+					ariaHideApp={this.props.ariaHideApp}
 					contentClassName="slds-modal__content slds-app-launcher__content slds-p-around--medium"
 					contentStyle={{ minHeight: modalContentStaticHeight }}
 					isOpen={isOpen}

--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -374,6 +374,17 @@
                     "computed": false
                 }
             },
+            "ariaHideApp": {
+                "type": {
+                    "name": "bool"
+                },
+                "required": false,
+                "description": "Boolean indicating if the appElement should be hidden. _Tested with snapshot testing._",
+                "defaultValue": {
+                    "value": "true",
+                    "computed": false
+                }
+            },
             "children": {
                 "type": {
                     "name": "node"
@@ -7333,6 +7344,17 @@
                 "description": "Vertical alignment of Modal.",
                 "defaultValue": {
                     "value": "'center'",
+                    "computed": false
+                }
+            },
+            "ariaHideApp": {
+                "type": {
+                    "name": "bool"
+                },
+                "required": false,
+                "description": "Boolean indicating if the appElement should be hidden. _Tested with snapshot testing._",
+                "defaultValue": {
+                    "value": "true",
                     "computed": false
                 }
             },

--- a/components/modal/index.jsx
+++ b/components/modal/index.jsx
@@ -24,6 +24,8 @@ import shortid from 'shortid';
 // This component's `checkProps` which issues warnings to developers about properties when in development mode (similar to React's built in development tools)
 import checkProps from './check-props';
 
+import checkAppElementIsSet from '../../utilities/warning/check-app-element-set';
+
 import Button from '../button';
 
 import { MODAL } from '../../utilities/constants';
@@ -33,6 +35,10 @@ const propTypes = {
 	 * Vertical alignment of Modal.
 	 */
 	align: PropTypes.oneOf(['top', 'center']),
+	/**
+	 * Boolean indicating if the appElement should be hidden.
+	 */
+	ariaHideApp: PropTypes.bool,
 	/**
 	 * **Assistive text for accessibility.**
 	 * This object is merged with the default props object on every render.
@@ -150,6 +156,7 @@ const defaultProps = {
 		closeButton: 'Close',
 	},
 	align: 'center',
+	ariaHideApp: true,
 	dismissible: true,
 };
 
@@ -181,6 +188,9 @@ class Modal extends React.Component {
 	componentWillMount () {
 		this.generatedId = shortid.generate();
 		checkProps(MODAL, this.props);
+		if (this.props.ariaHideApp) {
+			checkAppElementIsSet();
+		}
 	}
 
 	componentDidMount () {
@@ -450,6 +460,7 @@ class Modal extends React.Component {
 
 		return (
 			<ReactModal
+				ariaHideApp={this.props.ariaHideApp}
 				contentLabel="Modal"
 				isOpen={this.props.isOpen}
 				onRequestClose={this.closeModal}

--- a/utilities/warning/check-app-element-set.js
+++ b/utilities/warning/check-app-element-set.js
@@ -1,0 +1,24 @@
+/* Copyright (c) 2015-present, salesforce.com, inc. All rights reserved */
+/* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
+/* eslint-disable import/no-mutable-exports */
+
+import warning from 'warning';
+import Settings from '../../components/settings';
+
+let checkAppElementIsSet = function () {};
+
+if (process.env.NODE_ENV !== 'production') {
+	checkAppElementIsSet = function () {
+		const appElement = Settings.getAppElement();
+		/* eslint-disable max-len */
+		warning(
+			!!appElement,
+			'[Design System React] App element is not defined. Please use Settings.setAppElement(el).' +
+				' By default, `Modal` will add `aria-hidden=true` to the `body` tag, but this disables some assistive technologies.' +
+				' To prevent this you can add Settings.setAppElement(el) to your application with `el` being the root node of your application' +
+				' that you would like to hide from assistive technologies when the `Modal` is open.'
+		);
+	};
+}
+
+export default checkAppElementIsSet;


### PR DESCRIPTION
- Adds warning to Modal component to let consumer know when `Settings.setAppElement(el)` was not set prior to using this component.
- Adds prop `ariaHideApp` on `Modal` and `App Laucher` component as a way to opt-out of having to set `Settings.setAppElement(el)`.

Fixes #780 

### Additional description


---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [ ] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [ ] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
