### PR TITLE
Tree: Expand nodes with highlighted search results

### DIFF
--- a/components/tree/__examples__/default.jsx
+++ b/components/tree/__examples__/default.jsx
@@ -36,17 +36,20 @@ const sampleNodes = {
 		type: 'branch',
 		id: 4,
 		nodes: [12, 13, 14],
+		parentId: 2,
 	},
 	5: {
 		label: 'Tree Fruits',
 		type: 'branch',
 		id: 5,
 		nodes: [15, 16, 17, 18, 19, 6],
+		parentId: 2,
 	},
 	6: {
 		label: 'Raspberries',
 		type: 'item',
 		id: 6,
+		parentId: 5,
 	},
 	7: {
 		label: 'Empty folder',
@@ -57,137 +60,163 @@ const sampleNodes = {
 		label: 'Almonds',
 		type: 'item',
 		id: 8,
+		parentId: 3,
 	},
 	9: {
 		label: 'Cashews',
 		type: 'item',
 		id: 9,
+		parentId: 3,
 	},
 	10: {
 		label: 'Pecans',
 		type: 'item',
 		id: 10,
+		parentId: 3,
 	},
 	11: {
 		label: 'Walnuts',
 		type: 'item',
 		id: 11,
+		parentId: 3,
 	},
 	12: {
 		label: 'Watermelon',
 		type: 'item',
 		id: 12,
+		parentId: 4,
 	},
 	13: {
 		label: 'Canteloupe',
 		type: 'item',
 		_iconClass: 'glyphicon-file',
 		id: 13,
+		parentId: 4,
 	},
 	14: {
 		label: 'Strawberries',
 		type: 'item',
 		id: 14,
+		parentId: 4,
 	},
 	15: {
 		label: 'Peaches',
 		type: 'item',
 		id: 15,
+		parentId: 5,
 	},
 	16: {
 		label: 'Pears',
 		type: 'item',
 		_iconClass: 'glyphicon-file',
 		id: 16,
+		parentId: 5,
 	},
 	17: {
 		label: 'Citrus',
 		type: 'branch',
 		id: 17,
 		nodes: [20, 21, 22, 23],
+		parentId: 5,
 	},
 	18: {
 		label: 'Apples',
 		type: 'branch',
 		id: 18,
 		nodes: [24, 25, 26, 27],
+		parentId: 5,
 	},
 	19: {
 		label: 'Cherries',
 		type: 'branch',
 		id: 19,
 		nodes: [28, 29, 30, 31, 32, 33],
+		parentId: 5,
 	},
 	20: {
 		label: 'Orange',
 		type: 'item',
 		id: 20,
+		parentId: 17,
 	},
 	21: {
 		label: 'Grapefruit',
 		type: 'item',
 		id: 21,
+		parentId: 17,
 	},
 	22: {
 		label: 'Lemon',
 		type: 'item',
 		id: 22,
+		parentId: 17,
 	},
 	23: {
 		label: 'Lime',
 		type: 'item',
 		id: 23,
+		parentId: 17,
 	},
 	24: {
 		label: 'Granny Smith',
 		type: 'item',
 		id: 24,
+		parentId: 18,
 	},
 	25: {
 		label: 'Pinklady',
 		type: 'item',
 		_iconClass: 'glyphicon-file',
 		id: 25,
+		parentId: 18,
 	},
 	26: {
 		label: 'Rotten',
 		type: 'item',
 		id: 26,
+		parentId: 18,
 	},
 	27: {
 		label: 'Jonathan',
 		type: 'item',
 		id: 27,
+		parentId: 18,
 	},
 	28: {
 		label: 'Balaton',
 		type: 'item',
 		id: 28,
+		parentId: 19,
 	},
 	29: {
 		label: 'Erdi Botermo',
 		type: 'item',
 		id: 29,
+		parentId: 19,
 	},
 	30: {
 		label: 'Montmorency',
 		type: 'item',
 		id: 30,
+		parentId: 19,
 	},
 	31: {
 		label: 'Queen Ann',
 		type: 'item',
 		id: 31,
+		parentId: 19,
 	},
 	32: {
 		label: 'Ulster',
 		type: 'item',
 		id: 32,
+		parentId: 19,
 	},
 	33: {
 		label: 'Viva',
 		type: 'item',
 		id: 33,
+		parentId: 19,
 	},
 };
 
