### PR TITLE
Button: Add ability to add data attributes to DOM

### DIFF
--- a/components/button/__tests__/button.browser-test.jsx
+++ b/components/button/__tests__/button.browser-test.jsx
@@ -52,6 +52,9 @@ describe('SLDSButton: ', () => {
 				id: 'custom-id',
 				text: 'Brand',
 				theme: 'brand',
+				'data-*': {
+					id: 'custom-data-id',
+				},
 			});
 			btn = findRenderedDOMComponentWithClass(cmp, 'slds-button');
 		});
@@ -70,6 +73,10 @@ describe('SLDSButton: ', () => {
 
 		it('renders custom id', () => {
 			expect(btn.getAttribute('id')).to.equal('custom-id');
+		});
+
+		it('renders custom data-id', () => {
+			expect(btn.dataset.id).to.equal('custom-data-id');
 		});
 	});
 

--- a/components/button/index.jsx
+++ b/components/button/index.jsx
@@ -15,6 +15,7 @@ import componentDoc from './docs.json';
 import Tooltip from '../tooltip';
 
 import { BUTTON } from '../../utilities/constants';
+import { getDataIds } from '../../utilities/common';
 
 const defaultProps = {
 	assistiveText: { icon: '' },
@@ -51,6 +52,10 @@ const Button = createReactClass({
 		 * True if Button triggers a menu or popup to open/close.
 		 */
 		'aria-haspopup': PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+		/**
+		 * Data attrs
+		 */
+		'data-*': PropTypes.shape({}),
 		/**
 		 * **Assistive text for accessibility.**
 		 * This object is merged with the default props object on every render.
@@ -332,6 +337,7 @@ const Button = createReactClass({
 				tabIndex={this.props.tabIndex}
 				title={this.props.title}
 				type={this.props.type}
+				{...getDataIds(this.props)}
 			>
 				{this.props.iconPosition === 'right' ? this.renderLabel() : null}
 

--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -842,6 +842,144 @@
         "SLDS-component-path": "/components/avatar",
         "dependencies": []
     },
+    "brand-band": {
+        "description": "The brand band provides theming capability that adds personality and improves information density and contrast.",
+        "methods": [
+            {
+                "name": "getId",
+                "docblock": null,
+                "modifiers": [],
+                "params": [],
+                "returns": null
+            },
+            {
+                "name": "injectLightningBlueStyles",
+                "docblock": null,
+                "modifiers": [],
+                "params": [],
+                "returns": null
+            }
+        ],
+        "props": {
+            "children": {
+                "type": {
+                    "name": "node"
+                },
+                "required": false,
+                "description": "Content to be injected inside inside the brand band, if any"
+            },
+            "className": {
+                "type": {
+                    "name": "union",
+                    "value": [
+                        {
+                            "name": "array"
+                        },
+                        {
+                            "name": "object"
+                        },
+                        {
+                            "name": "string"
+                        }
+                    ]
+                },
+                "required": false,
+                "description": "CSS classes that are applied to the component"
+            },
+            "id": {
+                "type": {
+                    "name": "string"
+                },
+                "required": false,
+                "description": "Id of component, if desired. If not provided an id is automatically generated"
+            },
+            "image": {
+                "type": {
+                    "name": "enum",
+                    "value": [
+                        {
+                            "value": "'default'",
+                            "computed": false
+                        },
+                        {
+                            "value": "'none'",
+                            "computed": false
+                        }
+                    ]
+                },
+                "required": false,
+                "description": "Image of the brand band",
+                "defaultValue": {
+                    "value": "'default'",
+                    "computed": false
+                }
+            },
+            "size": {
+                "type": {
+                    "name": "enum",
+                    "value": [
+                        {
+                            "value": "'small'",
+                            "computed": false
+                        },
+                        {
+                            "value": "'medium'",
+                            "computed": false
+                        },
+                        {
+                            "value": "'large'",
+                            "computed": false
+                        }
+                    ]
+                },
+                "required": false,
+                "description": "Size of the brand band. Default is 'medium'",
+                "defaultValue": {
+                    "value": "'medium'",
+                    "computed": false
+                }
+            },
+            "style": {
+                "type": {
+                    "name": "object"
+                },
+                "required": false,
+                "description": "Custom styles to be passed to the component"
+            },
+            "styleContainer": {
+                "type": {
+                    "name": "object"
+                },
+                "required": false,
+                "description": "Custom styles to be passed to the component container"
+            },
+            "theme": {
+                "type": {
+                    "name": "enum",
+                    "value": [
+                        {
+                            "value": "'default'",
+                            "computed": false
+                        },
+                        {
+                            "value": "'lightning-blue'",
+                            "computed": false
+                        }
+                    ]
+                },
+                "required": false,
+                "description": "Different brand band styling",
+                "defaultValue": {
+                    "value": "'default'",
+                    "computed": false
+                }
+            }
+        },
+        "route": "brand-band",
+        "display-name": "BrandBand",
+        "SLDS-component-path": "/components/brand-band",
+        "dependencies": []
+    },
     "breadcrumb": {
         "description": "Use breadcrumbs to note the path of a record and help the user to navigate back to the parent.Breadcrumb based on SLDS 2.1.0-dev",
         "methods": [],
@@ -976,6 +1114,14 @@
                 },
                 "required": false,
                 "description": "True if Button triggers a menu or popup to open/close."
+            },
+            "data-*": {
+                "type": {
+                    "name": "shape",
+                    "value": {}
+                },
+                "required": false,
+                "description": "Data attrs"
             },
             "assistiveText": {
                 "type": {

--- a/utilities/common.js
+++ b/utilities/common.js
@@ -1,0 +1,13 @@
+// Gettings data ids from prop data-* as object
+export function getDataIds(props) {
+	const propDataIds = props['data-*'];
+	const dataIds = {};
+
+	Object.keys(propDataIds || []).forEach((key) => {
+		dataIds[`data-${key}`] = propDataIds[key];
+	});
+
+	return dataIds;
+}
+
+export default {};


### PR DESCRIPTION
### Additional description

Add Button data attrs

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [x] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [x] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [x] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [x] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
