### PR TITLE
Prevent scroll on focus in portal popovers

### DIFF
--- a/components/utilities/dialog/index.jsx
+++ b/components/utilities/dialog/index.jsx
@@ -335,7 +335,9 @@ const Dialog = createReactClass({
 			}); // eslint-disable-line react/no-find-dom-node
 			// Don't steal focus from inner elements
 			if (!DOMElementFocus.hasOrAncestorHasFocus()) {
-				DOMElementFocus.focusAncestor();
+				DOMElementFocus.focusAncestor({
+					isPortal: this.props.position === 'overflowBoundaryElement',
+				});
 			}
 		}
 

--- a/components/utilities/dialog/portal.jsx
+++ b/components/utilities/dialog/portal.jsx
@@ -47,6 +47,11 @@ class Portal extends Component {
 		const parentParentNode = this.getPortalParentNode();
 
 		this.portalNode = document.createElement(this.props.renderTag);
+		this.portalNode.setAttribute(
+			'style',
+			'display: block; height: 0px; width: 0px;'
+		);
+		this.portalNode.setAttribute('className', 'design-system-react-portal');
 		parentParentNode.appendChild(this.portalNode);
 		this.portalNodeInstance = this.props.onMount
 			? this.props.onMount(undefined, { portal: this.portalNode })

--- a/utilities/dom-element-focus.js
+++ b/utilities/dom-element-focus.js
@@ -26,9 +26,16 @@ const handleScopedKeyDown = (event) => {
 // PUBLIC methods
 
 const ElementFocus = {
-	focusAncestor: () => {
+	focusAncestor: ({ isPortal }) => {
 		if (canUseDOM) {
-			ancestor.focus();
+			// When a portal is used (that is attaching a separate React mount, such as with Popover) programatic focusing within that portal may cause the window to scroll down to the DOM insertion point at the end of `body`. The following prevents the scrolling from occuring.
+			if (isPortal) {
+				const offset = window.pageYOffset;
+				ancestor.focus({ preventScroll: true });
+				window.scrollTo(window.pageXOffset, offset);
+			} else {
+				ancestor.focus();
+			}
 		}
 	},
 	hasOrAncestorHasFocus: () =>


### PR DESCRIPTION
Fixes #1566

### Additional description
This removes the scrolling affect on focus for popovers in portals and adds styling to the portal element in order to ensure it is hidden and adds a class to make it targetable with styles.

The easiest way to test this is to add
```
<div style={{ height: '1000px' }} />
```
to a storybook example of a `Filter`

focus's `preventScroll: true` is fairly [new](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus). 

I'm hesitant to add an additional tests that looks at scrolling and focus events within the test suite, but I'm open to suggestions on how to prevent regressions.

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [ ] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [ ] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