@@ -335,7 +364,7 @@ class Example extends React.Component {
 			// SINGLE SELECTION
 			// Take the previous state, expand it, overwrite the `nodes` key with the previous state's `nodes` key expanded with the id of the node just clicked selected and the previously selected node unselected.
 			this.setState((prevState) => {
-				// Gaurd against no selection with the following. `selectedNode`
+				// Guard against no selection with the following. `selectedNode`
 				// is the previously selected "current state" that is about to
 				// be updated
 				const selectedNode = prevState.selectedNode
@@ -370,8 +399,47 @@ class Example extends React.Component {
 		});
 	};
 
+	expandParentNodes(currentNode, currentNodesArray) {
+		// All ids - 1 as we disregard the root node temporarily
+		if (!(currentNode.parentId - 1)) {
+			return;
+		}
+		currentNodesArray[currentNode.parentId - 1].expanded = true;
+		this.expandParentNodes(
+			currentNodesArray[currentNode.parentId - 1],
+			currentNodesArray
+		);
+	}
+
 	handleSearchChange = (event) => {
-		this.setState({ searchTerm: event.target.value });
+		const searchTerm = event.target.value;
+		const currentNodes = {
+			...this.state.nodes,
+		};
+		const rootNode = Object.values(currentNodes)[0];
+
+		// Root node not needed to update the state
+		const currentNodesArray = Object.values(currentNodes).slice(1);
+
+		// Loop through each node to find if its label includes the search term
+		for (let index = 0; index < currentNodesArray.length; index++) {
+			const currentNode = currentNodesArray[index];
+			if (
+				currentNode.label.toLowerCase().includes(searchTerm.toLowerCase()) &&
+				searchTerm !== ''
+			) {
+				// expand all affliated parent nodes of the searched item/branch
+				this.expandParentNodes(currentNode, currentNodesArray);
+			}
+		}
+		currentNodesArray.unshift(rootNode);
+
+		this.setState({
+			searchTerm,
+			nodes: {
+				...currentNodesArray,
+			},
+		});
 	};
 
 	render() {

--- a/components/tree/__examples__/default.jsx
+++ b/components/tree/__examples__/default.jsx
@@ -422,16 +422,15 @@ class Example extends React.Component {
 		const currentNodesArray = Object.values(currentNodes).slice(1);
 
 		// Loop through each node to find if its label includes the search term
-		for (let index = 0; index < currentNodesArray.length; index++) {
-			const currentNode = currentNodesArray[index];
+		currentNodesArray.forEach((node) => {
 			if (
-				currentNode.label.toLowerCase().includes(searchTerm.toLowerCase()) &&
+				node.label.toLowerCase().includes(searchTerm.toLowerCase()) &&
 				searchTerm !== ''
 			) {
 				// expand all affliated parent nodes of the searched item/branch
-				this.expandParentNodes(currentNode, currentNodesArray);
+				this.expandParentNodes(node, currentNodesArray);
 			}
-		}
+		});
 		currentNodesArray.unshift(rootNode);
 
 		this.setState({

--- a/components/tree/private/branch.jsx
+++ b/components/tree/private/branch.jsx
@@ -14,7 +14,7 @@ import RenderBranch from './render-branch';
 import { TREE_BRANCH } from '../../../utilities/constants';
 
 /**
- * A Tree Item is a non-branching node in a hierarchical list.
+ * A Tree Branch is a branching node in a hierarchical list.
  */
 const Branch = (props) => {
 	let treeIndex = '';


### PR DESCRIPTION
Fixes #1049 

### Additional description

Hi @interactivellama ! This PR has been loads of fun as I took a deep dive into the inner workings of the `Tree` component. Summary of what this PR does:
1. Whenever the `Search` component's `onChange` event fires, all nodes' `label` would be checked to identify if it contains the search term.
2. When the search term is found, its parent and the parent's parent ...... would be expanded. This is done recursively through `expandParentNodes`.

Some points to note:
1. This only happens when the `Search` component's `onChange` event fires, so the initial search with default` searchable` props value `fruit` would not trigger this behavior.
2. I'm experimenting with a version that allows users to pass a event handler function prop e.g. `handleSearchChangeExpand` from `default.jsx` down to the `Branch` and/or `Item` component. Expansion of the parent branches could then be done in `handleSearchChangeExpand` as the `Tree` component is a controlled component. This might be more involved and I'm not sure how feasible it is given that the work of the current PR already documents how to expand nodes with highlighted search results.
---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [ ] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
