### PR TITLE
Prop style for alert

### DIFF
--- a/components/alert/__docs__/storybook-stories.jsx
+++ b/components/alert/__docs__/storybook-stories.jsx
@@ -9,6 +9,7 @@ import Offline from '../__examples__/offline';
 import Dismissable from '../__examples__/dismissable';
 import CloseAlert from '../__examples__/close-alert';
 import CustomClassNames from '../__examples__/custom-class-name';
+import CustomStyles from '../__examples__/custom-style';
 
 /* eslint-disable react/display-name */
 
@@ -22,4 +23,5 @@ storiesOf(ALERT, module)
 	.add('Offline', () => <Offline />)
 	.add('Dismissable', () => <Dismissable />)
 	.add('Close alert', () => <CloseAlert />)
-	.add('Custom Class Names', () => <CustomClassNames />);
+	.add('Custom Class Names', () => <CustomClassNames />)
+	.add('Custom Styles', () => <CustomStyles />);

--- a/components/alert/__examples__/custom-style.jsx
+++ b/components/alert/__examples__/custom-style.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import Alert from '~/components/alert'; // `~` is replaced with design-system-react at runtime
+import AlertContainer from '~/components/alert/container'; // `~` is replaced with design-system-react at runtime
+import Icon from '~/components/icon'; // `~` is replaced with design-system-react at runtime
+import IconSettings from '~/components/icon-settings';
+
+class Example extends React.Component {
+	render() {
+		return (
+			<IconSettings iconPath="/assets/icons">
+				<AlertContainer className="this-is-the-container">
+					<Alert
+						style={{ backgroundColor: 'rgb(18, 49, 35)' }}
+						icon={<Icon category="utility" name="user" />}
+						labels={{
+							heading: 'Logged in as John Smith (johnsmith@acme.com).',
+							headingLink: 'Log out',
+						}}
+						onClickHeadingLink={() => {
+							console.log('Link clicked.');
+						}}
+					/>
+				</AlertContainer>
+			</IconSettings>
+		);
+	}
+}
+
+Example.displayName = 'AlertExample';
+
+export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/alert/__tests__/alert.browser-test.jsx
+++ b/components/alert/__tests__/alert.browser-test.jsx
@@ -32,6 +32,7 @@ class DemoComponent extends Component {
 					<AlertContainer>
 						{this.state.isOpen ? (
 							<Alert
+								style={this.props.style}
 								dismissible
 								icon={<Icon category="utility" name="user" />}
 								labels={{
@@ -79,6 +80,18 @@ describe('SLDSAlert: ', function() {
 			// If applicable, use second parameter to pass the data object
 			link.simulate('click', {});
 			expect(onClickHeadingLink.calledOnce).to.be.true;
+		});
+	});
+
+	describe('Basic Alert Props Render', function() {
+		beforeEach(
+			mountComponent(<DemoComponent style={{ backgroundColor: 'rgb(18, 49, 35)' }} />)
+		);
+
+		afterEach(unmountComponent);
+
+		it('render custom styles', function() {
+			expect(this.wrapper.find('.slds-notify').prop('style').backgroundColor).to.equal('rgb(18, 49, 35)');
 		});
 	});
 });

--- a/components/alert/__tests__/alert.browser-test.jsx
+++ b/components/alert/__tests__/alert.browser-test.jsx
@@ -85,13 +85,17 @@ describe('SLDSAlert: ', function() {
 
 	describe('Basic Alert Props Render', function() {
 		beforeEach(
-			mountComponent(<DemoComponent style={{ backgroundColor: 'rgb(18, 49, 35)' }} />)
+			mountComponent(
+				<DemoComponent style={{ backgroundColor: 'rgb(18, 49, 35)' }} />
+			)
 		);
 
 		afterEach(unmountComponent);
 
 		it('render custom styles', function() {
-			expect(this.wrapper.find('.slds-notify').prop('style').backgroundColor).to.equal('rgb(18, 49, 35)');
+			expect(
+				this.wrapper.find('.slds-notify').prop('style').backgroundColor
+			).to.equal('rgb(18, 49, 35)');
 		});
 	});
 });

--- a/components/alert/index.jsx
+++ b/components/alert/index.jsx
@@ -71,6 +71,10 @@ const propTypes = {
 	 */
 	onRequestClose: PropTypes.func,
 	/**
+	 * Custom styles to be passed to the component. _Tested with Mocha testing._
+	 */
+	style: PropTypes.object,
+	/**
 	 * The type of alert. _Tested with snapshot testing._
 	 */
 	variant: PropTypes.oneOf(['error', 'info', 'offline', 'warning']).isRequired,
@@ -175,6 +179,7 @@ class Alert extends React.Component {
 					this.props.className
 				)}
 				role="alert"
+				style={this.props.style}
 			>
 				<span className="slds-assistive-text">
 					{assistiveTextVariant[this.props.variant]}

--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -250,6 +250,13 @@
                 "required": false,
                 "description": "Triggered by close button. This is a controlled component. _Tested with Mocha testing._"
             },
+            "style": {
+                "type": {
+                    "name": "object"
+                },
+                "required": false,
+                "description": "Custom styles to be passed to the component. _Tested with Mocha testing._"
+            },
             "variant": {
                 "type": {
                     "name": "enum",


### PR DESCRIPTION
Fixes #1568

### Additional description

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [x] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [x] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [x] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [x] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
