### PR TITLE
Toast new prop style

### DIFF
--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -11770,6 +11770,13 @@
                 "required": false,
                 "description": "Triggered by close button. _Tested with Mocha testing._"
             },
+            "style": {
+                "type": {
+                    "name": "object"
+                },
+                "required": false,
+                "description": "Custom styles to be passed to the component. _Tested with Mocha testing._"
+            },
             "variant": {
                 "type": {
                     "name": "enum",

--- a/components/toast/__docs__/storybook-stories.jsx
+++ b/components/toast/__docs__/storybook-stories.jsx
@@ -10,6 +10,7 @@ import ErrorWithDetailsAlert from '../__examples__/error-with-details';
 import CloseToast from '../__examples__/close-toast';
 import DurationToast from '../__examples__/duration-toast';
 import CustomClassNames from '../__examples__/custom-class-name';
+import CustomStyle from '../__examples__/custom-style';
 
 /* eslint-disable react/display-name */
 
@@ -24,4 +25,5 @@ storiesOf(TOAST, module)
 	.add('Error With Details', () => <ErrorWithDetailsAlert />)
 	.add('Close Toast', () => <CloseToast />)
 	.add('Duration Toast', () => <DurationToast />)
-	.add('Custom Class Names', () => <CustomClassNames />);
+	.add('Custom Class Names', () => <CustomClassNames />)
+	.add('Custom Style', () => <CustomStyle />);

--- a/components/toast/__examples__/custom-style.jsx
+++ b/components/toast/__examples__/custom-style.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import Toast from '~/components/toast'; // `~` is replaced with design-system-react at runtime
+import ToastContainer from '~/components/toast/container'; // `~` is replaced with design-system-react at runtime
+import Icon from '~/components/icon'; // `~` is replaced with design-system-react at runtime
+import IconSettings from '~/components/icon-settings';
+
+class Example extends React.Component {
+	render() {
+		return (
+			<IconSettings iconPath="/assets/icons">
+				<ToastContainer className="this-is-the-container">
+					<Toast
+						labels={{
+							heading: '26 potential duplicate leads were found.',
+							headingLink: 'Select Leads to Merge',
+						}}
+						style={{ backgroundColor: 'rgb(18, 49, 35)' }}
+					/>
+				</ToastContainer>
+			</IconSettings>
+		);
+	}
+}
+
+Example.displayName = 'ToastExample';
+
+export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/toast/__tests__/toast.browser-test.jsx
+++ b/components/toast/__tests__/toast.browser-test.jsx
@@ -102,4 +102,16 @@ describe('SLDSToast: ', function() {
 			}, 2);
 		});
 	});
+
+	describe('Basic Toast Props Render', function() {
+		beforeEach(
+			mountComponent(<DemoComponent style={{ backgroundColor: 'rgb(18, 49, 35)' }} />)
+		);
+
+		afterEach(unmountComponent);
+
+		it('renders custom styles', function() {
+			expect(this.wrapper.find('.slds-notify').prop('style').backgroundColor).to.equal('rgb(18, 49, 35)')
+		});
+	})
 });

--- a/components/toast/index.jsx
+++ b/components/toast/index.jsx
@@ -74,6 +74,10 @@ const propTypes = {
 	 */
 	onRequestClose: PropTypes.func,
 	/**
+	 * Custom styles to be passed to the component. _Tested with Mocha testing._
+	 */
+	style: PropTypes.object,
+	/**
 	 * The type of Toast. _Tested with snapshot testing._
 	 */
 	variant: PropTypes.oneOf(['error', 'info', 'success', 'warning']).isRequired,
@@ -186,6 +190,7 @@ class Toast extends React.Component {
 					this.props.className
 				)}
 				role="alert"
+				style={this.props.style}
 			>
 				<span className="slds-assistive-text">
 					{assistiveTextVariant[this.props.variant]}


### PR DESCRIPTION
Fixes #1568

### Additional description

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [x] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [x] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [x] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [x] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
