### PR TITLE
Tree: Allow label to be a React node

### DIFF
--- a/components/tree/index.jsx
+++ b/components/tree/index.jsx
@@ -76,7 +76,8 @@ const propTypes = {
 			PropTypes.shape({
 				id: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
 					.isRequired,
-				label: PropTypes.string.isRequired,
+				label: PropTypes.oneOfType([PropTypes.node, PropTypes.string])
+					.isRequired,
 				type: PropTypes.string.isRequired,
 			}),
 		])


### PR DESCRIPTION
This allows icons and formatting with spans if it is needed. Both are outside the SLDS spec, but should be allowed with designer direction. This is already present in item and branch sub components, but was overlooked when added to Tree's top level propTypes