### PR TITLE
PillContainer id undefined bugfix

### DIFF
--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -9241,6 +9241,13 @@
         "description": "A `PillContainer` is a container that holds one or more pills. Use it for a list of pills in a container that resembles an `input` form field. It is not intended for navigation.",
         "methods": [
             {
+                "name": "getId",
+                "docblock": null,
+                "modifiers": [],
+                "params": [],
+                "returns": null
+            },
+            {
                 "name": "getNewActiveOptionIndex",
                 "docblock": null,
                 "modifiers": [],

--- a/components/pill-container/__examples__/avatars.jsx
+++ b/components/pill-container/__examples__/avatars.jsx
@@ -5,7 +5,7 @@ import IconSettings from '~/components/icon-settings';
 import PillContainer from '~/components/pill-container';
 
 class Example extends React.Component {
-	static displayName = 'PillWithAvatarListboxExample';
+	static displayName = 'PillContainerWithAvatarsExample';
 
 	constructor(props) {
 		super(props);
@@ -65,6 +65,7 @@ class Example extends React.Component {
 					</div>
 					<div className="slds-grid slds-grid_vertical-align-start">
 						<PillContainer
+							id="pill-container-with-avatars"
 							options={this.state.options}
 							onClickPill={this.onClickPill}
 							onRequestRemovePill={this.onRequestRemovePill}

--- a/components/pill-container/__examples__/bare.jsx
+++ b/components/pill-container/__examples__/bare.jsx
@@ -4,7 +4,7 @@ import IconSettings from '~/components/icon-settings';
 import PillContainer from '~/components/pill-container';
 
 class Example extends React.Component {
-	static displayName = 'BarePillListboxExample';
+	static displayName = 'BarePillContainerExample';
 
 	constructor(props) {
 		super(props);
@@ -50,6 +50,7 @@ class Example extends React.Component {
 					</div>
 					<div className="slds-grid slds-grid_vertical-align-start">
 						<PillContainer
+							id="bare-pill-container"
 							options={this.state.options}
 							onClickPill={this.onClickPill}
 							onRequestRemovePill={this.onRequestRemovePill}

--- a/components/pill-container/__examples__/base.jsx
+++ b/components/pill-container/__examples__/base.jsx
@@ -4,7 +4,7 @@ import IconSettings from '~/components/icon-settings';
 import PillContainer from '~/components/pill-container';
 
 class Example extends React.Component {
-	static displayName = 'BasePillListboxExample';
+	static displayName = 'BasePillContainerExample';
 
 	constructor(props) {
 		super(props);
@@ -50,6 +50,7 @@ class Example extends React.Component {
 					</div>
 					<div className="slds-grid slds-grid_vertical-align-start">
 						<PillContainer
+							id="base-pill-container"
 							options={this.state.options}
 							onClickPill={this.onClickPill}
 							onRequestRemovePill={this.onRequestRemovePill}

--- a/components/pill-container/__examples__/icons.jsx
+++ b/components/pill-container/__examples__/icons.jsx
@@ -5,7 +5,7 @@ import IconSettings from '~/components/icon-settings';
 import PillContainer from '~/components/pill-container';
 
 class Example extends React.Component {
-	static displayName = 'PillWithIconListboxExample';
+	static displayName = 'PillContainerWithIconsExample';
 
 	constructor(props) {
 		super(props);
@@ -103,6 +103,7 @@ class Example extends React.Component {
 					</div>
 					<div className="slds-grid slds-grid_vertical-align-start">
 						<PillContainer
+							id="pill-container-with-icons"
 							options={this.state.options}
 							onClickPill={this.onClickPill}
 							onRequestRemovePill={this.onRequestRemovePill}

--- a/components/pill-container/index.jsx
+++ b/components/pill-container/index.jsx
@@ -6,6 +6,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import shortid from 'shortid';
 import SelectedListBox from './private/selected-listbox';
 
 import { PILL_CONTAINER } from '../../utilities/constants';
@@ -114,6 +115,7 @@ class PillContainer extends React.Component {
 		};
 
 		this.activeSelectedOptionRef = null;
+		this.generatedId = shortid.generate();
 		this.preserveFocus = false;
 	}
 
@@ -128,6 +130,8 @@ class PillContainer extends React.Component {
 			this.preserveFocus = false;
 		}
 	}
+
+	getId = () => this.props.id || this.generatedId;
 
 	getNewActiveOptionIndex = ({ activeOptionIndex, offset, options }) => {
 		const nextIndex = activeOptionIndex + offset;
@@ -260,7 +264,7 @@ class PillContainer extends React.Component {
 					onRequestFocusOnPreviousPill: this.handleNavigatePillContainer,
 					onRequestRemove: this.handleRequestRemove,
 				}}
-				id={`${this.props.id}-listbox-of-pill-options`}
+				id={`${this.getId()}-listbox-of-pill-options`}
 				isBare={this.props.variant === 'bare'}
 				isPillContainer
 				labels={this.props.labels}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "design-system-react",
-	"version": "0.9.0",
+	"version": "0.9.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/tests/__snapshots__/story-based-tests.snapshot-test.js.snap
+++ b/tests/__snapshots__/story-based-tests.snapshot-test.js.snap
@@ -8576,7 +8576,7 @@ exports[`DOM snapshots SLDSPillContainer Bare Pill Container 1`] = `
       <div
         aria-orientation="horizontal"
         className="slds-pill_container"
-        id="undefined-listbox-of-pill-options"
+        id="bare-pill-container-listbox-of-pill-options"
         role="listbox"
       >
         <ul
@@ -8703,7 +8703,7 @@ exports[`DOM snapshots SLDSPillContainer Base Pill Container 1`] = `
       <div
         aria-orientation="horizontal"
         className="slds-pill_container"
-        id="undefined-listbox-of-pill-options"
+        id="base-pill-container-listbox-of-pill-options"
         role="listbox"
       >
         <ul
@@ -8830,7 +8830,7 @@ exports[`DOM snapshots SLDSPillContainer Pill Container With Avatars 1`] = `
       <div
         aria-orientation="horizontal"
         className="slds-pill_container"
-        id="undefined-listbox-of-pill-options"
+        id="pill-container-with-avatars-listbox-of-pill-options"
         role="listbox"
       >
         <ul
@@ -8989,7 +8989,7 @@ exports[`DOM snapshots SLDSPillContainer Pill Container With Icons 1`] = `
       <div
         aria-orientation="horizontal"
         className="slds-pill_container"
-        id="undefined-listbox-of-pill-options"
+        id="pill-container-with-icons-listbox-of-pill-options"
         role="listbox"
       >
         <ul


### PR DESCRIPTION
Fixes #1670

Ids are now generated for pill containers that don't have ids explicitly set.

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [ ] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [ ] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
