### PR TITLE
Adds `onRequestIconPath` to IconSettings

### DIFF
--- a/components/icon-settings/__docs__/site-stories.js
+++ b/components/icon-settings/__docs__/site-stories.js
@@ -6,6 +6,7 @@
 const siteStories = [
 	require('raw-loader!@salesforce/design-system-react/components/icon-settings/__examples__/icon-path.jsx'),
 	require('raw-loader!@salesforce/design-system-react/components/icon-settings/__examples__/sprite.jsx'),
+	require('raw-loader!@salesforce/design-system-react/components/icon-settings/__examples__/on-request-icon-path.jsx'),
 ];
 
 module.exports = siteStories;

--- a/components/icon-settings/__docs__/storybook-stories.jsx
+++ b/components/icon-settings/__docs__/storybook-stories.jsx
@@ -5,10 +5,12 @@ import { ICON_SETTINGS } from '../../../utilities/constants';
 
 import Sprite from '../__examples__/sprite';
 import IconPath from '../__examples__/icon-path';
+import OnRequestIconPath from '../__examples__/on-request-icon-path';
 
 storiesOf(ICON_SETTINGS, module)
 	.addDecorator((getStory) => (
 		<div className="slds-p-around--medium">{getStory()}</div>
 	))
 	.add('Base: Icon path', () => <IconPath />)
-	.add('Base: Sprite imports', () => <Sprite />);
+	.add('Base: Sprite imports', () => <Sprite />)
+	.add('Base: OnRequestIconPath', () => <OnRequestIconPath />);

