### PR TITLE
Tooltip: Require onClickTrigger for learn more pattern 

### DIFF
--- a/components/button/index.jsx
+++ b/components/button/index.jsx
@@ -13,6 +13,8 @@ import checkProps from './check-props';
 import componentDoc from './docs.json';
 import Tooltip from '../tooltip';
 
+import getAriaProps from '../../utilities/get-aria-props';
+
 import { BUTTON } from '../../utilities/constants';
 
 const defaultProps = {
@@ -27,29 +29,13 @@ const defaultProps = {
 
 /**
  * The Button component is the Lightning Design System Button component. The Button should be used for label buttons, icon buttons, or buttons that have both labels and icons.
- * Either a <code>label</code> or <code>assistiveText.icon</code> is required; see the Prop Details table below.
- * For buttons that maintain selected/unselected states, use the <a href="#/button-stateful">ButtonStateful</a> component.
+ * Either a <code>label</code> or <code>assistiveText.icon</code> is required; see the Prop Details table below. For buttons that maintain selected/unselected states, use the <a href="#/button-stateful">ButtonStateful</a> component.
+ * Although not listed in the prop table, all `aria-*` props will be added to the `button` element if passed in.
  */
 class Button extends React.Component {
 	static displayName = BUTTON;
 
 	static propTypes = {
-		/**
-		 * Used if the Button triggers a tooltip. The value should match the `id` of the element with `role="tooltip"`.
-		 */
-		'aria-describedby': PropTypes.string,
-		/**
-		 * Establishes a relationship between an interactive parent element and a child element to indicate which child element a parent element affects. Frequently used in cases where buttons or tabs are associated with exposing expandable regions.
-		 */
-		'aria-controls': PropTypes.string,
-		/**
-		 * Used if the Button triggers a menu or popup. Bool indicates if the menu or popup is open or closed.
-		 */
-		'aria-expanded': PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
-		/**
-		 * True if Button triggers a menu or popup to open/close.
-		 */
-		'aria-haspopup': PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
 		/**
 		 * **Assistive text for accessibility.**
 		 * This object is merged with the default props object on every render.
@@ -310,57 +296,57 @@ class Button extends React.Component {
 		);
 	};
 
-	renderButton = () => (
-		<button
-			aria-controls={this.props['aria-controls']}
-			aria-describedby={this.props['aria-describedby']}
-			aria-expanded={this.props['aria-expanded']}
-			aria-haspopup={this.props['aria-haspopup']}
-			className={this.getClassName()}
-			disabled={this.props.disabled}
-			id={this.props.id}
-			onBlur={this.props.onBlur}
-			onClick={this.handleClick}
-			onFocus={this.props.onFocus}
-			onKeyDown={this.props.onKeyDown}
-			onKeyPress={this.props.onKeyPress}
-			onKeyUp={this.props.onKeyUp}
-			onMouseDown={this.props.onMouseDown}
-			onMouseEnter={this.props.onMouseEnter}
-			onMouseLeave={this.props.onMouseLeave}
-			onMouseUp={this.props.onMouseUp}
-			ref={(component) => {
-				if (this.props.buttonRef) {
-					this.props.buttonRef(component);
+	renderButton = () => {
+		const ariaProps = getAriaProps(this.props);
+		return (
+			<button
+				className={this.getClassName()}
+				disabled={this.props.disabled}
+				id={this.props.id}
+				onBlur={this.props.onBlur}
+				onClick={this.handleClick}
+				onFocus={this.props.onFocus}
+				onKeyDown={this.props.onKeyDown}
+				onKeyPress={this.props.onKeyPress}
+				onKeyUp={this.props.onKeyUp}
+				onMouseDown={this.props.onMouseDown}
+				onMouseEnter={this.props.onMouseEnter}
+				onMouseLeave={this.props.onMouseLeave}
+				onMouseUp={this.props.onMouseUp}
+				ref={(component) => {
+					if (this.props.buttonRef) {
+						this.props.buttonRef(component);
+					}
+				}}
+				tabIndex={this.props.tabIndex}
+				title={this.props.title}
+				type={this.props.type}
+				style={this.props.style}
+				{...ariaProps}
+			>
+				{this.props.iconPosition === 'right' ? this.renderLabel() : null}
+
+				{this.props.iconName || this.props.iconPath
+					? this.renderIcon(this.props.iconName)
+					: null}
+				{this.props.iconVariant === 'more' ? (
+					<ButtonIcon
+						category="utility"
+						name="down"
+						size="x-small"
+						className={this.props.iconClassName}
+					/>
+				) : null}
+
+				{this.props.iconPosition === 'left' || !this.props.iconPosition
+					? this.renderLabel()
+					: null}
+				{
+					this.props.children // eslint-disable-line react/prop-types
 				}
-			}}
-			tabIndex={this.props.tabIndex}
-			title={this.props.title}
-			type={this.props.type}
-			style={this.props.style}
-		>
-			{this.props.iconPosition === 'right' ? this.renderLabel() : null}
-
-			{this.props.iconName || this.props.iconPath
-				? this.renderIcon(this.props.iconName)
-				: null}
-			{this.props.iconVariant === 'more' ? (
-				<ButtonIcon
-					category="utility"
-					name="down"
-					size="x-small"
-					className={this.props.iconClassName}
-				/>
-			) : null}
-
-			{this.props.iconPosition === 'left' || !this.props.iconPosition
-				? this.renderLabel()
-				: null}
-			{
-				this.props.children // eslint-disable-line react/prop-types
-			}
-		</button>
-	);
+			</button>
+		);
+	};
 
 	// This is present for backwards compatibility and should be removed at a future breaking change release. Please wrap a `Button` in a `PopoverTooltip` to achieve the same result. There will be an extra trigger `div` wrapping the `Button` though.
 	renderTooltip = () => (

--- a/components/date-picker/__tests__/__snapshots__/datepicker.snapshot-test.jsx.snap
+++ b/components/date-picker/__tests__/__snapshots__/datepicker.snapshot-test.jsx.snap
@@ -2570,7 +2570,7 @@ exports[`Datepicker Default DOM Snapshot 1`] = `
 exports[`Datepicker Default HTML Snapshot 1`] = `
 "<div class=\\"slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open\\">
   <div class=\\"slds-form-element\\">
-    <div class=\\"slds-form-element__control slds-input-has-icon slds-input-has-icon_right\\"><input type=\\"text\\" class=\\"slds-input\\" id=\\"sample-datepicker\\" placeholder=\\"Pick a Date\\" value=\\"7/23/2014\\" /><button aria-expanded=\\"true\\" aria-haspopup=\\"true\\" class=\\"slds-button slds-button_icon slds-input__icon slds-input__icon_right\\" type=\\"button\\"><svg aria-hidden=\\"true\\" class=\\"slds-button__icon\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#event\\"></use></svg><span class=\\"slds-assistive-text\\">Open Calendar</span></button></div>
+    <div class=\\"slds-form-element__control slds-input-has-icon slds-input-has-icon_right\\"><input type=\\"text\\" class=\\"slds-input\\" id=\\"sample-datepicker\\" placeholder=\\"Pick a Date\\" value=\\"7/23/2014\\" /><button class=\\"slds-button slds-button_icon slds-input__icon slds-input__icon_right\\" type=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"true\\"><svg aria-hidden=\\"true\\" class=\\"slds-button__icon\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#event\\"></use></svg><span class=\\"slds-assistive-text\\">Open Calendar</span></button></div>
   </div>
   <div class=\\"slds-datepicker slds-dropdown slds-dropdown_left\\">
     <div class=\\"\\" aria-hidden=\\"false\\" data-selection=\\"single\\">

--- a/components/split-view/__tests__/__snapshots__/split-view.snapshot-test.jsx.snap
+++ b/components/split-view/__tests__/__snapshots__/split-view.snapshot-test.jsx.snap
@@ -117,7 +117,7 @@ exports[`Base Closed DOM Snapshot 1`] = `
 exports[`Base Closed HTML Snapshot 1`] = `
 "<div style=\\"height:90vh\\">
   <div id=\\"base-example\\" class=\\"slds-grid\\" style=\\"height:100%\\">
-    <div style=\\"max-width:0\\" class=\\"slds-split-view_container slds-is-closed\\"><button aria-controls=\\"master_view_base-example\\" aria-expanded=\\"false\\" class=\\"slds-button slds-button slds-button_icon slds-split-view__toggle-button\\" title=\\"Open split view\\" type=\\"button\\"><svg aria-hidden=\\"true\\" class=\\"slds-button__icon slds-button__icon_x-small\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#left\\"></use></svg><span class=\\"slds-assistive-text\\">Open split view</span></button></div>
+    <div style=\\"max-width:0\\" class=\\"slds-split-view_container slds-is-closed\\"><button class=\\"slds-button slds-button slds-button_icon slds-split-view__toggle-button\\" title=\\"Open split view\\" type=\\"button\\" aria-expanded=\\"false\\" aria-controls=\\"master_view_base-example\\"><svg aria-hidden=\\"true\\" class=\\"slds-button__icon slds-button__icon_x-small\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#left\\"></use></svg><span class=\\"slds-assistive-text\\">Open split view</span></button></div>
     <div
       style=\\"margin-left:0.75rem\\" class=\\"slds-grow slds-scrollable_y\\">
       <dl class=\\"slds-box slds-m-left_medium slds-m-bottom_medium slds-list_horizontal slds-wrap\\"><dt class=\\"slds-item_label slds-text-color_weak slds-truncate\\" title=\\"Name\\">Name:</dt>
@@ -958,7 +958,7 @@ exports[`Base Multiple DOM Snapshot 1`] = `
 exports[`Base Multiple HTML Snapshot 1`] = `
 "<div style=\\"height:90vh\\">
   <div id=\\"base-multiple-example\\" class=\\"slds-grid\\" style=\\"height:100%\\">
-    <div style=\\"max-width:20rem\\" class=\\"slds-split-view_container slds-is-open\\"><button aria-controls=\\"master_view_base-multiple-example\\" aria-expanded=\\"true\\" class=\\"slds-button slds-button slds-button_icon slds-split-view__toggle-button slds-is-open\\" title=\\"Close split view\\" type=\\"button\\"><svg aria-hidden=\\"true\\" class=\\"slds-button__icon slds-button__icon_x-small\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#left\\"></use></svg><span class=\\"slds-assistive-text\\">Close split view</span></button>
+    <div style=\\"max-width:20rem\\" class=\\"slds-split-view_container slds-is-open\\"><button class=\\"slds-button slds-button slds-button_icon slds-split-view__toggle-button slds-is-open\\" title=\\"Close split view\\" type=\\"button\\" aria-expanded=\\"true\\" aria-controls=\\"master_view_base-multiple-example\\"><svg aria-hidden=\\"true\\" class=\\"slds-button__icon slds-button__icon_x-small\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#left\\"></use></svg><span class=\\"slds-assistive-text\\">Close split view</span></button>
       <article
         id=\\"master_view_base-multiple-example\\" class=\\"slds-split-view slds-grid slds-grid_vertical slds-grow slds-scrollable_none\\">
         <div class=\\"slds-page-header slds-page-header_object-home slds-split-view__header slds-has-bottom-magnet\\">
@@ -971,7 +971,7 @@ exports[`Base Multiple HTML Snapshot 1`] = `
                     <div>
                       <div class=\\"slds-media__body\\">
                         <h1 class=\\"slds-text-heading_small slds-text-color_default slds-p-right_x-small\\">
-                          <div class=\\"slds-dropdown-trigger slds-dropdown-trigger_click\\" id=\\"header-title-leads\\"><button aria-expanded=\\"false\\" aria-haspopup=\\"true\\" class=\\"slds-button slds-button_reset slds-type-focus\\" tabindex=\\"0\\" type=\\"button\\">My Leads<svg aria-hidden=\\"true\\" class=\\"slds-button__icon slds-button__icon_right\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#down\\"></use></svg></button></div>
+                          <div class=\\"slds-dropdown-trigger slds-dropdown-trigger_click\\" id=\\"header-title-leads\\"><button class=\\"slds-button slds-button_reset slds-type-focus\\" tabindex=\\"0\\" type=\\"button\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\">My Leads<svg aria-hidden=\\"true\\" class=\\"slds-button__icon slds-button__icon_right\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#down\\"></use></svg></button></div>
                         </h1>
                       </div>
                     </div>
@@ -980,7 +980,7 @@ exports[`Base Multiple HTML Snapshot 1`] = `
               </div>
               <div class=\\"slds-col slds-no-flex slds-grid slds-align-top slds-p-bottom_xx-small\\">
                 <div class=\\"slds-col slds-no-flex slds-grid slds-align-top\\">
-                  <div class=\\"slds-dropdown-trigger slds-dropdown-trigger_click\\" id=\\"header-nav-right-more\\"><button aria-expanded=\\"false\\" aria-haspopup=\\"true\\" class=\\"slds-button slds-button_icon-border-filled ignore-click-header-nav-right-more\\" tabindex=\\"0\\" type=\\"button\\"><svg aria-hidden=\\"true\\" class=\\"slds-button__icon\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#down\\"></use></svg><span class=\\"slds-assistive-text\\">More Options</span></button></div>
+                  <div class=\\"slds-dropdown-trigger slds-dropdown-trigger_click\\" id=\\"header-nav-right-more\\"><button class=\\"slds-button slds-button_icon-border-filled ignore-click-header-nav-right-more\\" tabindex=\\"0\\" type=\\"button\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\"><svg aria-hidden=\\"true\\" class=\\"slds-button__icon\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#down\\"></use></svg><span class=\\"slds-assistive-text\\">More Options</span></button></div>
                 </div>
               </div>
             </div>
@@ -990,7 +990,7 @@ exports[`Base Multiple HTML Snapshot 1`] = `
               </div>
               <div class=\\"slds-col slds-no-flex slds-grid slds-align-bottom\\">
                 <div class=\\"slds-grid\\">
-                  <div class=\\"slds-dropdown-trigger slds-dropdown-trigger_click\\" id=\\"header-right-refresh\\"><button aria-expanded=\\"false\\" aria-haspopup=\\"true\\" class=\\"slds-button slds-button_icon-more slds-button_icon-large ignore-click-header-right-refresh slds-m-right_xx-small\\" tabindex=\\"0\\" type=\\"button\\"><svg aria-hidden=\\"true\\" class=\\"slds-button__icon\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#side_list\\"></use></svg><svg aria-hidden=\\"true\\" class=\\"slds-button__icon slds-button__icon_x-small\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#down\\"></use></svg><span class=\\"slds-assistive-text\\">Checkmark with right icon</span></button></div>
+                  <div class=\\"slds-dropdown-trigger slds-dropdown-trigger_click\\" id=\\"header-right-refresh\\"><button class=\\"slds-button slds-button_icon-more slds-button_icon-large ignore-click-header-right-refresh slds-m-right_xx-small\\" tabindex=\\"0\\" type=\\"button\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\"><svg aria-hidden=\\"true\\" class=\\"slds-button__icon\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#side_list\\"></use></svg><svg aria-hidden=\\"true\\" class=\\"slds-button__icon slds-button__icon_x-small\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#down\\"></use></svg><span class=\\"slds-assistive-text\\">Checkmark with right icon</span></button></div>
                   <button
                     class=\\"slds-button slds-button_icon-border\\" type=\\"button\\"><svg aria-hidden=\\"true\\" class=\\"slds-button__icon\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#refresh\\"></use></svg><span class=\\"slds-assistive-text\\">Refresh</span></button>
                 </div>
@@ -1903,7 +1903,7 @@ exports[`Base Open DOM Snapshot 1`] = `
 exports[`Base Open HTML Snapshot 1`] = `
 "<div style=\\"height:90vh\\">
   <div id=\\"base-example\\" class=\\"slds-grid\\" style=\\"height:100%\\">
-    <div style=\\"max-width:20rem\\" class=\\"slds-split-view_container slds-is-open\\"><button aria-controls=\\"master_view_base-example\\" aria-expanded=\\"true\\" class=\\"slds-button slds-button slds-button_icon slds-split-view__toggle-button slds-is-open\\" title=\\"Close split view\\" type=\\"button\\"><svg aria-hidden=\\"true\\" class=\\"slds-button__icon slds-button__icon_x-small\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#left\\"></use></svg><span class=\\"slds-assistive-text\\">Close split view</span></button>
+    <div style=\\"max-width:20rem\\" class=\\"slds-split-view_container slds-is-open\\"><button class=\\"slds-button slds-button slds-button_icon slds-split-view__toggle-button slds-is-open\\" title=\\"Close split view\\" type=\\"button\\" aria-expanded=\\"true\\" aria-controls=\\"master_view_base-example\\"><svg aria-hidden=\\"true\\" class=\\"slds-button__icon slds-button__icon_x-small\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#left\\"></use></svg><span class=\\"slds-assistive-text\\">Close split view</span></button>
       <article
         id=\\"master_view_base-example\\" class=\\"slds-split-view slds-grid slds-grid_vertical slds-grow slds-scrollable_none\\">
         <div class=\\"slds-page-header slds-page-header_object-home slds-split-view__header slds-has-bottom-magnet\\">
@@ -1916,7 +1916,7 @@ exports[`Base Open HTML Snapshot 1`] = `
                     <div>
                       <div class=\\"slds-media__body\\">
                         <h1 class=\\"slds-text-heading_small slds-text-color_default slds-p-right_x-small\\">
-                          <div class=\\"slds-dropdown-trigger slds-dropdown-trigger_click\\" id=\\"header-title-leads\\"><button aria-expanded=\\"false\\" aria-haspopup=\\"true\\" class=\\"slds-button slds-button_reset slds-type-focus\\" tabindex=\\"0\\" type=\\"button\\">My Leads<svg aria-hidden=\\"true\\" class=\\"slds-button__icon slds-button__icon_right\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#down\\"></use></svg></button></div>
+                          <div class=\\"slds-dropdown-trigger slds-dropdown-trigger_click\\" id=\\"header-title-leads\\"><button class=\\"slds-button slds-button_reset slds-type-focus\\" tabindex=\\"0\\" type=\\"button\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\">My Leads<svg aria-hidden=\\"true\\" class=\\"slds-button__icon slds-button__icon_right\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#down\\"></use></svg></button></div>
                         </h1>
                       </div>
                     </div>
@@ -1925,7 +1925,7 @@ exports[`Base Open HTML Snapshot 1`] = `
               </div>
               <div class=\\"slds-col slds-no-flex slds-grid slds-align-top slds-p-bottom_xx-small\\">
                 <div class=\\"slds-col slds-no-flex slds-grid slds-align-top\\">
-                  <div class=\\"slds-dropdown-trigger slds-dropdown-trigger_click\\" id=\\"header-nav-right-more\\"><button aria-expanded=\\"false\\" aria-haspopup=\\"true\\" class=\\"slds-button slds-button_icon-border-filled ignore-click-header-nav-right-more\\" tabindex=\\"0\\" type=\\"button\\"><svg aria-hidden=\\"true\\" class=\\"slds-button__icon\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#down\\"></use></svg><span class=\\"slds-assistive-text\\">More Options</span></button></div>
+                  <div class=\\"slds-dropdown-trigger slds-dropdown-trigger_click\\" id=\\"header-nav-right-more\\"><button class=\\"slds-button slds-button_icon-border-filled ignore-click-header-nav-right-more\\" tabindex=\\"0\\" type=\\"button\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\"><svg aria-hidden=\\"true\\" class=\\"slds-button__icon\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#down\\"></use></svg><span class=\\"slds-assistive-text\\">More Options</span></button></div>
                 </div>
               </div>
             </div>
@@ -1935,7 +1935,7 @@ exports[`Base Open HTML Snapshot 1`] = `
               </div>
               <div class=\\"slds-col slds-no-flex slds-grid slds-align-bottom\\">
                 <div class=\\"slds-grid\\">
-                  <div class=\\"slds-dropdown-trigger slds-dropdown-trigger_click\\" id=\\"header-right-refresh\\"><button aria-expanded=\\"false\\" aria-haspopup=\\"true\\" class=\\"slds-button slds-button_icon-more slds-button_icon-large ignore-click-header-right-refresh slds-m-right_xx-small\\" tabindex=\\"0\\" type=\\"button\\"><svg aria-hidden=\\"true\\" class=\\"slds-button__icon\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#side_list\\"></use></svg><svg aria-hidden=\\"true\\" class=\\"slds-button__icon slds-button__icon_x-small\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#down\\"></use></svg><span class=\\"slds-assistive-text\\">Checkmark with right icon</span></button></div>
+                  <div class=\\"slds-dropdown-trigger slds-dropdown-trigger_click\\" id=\\"header-right-refresh\\"><button class=\\"slds-button slds-button_icon-more slds-button_icon-large ignore-click-header-right-refresh slds-m-right_xx-small\\" tabindex=\\"0\\" type=\\"button\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\"><svg aria-hidden=\\"true\\" class=\\"slds-button__icon\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#side_list\\"></use></svg><svg aria-hidden=\\"true\\" class=\\"slds-button__icon slds-button__icon_x-small\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#down\\"></use></svg><span class=\\"slds-assistive-text\\">Checkmark with right icon</span></button></div>
                   <button
                     class=\\"slds-button slds-button_icon-border\\" type=\\"button\\"><svg aria-hidden=\\"true\\" class=\\"slds-button__icon\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#refresh\\"></use></svg><span class=\\"slds-assistive-text\\">Refresh</span></button>
                 </div>
@@ -2586,7 +2586,7 @@ exports[`Custom DOM Snapshot 1`] = `
 exports[`Custom HTML Snapshot 1`] = `
 "<div style=\\"height:90vh\\">
   <div id=\\"custom-example\\" class=\\"slds-grid\\" style=\\"height:100%\\">
-    <div style=\\"max-width:20rem\\" class=\\"slds-split-view_container slds-is-open\\"><button aria-controls=\\"master_view_custom-example\\" aria-expanded=\\"true\\" class=\\"slds-button slds-button slds-button_icon slds-split-view__toggle-button slds-is-open\\" title=\\"Close split view\\" type=\\"button\\"><svg aria-hidden=\\"true\\" class=\\"slds-button__icon slds-button__icon_x-small\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#left\\"></use></svg><span class=\\"slds-assistive-text\\">Close split view</span></button>
+    <div style=\\"max-width:20rem\\" class=\\"slds-split-view_container slds-is-open\\"><button class=\\"slds-button slds-button slds-button_icon slds-split-view__toggle-button slds-is-open\\" title=\\"Close split view\\" type=\\"button\\" aria-expanded=\\"true\\" aria-controls=\\"master_view_custom-example\\"><svg aria-hidden=\\"true\\" class=\\"slds-button__icon slds-button__icon_x-small\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#left\\"></use></svg><span class=\\"slds-assistive-text\\">Close split view</span></button>
       <article
         id=\\"master_view_custom-example\\" class=\\"slds-split-view slds-grid slds-grid_vertical slds-grow slds-scrollable_none\\">
         <div class=\\"slds-page-header slds-page-header_object-home slds-split-view__header slds-has-bottom-magnet\\">
@@ -2599,7 +2599,7 @@ exports[`Custom HTML Snapshot 1`] = `
                     <div>
                       <div class=\\"slds-media__body\\">
                         <h1 class=\\"slds-text-heading_small slds-text-color_default slds-p-right_x-small\\">
-                          <div class=\\"slds-dropdown-trigger slds-dropdown-trigger_click\\" id=\\"header-title-leads\\"><button aria-expanded=\\"false\\" aria-haspopup=\\"true\\" class=\\"slds-button slds-button_reset slds-type-focus\\" tabindex=\\"0\\" type=\\"button\\">My Leads<svg aria-hidden=\\"true\\" class=\\"slds-button__icon slds-button__icon_right\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#down\\"></use></svg></button></div>
+                          <div class=\\"slds-dropdown-trigger slds-dropdown-trigger_click\\" id=\\"header-title-leads\\"><button class=\\"slds-button slds-button_reset slds-type-focus\\" tabindex=\\"0\\" type=\\"button\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\">My Leads<svg aria-hidden=\\"true\\" class=\\"slds-button__icon slds-button__icon_right\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#down\\"></use></svg></button></div>
                         </h1>
                       </div>
                     </div>
@@ -2608,7 +2608,7 @@ exports[`Custom HTML Snapshot 1`] = `
               </div>
               <div class=\\"slds-col slds-no-flex slds-grid slds-align-top slds-p-bottom_xx-small\\">
                 <div class=\\"slds-col slds-no-flex slds-grid slds-align-top\\">
-                  <div class=\\"slds-dropdown-trigger slds-dropdown-trigger_click\\" id=\\"header-nav-right-more\\"><button aria-expanded=\\"false\\" aria-haspopup=\\"true\\" class=\\"slds-button slds-button_icon-border-filled ignore-click-header-nav-right-more\\" tabindex=\\"0\\" type=\\"button\\"><svg aria-hidden=\\"true\\" class=\\"slds-button__icon\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#down\\"></use></svg><span class=\\"slds-assistive-text\\">More Options</span></button></div>
+                  <div class=\\"slds-dropdown-trigger slds-dropdown-trigger_click\\" id=\\"header-nav-right-more\\"><button class=\\"slds-button slds-button_icon-border-filled ignore-click-header-nav-right-more\\" tabindex=\\"0\\" type=\\"button\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\"><svg aria-hidden=\\"true\\" class=\\"slds-button__icon\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#down\\"></use></svg><span class=\\"slds-assistive-text\\">More Options</span></button></div>
                 </div>
               </div>
             </div>
@@ -2618,7 +2618,7 @@ exports[`Custom HTML Snapshot 1`] = `
               </div>
               <div class=\\"slds-col slds-no-flex slds-grid slds-align-bottom\\">
                 <div class=\\"slds-grid\\">
-                  <div class=\\"slds-dropdown-trigger slds-dropdown-trigger_click\\" id=\\"header-right-refresh\\"><button aria-expanded=\\"false\\" aria-haspopup=\\"true\\" class=\\"slds-button slds-button_icon-more slds-button_icon-large ignore-click-header-right-refresh slds-m-right_xx-small\\" tabindex=\\"0\\" type=\\"button\\"><svg aria-hidden=\\"true\\" class=\\"slds-button__icon\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#side_list\\"></use></svg><svg aria-hidden=\\"true\\" class=\\"slds-button__icon slds-button__icon_x-small\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#down\\"></use></svg><span class=\\"slds-assistive-text\\">Checkmark with right icon</span></button></div>
+                  <div class=\\"slds-dropdown-trigger slds-dropdown-trigger_click\\" id=\\"header-right-refresh\\"><button class=\\"slds-button slds-button_icon-more slds-button_icon-large ignore-click-header-right-refresh slds-m-right_xx-small\\" tabindex=\\"0\\" type=\\"button\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\"><svg aria-hidden=\\"true\\" class=\\"slds-button__icon\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#side_list\\"></use></svg><svg aria-hidden=\\"true\\" class=\\"slds-button__icon slds-button__icon_x-small\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#down\\"></use></svg><span class=\\"slds-assistive-text\\">Checkmark with right icon</span></button></div>
                   <button
                     class=\\"slds-button slds-button_icon-border\\" type=\\"button\\"><svg aria-hidden=\\"true\\" class=\\"slds-button__icon\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#refresh\\"></use></svg><span class=\\"slds-assistive-text\\">Refresh</span></button>
                 </div>

--- a/components/tooltip/__docs__/storybook-stories.jsx
+++ b/components/tooltip/__docs__/storybook-stories.jsx
@@ -7,6 +7,7 @@ import IconSettings from '../../icon-settings';
 import { POPOVER_TOOLTIP } from '../../../utilities/constants';
 import Tooltip from '../../tooltip';
 
+import Base from '../__examples__/base';
 import ButtonGroupExample from '../__examples__/button-group';
 import ButtonExample from '../__examples__/button';
 import LearnMoreExample from '../__examples__/learn-more';
@@ -64,14 +65,7 @@ storiesOf(POPOVER_TOOLTIP, module)
 			<IconSettings iconPath="/assets/icons">{getStory()}</IconSettings>
 		</div>
 	))
-	.add('Base', () =>
-		getPopoverTooltip({
-			align: 'bottom',
-			id: 'myPopoverId',
-			content:
-				'wjeifowejfiwoefjweoifjweiofjweiofwjefiowejfiowejfiowefjweiofjweiofjweiofjiwoefjowiefjoiwejfiowejfoie',
-		})
-	)
+	.add('Base', () => <Base />)
 	.add('Learn More', () => <LearnMoreExample />)
 	.add('Button Group', () => <ButtonGroupExample />)
 	.add('Button', () => <ButtonExample />)

--- a/components/tooltip/__examples__/base.jsx
+++ b/components/tooltip/__examples__/base.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import IconSettings from '~/components/icon-settings';
 import Tooltip from '~/components/tooltip'; // `~` is replaced with design-system-react at runtime
+import Button from '~/components/button'; // `~` is replaced with design-system-react at runtime
 import Icon from '~/components/icon';
 
 class Example extends React.Component {
@@ -13,16 +14,8 @@ class Example extends React.Component {
 				<Tooltip
 					align="top left"
 					content="Sit nulla est ex deserunt exercitation anim occaecat. Nostrud ullamco deserunt aute id consequat veniam incididunt duis in sint irure nisi."
-				>
-					<a href="javascript:void(0)">
-						<Icon
-							assistiveText={{ label: 'Tooltip with icon' }}
-							category="utility"
-							name="info"
-							size="x-small"
-						/>
-					</a>
-				</Tooltip>
+					variant="learnMore"
+				/>
 			</IconSettings>
 		);
 	}

--- a/components/tooltip/__examples__/base.jsx
+++ b/components/tooltip/__examples__/base.jsx
@@ -2,8 +2,6 @@ import React from 'react';
 
 import IconSettings from '~/components/icon-settings';
 import Tooltip from '~/components/tooltip'; // `~` is replaced with design-system-react at runtime
-import Button from '~/components/button'; // `~` is replaced with design-system-react at runtime
-import Icon from '~/components/icon';
 
 class Example extends React.Component {
 	static displayName = 'TooltipExample';

--- a/components/tooltip/index.jsx
+++ b/components/tooltip/index.jsx
@@ -17,6 +17,7 @@ import { POPOVER_TOOLTIP } from '../../utilities/constants';
 
 import Dialog from '../utilities/dialog';
 import Icon from '../icon';
+import Button from '../button';
 
 // This component's `checkProps` which issues warnings to developers about properties when in development mode (similar to React's built in development tools)
 import checkProps from './check-props';
@@ -164,8 +165,9 @@ class Tooltip extends React.Component {
 
 	getContent() {
 		let children;
+		const noChildrenProvided = React.Children.count(this.props.children) === 0;
 
-		if (React.Children.count(this.props.children) === 0) {
+		if (noChildrenProvided && this.props.onClickTrigger) {
 			children = [
 				<a href="javascript:void(0)" onClick={this.props.onClickTrigger}>
 					<Icon
@@ -177,6 +179,19 @@ class Tooltip extends React.Component {
 						size="x-small"
 					/>
 				</a>,
+			];
+		} else if (noChildrenProvided) {
+			children = [
+				<Button variant="icon" aria-disabled>
+					<Icon
+						category="utility"
+						name="info"
+						assistiveText={{
+							label: this.props.assistiveText.triggerLearnMoreIcon,
+						}}
+						size="x-small"
+					/>
+				</Button>,
 			];
 		} else {
 			children = this.props.children;
@@ -235,7 +250,7 @@ class Tooltip extends React.Component {
 		return (
 			<div className="slds-popover__body">
 				{this.props.content}
-				{this.props.variant === 'learnMore' ? (
+				{this.props.variant === 'learnMore' && this.props.onClickTrigger ? (
 					<div className="slds-m-top_x-small" aria-hidden="true">
 						{this.props.labels.learnMoreBefore}{' '}
 						<Icon

--- a/utilities/get-aria-props.js
+++ b/utilities/get-aria-props.js
@@ -1,0 +1,8 @@
+export default function getAriaProps(props) {
+	return Object.keys(props).reduce((prev, key) => {
+		if (key.substr(0, 5) === 'aria-') {
+			prev[key] = props[key];
+		}
+		return prev;
+	}, {});
+}


### PR DESCRIPTION
Fixes #1549 
Fixes #1705

### Additional description
* If `learnMore` Tooltip variant is used without onClickTrigger, then the “no click” basic info icon tooltip will be used with a “disabled” button as trigger.
* If onClickTrigger is defined, a link will be rendered (this is the current behavior for learn more tooltips)

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [ ] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [ ] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
