### PR TITLE
sethu1504/first time sort direction data table

### DIFF
--- a/components/data-table/__tests__/data-table.browser-test.jsx
+++ b/components/data-table/__tests__/data-table.browser-test.jsx
@@ -374,7 +374,7 @@ describe('DataTable: ', function() {
 	describe('Sortable', function() {
 		afterEach(removeTable);
 
-		it('first clicked on sortable column header should result in ascending sort', function(done) {
+		it('first clicked on sortable column header should result in ascending sort by default', function(done) {
 			this.onSort = (data) => {
 				data.property.should.equal('count');
 				data.sortDirection.should.equal('asc');
@@ -385,6 +385,28 @@ describe('DataTable: ', function() {
 				<DataTable {...defaultProps} fixedLayout onSort={this.onSort}>
 					{columns.map((columnProps) => (
 						<DataTableColumn {...columnProps} key={columnProps.property} />
+					))}
+				</DataTable>
+			).call(this);
+
+			const thead = getTable(this.dom).querySelectorAll('thead')[0];
+			const thirdColumn = thead.querySelectorAll('th')[2];
+			const sortButton = thead.querySelectorAll('a')[0];
+
+			Simulate.click(sortButton, {});
+		});
+
+		it('first clicked on sortable column header should result in desceding sort if defaultSortDirection is given', function(done) {
+			this.onSort = (data) => {
+				data.property.should.equal('count');
+				data.sortDirection.should.equal('desc');
+				done();
+			};
+
+			renderTable(
+				<DataTable {...defaultProps} fixedLayout onSort={this.onSort}>
+					{columns.map((columnProps) => (
+						<DataTableColumn {...{...columnProps, ...{defaultSortDirection: 'desc'}}} key={columnProps.property} />
 					))}
 				</DataTable>
 			).call(this);

--- a/components/data-table/__tests__/data-table.browser-test.jsx
+++ b/components/data-table/__tests__/data-table.browser-test.jsx
@@ -396,7 +396,7 @@ describe('DataTable: ', function() {
 			Simulate.click(sortButton, {});
 		});
 
-		it('first clicked on sortable column header should result in sort specifid in defaultSortDirection if given', function(done) {
+		it('first clicked on sortable column header should result in sort specifid in firstSortDirection if given', function(done) {
 			this.onSort = (data) => {
 				data.property.should.equal('count');
 				data.sortDirection.should.equal('desc');
@@ -406,7 +406,7 @@ describe('DataTable: ', function() {
 			renderTable(
 				<DataTable {...defaultProps} fixedLayout onSort={this.onSort}>
 					{columns.map((columnProps) => (
-						<DataTableColumn {...columnProps} defaultSortDirection='desc' key={columnProps.property} />
+						<DataTableColumn {...columnProps} firstSortDirection='desc' key={columnProps.property} />
 					))}
 				</DataTable>
 			).call(this);

--- a/components/data-table/__tests__/data-table.browser-test.jsx
+++ b/components/data-table/__tests__/data-table.browser-test.jsx
@@ -396,7 +396,7 @@ describe('DataTable: ', function() {
 			Simulate.click(sortButton, {});
 		});
 
-		it('first clicked on sortable column header should result in desceding sort if defaultSortDirection is given', function(done) {
+		it('first clicked on sortable column header should result in sort specifid in defaultSortDirection if given', function(done) {
 			this.onSort = (data) => {
 				data.property.should.equal('count');
 				data.sortDirection.should.equal('desc');
@@ -406,7 +406,7 @@ describe('DataTable: ', function() {
 			renderTable(
 				<DataTable {...defaultProps} fixedLayout onSort={this.onSort}>
 					{columns.map((columnProps) => (
-						<DataTableColumn {...{...columnProps, ...{defaultSortDirection: 'desc'}}} key={columnProps.property} />
+						<DataTableColumn {...columnProps} defaultSortDirection='desc' key={columnProps.property} />
 					))}
 				</DataTable>
 			).call(this);

--- a/components/data-table/column.jsx
+++ b/components/data-table/column.jsx
@@ -78,6 +78,10 @@ DataTableColumn.propTypes = {
 	 * Width of column. This is required for advanced/fixed layout tables. Please provide units. (`rems` are recommended)
 	 */
 	width: PropTypes.string,
+	/**
+	 * The default sort direction for the first time if the column is not sorted
+	 */
+	defaultSortDirection: PropTypes.oneOf(['asc', 'desc'])
 };
 
 export default DataTableColumn;

--- a/components/data-table/column.jsx
+++ b/components/data-table/column.jsx
@@ -79,7 +79,7 @@ DataTableColumn.propTypes = {
 	 */
 	width: PropTypes.string,
 	/**
-	 * The default sort direction for the first time if the column is not sorted
+	 * The default sort direction for the first time if the column is not sorted and sortDirection not given
 	 */
 	firstSortDirection: PropTypes.oneOf(['asc', 'desc'])
 };

--- a/components/data-table/column.jsx
+++ b/components/data-table/column.jsx
@@ -81,7 +81,7 @@ DataTableColumn.propTypes = {
 	/**
 	 * The default sort direction for the first time if the column is not sorted
 	 */
-	defaultSortDirection: PropTypes.oneOf(['asc', 'desc'])
+	firstSortDirection: PropTypes.oneOf(['asc', 'desc'])
 };
 
 export default DataTableColumn;

--- a/components/data-table/private/header-cell.jsx
+++ b/components/data-table/private/header-cell.jsx
@@ -124,7 +124,7 @@ class DataTableHeaderCell extends React.Component {
 		const { fixedHeader, isSorted, label, sortable, width } = this.props;
 
 		const labelType = typeof label;
-		const sortDirection = (this.props.sortDirection === null && this.state.sortDirection === null) ? this.props.defaultSortDirection : (this.props.sortDirection || this.state.sortDirection);
+		const sortDirection = (!this.props.sortDirection && !this.state.sortDirection) ? this.props.defaultSortDirection : (this.props.sortDirection || this.state.sortDirection);
 		const expandedSortDirection =
 			sortDirection === 'desc' ? 'descending' : 'ascending';
 		const ariaSort = isSorted ? expandedSortDirection : 'none';

--- a/components/data-table/private/header-cell.jsx
+++ b/components/data-table/private/header-cell.jsx
@@ -26,7 +26,7 @@ import {
 } from '../../../utilities/constants';
 
 const defaultProps = {
-	defaultSortDirection: 'asc'
+	firstSortDirection: 'asc'
 };
 
 /**
@@ -77,7 +77,7 @@ class DataTableHeaderCell extends React.Component {
 		/**
 		 * The default sort direction for the first time if the column is not sorted.
 		 */
-		defaultSortDirection: PropTypes.oneOf(['asc', 'desc']),
+		firstSortDirection: PropTypes.oneOf(['asc', 'desc']),
 		/**
 		 * Width of column. This is required for advanced/fixed layout tables. Please provide units. (`rems` are recommended)
 		 */
@@ -104,7 +104,7 @@ class DataTableHeaderCell extends React.Component {
 	handleSort = (e) => {
 		const oldSortDirection =
 			this.props.sortDirection || this.state.sortDirection;
-		const sortDirection = oldSortDirection ? (oldSortDirection === 'asc' ? 'desc' : 'asc') : (this.props.defaultSortDirection)
+		const sortDirection = oldSortDirection ? (oldSortDirection === 'asc' ? 'desc' : 'asc') : (this.props.firstSortDirection)
 		const data = {
 			property: this.props.property,
 			sortDirection,
@@ -124,7 +124,7 @@ class DataTableHeaderCell extends React.Component {
 		const { fixedHeader, isSorted, label, sortable, width } = this.props;
 
 		const labelType = typeof label;
-		const sortDirection = (!this.props.sortDirection && !this.state.sortDirection && this.state.sortable) ? this.props.defaultSortDirection : (this.props.sortDirection || this.state.sortDirection);
+		const sortDirection = (!this.props.sortDirection && !this.state.sortDirection && this.state.sortable) ? this.props.firstSortDirection : (this.props.sortDirection || this.state.sortDirection);
 		const expandedSortDirection =
 			sortDirection === 'desc' ? 'descending' : 'ascending';
 		const ariaSort = isSorted ? expandedSortDirection : 'none';

--- a/components/data-table/private/header-cell.jsx
+++ b/components/data-table/private/header-cell.jsx
@@ -124,7 +124,7 @@ class DataTableHeaderCell extends React.Component {
 		const { fixedHeader, isSorted, label, sortable, width } = this.props;
 
 		const labelType = typeof label;
-		const sortDirection = (!this.props.sortDirection && !this.state.sortDirection) ? this.props.defaultSortDirection : (this.props.sortDirection || this.state.sortDirection);
+		const sortDirection = (!this.props.sortDirection && !this.state.sortDirection && this.state.sortable) ? this.props.defaultSortDirection : (this.props.sortDirection || this.state.sortDirection);
 		const expandedSortDirection =
 			sortDirection === 'desc' ? 'descending' : 'ascending';
 		const ariaSort = isSorted ? expandedSortDirection : 'none';

--- a/components/data-table/private/header-cell.jsx
+++ b/components/data-table/private/header-cell.jsx
@@ -25,6 +25,10 @@ import {
 	DATA_TABLE_COLUMN,
 } from '../../../utilities/constants';
 
+const defaultProps = {
+	defaultSortDirection: 'asc'
+};
+
 /**
  * Used internally, renders each individual column heading.
  */
@@ -71,10 +75,16 @@ class DataTableHeaderCell extends React.Component {
 		 */
 		sortDirection: PropTypes.oneOf(['desc', 'asc']),
 		/**
+		 * The default sort direction for the first time if the column is not sorted.
+		 */
+		defaultSortDirection: PropTypes.oneOf(['asc', 'desc']),
+		/**
 		 * Width of column. This is required for advanced/fixed layout tables. Please provide units. (`rems` are recommended)
 		 */
 		width: PropTypes.string,
 	};
+
+	static defaultProps = defaultProps;
 
 	state = {
 		sortDirection: null,
@@ -94,7 +104,7 @@ class DataTableHeaderCell extends React.Component {
 	handleSort = (e) => {
 		const oldSortDirection =
 			this.props.sortDirection || this.state.sortDirection;
-		const sortDirection = oldSortDirection === 'asc' ? 'desc' : 'asc';
+		const sortDirection = oldSortDirection ? (oldSortDirection === 'asc' ? 'desc' : 'asc') : (this.props.defaultSortDirection)
 		const data = {
 			property: this.props.property,
 			sortDirection,
@@ -114,7 +124,7 @@ class DataTableHeaderCell extends React.Component {
 		const { fixedHeader, isSorted, label, sortable, width } = this.props;
 
 		const labelType = typeof label;
-		const sortDirection = this.props.sortDirection || this.state.sortDirection;
+		const sortDirection = (this.props.sortDirection === null && this.state.sortDirection === null) ? this.props.defaultSortDirection : (this.props.sortDirection || this.state.sortDirection);
 		const expandedSortDirection =
 			sortDirection === 'desc' ? 'descending' : 'ascending';
 		const ariaSort = isSorted ? expandedSortDirection : 'none';

--- a/components/data-table/private/header-cell.jsx
+++ b/components/data-table/private/header-cell.jsx
@@ -75,7 +75,7 @@ class DataTableHeaderCell extends React.Component {
 		 */
 		sortDirection: PropTypes.oneOf(['desc', 'asc']),
 		/**
-		 * The default sort direction for the first time if the column is not sorted.
+		 * The default sort direction for the first time if the column is not sorted and sortDirection not given
 		 */
 		firstSortDirection: PropTypes.oneOf(['asc', 'desc']),
 		/**


### PR DESCRIPTION
Fixes #

### Additional description

In Data table, when a sortable column is not sorted, then for the first click, it sorts the column ascending by default. 
A prop "firstSortDirection" is added to address this case. When this prop is mentioned, the first click will sort in the specified direction or default to ascending (as per the current working).
A unit test is added in the appropriate file and snapshot testing is done.


---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [ ] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [ ] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