--- a/components/icon-settings/__examples__/on-request-icon-path.jsx
+++ b/components/icon-settings/__examples__/on-request-icon-path.jsx
@@ -30,7 +30,7 @@ const Example = createReactClass({
 	},
 	render() {
 		return (
-			<IconSettings onRequestIconPath={(category, name) => `#${name}`}>
+			<IconSettings onRequestIconPath={({category, name}) => `#${name}`}>
 				<div
 					ref={(el) => {
 						this.spriteInlineContainer = el;

--- a/components/icon-settings/__examples__/on-request-icon-path.jsx
+++ b/components/icon-settings/__examples__/on-request-icon-path.jsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import createReactClass from 'create-react-class';
+import Icon from '~/components/icon'; // `~` is replaced with design-system-react at runtime
+import IconSettings from '~/components/icon-settings';
+
+import action from '@salesforce-ux/design-system/assets/icons/action-sprite/svg/symbols.svg';
+import custom from '@salesforce-ux/design-system/assets/icons/custom-sprite/svg/symbols.svg';
+import utility from '@salesforce-ux/design-system/assets/icons/utility-sprite/svg/symbols.svg';
+import standard from '@salesforce-ux/design-system/assets/icons/standard-sprite/svg/symbols.svg';
+import doctype from '@salesforce-ux/design-system/assets/icons/doctype-sprite/svg/symbols.svg';
+
+const sprites = {
+	action,
+	custom,
+	utility,
+	standard,
+	doctype,
+};
+
+const Example = createReactClass({
+	displayName: 'IconSettingsExample',
+	componentDidMount() {
+		Promise.all(
+			Object.keys(sprites).map((category) =>
+				fetch(sprites[category]).then((resp) => resp.text())
+			)
+		).then((texts) => {
+			this.spriteInlineContainer.innerHTML = texts.join('');
+		});
+	},
+	render() {
+		return (
+			<IconSettings onRequestIconPath={(category, name) => `#${name}`}>
+				<div
+					ref={(el) => {
+						this.spriteInlineContainer = el;
+					}}
+				/>
+				<div className="slds-grid slds-grid--pull-padded slds-grid--vertical-align-center">
+					<div className="slds-col--padded">
+						<Icon
+							assistiveText={{ label: 'Account' }}
+							category="standard"
+							name="account"
+							size="small"
+						/>
+					</div>
+					<div className="slds-col--padded">
+						<Icon
+							assistiveText={{ label: 'Announcement' }}
+							category="utility"
+							name="announcement"
+							size="small"
+						/>
+					</div>
+					<div className="slds-col--padded">
+						<Icon
+							assistiveText={{ label: 'Description' }}
+							category="action"
+							name="description"
+							size="small"
+						/>
+					</div>
+					<div className="slds-col--padded">
+						<Icon
+							assistiveText={{ label: 'XML' }}
+							category="doctype"
+							name="xml"
+							size="small"
+						/>
+					</div>
+					<div className="slds-col--padded">
+						<Icon
+							assistiveText={{ label: 'custom5' }}
+							category="custom"
+							name="custom5"
+							size="small"
+						/>
+					</div>
+				</div>
+			</IconSettings>
+		);
+	},
+});
+
+export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/icon-settings/index.jsx
+++ b/components/icon-settings/index.jsx
@@ -26,6 +26,7 @@ class IconSettings extends React.Component {
 	getChildContext() {
 		return {
 			iconPath: this.props.iconPath,
+			onRequestIconPath: this.props.onRequestIconPath,
 			actionSprite: this.props.actionSprite,
 			customSprite: this.props.customSprite,
 			doctypeSprite: this.props.doctypeSprite,
@@ -43,6 +44,7 @@ IconSettings.displayName = ICON_SETTINGS;
 
 IconSettings.childContextTypes = {
 	iconPath: PropTypes.string,
+	onRequestIconPath: PropTypes.func,
 	actionSprite: PropTypes.string,
 	customSprite: PropTypes.string,
 	doctypeSprite: PropTypes.string,
@@ -56,6 +58,11 @@ IconSettings.propTypes = {
 	 * example: `/assets/icons`
 	 */
 	iconPath: PropTypes.string,
+	/**
+	 * Function to allow developers to return a custom icon path
+	 * example: `(category, name) => { return "#" + category + "_" + name }`
+	 */
+	onRequestIconPath: PropTypes.func,
 	/**
 	 * Path to the action sprite
 	 * example: '@salesforce-ux/design-system/assets/icons/action-sprite/svg/symbols.svg';

--- a/components/icon-settings/index.jsx
+++ b/components/icon-settings/index.jsx
@@ -59,8 +59,7 @@ IconSettings.propTypes = {
 	 */
 	iconPath: PropTypes.string,
 	/**
-	 * Function to allow developers to return a custom icon path
-	 * example: `(category, name) => { return "#" + category + "_" + name }`
+	 * Function to allow developers to return a custom icon path--for instance, on the same page with a local anchor (`#down`). This is helpful for when there are Cross-Origin Resource Sharing (CORS) issues with SVGs that are located on another domain such as a CDN. `({category, name}) => { return \`#${name}\` }`
 	 */
 	onRequestIconPath: PropTypes.func,
 	/**

--- a/components/utilities/utility-icon/check-props.js
+++ b/components/utilities/utility-icon/check-props.js
@@ -8,7 +8,7 @@ let checkProps = function() {};
 
 if (process.env.NODE_ENV !== 'production') {
 	checkProps = function(COMPONENT, props) {
-		if (!props.context[`${props.category}Sprite`]) {
+		if (!props.context[`${props.category}Sprite`] && !props.context.onRequestIconPath) {
 			const modifiedPath = props.path || props.context.iconPath;
 			urlExists(
 				COMPONENT,

--- a/components/utilities/utility-icon/index.jsx
+++ b/components/utilities/utility-icon/index.jsx
@@ -55,6 +55,8 @@ const UtilityIcon = (
 	if (path) {
 		// Use `path` prop of Icon if present
 		modifiedPath = path;
+	} else if (context.onRequestIconPath) {
+		modifiedPath = context.onRequestIconPath(category, name);
 	} else if (context[`${category}Sprite`]) {
 		// Use category sprite file from IconSettings if present
 		modifiedPath = `${context[`${category}Sprite`]}#${name}`;
@@ -105,6 +107,7 @@ UtilityIcon.defaultProps = {
 
 UtilityIcon.contextTypes = {
 	iconPath: PropTypes.string,
+	onRequestIconPath: PropTypes.func,
 	actionSprite: PropTypes.string,
 	customSprite: PropTypes.string,
 	doctypeSprite: PropTypes.string,

--- a/components/utilities/utility-icon/index.jsx
+++ b/components/utilities/utility-icon/index.jsx
@@ -56,7 +56,7 @@ const UtilityIcon = (
 		// Use `path` prop of Icon if present
 		modifiedPath = path;
 	} else if (context.onRequestIconPath) {
-		modifiedPath = context.onRequestIconPath(category, name);
+		modifiedPath = context.onRequestIconPath({category, name});
 	} else if (context[`${category}Sprite`]) {
 		// Use category sprite file from IconSettings if present
 		modifiedPath = `${context[`${category}Sprite`]}#${name}`;


### PR DESCRIPTION
…paths.

The motivation for this change is tied to Quip's Live Apps platform where we cannot serve
sprite sheets on the same domain as our iframe, thus breaking the ability to load XML-like
data (the SVG sprite sheets) due to browser security restrictions arounds same domain+port.

Fixes #1408

### Additional description

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [x] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [x] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
