### PR TITLE
Deprecate this one little weird Modal Trigger trick your grandmother knew about

### DIFF
--- a/components/modal/trigger.jsx
+++ b/components/modal/trigger.jsx
@@ -4,6 +4,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
+import componentIsDeprecated from '../../utilities/warning/component-is-deprecated';
+
 import Modal from './index';
 
 // This component should be deprecated and appears to have
@@ -11,6 +13,11 @@ import Modal from './index';
 
 const ModalTrigger = {
 	open: (cfg) => {
+		componentIsDeprecated(
+			'components/modal/trigger.jsx',
+			'This component is deprecated and appears to have been created in order to do modals in portals which is what current Modal has done for years.'
+		);
+
 		const el = document.createElement('span');
 		el.setAttribute('data-slds-modal', true);
 		document.body.appendChild(el);


### PR DESCRIPTION
Fixes #1394

### Additional description
Add the following to any Storybook example to see output.
```
import ModalTrigger from '~/components/modal/trigger';
ModalTrigger.open({ content: '', footer: ' ' });
```

![screen shot 2018-08-07 at 5 30 19 pm](https://user-images.githubusercontent.com/1290832/43812974-fd290524-9a80-11e8-9b27-e9bccb1e81f5.png)


---

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
