### PR TITLE
Use Tooltip instead of PopoverTooltip internally

### DIFF
--- a/components/app-launcher/tile.jsx
+++ b/components/app-launcher/tile.jsx
@@ -12,7 +12,7 @@ import Truncate from '../utilities/truncate';
 
 // ## Children
 import Highlighter from '../utilities/highlighter';
-import PopoverTooltip from '../popover-tooltip';
+import Tooltip from '../tooltip';
 
 import { APP_LAUNCHER_TILE } from '../../utilities/constants';
 
@@ -73,7 +73,7 @@ const AppLauncherTile = (props) => {
 						suffix={props.moreLabel}
 						text={props.description}
 						textTruncateChild={
-							<PopoverTooltip
+							<Tooltip
 								align="bottom"
 								content={
 									<Highlighter search={props.search}>
@@ -88,7 +88,7 @@ const AppLauncherTile = (props) => {
 								>
 									{props.moreLabel}
 								</span>
-							</PopoverTooltip>
+							</Tooltip>
 						}
 						wrapper={(text, textTruncateChild) => (
 							<div>

--- a/components/button/index.jsx
+++ b/components/button/index.jsx
@@ -12,7 +12,7 @@ import classNames from 'classnames';
 import ButtonIcon from '../icon/button-icon';
 import checkProps from './check-props';
 import componentDoc from './docs.json';
-import PopoverTooltip from '../popover-tooltip';
+import Tooltip from '../tooltip';
 
 import { BUTTON } from '../../utilities/constants';
 
@@ -354,11 +354,7 @@ const Button = createReactClass({
 
 	// This is present for backwards compatibility and should be removed at a future breaking change release. Please wrap a `Button` in a `PopoverTooltip` to achieve the same result. There will be an extra trigger `div` wrapping the `Button` though.
 	renderTooltip () {
-		return (
-			<PopoverTooltip content={this.props.tooltip}>
-				{this.renderButton}
-			</PopoverTooltip>
-		);
+		return <Tooltip content={this.props.tooltip}>{this.renderButton}</Tooltip>;
 	},
 
 	render () {

--- a/components/menu-picklist/__examples__/tooltip-list-item.jsx
+++ b/components/menu-picklist/__examples__/tooltip-list-item.jsx
@@ -2,16 +2,16 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import IconSettings from '~/components/icon-settings';
 import Picklist from '~/components/menu-picklist'; // `~` is replaced with design-system-react at runtime
-import PopoverTooltip from '~/components/popover-tooltip';
+import Tooltip from '~/components/tooltip';
 
 const ListItemRenderer = (props) => (
-	<PopoverTooltip
+	<Tooltip
 		openByDefault={props.isHighlighted}
 		align="bottom left"
 		content={`${props.label} tooltip on bottom left`}
 	>
 		<p className="slds-truncate">{props.label} (Hover for tooltip)</p>
-	</PopoverTooltip>
+	</Tooltip>
 );
 
 const Example = createReactClass({

--- a/components/page-header/__docs__/storybook-stories.jsx
+++ b/components/page-header/__docs__/storybook-stories.jsx
@@ -11,7 +11,7 @@ import SLDSButtonStateful from '../../button-stateful';
 import SLDSButtonGroup from '../../button-group';
 import SLDSButton from '../../button';
 import SLDSMenuDropdown from '../../menu-dropdown';
-import PopoverTooltip from '../../popover-tooltip';
+import Tooltip from '../../tooltip';
 
 import ObjectHome from '../__examples__/object-home';
 
@@ -117,11 +117,11 @@ const customTooltip = () => {
 	const content =
 		'here is a super long description that will truncate and the rest of it will show in the tooltip.';
 	return (
-		<PopoverTooltip align="top" content={content}>
+		<Tooltip align="top" content={content}>
 			<p tabIndex="0" className="slds-truncate">
 				{content}
 			</p>
-		</PopoverTooltip>
+		</Tooltip>
 	);
 };
 

--- a/components/page-header/private/detail-block.jsx
+++ b/components/page-header/private/detail-block.jsx
@@ -6,7 +6,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import PopoverTooltip from '../../popover-tooltip';
+import Tooltip from '../../tooltip';
 
 const displayName = 'PageHeaderDetailRow';
 const propTypes = {
@@ -124,11 +124,11 @@ class DetailBlock extends Component {
 				'slds-truncate': truncate,
 			});
 			return (
-				<PopoverTooltip align="top" content={content}>
+				<Tooltip align="top" content={content}>
 					<p tabIndex="0" className={labelClasses}>
 						{content}
 					</p>
-				</PopoverTooltip>
+				</Tooltip>
 			);
 		};
 

--- a/components/tooltip/__docs__/storybook-stories.jsx
+++ b/components/tooltip/__docs__/storybook-stories.jsx
@@ -5,7 +5,7 @@ import { storiesOf } from '@storybook/react';
 import IconSettings from '../../icon-settings';
 
 import { POPOVER_TOOLTIP } from '../../../utilities/constants';
-import PopoverTooltip from '../../popover-tooltip';
+import Tooltip from '../../tooltip';
 
 import ButtonGroupExample from '../__examples__/button-group';
 import ButtonExample from '../__examples__/button';
@@ -15,9 +15,9 @@ import Icon from '../../icon';
 import Button from '../../button';
 
 const getPopoverTooltip = (props) => (
-	<PopoverTooltip {...props}>
+	<Tooltip {...props}>
 		<Button label="Trigger Tooltip" />
-	</PopoverTooltip>
+	</Tooltip>
 );
 
 const getPopoverTooltipAlign = (props) => {
@@ -42,9 +42,9 @@ const getPopoverTooltipAlign = (props) => {
 	align.forEach((value) => {
 		children.push(
 			<div key={value} style={{ margin: '100px auto' }}>
-				<PopoverTooltip {...props} align={value}>
+				<Tooltip {...props} align={value}>
 					{props.trigger}
-				</PopoverTooltip>
+				</Tooltip>
 			</div>
 		);
 	});

--- a/components/tooltip/__examples__/base.jsx
+++ b/components/tooltip/__examples__/base.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
 import IconSettings from '~/components/icon-settings';
-import PopoverTooltip from '~/components/popover-tooltip'; // `~` is replaced with design-system-react at runtime
+import Tooltip from '~/components/tooltip'; // `~` is replaced with design-system-react at runtime
 import Icon from '~/components/icon';
 
 const Example = createReactClass({
@@ -10,7 +10,7 @@ const Example = createReactClass({
 	render () {
 		return (
 			<IconSettings iconPath="/assets/icons">
-				<PopoverTooltip
+				<Tooltip
 					align="top left"
 					content="Sit nulla est ex deserunt exercitation anim occaecat. Nostrud ullamco deserunt aute id consequat veniam incididunt duis in sint irure nisi."
 				>
@@ -22,7 +22,7 @@ const Example = createReactClass({
 							size="x-small"
 						/>
 					</a>
-				</PopoverTooltip>
+				</Tooltip>
 			</IconSettings>
 		);
 	},

--- a/components/tooltip/__examples__/button-group.jsx
+++ b/components/tooltip/__examples__/button-group.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
 import IconSettings from '~/components/icon-settings';
-import PopoverTooltip from '~/components/popover-tooltip'; // `~` is replaced with design-system-react at runtime
+import Tooltip from '~/components/tooltip'; // `~` is replaced with design-system-react at runtime
 import ButtonGroup from '~/components/button-group';
 import Button from '~/components/button';
 import Dropdown from '~/components/menu-dropdown';
@@ -13,12 +13,12 @@ const Example = createReactClass({
 		return (
 			<IconSettings iconPath="/assets/icons">
 				<ButtonGroup className="slds-p-bottom--medium">
-					<PopoverTooltip align="bottom" content="Buttonbar Tooltip">
+					<Tooltip align="bottom" content="Buttonbar Tooltip">
 						<Button label="Refresh" />
-					</PopoverTooltip>
-					<PopoverTooltip align="bottom right" content="Buttonbar Tooltip">
+					</Tooltip>
+					<Tooltip align="bottom right" content="Buttonbar Tooltip">
 						<Button label="Edit" />
-					</PopoverTooltip>
+					</Tooltip>
 					<Dropdown
 						assistiveText={{ icon: 'More Options' }}
 						buttonVariant="icon"

--- a/components/tooltip/__examples__/button.jsx
+++ b/components/tooltip/__examples__/button.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
 import IconSettings from '~/components/icon-settings';
-import PopoverTooltip from '~/components/popover-tooltip'; // `~` is replaced with design-system-react at runtime
+import Tooltip from '~/components/tooltip'; // `~` is replaced with design-system-react at runtime
 import Button from '~/components/button';
 
 const Example = createReactClass({
@@ -10,9 +10,9 @@ const Example = createReactClass({
 	render () {
 		return (
 			<IconSettings iconPath="/assets/icons">
-				<PopoverTooltip align="right" content="Tooltip with right alignment">
+				<Tooltip align="right" content="Tooltip with right alignment">
 					<Button label="Hover or focus to Open" />
-				</PopoverTooltip>
+				</Tooltip>
 			</IconSettings>
 		);
 	},

--- a/components/tooltip/__tests__/tooltip.browser-test.jsx
+++ b/components/tooltip/__tests__/tooltip.browser-test.jsx
@@ -5,7 +5,7 @@ import ReactDOM from 'react-dom';
 import { expect } from 'chai';
 import TestUtils from 'react-dom/test-utils';
 
-import SLDSPopoverTooltip from '../../popover-tooltip';
+import SLDSTooltip from '../../tooltip';
 import SLDSButton from '../../button';
 
 const {
@@ -56,7 +56,7 @@ describe('SLDSTooltip: ', function () {
 	const renderTooltip = (inst) => ReactDOM.render(inst, body);
 
 	const createTooltip = (props, kids) =>
-		React.createElement(SLDSPopoverTooltip, props, kids);
+		React.createElement(SLDSTooltip, props, kids);
 
 	const generateTooltip = (props, kids) =>
 		renderTooltip(createTooltip(props, kids));


### PR DESCRIPTION
Prevent warnings when importing components like `Button` and `PageHeader` or their dependents.

Also update examples to import Tooltip instead of moved PopoverTooltip.

Fixes #1514 

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [x] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [x] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [x] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [x] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
