### PR TITLE
Color picker accessibility fixes

### DIFF
--- a/components/color-picker/__docs__/storybook-stories.jsx
+++ b/components/color-picker/__docs__/storybook-stories.jsx
@@ -52,7 +52,6 @@ storiesOf(COLOR_PICKER, module)
 			id="predefined-color-picker"
 			labels={{ label: 'Choose Color' }}
 			swatchColors={[
-				'',
 				'#000000',
 				'#ff0000',
 				'#00ff00',
@@ -61,6 +60,7 @@ storiesOf(COLOR_PICKER, module)
 				'#ff00ff',
 				'#00ffff',
 				'#ffffff',
+				'',
 			]}
 			value="#000000"
 		/>
@@ -74,7 +74,6 @@ storiesOf(COLOR_PICKER, module)
 			id="predefined-only-color-picker"
 			labels={{ label: 'Choose Color' }}
 			swatchColors={[
-				'',
 				'#000000',
 				'#ff0000',
 				'#00ff00',
@@ -83,6 +82,7 @@ storiesOf(COLOR_PICKER, module)
 				'#ff00ff',
 				'#00ffff',
 				'#ffffff',
+				'',
 			]}
 			variant="swatches"
 		/>
@@ -119,6 +119,7 @@ storiesOf(COLOR_PICKER, module)
 			id="working-color-error-state-color-picker"
 			labels={{ label: 'Choose Color' }}
 			valueWorking="#f"
+			variant="custom"
 		/>
 	))
 	.add('Custom Validator', () => (

--- a/components/color-picker/index.jsx
+++ b/components/color-picker/index.jsx
@@ -224,6 +224,7 @@ const defaultProps = {
 		'#0b6b50',
 		'#b67e11',
 		'#b85d0d',
+		''
 	],
 	defaultSelectedTab: 'swatches',
 	variant: 'base',

--- a/components/color-picker/index.jsx
+++ b/components/color-picker/index.jsx
@@ -131,7 +131,7 @@ const propTypes = {
 		label: PropTypes.string,
 		redAbbreviated: PropTypes.string,
 		swatchTab: PropTypes.string,
-		submitButton: PropTypes.string,
+		submitButton: PropTypes.string
 	}),
 	/**
 	 * Please select one of the following:
@@ -599,8 +599,8 @@ class ColorPicker extends React.Component {
 							{this.state.colorErrorMessage}
 						</p>
 					) : (
-						''
-					)}
+							''
+						)}
 				</div>
 			</div>
 		);

--- a/components/color-picker/private/hsv-color.jsx
+++ b/components/color-picker/private/hsv-color.jsx
@@ -122,7 +122,9 @@ class HsvColor extends React.Component {
 							left: `${workingColor.hsv.saturation}%`,
 						}}
 						tabIndex={0}
-					/>
+					>
+						<span className="slds-assistive-text">{`Saturation ${workingColor.hsv.saturation}% Brightness: ${workingColor.hsv.value}%`}</span>
+					</a>
 				</div>
 				<div className="slds-color-picker__hue-and-preview">
 					<label

--- a/components/color-picker/private/hsv-color.jsx
+++ b/components/color-picker/private/hsv-color.jsx
@@ -161,7 +161,7 @@ class HsvColor extends React.Component {
 							checked={this.isTransparent()}
 							id={`color-picker-transparent-swatch-${this.props.id}`}
 							key="transparent"
-							label={this.props.labels.customTabTransparentSwatch}
+							label={this.props.labels.customTabTransparentSwatch || 'transparent'}
 							style={transparentSwatchStyle}
 							value="" // transparent
 							variant="swatch"

--- a/components/color-picker/private/swatch.jsx
+++ b/components/color-picker/private/swatch.jsx
@@ -15,7 +15,7 @@ const Swatch = ({ color, style, label }) => {
 
 	return (
 		<span className="slds-swatch" style={innerStyle}>
-			<span className="slds-assistive-text">{label || color}</span>
+			<span className="slds-assistive-text">{label || color || "transparent"}</span>
 		</span>
 	);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "design-system-react",
-	"version": "0.9.0",
+	"version": "0.9.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -13157,7 +13157,7 @@
 				},
 				"onetime": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+					"resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
 					"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
 					"dev": true
 				},
@@ -13531,7 +13531,7 @@
 				},
 				"onetime": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+					"resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
 					"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
 					"dev": true
 				},
@@ -14976,7 +14976,7 @@
 				},
 				"onetime": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+					"resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
 					"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
 					"dev": true
 				},


### PR DESCRIPTION
Fixes #1627

### Additional description

* **[done]** Add updated description: "Saturation: 0%. Brightness: 11%" to anchor with role=[button] on the custom panel within an assistive text span.
* **[done, note that label already exists for transparent swatch : `labels.customTabTransparentSwatch`]** Update text for transparent swatch to read "transparent" when it's empty string. We should add a `labels.transparent` string.
* **[done]** Add `transparent` swatch to all examples and put it at the end. If transparent is the selected color, then it should be the selected working color when default swatches are shown.

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [ ] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [ ] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
