### PR TITLE
Input inlineHelpText can be `node` as well as `string`.

### DIFF
--- a/components/input/private/inner-input.jsx
+++ b/components/input/private/inner-input.jsx
@@ -97,7 +97,7 @@ const propTypes = {
 	/**
 	 * Displays help text under the input.
 	 */
-	inlineHelpText: PropTypes.string,
+	inlineHelpText: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
 	/**
 	 * This callback exposes the input reference / DOM node to parent components. `<Parent inputRef={(inputComponent) => this.input = inputComponent} />
 	 */


### PR DESCRIPTION
Matches type defined in https://github.com/salesforce/design-system-react/blob/master/components/input/index.jsx#L173.