### PR TITLE
Add preset package.json

### DIFF
--- a/preset/package.json.txt
+++ b/preset/package.json.txt
@@ -1,0 +1,33 @@
+{
+  "name": "@salesforce/babel-preset-design-system-react",
+  "version": "3.0.0",
+  "description": "Babel preset to parse the Salesforce Design System React source code.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/salesforce/design-system-react.git"
+  },
+  "keywords": [
+    "babel",
+    "preset",
+    "react",
+    "es6",
+    "javascript",
+    "design system",
+    "lightning",
+    "salesforce-lightning",
+    "salesforce"
+  ],
+  "author": {
+    "name": "Stephen James",
+    "email": "sjames@salesforce.com"
+  },
+  "license": "SEE LICENSE IN README.md",
+  "bugs": {
+    "url": "https://github.com/salesforce/design-system-react/issues"
+  },
+  "homepage": "https://github.com/salesforce/design-system-react#readme"
+}


### PR DESCRIPTION
Add txt file copy of package.json so that new preset versions did not have to be created from scatch.
Non-production code.

---

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
