### PR TITLE
Dropdown: Document that default menu height is 5

### DIFF
--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -6796,7 +6796,11 @@
                     ]
                 },
                 "required": false,
-                "description": "This prop is passed into the List for the menu. Pass null to make it the size of the content, or a string with an integer from here: https://www.lightningdesignsystem.com/components/menus/#flavor-dropdown-height"
+                "description": "This prop is passed into the List for the menu. Pass null to make it the size of the content, or a string with an integer from here: https://www.lightningdesignsystem.com/components/menus/#flavor-dropdown-height",
+                "defaultValue": {
+                    "value": "'5'",
+                    "computed": false
+                }
             },
             "menuPosition": {
                 "type": {
@@ -7589,8 +7593,8 @@
                 "description": "Allows adding additional notifications within the modal."
             }
         },
-        "route": "modals",
-        "display-name": "Modals",
+        "route": "modals-and-prompts",
+        "display-name": "Modals and Prompts",
         "SLDS-component-path": "/components/modals",
         "dependencies": []
     },

--- a/components/menu-dropdown/menu-dropdown.jsx
+++ b/components/menu-dropdown/menu-dropdown.jsx
@@ -378,6 +378,7 @@ const MenuDropdown = createReactClass({
 		return {
 			align: 'left',
 			hoverCloseDelay: 300,
+			length: '5',
 			menuPosition: 'absolute',
 			openOn: 'click',
 		};


### PR DESCRIPTION
Fixes #799

### Additional description
Surfaces and documents default of menu height of 5

---

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
