### PR TITLE
Combobox: Update menuItem to onRenderMenuItem

### DIFF
--- a/components/combobox/__examples__/base-custom-menu-item-disabled.jsx
+++ b/components/combobox/__examples__/base-custom-menu-item-disabled.jsx
@@ -157,7 +157,7 @@ class Example extends React.Component {
 						label: 'Search',
 						placeholder: 'Search Salesforce',
 					}}
-					menuItem={CustomMenuItem}
+					onRenderMenuItem={CustomMenuItem}
 					multiple
 					options={comboboxFilterAndLimit({
 						inputValue: this.state.inputValue,

--- a/components/combobox/__examples__/base-custom-menu-item.jsx
+++ b/components/combobox/__examples__/base-custom-menu-item.jsx
@@ -150,7 +150,7 @@ class Example extends React.Component {
 						label: 'Search',
 						placeholder: 'Search Salesforce',
 					}}
-					menuItem={CustomMenuItem}
+					onRenderMenuItem={CustomMenuItem}
 					multiple
 					options={comboboxFilterAndLimit({
 						inputValue: this.state.inputValue,

--- a/components/combobox/__examples__/readonly-single-selection-custom-menu-item.jsx
+++ b/components/combobox/__examples__/readonly-single-selection-custom-menu-item.jsx
@@ -119,7 +119,7 @@ class Example extends React.Component {
 						label: 'Search',
 						placeholderReadOnly: 'Select company',
 					}}
-					menuItem={CustomMenuItem}
+					onRenderMenuItem={CustomMenuItem}
 					options={accountsWithIcon}
 					selection={this.state.selection}
 					value={this.state.inputValue}

--- a/components/combobox/check-props.js
+++ b/components/combobox/check-props.js
@@ -18,6 +18,13 @@ if (process.env.NODE_ENV !== 'production') {
 			'menuPosition="relative"',
 			createDocUrl('menuPosition')
 		);
+		deprecatedProperty(
+			COMPONENT,
+			props.menuItem,
+			'menuItem',
+			'onRenderMenuItem',
+			createDocUrl('onRenderItem')
+		);
 		/* eslint-enable max-len */
 	};
 }

--- a/components/combobox/combobox.jsx
+++ b/components/combobox/combobox.jsx
@@ -182,7 +182,8 @@ const propTypes = {
 	 *
 	 * _Tested with snapshot testing._
 	 */
-	menuItem: PropTypes.func,
+	menuItem: PropTypes.func, // For backward compatibiity, 'menuItem' will be deprecated soon
+	onRenderMenuItem: PropTypes.func,
 	/**
 	 * Please select one of the following:
 	 * * `absolute` - (default) The dialog will use `position: absolute` and style attributes to position itself. This allows inverted placement or flipping of the dialog.
@@ -1207,7 +1208,12 @@ class Combobox extends React.Component {
 						: null
 				}
 				labels={labels}
-				menuItem={this.props.menuItem}
+				// For backward compatibility, 'menuItem' prop will be deprecated soon
+				onRenderMenuItem={
+					this.props.onRenderMenuItem
+						? this.props.onRenderMenuItem
+						: this.props.menuItem
+				}
 				menuPosition={this.props.menuPosition}
 				menuRef={(ref) => {
 					this.menuRef = ref;

--- a/components/combobox/combobox.jsx
+++ b/components/combobox/combobox.jsx
@@ -182,7 +182,6 @@ const propTypes = {
 	 *
 	 * _Tested with snapshot testing._
 	 */
-	menuItem: PropTypes.func, // For backward compatibiity, 'menuItem' will be deprecated soon
 	onRenderMenuItem: PropTypes.func,
 	/**
 	 * Please select one of the following:

--- a/components/combobox/private/menu.jsx
+++ b/components/combobox/private/menu.jsx
@@ -75,7 +75,7 @@ const propTypes = {
 	 *
 	 * _Tested with snapshot testing._
 	 */
-	menuItem: PropTypes.func,
+	onRenderMenuItem: PropTypes.func,
 	/**
 	 * Accepts a ref function or object (React.createRef() or otherwise) to store the menu DOM reference once available
 	 */
@@ -132,7 +132,7 @@ const Menu = (props) => {
 			selection: props.selection,
 			option: optionData,
 		});
-		const MenuItem = props.menuItem;
+		const MenuItem = props.onRenderMenuItem;
 
 		if (optionData.type === 'separator') {
 			return optionData.label ? (
@@ -190,10 +190,11 @@ const Menu = (props) => {
 					}
 					role="option"
 				>
-					{optionData.icon && !props.menuItem ? (
+					{/* For backward compatibility,  */}
+					{optionData.icon && !props.onRenderMenuItem ? (
 						<span className="slds-media__figure">{optionData.icon}</span>
 					) : null}
-					{props.menuItem ? (
+					{props.onRenderMenuItem ? (
 						<MenuItem
 							assistiveText={props.assistiveText}
 							selected={selected}
@@ -256,7 +257,7 @@ const Menu = (props) => {
 						/>
 					</span>
 					<span className="slds-media__body">
-						{props.menuItem ? (
+						{props.onRenderMenuItem ? (
 							<MenuItem
 								assistiveText={props.assistiveText}
 								selected={selected}

--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -3646,6 +3646,13 @@
                 "required": false,
                 "description": "Accepts a custom menu item rendering function that becomes a custom component. It should return a React node. The checkmark is still rendered in readonly variants. This function is passed the following props:\n* `assistiveText`: Object, `assistiveText` prop that is passed into Combobox\n* `option`: Object, option data for item being rendered that is passed into Combobox\n* `selected`: Boolean, allows rendering of `assistiveText.optionSelectedInMenu` in Readonly Combobox\n\n_Tested with snapshot testing._"
             },
+            "onRenderMenuItem": {
+                "type": {
+                    "name": "func"
+                },
+                "required": false,
+                "description": ""
+            },
             "menuPosition": {
                 "type": {
                     "name": "enum",

--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -3639,19 +3639,12 @@
                     "computed": false
                 }
             },
-            "menuItem": {
-                "type": {
-                    "name": "func"
-                },
-                "required": false,
-                "description": "Accepts a custom menu item rendering function that becomes a custom component. It should return a React node. The checkmark is still rendered in readonly variants. This function is passed the following props:\n* `assistiveText`: Object, `assistiveText` prop that is passed into Combobox\n* `option`: Object, option data for item being rendered that is passed into Combobox\n* `selected`: Boolean, allows rendering of `assistiveText.optionSelectedInMenu` in Readonly Combobox\n\n_Tested with snapshot testing._"
-            },
             "onRenderMenuItem": {
                 "type": {
                     "name": "func"
                 },
                 "required": false,
-                "description": ""
+                "description": "Accepts a custom menu item rendering function that becomes a custom component. It should return a React node. The checkmark is still rendered in readonly variants. This function is passed the following props:\n* `assistiveText`: Object, `assistiveText` prop that is passed into Combobox\n* `option`: Object, option data for item being rendered that is passed into Combobox\n* `selected`: Boolean, allows rendering of `assistiveText.optionSelectedInMenu` in Readonly Combobox\n\n_Tested with snapshot testing._"
             },
             "menuPosition": {
                 "type": {


### PR DESCRIPTION
Fixes #1707 

### Additional description

Updated `menuItem` prop to `onRenderMenuItem` in such a way that the code base is backward compatible raising following warning in the console in the case using `menuItem` prop.
![image](https://user-images.githubusercontent.com/34851451/54127084-ffa99900-442e-11e9-836c-cbaa27ae2e68.png)

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [x] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [x] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.