### PR TITLE
Fix Datepicker Year Picklist Display Issue

### DIFF
--- a/components/date-picker/__tests__/__snapshots__/datepicker.snapshot-test.jsx.snap
+++ b/components/date-picker/__tests__/__snapshots__/datepicker.snapshot-test.jsx.snap
@@ -155,7 +155,7 @@ exports[`Datepicker
                 <div
                   aria-expanded={false}
                   aria-haspopup="listbox"
-                  className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-picklist--fluid slds-shrink-none"
+                  className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-shrink-none"
                   role="combobox"
                 >
                   <div
@@ -1002,7 +1002,7 @@ exports[`Datepicker
                 <div
                   aria-expanded={false}
                   aria-haspopup="listbox"
-                  className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-picklist--fluid slds-shrink-none"
+                  className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-shrink-none"
                   role="combobox"
                 >
                   <div
@@ -1847,7 +1847,7 @@ exports[`Datepicker Default DOM Snapshot 1`] = `
                 <div
                   aria-expanded={false}
                   aria-haspopup="listbox"
-                  className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-picklist--fluid slds-shrink-none"
+                  className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-shrink-none"
                   role="combobox"
                 >
                   <div
@@ -2570,7 +2570,7 @@ exports[`Datepicker Default HTML Snapshot 1`] = `
           <div class=\\"slds-form-element\\">
             <div class=\\"slds-form-element__control\\">
               <div class=\\"slds-combobox_container\\">
-                <div class=\\"slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-picklist--fluid slds-shrink-none\\" aria-expanded=\\"false\\" aria-haspopup=\\"listbox\\" role=\\"combobox\\">
+                <div class=\\"slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-shrink-none\\" aria-expanded=\\"false\\" aria-haspopup=\\"listbox\\" role=\\"combobox\\">
                   <div class=\\"slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right\\" aria-expanded=\\"false\\" aria-haspopup=\\"listbox\\" role=\\"none\\"><input type=\\"text\\" aria-autocomplete=\\"list\\" aria-controls=\\"sample-datepicker-year-picklist-listbox\\" autocomplete=\\"off\\" class=\\"slds-input slds-combobox__input\\" id=\\"sample-datepicker-year-picklist\\" placeholder=\\"Select an Option\\" readonly=\\"\\"
                       role=\\"textbox\\" value=\\"2014\\" /><span class=\\"slds-icon_container slds-input__icon slds-input__icon_right\\"><svg aria-hidden=\\"true\\" class=\\"slds-icon slds-icon_x-small slds-icon-text-default\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#down\\"></use></svg></span></div>
                 </div>

--- a/components/date-picker/private/year-picklist.jsx
+++ b/components/date-picker/private/year-picklist.jsx
@@ -72,7 +72,7 @@ const DatepickerYearSelector = createReactClass({
 		return (
 			<div className="slds-form-element slds-align-content-center">
 				<Combobox
-					className="slds-picklist--fluid slds-shrink-none"
+					className="slds-shrink-none"
 					events={{
 						onSelect: this.handleSelect,
 					}}


### PR DESCRIPTION
Fix for the Datepicker component where the year list did not show the full year in Firefox and IE.

![image](https://user-images.githubusercontent.com/20672636/42964695-cf2992da-8b65-11e8-8c73-279aa4c1cc28.png)

### Additional description

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [ ] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [ ] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
