### PR TITLE
Fix inheritance of IconSettings context for overflowBoundaryElement Dialog. Add ESLINT skipBlankLines/skipComments max lines rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -119,7 +119,10 @@ module.exports = {
 		//
 		'prefer-object-spread/prefer-object-spread': [2, 'always'],
 
-		'max-lines': ['error', 500],
+		'max-lines': [
+			'error',
+			{ max: 500, skipBlankLines: true, skipComments: true },
+		],
 
 		// Can't be used because it doesn't currently recognize props used in functions
 		'react/no-unused-prop-types': 'off',

--- a/components/utilities/dialog/index.jsx
+++ b/components/utilities/dialog/index.jsx
@@ -471,13 +471,19 @@ class Dialog extends React.Component {
 		const subRenders = {
 			absolute: () => contents,
 			relative: () => contents,
-			overflowBoundaryElement: () => (
-				<Portal onOpen={this.handleOpen} portalMount={this.props.portalMount}>
-					<IconSettings iconPath={this.context.iconPath}>
-						{contents}
-					</IconSettings>
-				</Portal>
-			),
+			overflowBoundaryElement: () => {
+				const iconSettingsContext = Object.keys(IconSettings.childContextTypes)
+					.filter((key) => !!this.context[key])
+					.reduce(
+						(context, key) => ({ ...context, ...{ [key]: this.context[key] } }),
+						{}
+					);
+				return (
+					<Portal onOpen={this.handleOpen} portalMount={this.props.portalMount}>
+						<IconSettings {...iconSettingsContext}>{contents}</IconSettings>
+					</Portal>
+				);
+			},
 		};
 
 		return subRenders[this.props.position] && subRenders[this.props.position]();

--- a/components/utilities/dialog/index.jsx
+++ b/components/utilities/dialog/index.jsx
@@ -1,6 +1,5 @@
 /* Copyright (c) 2015-present, salesforce.com, inc. All rights reserved */
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
-/* eslint-disable max-len */
 import React from 'react';
 
 import PropTypes from 'prop-types';

--- a/components/utilities/dialog/index.jsx
+++ b/components/utilities/dialog/index.jsx
@@ -1,6 +1,6 @@
 /* Copyright (c) 2015-present, salesforce.com, inc. All rights reserved */
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
-
+/* eslint-disable max-len */
 import React from 'react';
 
 import PropTypes from 'prop-types';
@@ -472,15 +472,26 @@ class Dialog extends React.Component {
 			absolute: () => contents,
 			relative: () => contents,
 			overflowBoundaryElement: () => {
-				const iconSettingsContext = Object.keys(IconSettings.childContextTypes)
-					.filter((key) => !!this.context[key])
+				// Cycle through current context, create object of
+				// truthy values, and pass into Portal's context.
+
+				// TODO: Add test when switched to `ReactDOM.createPortal`
+				const truthyIconSettingsContext = Object.keys(
+					IconSettings.childContextTypes
+				)
+					.filter((key) => Boolean(this.context[key]))
 					.reduce(
-						(context, key) => ({ ...context, ...{ [key]: this.context[key] } }),
+						(accumulatedContext, key) => ({
+							...accumulatedContext,
+							...{ [key]: this.context[key] },
+						}),
 						{}
 					);
 				return (
 					<Portal onOpen={this.handleOpen} portalMount={this.props.portalMount}>
-						<IconSettings {...iconSettingsContext}>{contents}</IconSettings>
+						<IconSettings {...truthyIconSettingsContext}>
+							{contents}
+						</IconSettings>
 					</Portal>
 				);
 			},


### PR DESCRIPTION
Fixes #1744

### Additional description

Instead of only inheriting `iconAssets`, inherit all `IconSettings` related context properties based on `IconSettings.childContextTypes`.

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [x] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [x] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [x] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [x] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
