### PR TITLE
Hotfix GlobalHeaderButton invalid markup when used within GlobalHeaderTrigger

### DIFF
--- a/components/global-header/button.jsx
+++ b/components/global-header/button.jsx
@@ -17,11 +17,11 @@ import { GLOBAL_HEADER_TOOL } from '../../utilities/constants';
 /**
  * A helper component that renders a Button in the tools area of the Global Header. Currently defaults to a bare icon, but this can be overriden if text-based buttons are required.
  */
-const GlobalHeaderButton = (props) => (
-	<li>
-		<Button iconVariant="global-header" variant="icon" {...props} />
-	</li>
-);
+const GlobalHeaderButton = (props) => {
+	const { buttonVariant, ...rest } = props;
+	const btn = <Button iconVariant="global-header" variant="icon" {...rest} />;
+	return buttonVariant === 'dropdown' ? btn : <li>{btn}</li>;
+};
 
 GlobalHeaderButton.displayName = GLOBAL_HEADER_TOOL;
 

--- a/components/global-header/private/dropdown-trigger.jsx
+++ b/components/global-header/private/dropdown-trigger.jsx
@@ -160,6 +160,7 @@ const GlobalHeaderDropdownTrigger = createReactClass({
 						'slds-global-header__icon-actions': globalAction,
 					})}
 					aria-haspopup="true"
+					buttonVariant="dropdown"
 					{...rest}
 				>
 					{avatar ? (


### PR DESCRIPTION
Fixes #1318 

### Additional description

When `GlobalHeaderButton` is used on its own, it is appropriately wrapped in an `<li>`. This PR makes it so that when it's called from within `GlobalHeaderTrigger` (which adds its own wrapping `<li>`, it is not double-wrapped.

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [x] ~~Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).~~
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [x] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [x] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
