### PR TITLE
SLDS update to 2.8.x and store image snapshots when tests fail

### DIFF
--- a/components/data-table/__examples__/advanced-single-select.jsx
+++ b/components/data-table/__examples__/advanced-single-select.jsx
@@ -113,99 +113,97 @@ class Example extends React.Component {
 		return (
 			<div>
 				<IconSettings iconPath="/assets/icons">
-					<div style={{ overflow: 'auto' }}>
-						<h3 className="slds-text-heading_medium slds-m-vertical_medium">
-							Advanced Single Select (Fixed Layout)
-						</h3>
-						<DataTable
-							assistiveText={{
-								actionsHeader: 'actions',
-								columnSort: 'sort this column',
-								columnSortedAscending: 'asc',
-								columnSortedDescending: 'desc',
-								selectAllRows: 'all rows',
-								selectRow: 'select this row',
-							}}
-							fixedLayout
-							items={this.state.items}
-							id="DataTableExample-SingleRequiredSelect"
-							onRowChange={this.handleChanged}
-							onSort={this.handleSort}
-							selection={this.state.selection}
-							selectRows="radio"
+					<h3 className="slds-text-heading_medium slds-m-vertical_medium">
+						Advanced Single Select (Fixed Layout)
+					</h3>
+					<DataTable
+						assistiveText={{
+							actionsHeader: 'actions',
+							columnSort: 'sort this column',
+							columnSortedAscending: 'asc',
+							columnSortedDescending: 'desc',
+							selectAllRows: 'all rows',
+							selectRow: 'select this row',
+						}}
+						fixedLayout
+						items={this.state.items}
+						id="DataTableExample-SingleRequiredSelect"
+						onRowChange={this.handleChanged}
+						onSort={this.handleSort}
+						selection={this.state.selection}
+						selectRows="radio"
+					>
+						<DataTableColumn
+							isSorted={this.state.sortColumn === 'opportunityName'}
+							label="Name"
+							primaryColumn
+							property="opportunityName"
+							sortable
+							sortDirection={this.state.sortColumnDirection.opportunityName}
+							width="10rem"
 						>
-							<DataTableColumn
-								isSorted={this.state.sortColumn === 'opportunityName'}
-								label="Name"
-								primaryColumn
-								property="opportunityName"
-								sortable
-								sortDirection={this.state.sortColumnDirection.opportunityName}
-								width="10rem"
-							>
-								<CustomDataTableCell />
-							</DataTableColumn>
-							<DataTableColumn
-								label="Account Name"
-								property="accountName"
-								width="8rem"
-							/>
-							<DataTableColumn label="Close Date" property="closeDate" />
-							<DataTableColumn label="Stage" property="stage" />
-							<DataTableColumn
-								isSorted={this.state.sortColumn === 'confidence'}
-								label="Confidence"
-								property="confidence"
-								sortable
-								sortDirection={this.state.sortColumnDirection.confidence}
-							/>
-							<DataTableColumn label="Amount" property="amount" />
-							<DataTableColumn label="Contact" property="contact">
-								<CustomDataTableCell />
-							</DataTableColumn>
-							<DataTableRowActions
-								options={[
-									{
-										id: 0,
-										label: 'Add to Group',
-										value: '1',
-									},
-									{
-										id: 1,
-										label: 'Publish',
-										value: '2',
-									},
-									{
-										id: 2,
-										label: 'Third of Seven',
-										value: '3',
-									},
-									{
-										id: 3,
-										label: 'Fourth of Seven',
-										value: '4',
-									},
-									{
-										id: 4,
-										label: 'Fifth of Seven',
-										value: '5',
-									},
-									{
-										id: 5,
-										label: 'Sixth of Seven',
-										value: '6',
-									},
-									{
-										id: 6,
-										label: 'Seventh of Seven',
-										value: '7',
-									},
-								]}
-								onAction={this.handleRowAction}
-								dropdown={<Dropdown length="7" />}
-							/>
-						</DataTable>
-					</div>
+							<CustomDataTableCell />
+						</DataTableColumn>
+						<DataTableColumn
+							label="Account Name"
+							property="accountName"
+							width="8rem"
+						/>
+						<DataTableColumn label="Close Date" property="closeDate" />
+						<DataTableColumn label="Stage" property="stage" />
+						<DataTableColumn
+							isSorted={this.state.sortColumn === 'confidence'}
+							label="Confidence"
+							property="confidence"
+							sortable
+							sortDirection={this.state.sortColumnDirection.confidence}
+						/>
+						<DataTableColumn label="Amount" property="amount" />
+						<DataTableColumn label="Contact" property="contact">
+							<CustomDataTableCell />
+						</DataTableColumn>
+						<DataTableRowActions
+							options={[
+								{
+									id: 0,
+									label: 'Add to Group',
+									value: '1',
+								},
+								{
+									id: 1,
+									label: 'Publish',
+									value: '2',
+								},
+								{
+									id: 2,
+									label: 'Third of Seven',
+									value: '3',
+								},
+								{
+									id: 3,
+									label: 'Fourth of Seven',
+									value: '4',
+								},
+								{
+									id: 4,
+									label: 'Fifth of Seven',
+									value: '5',
+								},
+								{
+									id: 5,
+									label: 'Sixth of Seven',
+									value: '6',
+								},
+								{
+									id: 6,
+									label: 'Seventh of Seven',
+									value: '7',
+								},
+							]}
+							onAction={this.handleRowAction}
+							dropdown={<Dropdown length="7" />}
+						/>
+					</DataTable>
 				</IconSettings>
 			</div>
 		);

--- a/components/data-table/__examples__/advanced.jsx
+++ b/components/data-table/__examples__/advanced.jsx
@@ -124,104 +124,102 @@ class Example extends React.Component {
 		return (
 			<div>
 				<IconSettings iconPath="/assets/icons">
-					<div style={{ overflow: 'auto' }}>
-						<h3 className="slds-text-heading_medium slds-m-vertical_medium">
-							Advanced (Fixed Layout)
-						</h3>
-						<DataTable
-							assistiveText={{
-								actionsHeader: 'actions',
-								columnSort: 'sort this column',
-								columnSortedAscending: 'asc',
-								columnSortedDescending: 'desc',
-								selectAllRows: 'all rows',
-								selectRow: 'select this row',
-							}}
-							fixedLayout
-							items={this.state.items}
-							id="DataTableExample-2"
-							onRowChange={this.handleChanged}
-							onSort={this.handleSort}
-							selection={this.state.selection}
-							selectRows="checkbox"
+					<h3 className="slds-text-heading_medium slds-m-vertical_medium">
+						Advanced (Fixed Layout)
+					</h3>
+					<DataTable
+						assistiveText={{
+							actionsHeader: 'actions',
+							columnSort: 'sort this column',
+							columnSortedAscending: 'asc',
+							columnSortedDescending: 'desc',
+							selectAllRows: 'all rows',
+							selectRow: 'select this row',
+						}}
+						fixedLayout
+						items={this.state.items}
+						id="DataTableExample-2"
+						onRowChange={this.handleChanged}
+						onSort={this.handleSort}
+						selection={this.state.selection}
+						selectRows="checkbox"
+					>
+						<DataTableColumn
+							isSorted={this.state.sortColumn === 'opportunityName'}
+							label="Name"
+							primaryColumn
+							property="opportunityName"
+							sortable
+							sortDirection={this.state.sortColumnDirection.opportunityName}
+							width="10rem"
 						>
-							<DataTableColumn
-								isSorted={this.state.sortColumn === 'opportunityName'}
-								label="Name"
-								primaryColumn
-								property="opportunityName"
-								sortable
-								sortDirection={this.state.sortColumnDirection.opportunityName}
-								width="10rem"
-							>
-								<CustomDataTableCell />
-							</DataTableColumn>
-							<DataTableColumn
-								label="Account Name"
-								property="accountName"
-								width="8rem"
-							/>
-							<DataTableColumn
-								sortable
-								isDefaultSortDescending
-								label="Close Date"
-								property="closeDate"
-							/>
-							<DataTableColumn label="Stage" property="stage" />
-							<DataTableColumn
-								isSorted={this.state.sortColumn === 'confidence'}
-								label="Confidence"
-								property="confidence"
-								sortable
-								sortDirection={this.state.sortColumnDirection.confidence}
-							/>
-							<DataTableColumn label="Amount" property="amount" />
-							<DataTableColumn label="Contact" property="contact">
-								<CustomDataTableCell />
-							</DataTableColumn>
-							<DataTableRowActions
-								options={[
-									{
-										id: 0,
-										label: 'Add to Group',
-										value: '1',
-									},
-									{
-										id: 1,
-										label: 'Publish',
-										value: '2',
-									},
-									{
-										id: 2,
-										label: 'Third of Seven',
-										value: '3',
-									},
-									{
-										id: 3,
-										label: 'Fourth of Seven',
-										value: '4',
-									},
-									{
-										id: 4,
-										label: 'Fifth of Seven',
-										value: '5',
-									},
-									{
-										id: 5,
-										label: 'Sixth of Seven',
-										value: '6',
-									},
-									{
-										id: 6,
-										label: 'Seventh of Seven',
-										value: '7',
-									},
-								]}
-								onAction={this.handleRowAction}
-								dropdown={<Dropdown length="7" />}
-							/>
-						</DataTable>
-					</div>
+							<CustomDataTableCell />
+						</DataTableColumn>
+						<DataTableColumn
+							label="Account Name"
+							property="accountName"
+							width="8rem"
+						/>
+						<DataTableColumn
+							sortable
+							isDefaultSortDescending
+							label="Close Date"
+							property="closeDate"
+						/>
+						<DataTableColumn label="Stage" property="stage" />
+						<DataTableColumn
+							isSorted={this.state.sortColumn === 'confidence'}
+							label="Confidence"
+							property="confidence"
+							sortable
+							sortDirection={this.state.sortColumnDirection.confidence}
+						/>
+						<DataTableColumn label="Amount" property="amount" />
+						<DataTableColumn label="Contact" property="contact">
+							<CustomDataTableCell />
+						</DataTableColumn>
+						<DataTableRowActions
+							options={[
+								{
+									id: 0,
+									label: 'Add to Group',
+									value: '1',
+								},
+								{
+									id: 1,
+									label: 'Publish',
+									value: '2',
+								},
+								{
+									id: 2,
+									label: 'Third of Seven',
+									value: '3',
+								},
+								{
+									id: 3,
+									label: 'Fourth of Seven',
+									value: '4',
+								},
+								{
+									id: 4,
+									label: 'Fifth of Seven',
+									value: '5',
+								},
+								{
+									id: 5,
+									label: 'Sixth of Seven',
+									value: '6',
+								},
+								{
+									id: 6,
+									label: 'Seventh of Seven',
+									value: '7',
+								},
+							]}
+							onAction={this.handleRowAction}
+							dropdown={<Dropdown length="7" />}
+						/>
+					</DataTable>
 				</IconSettings>
 			</div>
 		);

--- a/components/data-table/__examples__/fixed-header.jsx
+++ b/components/data-table/__examples__/fixed-header.jsx
@@ -201,106 +201,103 @@ class Example extends React.Component {
 
 	render() {
 		return (
-			<IconSettings iconPath="/assets/icons">
-				<div>
+			<div
+				style={{
+					height: '200px',
+					width: '100%',
+				}}
+			>
+				<IconSettings iconPath="/assets/icons">
 					<h3 className="slds-text-heading_medium slds-m-vertical_medium">
-						Fixed Header
+						Fixed Header Layout
 					</h3>
-
-					<div
-						style={{
-							height: '200px',
-							width: '100%',
+					<DataTable
+						assistiveText={{
+							actionsHeader: 'actions',
+							columnSort: 'sort this column',
+							columnSortedAscending: 'asc',
+							columnSortedDescending: 'desc',
+							selectAllRows: 'all rows',
+							selectRow: 'select this row',
 						}}
+						fixedHeader
+						fixedLayout
+						items={this.state.items}
+						id="DataTableExample-FixedHeaders"
+						onRowChange={this.handleChanged}
+						onSort={this.handleSort}
+						selection={this.state.selection}
+						selectRows="checkbox"
 					>
-						<DataTable
-							assistiveText={{
-								actionsHeader: 'actions',
-								columnSort: 'sort this column',
-								columnSortedAscending: 'asc',
-								columnSortedDescending: 'desc',
-								selectAllRows: 'all rows',
-								selectRow: 'select this row',
-							}}
-							fixedHeader
-							fixedLayout
-							items={this.state.items}
-							id="DataTableExample-FixedHeaders"
-							onRowChange={this.handleChanged}
-							onSort={this.handleSort}
-							selection={this.state.selection}
-							selectRows="checkbox"
+						<DataTableColumn
+							isSorted={this.state.sortColumn === 'opportunityName'}
+							label="Name"
+							primaryColumn
+							property="opportunityName"
+							sortable
+							sortDirection={this.state.sortColumnDirection.opportunityName}
 						>
-							<DataTableColumn
-								isSorted={this.state.sortColumn === 'opportunityName'}
-								label="Name"
-								primaryColumn
-								property="opportunityName"
-								sortable
-								sortDirection={this.state.sortColumnDirection.opportunityName}
-							>
-								<CustomDataTableCell />
-							</DataTableColumn>
-							<DataTableColumn label="Account Name" property="accountName" />
-							<DataTableColumn label="Close Date" property="closeDate" />
-							<DataTableColumn label="Stage" property="stage" />
-							<DataTableColumn
-								isSorted={this.state.sortColumn === 'confidence'}
-								label="Confidence"
-								property="confidence"
-								sortable
-								sortDirection={this.state.sortColumnDirection.confidence}
-							/>
-							<DataTableColumn label="Amount" property="amount" />
-							<DataTableColumn label="Contact" property="contact">
-								<CustomDataTableCell />
-							</DataTableColumn>
-							<DataTableRowActions
-								options={[
-									{
-										id: 0,
-										label: 'Add to Group',
-										value: '1',
-									},
-									{
-										id: 1,
-										label: 'Publish',
-										value: '2',
-									},
-									{
-										id: 2,
-										label: 'Third of Seven',
-										value: '3',
-									},
-									{
-										id: 3,
-										label: 'Fourth of Seven',
-										value: '4',
-									},
-									{
-										id: 4,
-										label: 'Fifth of Seven',
-										value: '5',
-									},
-									{
-										id: 5,
-										label: 'Sixth of Seven',
-										value: '6',
-									},
-									{
-										id: 6,
-										label: 'Seventh of Seven',
-										value: '7',
-									},
-								]}
-								menuPosition="overflowBoundaryElement"
-								onAction={this.handleRowAction}
-								dropdown={<Dropdown length="7" />}
-							/>
-						</DataTable>
-					</div>
-				</div>
-			</IconSettings>
+							<CustomDataTableCell />
+						</DataTableColumn>
+						<DataTableColumn label="Account Name" property="accountName" />
+						<DataTableColumn label="Close Date" property="closeDate" />
+						<DataTableColumn label="Stage" property="stage" />
+						<DataTableColumn
+							isSorted={this.state.sortColumn === 'confidence'}
+							label="Confidence"
+							property="confidence"
+							sortable
+							sortDirection={this.state.sortColumnDirection.confidence}
+						/>
+						<DataTableColumn label="Amount" property="amount" />
+						<DataTableColumn label="Contact" property="contact">
+							<CustomDataTableCell />
+						</DataTableColumn>
+						<DataTableRowActions
+							options={[
+								{
+									id: 0,
+									label: 'Add to Group',
+									value: '1',
+								},
+								{
+									id: 1,
+									label: 'Publish',
+									value: '2',
+								},
+								{
+									id: 2,
+									label: 'Third of Seven',
+									value: '3',
+								},
+								{
+									id: 3,
+									label: 'Fourth of Seven',
+									value: '4',
+								},
+								{
+									id: 4,
+									label: 'Fifth of Seven',
+									value: '5',
+								},
+								{
+									id: 5,
+									label: 'Sixth of Seven',
+									value: '6',
+								},
+								{
+									id: 6,
+									label: 'Seventh of Seven',
+									value: '7',
+								},
+							]}
+							menuPosition="overflowBoundaryElement"
+							onAction={this.handleRowAction}
+							dropdown={<Dropdown length="7" />}
+						/>
+					</DataTable>
+				</IconSettings>
+			</div>
 		);
 	}
 }

--- a/components/tooltip/index.jsx
+++ b/components/tooltip/index.jsx
@@ -196,8 +196,9 @@ class Tooltip extends React.Component {
 			children = this.props.children;
 		}
 
-		return React.Children.map(children, (child) =>
+		return React.Children.map(children, (child, i) =>
 			React.cloneElement(child, {
+				key: i, // eslint-disable-line react/no-array-index-key
 				'aria-describedby': this.getId(),
 				onBlur: this.handleMouseLeave,
 				onFocus: this.handleMouseEnter,

--- a/package-lock.json
+++ b/package-lock.json
@@ -7935,24 +7935,29 @@
 			"dependencies": {
 				"abbrev": {
 					"version": "1.1.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 					"dev": true,
 					"optional": true
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true,
-					"dev": true
+					"resolved": false,
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
 					"dev": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.5",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -7962,13 +7967,17 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
+					"resolved": false,
+					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+					"dev": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -7976,34 +7985,43 @@
 				},
 				"chownr": {
 					"version": "1.1.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
 					"dev": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true,
-					"dev": true
+					"resolved": false,
+					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+					"dev": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true,
-					"dev": true
+					"resolved": false,
+					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+					"dev": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true,
-					"dev": true
+					"resolved": false,
+					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+					"dev": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 					"dev": true,
 					"optional": true
 				},
 				"debug": {
 					"version": "2.6.9",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8012,25 +8030,29 @@
 				},
 				"deep-extend": {
 					"version": "0.6.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
 					"dev": true,
 					"optional": true
 				},
 				"delegates": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
 					"dev": true,
 					"optional": true
 				},
 				"detect-libc": {
 					"version": "1.0.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
 					"dev": true,
 					"optional": true
 				},
 				"fs-minipass": {
 					"version": "1.2.5",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8039,13 +8061,15 @@
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 					"dev": true,
 					"optional": true
 				},
 				"gauge": {
 					"version": "2.7.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8061,7 +8085,8 @@
 				},
 				"glob": {
 					"version": "7.1.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8075,13 +8100,15 @@
 				},
 				"has-unicode": {
 					"version": "2.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
 					"dev": true,
 					"optional": true
 				},
 				"iconv-lite": {
 					"version": "0.4.24",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8090,7 +8117,8 @@
 				},
 				"ignore-walk": {
 					"version": "3.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8099,7 +8127,8 @@
 				},
 				"inflight": {
 					"version": "1.0.6",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8109,46 +8138,58 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true,
-					"dev": true
+					"resolved": false,
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+					"dev": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
 					"dev": true,
 					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 					"dev": true,
 					"optional": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true,
-					"dev": true
+					"resolved": false,
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+					"dev": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.3.5",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -8156,7 +8197,8 @@
 				},
 				"minizlib": {
 					"version": "1.2.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8165,21 +8207,25 @@
 				},
 				"mkdirp": {
 					"version": "0.5.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
 				},
 				"ms": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 					"dev": true,
 					"optional": true
 				},
 				"needle": {
 					"version": "2.2.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8190,7 +8236,8 @@
 				},
 				"node-pre-gyp": {
 					"version": "0.10.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8208,7 +8255,8 @@
 				},
 				"nopt": {
 					"version": "4.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8218,13 +8266,15 @@
 				},
 				"npm-bundled": {
 					"version": "1.0.5",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g==",
 					"dev": true,
 					"optional": true
 				},
 				"npm-packlist": {
 					"version": "1.2.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-7Mni4Z8Xkx0/oegoqlcao/JpPCPEMtUvsmB0q7mgvlMinykJLSRTYuFqoQLYgGY8biuxIeiHO+QNJKbCfljewQ==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8234,7 +8284,8 @@
 				},
 				"npmlog": {
 					"version": "4.1.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8246,38 +8297,46 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
+					"resolved": false,
+					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+					"dev": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
 					"dev": true,
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 					"dev": true,
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 					"dev": true,
 					"optional": true
 				},
 				"osenv": {
 					"version": "0.1.5",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8287,19 +8346,22 @@
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 					"dev": true,
 					"optional": true
 				},
 				"process-nextick-args": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
 					"dev": true,
 					"optional": true
 				},
 				"rc": {
 					"version": "1.2.8",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8311,7 +8373,8 @@
 					"dependencies": {
 						"minimist": {
 							"version": "1.2.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 							"dev": true,
 							"optional": true
 						}
@@ -8319,7 +8382,8 @@
 				},
 				"readable-stream": {
 					"version": "2.3.6",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8334,7 +8398,8 @@
 				},
 				"rimraf": {
 					"version": "2.6.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8343,43 +8408,52 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.2",
-					"bundled": true,
-					"dev": true
+					"resolved": false,
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 					"dev": true,
 					"optional": true
 				},
 				"sax": {
 					"version": "1.2.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
 					"dev": true,
 					"optional": true
 				},
 				"semver": {
 					"version": "5.6.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
 					"dev": true,
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 					"dev": true,
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 					"dev": true,
 					"optional": true
 				},
 				"string-width": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -8388,7 +8462,8 @@
 				},
 				"string_decoder": {
 					"version": "1.1.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8397,21 +8472,25 @@
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
 				},
 				"strip-json-comments": {
 					"version": "2.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 					"dev": true,
 					"optional": true
 				},
 				"tar": {
 					"version": "4.4.8",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8426,13 +8505,15 @@
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 					"dev": true,
 					"optional": true
 				},
 				"wide-align": {
 					"version": "1.1.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8441,13 +8522,17 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
+					"resolved": false,
+					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.3",
-					"bundled": true,
-					"dev": true
+					"resolved": false,
+					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
@@ -8587,7 +8672,7 @@
 		},
 		"glob": {
 			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+			"resolved": "http://npm.lwcjs.org/glob/-/glob-7.1.3/3960832d3f1574108342dafd3a67b332c0969df1.tgz",
 			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
 			"dev": true,
 			"requires": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 		"test:accessibility": "cross-env NODE_ENV=test npx jest --config=tests/a11y-config.json",
 		"test:a11y": "npm run test:accessibility",
 		"travis-ci": "cross-env NODE_ENV=test scripts/travis-ci.sh",
+		"upload-diffs": "scripts/upload-diffs.sh",
 		"validate": "npm ls",
 		"version": "git add package.json && git commit -m \"Bump package version\""
 	},
@@ -92,7 +93,7 @@
 		"warning": "^3.0.0"
 	},
 	"peerDependencies": {
-		"@salesforce-ux/design-system": "^2.7.4",
+		"@salesforce-ux/design-system": "^2.8.3",
 		"react": ">=16.3 <17",
 		"react-dom": ">=16.3 <17"
 	},

--- a/scripts/travis-ci.sh
+++ b/scripts/travis-ci.sh
@@ -3,6 +3,10 @@
 # Copyright (c) 2015-present, salesforce.com, inc. All rights reserved
 # Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license
 
+# Jest markup & image snapshot tests (this is here so this variable can be used in runTest & elsewhere)
+SNAPSHOT_TESTS='npm run test:snapshot'
+SKIP_SNAPSHOT_TESTS=false
+
 function runTests() {
 COMMANDS=( "$@" )
 
@@ -66,6 +70,12 @@ NODE_ENV=test ${COMMAND}
                                  ☹︎ Failed ☹︎
 ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡
 "
+		if [ "${COMMAND}" = "${SNAPSHOT_TESTS}" ]; then
+        	echo "uploading diffs"
+        	npm run upload-diffs
+        else
+        	echo "COMMAND: ${COMMAND} != SNAPSHOT_TESTS: ${SNAPSHOT_TESTS}"
+        fi
 		exit $((10#$ERROR_CODE))
 	fi
 done
@@ -87,12 +97,11 @@ echo "
 # Prettier ONLY on JSON and markdown files.
 RUN_LINT='npm run lint'
 SKIP_LINT=false
+
 # Mocha framework tests that focus on user interaction
 START_KARMA='npm run test:unit'
 SKIP_START_KARMA=false
-# Jest markup & image snapshot tests
-SNAPSHOT_TESTS='npm run test:snapshot'
-SKIP_SNAPSHOT_TESTS=false
+
 # React DocGen library build of source code PropType comments into a JSON file for documentation site
 DOCGEN='npm run build:docs && npm run test:docs'
 SKIP_DOCGEN=false

--- a/scripts/upload-diffs.sh
+++ b/scripts/upload-diffs.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+shopt -s nullglob # ignore empty directories
+
+STARTING_DIR=$(pwd)
+UPLOAD_MAX=3
+UPLOADS=0
+
+function uploadDiffs() {
+	DIRECTORY=( "$@" )
+	if [ -d "$DIRECTORY" ]; then
+		cd "${DIRECTORY}"
+
+		for file in *.png
+		do
+			if (($UPLOADS < $UPLOAD_MAX)); then
+				# echo "$file"
+				echo
+				echo "curl --upload-file $file -H \"Max-Days: 1\" https://transfer.sh/$file"
+				curl --upload-file $file https://transfer.sh/$file
+				UPLOADS=$((UPLOADS+1))
+			else
+				echo
+				echo "max uploads set to $UPLOAD_MAX. Skipping uploading $file"
+			fi
+		done
+		echo
+		cd "${STARTING_DIR}"
+	fi
+}
+
+declare -a DIRECTORIES=(
+	"/home/travis/build/salesforce/design-system-react/tests/__image_snapshots__/__diff_output__/"
+)
+
+for DIRECTORY in "${DIRECTORIES[@]}"
+do
+	uploadDiffs "${DIRECTORY}"
+done
+
+shopt -u nullglob # revert nullglob back to it's normal default state

--- a/tests/__snapshots__/story-based-tests.snapshot-test.js.snap
+++ b/tests/__snapshots__/story-based-tests.snapshot-test.js.snap
@@ -13554,918 +13554,910 @@ exports[`DOM snapshots SLDSDataTable Advanced (Fixed Layout) 1`] = `
   className="slds-p-around_medium"
 >
   <div>
-    <div
-      style={
-        Object {
-          "overflow": "auto",
-        }
-      }
+    <h3
+      className="slds-text-heading_medium slds-m-vertical_medium"
     >
-      <h3
-        className="slds-text-heading_medium slds-m-vertical_medium"
-      >
-        Advanced (Fixed Layout)
-      </h3>
-      <table
-        aria-multiselectable="true"
-        className="slds-table slds-table_fixed-layout slds-table_resizable-cols slds-table_bordered"
-        id="DataTableExample-2"
-        role="grid"
-      >
-        <thead>
-          <tr
-            className="slds-line-height_reset"
+      Advanced (Fixed Layout)
+    </h3>
+    <table
+      aria-multiselectable="true"
+      className="slds-table slds-table_fixed-layout slds-table_resizable-cols slds-table_bordered"
+      id="DataTableExample-2"
+      role="grid"
+    >
+      <thead>
+        <tr
+          className="slds-line-height_reset"
+        >
+          <th
+            className="slds-text-align_right"
+            scope="col"
+            style={
+              Object {
+                "height": null,
+                "lineHeight": null,
+                "width": "3.25rem",
+              }
+            }
           >
-            <th
-              className="slds-text-align_right"
-              scope="col"
+            <div
+              className="slds-th__action slds-th__action_form"
+              style={null}
+            >
+              <div
+                className="slds-form-element"
+              >
+                <div
+                  className="slds-form-element__control"
+                >
+                  <span
+                    className="slds-checkbox"
+                  >
+                    <input
+                      checked={false}
+                      id="DataTableExample-2-SLDSDataTableHead-SelectAll"
+                      name="SelectAll"
+                      onChange={[Function]}
+                      type="checkbox"
+                    />
+                    <label
+                      className="slds-checkbox__label"
+                      htmlFor="DataTableExample-2-SLDSDataTableHead-SelectAll"
+                    >
+                      <span
+                        className="slds-checkbox_faux"
+                      />
+                      <span
+                        className="slds-assistive-text"
+                      >
+                        all rows
+                      </span>
+                    </label>
+                  </span>
+                </div>
+              </div>
+            </div>
+          </th>
+          <th
+            aria-label="Name"
+            aria-sort="ascending"
+            className="slds-is-sortable slds-is-sorted slds-text-title_caps"
+            scope="col"
+            style={
+              Object {
+                "height": null,
+                "lineHeight": null,
+                "width": "10rem",
+              }
+            }
+          >
+            <a
+              className="slds-th__action slds-text-link_reset"
+              href="javascript:void(0)"
+              onClick={[Function]}
+              role="button"
+              tabIndex="0"
+            >
+              <span
+                className="slds-assistive-text"
+              >
+                sort this column
+                 
+              </span>
+              <span
+                className="slds-truncate"
+                title="Name"
+              >
+                Name
+              </span>
+              <span>
+                <svg
+                  aria-hidden="true"
+                  className="slds-is-sortable__icon slds-icon slds-icon_x-small slds-icon-text-default"
+                >
+                  <use
+                    xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#arrowup"
+                  />
+                </svg>
+                
+              </span>
+              <span
+                aria-atomic="true"
+                aria-live="assertive"
+                className="slds-assistive-text"
+              >
+                asc
+              </span>
+            </a>
+          </th>
+          <th
+            aria-label="Account Name"
+            aria-sort="none"
+            className="slds-text-title_caps"
+            scope="col"
+            style={
+              Object {
+                "height": null,
+                "lineHeight": null,
+                "width": "8rem",
+              }
+            }
+          >
+            <span
+              className="slds-p-horizontal_x-small"
               style={
                 Object {
-                  "height": null,
-                  "lineHeight": null,
-                  "width": "3.25rem",
+                  "display": "flex",
                 }
               }
             >
-              <div
-                className="slds-th__action slds-th__action_form"
-                style={null}
+              <span
+                className="slds-truncate"
+                title="Account Name"
               >
-                <div
-                  className="slds-form-element"
+                Account Name
+              </span>
+            </span>
+          </th>
+          <th
+            aria-label="Close Date"
+            aria-sort="none"
+            className="slds-is-sortable slds-is-sorted_desc slds-text-title_caps"
+            scope="col"
+            style={null}
+          >
+            <a
+              className="slds-th__action slds-text-link_reset"
+              href="javascript:void(0)"
+              onClick={[Function]}
+              role="button"
+              tabIndex="0"
+            >
+              <span
+                className="slds-assistive-text"
+              >
+                sort this column
+                 
+              </span>
+              <span
+                className="slds-truncate"
+                title="Close Date"
+              >
+                Close Date
+              </span>
+              <span>
+                <svg
+                  aria-hidden="true"
+                  className="slds-is-sortable__icon slds-icon slds-icon_x-small slds-icon-text-default"
                 >
-                  <div
-                    className="slds-form-element__control"
+                  <use
+                    xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#arrowdown"
+                  />
+                </svg>
+                
+              </span>
+              <span
+                aria-atomic="true"
+                aria-live="assertive"
+                className="slds-assistive-text"
+              >
+                desc
+              </span>
+            </a>
+          </th>
+          <th
+            aria-label="Stage"
+            aria-sort="none"
+            className="slds-text-title_caps"
+            scope="col"
+            style={null}
+          >
+            <span
+              className="slds-p-horizontal_x-small"
+              style={
+                Object {
+                  "display": "flex",
+                }
+              }
+            >
+              <span
+                className="slds-truncate"
+                title="Stage"
+              >
+                Stage
+              </span>
+            </span>
+          </th>
+          <th
+            aria-label="Confidence"
+            aria-sort="none"
+            className="slds-is-sortable slds-text-title_caps"
+            scope="col"
+            style={null}
+          >
+            <a
+              className="slds-th__action slds-text-link_reset"
+              href="javascript:void(0)"
+              onClick={[Function]}
+              role="button"
+              tabIndex="0"
+            >
+              <span
+                className="slds-assistive-text"
+              >
+                sort this column
+                 
+              </span>
+              <span
+                className="slds-truncate"
+                title="Confidence"
+              >
+                Confidence
+              </span>
+              <span>
+                <svg
+                  aria-hidden="true"
+                  className="slds-is-sortable__icon slds-icon slds-icon_x-small slds-icon-text-default"
+                >
+                  <use
+                    xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#arrowup"
+                  />
+                </svg>
+                
+              </span>
+            </a>
+          </th>
+          <th
+            aria-label="Amount"
+            aria-sort="none"
+            className="slds-text-title_caps"
+            scope="col"
+            style={null}
+          >
+            <span
+              className="slds-p-horizontal_x-small"
+              style={
+                Object {
+                  "display": "flex",
+                }
+              }
+            >
+              <span
+                className="slds-truncate"
+                title="Amount"
+              >
+                Amount
+              </span>
+            </span>
+          </th>
+          <th
+            aria-label="Contact"
+            aria-sort="none"
+            className="slds-text-title_caps"
+            scope="col"
+            style={null}
+          >
+            <span
+              className="slds-p-horizontal_x-small"
+              style={
+                Object {
+                  "display": "flex",
+                }
+              }
+            >
+              <span
+                className="slds-truncate"
+                title="Contact"
+              >
+                Contact
+              </span>
+            </span>
+          </th>
+          <th
+            scope="col"
+            style={
+              Object {
+                "height": null,
+                "lineHeight": null,
+                "width": "3.25rem",
+              }
+            }
+          >
+            <div
+              className="slds-th__action"
+              style={null}
+            >
+              <span
+                className="slds-assistive-text"
+              >
+                actions
+              </span>
+            </div>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          aria-selected="false"
+          className="slds-hint-parent"
+        >
+          <td
+            className="slds-text-align_right"
+            role="gridcell"
+            style={
+              Object {
+                "width": "3.25rem",
+              }
+            }
+          >
+            <div
+              className="slds-form-element"
+            >
+              <div
+                className="slds-form-element__control"
+              >
+                <span
+                  className="slds-checkbox"
+                >
+                  <input
+                    checked={false}
+                    id="DataTableExample-2-SLDSDataTableRow-8IKZHZZV80-SelectRow"
+                    name="SelectRow"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  <label
+                    className="slds-checkbox__label"
+                    htmlFor="DataTableExample-2-SLDSDataTableRow-8IKZHZZV80-SelectRow"
                   >
                     <span
-                      className="slds-checkbox"
+                      className="slds-checkbox_faux"
+                    />
+                    <span
+                      className="slds-assistive-text"
                     >
-                      <input
-                        checked={false}
-                        id="DataTableExample-2-SLDSDataTableHead-SelectAll"
-                        name="SelectAll"
-                        onChange={[Function]}
-                        type="checkbox"
-                      />
-                      <label
-                        className="slds-checkbox__label"
-                        htmlFor="DataTableExample-2-SLDSDataTableHead-SelectAll"
-                      >
-                        <span
-                          className="slds-checkbox_faux"
-                        />
-                        <span
-                          className="slds-assistive-text"
-                        >
-                          all rows
-                        </span>
-                      </label>
+                      select this row
                     </span>
-                  </div>
-                </div>
+                  </label>
+                </span>
               </div>
-            </th>
-            <th
-              aria-label="Name"
-              aria-sort="ascending"
-              className="slds-is-sortable slds-is-sorted slds-text-title_caps"
-              scope="col"
-              style={
-                Object {
-                  "height": null,
-                  "lineHeight": null,
-                  "width": "10rem",
-                }
+            </div>
+          </td>
+          <th
+            className={null}
+            role="gridcell"
+            style={
+              Object {
+                "width": "10rem",
               }
+            }
+          >
+            <div
+              className="slds-truncate"
+              title="Acme - 1,200 Widgets"
             >
               <a
-                className="slds-th__action slds-text-link_reset"
-                href="javascript:void(0)"
+                href="javascript:void(0);"
                 onClick={[Function]}
-                role="button"
-                tabIndex="0"
               >
-                <span
-                  className="slds-assistive-text"
-                >
-                  sort this column
-                   
-                </span>
-                <span
-                  className="slds-truncate"
-                  title="Name"
-                >
-                  Name
-                </span>
-                <span>
-                  <svg
-                    aria-hidden="true"
-                    className="slds-is-sortable__icon slds-icon slds-icon_x-small slds-icon-text-default"
-                  >
-                    <use
-                      xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#arrowup"
-                    />
-                  </svg>
-                  
-                </span>
-                <span
-                  aria-atomic="true"
-                  aria-live="assertive"
-                  className="slds-assistive-text"
-                >
-                  asc
-                </span>
+                Acme - 1,200 Widgets
               </a>
-            </th>
-            <th
-              aria-label="Account Name"
-              aria-sort="none"
-              className="slds-text-title_caps"
-              scope="col"
-              style={
-                Object {
-                  "height": null,
-                  "lineHeight": null,
-                  "width": "8rem",
-                }
+            </div>
+          </th>
+          <td
+            className={null}
+            role="gridcell"
+            style={
+              Object {
+                "width": "8rem",
               }
+            }
+          >
+            <div
+              className="slds-truncate"
+              title="Acme"
             >
-              <span
-                className="slds-p-horizontal_x-small"
-                style={
-                  Object {
-                    "display": "flex",
-                  }
-                }
-              >
-                <span
-                  className="slds-truncate"
-                  title="Account Name"
-                >
-                  Account Name
-                </span>
-              </span>
-            </th>
-            <th
-              aria-label="Close Date"
-              aria-sort="none"
-              className="slds-is-sortable slds-is-sorted_desc slds-text-title_caps"
-              scope="col"
-              style={null}
+              Acme
+            </div>
+          </td>
+          <td
+            className={null}
+            role="gridcell"
+            style={null}
+          >
+            <div
+              className="slds-truncate"
+              title="4/10/15"
+            >
+              4/10/15
+            </div>
+          </td>
+          <td
+            className={null}
+            role="gridcell"
+            style={null}
+          >
+            <div
+              className="slds-truncate"
+              title="Value Proposition"
+            >
+              Value Proposition
+            </div>
+          </td>
+          <td
+            className={null}
+            role="gridcell"
+            style={null}
+          >
+            <div
+              className="slds-truncate"
+              title="70%"
+            >
+              70%
+            </div>
+          </td>
+          <td
+            className={null}
+            role="gridcell"
+            style={null}
+          >
+            <div
+              className="slds-truncate"
+              title="$25,000,000"
+            >
+              $25,000,000
+            </div>
+          </td>
+          <td
+            className={null}
+            role="gridcell"
+            style={null}
+          >
+            <div
+              className="slds-truncate"
+              title="jrogers@acme.com"
             >
               <a
-                className="slds-th__action slds-text-link_reset"
-                href="javascript:void(0)"
+                href="javascript:void(0);"
                 onClick={[Function]}
-                role="button"
-                tabIndex="0"
               >
-                <span
-                  className="slds-assistive-text"
-                >
-                  sort this column
-                   
-                </span>
-                <span
-                  className="slds-truncate"
-                  title="Close Date"
-                >
-                  Close Date
-                </span>
-                <span>
-                  <svg
-                    aria-hidden="true"
-                    className="slds-is-sortable__icon slds-icon slds-icon_x-small slds-icon-text-default"
-                  >
-                    <use
-                      xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#arrowdown"
-                    />
-                  </svg>
-                  
-                </span>
-                <span
-                  aria-atomic="true"
-                  aria-live="assertive"
-                  className="slds-assistive-text"
-                >
-                  desc
-                </span>
+                jrogers@acme.com
               </a>
-            </th>
-            <th
-              aria-label="Stage"
-              aria-sort="none"
-              className="slds-text-title_caps"
-              scope="col"
-              style={null}
+            </div>
+          </td>
+          <td
+            className=""
+            data-label="Actions"
+            onClick={[Function]}
+            style={
+              Object {
+                "width": "3.25rem",
+              }
+            }
+          >
+            <div
+              className="slds-dropdown-trigger slds-dropdown-trigger_click"
+              id="DataTableExample-2-SLDSDataTableRow-8IKZHZZV80-SLDSDataTableRowActions"
+              onClick={[Function]}
+              onFocus={null}
+              onKeyDown={[Function]}
+              onMouseEnter={null}
+              onMouseLeave={null}
             >
-              <span
-                className="slds-p-horizontal_x-small"
-                style={
-                  Object {
-                    "display": "flex",
-                  }
-                }
+              <button
+                aria-expanded={false}
+                aria-haspopup={true}
+                className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-2-SLDSDataTableRow-8IKZHZZV80-SLDSDataTableRowActions slds-button_icon-x-small"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex="0"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="slds-button__icon slds-button__icon_hint"
+                >
+                  <use
+                    xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
+                  />
+                </svg>
+                <span
+                  className="slds-assistive-text"
+                >
+                  Actions
+                </span>
+              </button>
+            </div>
+          </td>
+        </tr>
+        <tr
+          aria-selected="false"
+          className="slds-hint-parent"
+        >
+          <td
+            className="slds-text-align_right"
+            role="gridcell"
+            style={
+              Object {
+                "width": "3.25rem",
+              }
+            }
+          >
+            <div
+              className="slds-form-element"
+            >
+              <div
+                className="slds-form-element__control"
               >
                 <span
-                  className="slds-truncate"
-                  title="Stage"
+                  className="slds-checkbox"
                 >
-                  Stage
+                  <input
+                    checked={false}
+                    id="DataTableExample-2-SLDSDataTableRow-5GJOOOPWU7-SelectRow"
+                    name="SelectRow"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  <label
+                    className="slds-checkbox__label"
+                    htmlFor="DataTableExample-2-SLDSDataTableRow-5GJOOOPWU7-SelectRow"
+                  >
+                    <span
+                      className="slds-checkbox_faux"
+                    />
+                    <span
+                      className="slds-assistive-text"
+                    >
+                      select this row
+                    </span>
+                  </label>
                 </span>
-              </span>
-            </th>
-            <th
-              aria-label="Confidence"
-              aria-sort="none"
-              className="slds-is-sortable slds-text-title_caps"
-              scope="col"
-              style={null}
+              </div>
+            </div>
+          </td>
+          <th
+            className={null}
+            role="gridcell"
+            style={
+              Object {
+                "width": "10rem",
+              }
+            }
+          >
+            <div
+              className="slds-truncate"
+              title="Acme - 200 Widgets"
             >
               <a
-                className="slds-th__action slds-text-link_reset"
-                href="javascript:void(0)"
+                href="javascript:void(0);"
                 onClick={[Function]}
-                role="button"
-                tabIndex="0"
               >
-                <span
-                  className="slds-assistive-text"
-                >
-                  sort this column
-                   
-                </span>
-                <span
-                  className="slds-truncate"
-                  title="Confidence"
-                >
-                  Confidence
-                </span>
-                <span>
-                  <svg
-                    aria-hidden="true"
-                    className="slds-is-sortable__icon slds-icon slds-icon_x-small slds-icon-text-default"
-                  >
-                    <use
-                      xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#arrowup"
-                    />
-                  </svg>
-                  
-                </span>
+                Acme - 200 Widgets
               </a>
-            </th>
-            <th
-              aria-label="Amount"
-              aria-sort="none"
-              className="slds-text-title_caps"
-              scope="col"
-              style={null}
-            >
-              <span
-                className="slds-p-horizontal_x-small"
-                style={
-                  Object {
-                    "display": "flex",
-                  }
-                }
-              >
-                <span
-                  className="slds-truncate"
-                  title="Amount"
-                >
-                  Amount
-                </span>
-              </span>
-            </th>
-            <th
-              aria-label="Contact"
-              aria-sort="none"
-              className="slds-text-title_caps"
-              scope="col"
-              style={null}
-            >
-              <span
-                className="slds-p-horizontal_x-small"
-                style={
-                  Object {
-                    "display": "flex",
-                  }
-                }
-              >
-                <span
-                  className="slds-truncate"
-                  title="Contact"
-                >
-                  Contact
-                </span>
-              </span>
-            </th>
-            <th
-              scope="col"
-              style={
-                Object {
-                  "height": null,
-                  "lineHeight": null,
-                  "width": "3.25rem",
-                }
+            </div>
+          </th>
+          <td
+            className={null}
+            role="gridcell"
+            style={
+              Object {
+                "width": "8rem",
               }
+            }
+          >
+            <div
+              className="slds-truncate"
+              title="Acme"
             >
-              <div
-                className="slds-th__action"
-                style={null}
+              Acme
+            </div>
+          </td>
+          <td
+            className={null}
+            role="gridcell"
+            style={null}
+          >
+            <div
+              className="slds-truncate"
+              title="1/31/15"
+            >
+              1/31/15
+            </div>
+          </td>
+          <td
+            className={null}
+            role="gridcell"
+            style={null}
+          >
+            <div
+              className="slds-truncate"
+              title="Prospecting"
+            >
+              Prospecting
+            </div>
+          </td>
+          <td
+            className={null}
+            role="gridcell"
+            style={null}
+          >
+            <div
+              className="slds-truncate"
+              title="30%"
+            >
+              30%
+            </div>
+          </td>
+          <td
+            className={null}
+            role="gridcell"
+            style={null}
+          >
+            <div
+              className="slds-truncate"
+              title="$5,000,000"
+            >
+              $5,000,000
+            </div>
+          </td>
+          <td
+            className={null}
+            role="gridcell"
+            style={null}
+          >
+            <div
+              className="slds-truncate"
+              title="bob@acme.com"
+            >
+              <a
+                href="javascript:void(0);"
+                onClick={[Function]}
               >
+                bob@acme.com
+              </a>
+            </div>
+          </td>
+          <td
+            className=""
+            data-label="Actions"
+            onClick={[Function]}
+            style={
+              Object {
+                "width": "3.25rem",
+              }
+            }
+          >
+            <div
+              className="slds-dropdown-trigger slds-dropdown-trigger_click"
+              id="DataTableExample-2-SLDSDataTableRow-5GJOOOPWU7-SLDSDataTableRowActions"
+              onClick={[Function]}
+              onFocus={null}
+              onKeyDown={[Function]}
+              onMouseEnter={null}
+              onMouseLeave={null}
+            >
+              <button
+                aria-expanded={false}
+                aria-haspopup={true}
+                className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-2-SLDSDataTableRow-5GJOOOPWU7-SLDSDataTableRowActions slds-button_icon-x-small"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex="0"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="slds-button__icon slds-button__icon_hint"
+                >
+                  <use
+                    xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
+                  />
+                </svg>
                 <span
                   className="slds-assistive-text"
                 >
-                  actions
+                  Actions
+                </span>
+              </button>
+            </div>
+          </td>
+        </tr>
+        <tr
+          aria-selected="true"
+          className="slds-hint-parent slds-is-selected"
+        >
+          <td
+            className="slds-text-align_right"
+            role="gridcell"
+            style={
+              Object {
+                "width": "3.25rem",
+              }
+            }
+          >
+            <div
+              className="slds-form-element"
+            >
+              <div
+                className="slds-form-element__control"
+              >
+                <span
+                  className="slds-checkbox"
+                >
+                  <input
+                    checked={true}
+                    id="DataTableExample-2-SLDSDataTableRow-8IKZHZZV81-SelectRow"
+                    name="SelectRow"
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  <label
+                    className="slds-checkbox__label"
+                    htmlFor="DataTableExample-2-SLDSDataTableRow-8IKZHZZV81-SelectRow"
+                  >
+                    <span
+                      className="slds-checkbox_faux"
+                    />
+                    <span
+                      className="slds-assistive-text"
+                    >
+                      select this row
+                    </span>
+                  </label>
                 </span>
               </div>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr
-            aria-selected="false"
-            className="slds-hint-parent"
+            </div>
+          </td>
+          <th
+            className={null}
+            role="gridcell"
+            style={
+              Object {
+                "width": "10rem",
+              }
+            }
           >
-            <td
-              className="slds-text-align_right"
-              role="gridcell"
-              style={
-                Object {
-                  "width": "3.25rem",
-                }
-              }
+            <div
+              className="slds-truncate"
+              title="salesforce.com - 1,000 Widgets"
             >
-              <div
-                className="slds-form-element"
-              >
-                <div
-                  className="slds-form-element__control"
-                >
-                  <span
-                    className="slds-checkbox"
-                  >
-                    <input
-                      checked={false}
-                      id="DataTableExample-2-SLDSDataTableRow-8IKZHZZV80-SelectRow"
-                      name="SelectRow"
-                      onChange={[Function]}
-                      type="checkbox"
-                    />
-                    <label
-                      className="slds-checkbox__label"
-                      htmlFor="DataTableExample-2-SLDSDataTableRow-8IKZHZZV80-SelectRow"
-                    >
-                      <span
-                        className="slds-checkbox_faux"
-                      />
-                      <span
-                        className="slds-assistive-text"
-                      >
-                        select this row
-                      </span>
-                    </label>
-                  </span>
-                </div>
-              </div>
-            </td>
-            <th
-              className={null}
-              role="gridcell"
-              style={
-                Object {
-                  "width": "10rem",
-                }
-              }
-            >
-              <div
-                className="slds-truncate"
-                title="Acme - 1,200 Widgets"
-              >
-                <a
-                  href="javascript:void(0);"
-                  onClick={[Function]}
-                >
-                  Acme - 1,200 Widgets
-                </a>
-              </div>
-            </th>
-            <td
-              className={null}
-              role="gridcell"
-              style={
-                Object {
-                  "width": "8rem",
-                }
-              }
-            >
-              <div
-                className="slds-truncate"
-                title="Acme"
-              >
-                Acme
-              </div>
-            </td>
-            <td
-              className={null}
-              role="gridcell"
-              style={null}
-            >
-              <div
-                className="slds-truncate"
-                title="4/10/15"
-              >
-                4/10/15
-              </div>
-            </td>
-            <td
-              className={null}
-              role="gridcell"
-              style={null}
-            >
-              <div
-                className="slds-truncate"
-                title="Value Proposition"
-              >
-                Value Proposition
-              </div>
-            </td>
-            <td
-              className={null}
-              role="gridcell"
-              style={null}
-            >
-              <div
-                className="slds-truncate"
-                title="70%"
-              >
-                70%
-              </div>
-            </td>
-            <td
-              className={null}
-              role="gridcell"
-              style={null}
-            >
-              <div
-                className="slds-truncate"
-                title="$25,000,000"
-              >
-                $25,000,000
-              </div>
-            </td>
-            <td
-              className={null}
-              role="gridcell"
-              style={null}
-            >
-              <div
-                className="slds-truncate"
-                title="jrogers@acme.com"
-              >
-                <a
-                  href="javascript:void(0);"
-                  onClick={[Function]}
-                >
-                  jrogers@acme.com
-                </a>
-              </div>
-            </td>
-            <td
-              className=""
-              data-label="Actions"
-              onClick={[Function]}
-              style={
-                Object {
-                  "width": "3.25rem",
-                }
-              }
-            >
-              <div
-                className="slds-dropdown-trigger slds-dropdown-trigger_click"
-                id="DataTableExample-2-SLDSDataTableRow-8IKZHZZV80-SLDSDataTableRowActions"
+              <a
+                href="javascript:void(0);"
                 onClick={[Function]}
-                onFocus={null}
-                onKeyDown={[Function]}
-                onMouseEnter={null}
-                onMouseLeave={null}
               >
-                <button
-                  aria-expanded={false}
-                  aria-haspopup={true}
-                  className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-2-SLDSDataTableRow-8IKZHZZV80-SLDSDataTableRowActions slds-button_icon-x-small"
-                  disabled={false}
-                  onClick={[Function]}
-                  tabIndex="0"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    className="slds-button__icon slds-button__icon_hint"
-                  >
-                    <use
-                      xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
-                    />
-                  </svg>
-                  <span
-                    className="slds-assistive-text"
-                  >
-                    Actions
-                  </span>
-                </button>
-              </div>
-            </td>
-          </tr>
-          <tr
-            aria-selected="false"
-            className="slds-hint-parent"
+                salesforce.com - 1,000 Widgets
+              </a>
+            </div>
+          </th>
+          <td
+            className={null}
+            role="gridcell"
+            style={
+              Object {
+                "width": "8rem",
+              }
+            }
           >
-            <td
-              className="slds-text-align_right"
-              role="gridcell"
-              style={
-                Object {
-                  "width": "3.25rem",
-                }
-              }
+            <div
+              className="slds-truncate"
+              title="salesforce.com"
             >
-              <div
-                className="slds-form-element"
-              >
-                <div
-                  className="slds-form-element__control"
-                >
-                  <span
-                    className="slds-checkbox"
-                  >
-                    <input
-                      checked={false}
-                      id="DataTableExample-2-SLDSDataTableRow-5GJOOOPWU7-SelectRow"
-                      name="SelectRow"
-                      onChange={[Function]}
-                      type="checkbox"
-                    />
-                    <label
-                      className="slds-checkbox__label"
-                      htmlFor="DataTableExample-2-SLDSDataTableRow-5GJOOOPWU7-SelectRow"
-                    >
-                      <span
-                        className="slds-checkbox_faux"
-                      />
-                      <span
-                        className="slds-assistive-text"
-                      >
-                        select this row
-                      </span>
-                    </label>
-                  </span>
-                </div>
-              </div>
-            </td>
-            <th
-              className={null}
-              role="gridcell"
-              style={
-                Object {
-                  "width": "10rem",
-                }
-              }
-            >
-              <div
-                className="slds-truncate"
-                title="Acme - 200 Widgets"
-              >
-                <a
-                  href="javascript:void(0);"
-                  onClick={[Function]}
-                >
-                  Acme - 200 Widgets
-                </a>
-              </div>
-            </th>
-            <td
-              className={null}
-              role="gridcell"
-              style={
-                Object {
-                  "width": "8rem",
-                }
-              }
-            >
-              <div
-                className="slds-truncate"
-                title="Acme"
-              >
-                Acme
-              </div>
-            </td>
-            <td
-              className={null}
-              role="gridcell"
-              style={null}
-            >
-              <div
-                className="slds-truncate"
-                title="1/31/15"
-              >
-                1/31/15
-              </div>
-            </td>
-            <td
-              className={null}
-              role="gridcell"
-              style={null}
-            >
-              <div
-                className="slds-truncate"
-                title="Prospecting"
-              >
-                Prospecting
-              </div>
-            </td>
-            <td
-              className={null}
-              role="gridcell"
-              style={null}
-            >
-              <div
-                className="slds-truncate"
-                title="30%"
-              >
-                30%
-              </div>
-            </td>
-            <td
-              className={null}
-              role="gridcell"
-              style={null}
-            >
-              <div
-                className="slds-truncate"
-                title="$5,000,000"
-              >
-                $5,000,000
-              </div>
-            </td>
-            <td
-              className={null}
-              role="gridcell"
-              style={null}
-            >
-              <div
-                className="slds-truncate"
-                title="bob@acme.com"
-              >
-                <a
-                  href="javascript:void(0);"
-                  onClick={[Function]}
-                >
-                  bob@acme.com
-                </a>
-              </div>
-            </td>
-            <td
-              className=""
-              data-label="Actions"
-              onClick={[Function]}
-              style={
-                Object {
-                  "width": "3.25rem",
-                }
-              }
-            >
-              <div
-                className="slds-dropdown-trigger slds-dropdown-trigger_click"
-                id="DataTableExample-2-SLDSDataTableRow-5GJOOOPWU7-SLDSDataTableRowActions"
-                onClick={[Function]}
-                onFocus={null}
-                onKeyDown={[Function]}
-                onMouseEnter={null}
-                onMouseLeave={null}
-              >
-                <button
-                  aria-expanded={false}
-                  aria-haspopup={true}
-                  className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-2-SLDSDataTableRow-5GJOOOPWU7-SLDSDataTableRowActions slds-button_icon-x-small"
-                  disabled={false}
-                  onClick={[Function]}
-                  tabIndex="0"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    className="slds-button__icon slds-button__icon_hint"
-                  >
-                    <use
-                      xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
-                    />
-                  </svg>
-                  <span
-                    className="slds-assistive-text"
-                  >
-                    Actions
-                  </span>
-                </button>
-              </div>
-            </td>
-          </tr>
-          <tr
-            aria-selected="true"
-            className="slds-hint-parent slds-is-selected"
+              salesforce.com
+            </div>
+          </td>
+          <td
+            className={null}
+            role="gridcell"
+            style={null}
           >
-            <td
-              className="slds-text-align_right"
-              role="gridcell"
-              style={
-                Object {
-                  "width": "3.25rem",
-                }
-              }
+            <div
+              className="slds-truncate"
+              title="1/31/15 3:45PM"
             >
-              <div
-                className="slds-form-element"
-              >
-                <div
-                  className="slds-form-element__control"
-                >
-                  <span
-                    className="slds-checkbox"
-                  >
-                    <input
-                      checked={true}
-                      id="DataTableExample-2-SLDSDataTableRow-8IKZHZZV81-SelectRow"
-                      name="SelectRow"
-                      onChange={[Function]}
-                      type="checkbox"
-                    />
-                    <label
-                      className="slds-checkbox__label"
-                      htmlFor="DataTableExample-2-SLDSDataTableRow-8IKZHZZV81-SelectRow"
-                    >
-                      <span
-                        className="slds-checkbox_faux"
-                      />
-                      <span
-                        className="slds-assistive-text"
-                      >
-                        select this row
-                      </span>
-                    </label>
-                  </span>
-                </div>
-              </div>
-            </td>
-            <th
-              className={null}
-              role="gridcell"
-              style={
-                Object {
-                  "width": "10rem",
-                }
-              }
+              1/31/15 3:45PM
+            </div>
+          </td>
+          <td
+            className={null}
+            role="gridcell"
+            style={null}
+          >
+            <div
+              className="slds-truncate"
+              title="Id. Decision Makers"
             >
-              <div
-                className="slds-truncate"
-                title="salesforce.com - 1,000 Widgets"
-              >
-                <a
-                  href="javascript:void(0);"
-                  onClick={[Function]}
-                >
-                  salesforce.com - 1,000 Widgets
-                </a>
-              </div>
-            </th>
-            <td
-              className={null}
-              role="gridcell"
-              style={
-                Object {
-                  "width": "8rem",
-                }
-              }
+              Id. Decision Makers
+            </div>
+          </td>
+          <td
+            className={null}
+            role="gridcell"
+            style={null}
+          >
+            <div
+              className="slds-truncate"
+              title="60%"
             >
-              <div
-                className="slds-truncate"
-                title="salesforce.com"
-              >
-                salesforce.com
-              </div>
-            </td>
-            <td
-              className={null}
-              role="gridcell"
-              style={null}
+              60%
+            </div>
+          </td>
+          <td
+            className={null}
+            role="gridcell"
+            style={null}
+          >
+            <div
+              className="slds-truncate"
+              title="$25,000"
             >
-              <div
-                className="slds-truncate"
-                title="1/31/15 3:45PM"
-              >
-                1/31/15 3:45PM
-              </div>
-            </td>
-            <td
-              className={null}
-              role="gridcell"
-              style={null}
+              $25,000
+            </div>
+          </td>
+          <td
+            className={null}
+            role="gridcell"
+            style={null}
+          >
+            <div
+              className="slds-truncate"
+              title="nathan@salesforce.com"
             >
-              <div
-                className="slds-truncate"
-                title="Id. Decision Makers"
-              >
-                Id. Decision Makers
-              </div>
-            </td>
-            <td
-              className={null}
-              role="gridcell"
-              style={null}
-            >
-              <div
-                className="slds-truncate"
-                title="60%"
-              >
-                60%
-              </div>
-            </td>
-            <td
-              className={null}
-              role="gridcell"
-              style={null}
-            >
-              <div
-                className="slds-truncate"
-                title="$25,000"
-              >
-                $25,000
-              </div>
-            </td>
-            <td
-              className={null}
-              role="gridcell"
-              style={null}
-            >
-              <div
-                className="slds-truncate"
-                title="nathan@salesforce.com"
-              >
-                <a
-                  href="javascript:void(0);"
-                  onClick={[Function]}
-                >
-                  nathan@salesforce.com
-                </a>
-              </div>
-            </td>
-            <td
-              className=""
-              data-label="Actions"
-              onClick={[Function]}
-              style={
-                Object {
-                  "width": "3.25rem",
-                }
-              }
-            >
-              <div
-                className="slds-dropdown-trigger slds-dropdown-trigger_click"
-                id="DataTableExample-2-SLDSDataTableRow-8IKZHZZV81-SLDSDataTableRowActions"
+              <a
+                href="javascript:void(0);"
                 onClick={[Function]}
-                onFocus={null}
-                onKeyDown={[Function]}
-                onMouseEnter={null}
-                onMouseLeave={null}
               >
-                <button
-                  aria-expanded={false}
-                  aria-haspopup={true}
-                  className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-2-SLDSDataTableRow-8IKZHZZV81-SLDSDataTableRowActions slds-button_icon-x-small"
-                  disabled={false}
-                  onClick={[Function]}
-                  tabIndex="0"
-                  type="button"
+                nathan@salesforce.com
+              </a>
+            </div>
+          </td>
+          <td
+            className=""
+            data-label="Actions"
+            onClick={[Function]}
+            style={
+              Object {
+                "width": "3.25rem",
+              }
+            }
+          >
+            <div
+              className="slds-dropdown-trigger slds-dropdown-trigger_click"
+              id="DataTableExample-2-SLDSDataTableRow-8IKZHZZV81-SLDSDataTableRowActions"
+              onClick={[Function]}
+              onFocus={null}
+              onKeyDown={[Function]}
+              onMouseEnter={null}
+              onMouseLeave={null}
+            >
+              <button
+                aria-expanded={false}
+                aria-haspopup={true}
+                className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-2-SLDSDataTableRow-8IKZHZZV81-SLDSDataTableRowActions slds-button_icon-x-small"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex="0"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="slds-button__icon slds-button__icon_hint"
                 >
-                  <svg
-                    aria-hidden="true"
-                    className="slds-button__icon slds-button__icon_hint"
-                  >
-                    <use
-                      xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
-                    />
-                  </svg>
-                  <span
-                    className="slds-assistive-text"
-                  >
-                    Actions
-                  </span>
-                </button>
-              </div>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+                  <use
+                    xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
+                  />
+                </svg>
+                <span
+                  className="slds-assistive-text"
+                >
+                  Actions
+                </span>
+              </button>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </div>
 `;
@@ -15308,838 +15300,830 @@ exports[`DOM snapshots SLDSDataTable Advanced Single Select (Fixed Layout) 1`] =
   className="slds-p-around_medium"
 >
   <div>
-    <div
-      style={
-        Object {
-          "overflow": "auto",
-        }
-      }
+    <h3
+      className="slds-text-heading_medium slds-m-vertical_medium"
     >
-      <h3
-        className="slds-text-heading_medium slds-m-vertical_medium"
-      >
-        Advanced Single Select (Fixed Layout)
-      </h3>
-      <table
-        className="slds-table slds-table_fixed-layout slds-table_resizable-cols slds-table_bordered"
-        id="DataTableExample-SingleRequiredSelect"
-        role="grid"
-      >
-        <thead>
-          <tr
-            className="slds-line-height_reset"
-          >
-            <th
-              className="slds-text-align_right"
-              scope="col"
-              style={
-                Object {
-                  "height": null,
-                  "lineHeight": null,
-                  "width": "3.25rem",
-                }
+      Advanced Single Select (Fixed Layout)
+    </h3>
+    <table
+      className="slds-table slds-table_fixed-layout slds-table_resizable-cols slds-table_bordered"
+      id="DataTableExample-SingleRequiredSelect"
+      role="grid"
+    >
+      <thead>
+        <tr
+          className="slds-line-height_reset"
+        >
+          <th
+            className="slds-text-align_right"
+            scope="col"
+            style={
+              Object {
+                "height": null,
+                "lineHeight": null,
+                "width": "3.25rem",
               }
-            />
-            <th
-              aria-label="Name"
-              aria-sort="ascending"
-              className="slds-is-sortable slds-is-sorted slds-text-title_caps"
-              scope="col"
+            }
+          />
+          <th
+            aria-label="Name"
+            aria-sort="ascending"
+            className="slds-is-sortable slds-is-sorted slds-text-title_caps"
+            scope="col"
+            style={
+              Object {
+                "height": null,
+                "lineHeight": null,
+                "width": "10rem",
+              }
+            }
+          >
+            <a
+              className="slds-th__action slds-text-link_reset"
+              href="javascript:void(0)"
+              onClick={[Function]}
+              role="button"
+              tabIndex="0"
+            >
+              <span
+                className="slds-assistive-text"
+              >
+                sort this column
+                 
+              </span>
+              <span
+                className="slds-truncate"
+                title="Name"
+              >
+                Name
+              </span>
+              <span>
+                <svg
+                  aria-hidden="true"
+                  className="slds-is-sortable__icon slds-icon slds-icon_x-small slds-icon-text-default"
+                >
+                  <use
+                    xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#arrowup"
+                  />
+                </svg>
+                
+              </span>
+              <span
+                aria-atomic="true"
+                aria-live="assertive"
+                className="slds-assistive-text"
+              >
+                asc
+              </span>
+            </a>
+          </th>
+          <th
+            aria-label="Account Name"
+            aria-sort="none"
+            className="slds-text-title_caps"
+            scope="col"
+            style={
+              Object {
+                "height": null,
+                "lineHeight": null,
+                "width": "8rem",
+              }
+            }
+          >
+            <span
+              className="slds-p-horizontal_x-small"
               style={
                 Object {
-                  "height": null,
-                  "lineHeight": null,
-                  "width": "10rem",
+                  "display": "flex",
                 }
               }
             >
-              <a
-                className="slds-th__action slds-text-link_reset"
-                href="javascript:void(0)"
+              <span
+                className="slds-truncate"
+                title="Account Name"
+              >
+                Account Name
+              </span>
+            </span>
+          </th>
+          <th
+            aria-label="Close Date"
+            aria-sort="none"
+            className="slds-text-title_caps"
+            scope="col"
+            style={null}
+          >
+            <span
+              className="slds-p-horizontal_x-small"
+              style={
+                Object {
+                  "display": "flex",
+                }
+              }
+            >
+              <span
+                className="slds-truncate"
+                title="Close Date"
+              >
+                Close Date
+              </span>
+            </span>
+          </th>
+          <th
+            aria-label="Stage"
+            aria-sort="none"
+            className="slds-text-title_caps"
+            scope="col"
+            style={null}
+          >
+            <span
+              className="slds-p-horizontal_x-small"
+              style={
+                Object {
+                  "display": "flex",
+                }
+              }
+            >
+              <span
+                className="slds-truncate"
+                title="Stage"
+              >
+                Stage
+              </span>
+            </span>
+          </th>
+          <th
+            aria-label="Confidence"
+            aria-sort="none"
+            className="slds-is-sortable slds-text-title_caps"
+            scope="col"
+            style={null}
+          >
+            <a
+              className="slds-th__action slds-text-link_reset"
+              href="javascript:void(0)"
+              onClick={[Function]}
+              role="button"
+              tabIndex="0"
+            >
+              <span
+                className="slds-assistive-text"
+              >
+                sort this column
+                 
+              </span>
+              <span
+                className="slds-truncate"
+                title="Confidence"
+              >
+                Confidence
+              </span>
+              <span>
+                <svg
+                  aria-hidden="true"
+                  className="slds-is-sortable__icon slds-icon slds-icon_x-small slds-icon-text-default"
+                >
+                  <use
+                    xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#arrowup"
+                  />
+                </svg>
+                
+              </span>
+            </a>
+          </th>
+          <th
+            aria-label="Amount"
+            aria-sort="none"
+            className="slds-text-title_caps"
+            scope="col"
+            style={null}
+          >
+            <span
+              className="slds-p-horizontal_x-small"
+              style={
+                Object {
+                  "display": "flex",
+                }
+              }
+            >
+              <span
+                className="slds-truncate"
+                title="Amount"
+              >
+                Amount
+              </span>
+            </span>
+          </th>
+          <th
+            aria-label="Contact"
+            aria-sort="none"
+            className="slds-text-title_caps"
+            scope="col"
+            style={null}
+          >
+            <span
+              className="slds-p-horizontal_x-small"
+              style={
+                Object {
+                  "display": "flex",
+                }
+              }
+            >
+              <span
+                className="slds-truncate"
+                title="Contact"
+              >
+                Contact
+              </span>
+            </span>
+          </th>
+          <th
+            scope="col"
+            style={
+              Object {
+                "height": null,
+                "lineHeight": null,
+                "width": "3.25rem",
+              }
+            }
+          >
+            <div
+              className="slds-th__action"
+              style={null}
+            >
+              <span
+                className="slds-assistive-text"
+              >
+                actions
+              </span>
+            </div>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          aria-selected="false"
+          className="slds-hint-parent"
+        >
+          <td
+            className="slds-text-align_right"
+            role="gridcell"
+            style={
+              Object {
+                "width": "3.25rem",
+              }
+            }
+          >
+            <span
+              className="slds-radio slds-m-right_x-small"
+            >
+              <input
+                checked={false}
+                id="DataTableExample-SingleRequiredSelect-SLDSDataTableRow-8IKZHZZV80-SelectRow"
+                name="DataTableExample-SingleRequiredSelect-SelectRow"
+                onChange={[Function]}
                 onClick={[Function]}
-                role="button"
-                tabIndex="0"
+                onKeyPress={[Function]}
+                type="radio"
+              />
+              <label
+                className="slds-radio__label"
+                htmlFor="DataTableExample-SingleRequiredSelect-SLDSDataTableRow-8IKZHZZV80-SelectRow"
               >
                 <span
-                  className="slds-assistive-text"
-                >
-                  sort this column
-                   
-                </span>
+                  className="slds-radio_faux"
+                />
                 <span
-                  className="slds-truncate"
-                  title="Name"
+                  className="slds-form-element__label"
                 >
-                  Name
-                </span>
-                <span>
-                  <svg
-                    aria-hidden="true"
-                    className="slds-is-sortable__icon slds-icon slds-icon_x-small slds-icon-text-default"
-                  >
-                    <use
-                      xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#arrowup"
-                    />
-                  </svg>
                   
                 </span>
-                <span
-                  aria-atomic="true"
-                  aria-live="assertive"
-                  className="slds-assistive-text"
-                >
-                  asc
-                </span>
-              </a>
-            </th>
-            <th
-              aria-label="Account Name"
-              aria-sort="none"
-              className="slds-text-title_caps"
-              scope="col"
-              style={
-                Object {
-                  "height": null,
-                  "lineHeight": null,
-                  "width": "8rem",
-                }
+              </label>
+            </span>
+          </td>
+          <th
+            className={null}
+            role="gridcell"
+            style={
+              Object {
+                "width": "10rem",
               }
-            >
-              <span
-                className="slds-p-horizontal_x-small"
-                style={
-                  Object {
-                    "display": "flex",
-                  }
-                }
-              >
-                <span
-                  className="slds-truncate"
-                  title="Account Name"
-                >
-                  Account Name
-                </span>
-              </span>
-            </th>
-            <th
-              aria-label="Close Date"
-              aria-sort="none"
-              className="slds-text-title_caps"
-              scope="col"
-              style={null}
-            >
-              <span
-                className="slds-p-horizontal_x-small"
-                style={
-                  Object {
-                    "display": "flex",
-                  }
-                }
-              >
-                <span
-                  className="slds-truncate"
-                  title="Close Date"
-                >
-                  Close Date
-                </span>
-              </span>
-            </th>
-            <th
-              aria-label="Stage"
-              aria-sort="none"
-              className="slds-text-title_caps"
-              scope="col"
-              style={null}
-            >
-              <span
-                className="slds-p-horizontal_x-small"
-                style={
-                  Object {
-                    "display": "flex",
-                  }
-                }
-              >
-                <span
-                  className="slds-truncate"
-                  title="Stage"
-                >
-                  Stage
-                </span>
-              </span>
-            </th>
-            <th
-              aria-label="Confidence"
-              aria-sort="none"
-              className="slds-is-sortable slds-text-title_caps"
-              scope="col"
-              style={null}
+            }
+          >
+            <div
+              className="slds-truncate"
+              title="Acme - 1,200 Widgets"
             >
               <a
-                className="slds-th__action slds-text-link_reset"
-                href="javascript:void(0)"
+                href="javascript:void(0);"
                 onClick={[Function]}
-                role="button"
-                tabIndex="0"
               >
+                Acme - 1,200 Widgets
+              </a>
+            </div>
+          </th>
+          <td
+            className={null}
+            role="gridcell"
+            style={
+              Object {
+                "width": "8rem",
+              }
+            }
+          >
+            <div
+              className="slds-truncate"
+              title="Acme"
+            >
+              Acme
+            </div>
+          </td>
+          <td
+            className={null}
+            role="gridcell"
+            style={null}
+          >
+            <div
+              className="slds-truncate"
+              title="4/10/15"
+            >
+              4/10/15
+            </div>
+          </td>
+          <td
+            className={null}
+            role="gridcell"
+            style={null}
+          >
+            <div
+              className="slds-truncate"
+              title="Value Proposition"
+            >
+              Value Proposition
+            </div>
+          </td>
+          <td
+            className={null}
+            role="gridcell"
+            style={null}
+          >
+            <div
+              className="slds-truncate"
+              title="70%"
+            >
+              70%
+            </div>
+          </td>
+          <td
+            className={null}
+            role="gridcell"
+            style={null}
+          >
+            <div
+              className="slds-truncate"
+              title="$25,000,000"
+            >
+              $25,000,000
+            </div>
+          </td>
+          <td
+            className={null}
+            role="gridcell"
+            style={null}
+          >
+            <div
+              className="slds-truncate"
+              title="jrogers@acme.com"
+            >
+              <a
+                href="javascript:void(0);"
+                onClick={[Function]}
+              >
+                jrogers@acme.com
+              </a>
+            </div>
+          </td>
+          <td
+            className=""
+            data-label="Actions"
+            onClick={[Function]}
+            style={
+              Object {
+                "width": "3.25rem",
+              }
+            }
+          >
+            <div
+              className="slds-dropdown-trigger slds-dropdown-trigger_click"
+              id="DataTableExample-SingleRequiredSelect-SLDSDataTableRow-8IKZHZZV80-SLDSDataTableRowActions"
+              onClick={[Function]}
+              onFocus={null}
+              onKeyDown={[Function]}
+              onMouseEnter={null}
+              onMouseLeave={null}
+            >
+              <button
+                aria-expanded={false}
+                aria-haspopup={true}
+                className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-SingleRequiredSelect-SLDSDataTableRow-8IKZHZZV80-SLDSDataTableRowActions slds-button_icon-x-small"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex="0"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="slds-button__icon slds-button__icon_hint"
+                >
+                  <use
+                    xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
+                  />
+                </svg>
                 <span
                   className="slds-assistive-text"
                 >
-                  sort this column
-                   
+                  Actions
                 </span>
+              </button>
+            </div>
+          </td>
+        </tr>
+        <tr
+          aria-selected="false"
+          className="slds-hint-parent"
+        >
+          <td
+            className="slds-text-align_right"
+            role="gridcell"
+            style={
+              Object {
+                "width": "3.25rem",
+              }
+            }
+          >
+            <span
+              className="slds-radio slds-m-right_x-small"
+            >
+              <input
+                checked={false}
+                id="DataTableExample-SingleRequiredSelect-SLDSDataTableRow-5GJOOOPWU7-SelectRow"
+                name="DataTableExample-SingleRequiredSelect-SelectRow"
+                onChange={[Function]}
+                onClick={[Function]}
+                onKeyPress={[Function]}
+                type="radio"
+              />
+              <label
+                className="slds-radio__label"
+                htmlFor="DataTableExample-SingleRequiredSelect-SLDSDataTableRow-5GJOOOPWU7-SelectRow"
+              >
                 <span
-                  className="slds-truncate"
-                  title="Confidence"
+                  className="slds-radio_faux"
+                />
+                <span
+                  className="slds-form-element__label"
                 >
-                  Confidence
-                </span>
-                <span>
-                  <svg
-                    aria-hidden="true"
-                    className="slds-is-sortable__icon slds-icon slds-icon_x-small slds-icon-text-default"
-                  >
-                    <use
-                      xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#arrowup"
-                    />
-                  </svg>
                   
                 </span>
-              </a>
-            </th>
-            <th
-              aria-label="Amount"
-              aria-sort="none"
-              className="slds-text-title_caps"
-              scope="col"
-              style={null}
-            >
-              <span
-                className="slds-p-horizontal_x-small"
-                style={
-                  Object {
-                    "display": "flex",
-                  }
-                }
-              >
-                <span
-                  className="slds-truncate"
-                  title="Amount"
-                >
-                  Amount
-                </span>
-              </span>
-            </th>
-            <th
-              aria-label="Contact"
-              aria-sort="none"
-              className="slds-text-title_caps"
-              scope="col"
-              style={null}
-            >
-              <span
-                className="slds-p-horizontal_x-small"
-                style={
-                  Object {
-                    "display": "flex",
-                  }
-                }
-              >
-                <span
-                  className="slds-truncate"
-                  title="Contact"
-                >
-                  Contact
-                </span>
-              </span>
-            </th>
-            <th
-              scope="col"
-              style={
-                Object {
-                  "height": null,
-                  "lineHeight": null,
-                  "width": "3.25rem",
-                }
+              </label>
+            </span>
+          </td>
+          <th
+            className={null}
+            role="gridcell"
+            style={
+              Object {
+                "width": "10rem",
               }
+            }
+          >
+            <div
+              className="slds-truncate"
+              title="Acme - 200 Widgets"
             >
-              <div
-                className="slds-th__action"
-                style={null}
+              <a
+                href="javascript:void(0);"
+                onClick={[Function]}
               >
+                Acme - 200 Widgets
+              </a>
+            </div>
+          </th>
+          <td
+            className={null}
+            role="gridcell"
+            style={
+              Object {
+                "width": "8rem",
+              }
+            }
+          >
+            <div
+              className="slds-truncate"
+              title="Acme"
+            >
+              Acme
+            </div>
+          </td>
+          <td
+            className={null}
+            role="gridcell"
+            style={null}
+          >
+            <div
+              className="slds-truncate"
+              title="1/31/15"
+            >
+              1/31/15
+            </div>
+          </td>
+          <td
+            className={null}
+            role="gridcell"
+            style={null}
+          >
+            <div
+              className="slds-truncate"
+              title="Prospecting"
+            >
+              Prospecting
+            </div>
+          </td>
+          <td
+            className={null}
+            role="gridcell"
+            style={null}
+          >
+            <div
+              className="slds-truncate"
+              title="30%"
+            >
+              30%
+            </div>
+          </td>
+          <td
+            className={null}
+            role="gridcell"
+            style={null}
+          >
+            <div
+              className="slds-truncate"
+              title="$5,000,000"
+            >
+              $5,000,000
+            </div>
+          </td>
+          <td
+            className={null}
+            role="gridcell"
+            style={null}
+          >
+            <div
+              className="slds-truncate"
+              title="bob@acme.com"
+            >
+              <a
+                href="javascript:void(0);"
+                onClick={[Function]}
+              >
+                bob@acme.com
+              </a>
+            </div>
+          </td>
+          <td
+            className=""
+            data-label="Actions"
+            onClick={[Function]}
+            style={
+              Object {
+                "width": "3.25rem",
+              }
+            }
+          >
+            <div
+              className="slds-dropdown-trigger slds-dropdown-trigger_click"
+              id="DataTableExample-SingleRequiredSelect-SLDSDataTableRow-5GJOOOPWU7-SLDSDataTableRowActions"
+              onClick={[Function]}
+              onFocus={null}
+              onKeyDown={[Function]}
+              onMouseEnter={null}
+              onMouseLeave={null}
+            >
+              <button
+                aria-expanded={false}
+                aria-haspopup={true}
+                className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-SingleRequiredSelect-SLDSDataTableRow-5GJOOOPWU7-SLDSDataTableRowActions slds-button_icon-x-small"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex="0"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="slds-button__icon slds-button__icon_hint"
+                >
+                  <use
+                    xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
+                  />
+                </svg>
                 <span
                   className="slds-assistive-text"
                 >
-                  actions
+                  Actions
                 </span>
-              </div>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr
-            aria-selected="false"
-            className="slds-hint-parent"
+              </button>
+            </div>
+          </td>
+        </tr>
+        <tr
+          aria-selected="false"
+          className="slds-hint-parent"
+        >
+          <td
+            className="slds-text-align_right"
+            role="gridcell"
+            style={
+              Object {
+                "width": "3.25rem",
+              }
+            }
           >
-            <td
-              className="slds-text-align_right"
-              role="gridcell"
-              style={
-                Object {
-                  "width": "3.25rem",
-                }
-              }
+            <span
+              className="slds-radio slds-m-right_x-small"
             >
-              <span
-                className="slds-radio slds-m-right_x-small"
-              >
-                <input
-                  checked={false}
-                  id="DataTableExample-SingleRequiredSelect-SLDSDataTableRow-8IKZHZZV80-SelectRow"
-                  name="DataTableExample-SingleRequiredSelect-SelectRow"
-                  onChange={[Function]}
-                  onClick={[Function]}
-                  onKeyPress={[Function]}
-                  type="radio"
-                />
-                <label
-                  className="slds-radio__label"
-                  htmlFor="DataTableExample-SingleRequiredSelect-SLDSDataTableRow-8IKZHZZV80-SelectRow"
-                >
-                  <span
-                    className="slds-radio_faux"
-                  />
-                  <span
-                    className="slds-form-element__label"
-                  >
-                    
-                  </span>
-                </label>
-              </span>
-            </td>
-            <th
-              className={null}
-              role="gridcell"
-              style={
-                Object {
-                  "width": "10rem",
-                }
-              }
-            >
-              <div
-                className="slds-truncate"
-                title="Acme - 1,200 Widgets"
-              >
-                <a
-                  href="javascript:void(0);"
-                  onClick={[Function]}
-                >
-                  Acme - 1,200 Widgets
-                </a>
-              </div>
-            </th>
-            <td
-              className={null}
-              role="gridcell"
-              style={
-                Object {
-                  "width": "8rem",
-                }
-              }
-            >
-              <div
-                className="slds-truncate"
-                title="Acme"
-              >
-                Acme
-              </div>
-            </td>
-            <td
-              className={null}
-              role="gridcell"
-              style={null}
-            >
-              <div
-                className="slds-truncate"
-                title="4/10/15"
-              >
-                4/10/15
-              </div>
-            </td>
-            <td
-              className={null}
-              role="gridcell"
-              style={null}
-            >
-              <div
-                className="slds-truncate"
-                title="Value Proposition"
-              >
-                Value Proposition
-              </div>
-            </td>
-            <td
-              className={null}
-              role="gridcell"
-              style={null}
-            >
-              <div
-                className="slds-truncate"
-                title="70%"
-              >
-                70%
-              </div>
-            </td>
-            <td
-              className={null}
-              role="gridcell"
-              style={null}
-            >
-              <div
-                className="slds-truncate"
-                title="$25,000,000"
-              >
-                $25,000,000
-              </div>
-            </td>
-            <td
-              className={null}
-              role="gridcell"
-              style={null}
-            >
-              <div
-                className="slds-truncate"
-                title="jrogers@acme.com"
-              >
-                <a
-                  href="javascript:void(0);"
-                  onClick={[Function]}
-                >
-                  jrogers@acme.com
-                </a>
-              </div>
-            </td>
-            <td
-              className=""
-              data-label="Actions"
-              onClick={[Function]}
-              style={
-                Object {
-                  "width": "3.25rem",
-                }
-              }
-            >
-              <div
-                className="slds-dropdown-trigger slds-dropdown-trigger_click"
-                id="DataTableExample-SingleRequiredSelect-SLDSDataTableRow-8IKZHZZV80-SLDSDataTableRowActions"
+              <input
+                checked={false}
+                id="DataTableExample-SingleRequiredSelect-SLDSDataTableRow-8IKZHZZV81-SelectRow"
+                name="DataTableExample-SingleRequiredSelect-SelectRow"
+                onChange={[Function]}
                 onClick={[Function]}
-                onFocus={null}
-                onKeyDown={[Function]}
-                onMouseEnter={null}
-                onMouseLeave={null}
+                onKeyPress={[Function]}
+                type="radio"
+              />
+              <label
+                className="slds-radio__label"
+                htmlFor="DataTableExample-SingleRequiredSelect-SLDSDataTableRow-8IKZHZZV81-SelectRow"
               >
-                <button
-                  aria-expanded={false}
-                  aria-haspopup={true}
-                  className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-SingleRequiredSelect-SLDSDataTableRow-8IKZHZZV80-SLDSDataTableRowActions slds-button_icon-x-small"
-                  disabled={false}
-                  onClick={[Function]}
-                  tabIndex="0"
-                  type="button"
+                <span
+                  className="slds-radio_faux"
+                />
+                <span
+                  className="slds-form-element__label"
                 >
-                  <svg
-                    aria-hidden="true"
-                    className="slds-button__icon slds-button__icon_hint"
-                  >
-                    <use
-                      xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
-                    />
-                  </svg>
-                  <span
-                    className="slds-assistive-text"
-                  >
-                    Actions
-                  </span>
-                </button>
-              </div>
-            </td>
-          </tr>
-          <tr
-            aria-selected="false"
-            className="slds-hint-parent"
+                  
+                </span>
+              </label>
+            </span>
+          </td>
+          <th
+            className={null}
+            role="gridcell"
+            style={
+              Object {
+                "width": "10rem",
+              }
+            }
           >
-            <td
-              className="slds-text-align_right"
-              role="gridcell"
-              style={
-                Object {
-                  "width": "3.25rem",
-                }
-              }
+            <div
+              className="slds-truncate"
+              title="salesforce.com - 1,000 Widgets"
             >
-              <span
-                className="slds-radio slds-m-right_x-small"
-              >
-                <input
-                  checked={false}
-                  id="DataTableExample-SingleRequiredSelect-SLDSDataTableRow-5GJOOOPWU7-SelectRow"
-                  name="DataTableExample-SingleRequiredSelect-SelectRow"
-                  onChange={[Function]}
-                  onClick={[Function]}
-                  onKeyPress={[Function]}
-                  type="radio"
-                />
-                <label
-                  className="slds-radio__label"
-                  htmlFor="DataTableExample-SingleRequiredSelect-SLDSDataTableRow-5GJOOOPWU7-SelectRow"
-                >
-                  <span
-                    className="slds-radio_faux"
-                  />
-                  <span
-                    className="slds-form-element__label"
-                  >
-                    
-                  </span>
-                </label>
-              </span>
-            </td>
-            <th
-              className={null}
-              role="gridcell"
-              style={
-                Object {
-                  "width": "10rem",
-                }
-              }
-            >
-              <div
-                className="slds-truncate"
-                title="Acme - 200 Widgets"
-              >
-                <a
-                  href="javascript:void(0);"
-                  onClick={[Function]}
-                >
-                  Acme - 200 Widgets
-                </a>
-              </div>
-            </th>
-            <td
-              className={null}
-              role="gridcell"
-              style={
-                Object {
-                  "width": "8rem",
-                }
-              }
-            >
-              <div
-                className="slds-truncate"
-                title="Acme"
-              >
-                Acme
-              </div>
-            </td>
-            <td
-              className={null}
-              role="gridcell"
-              style={null}
-            >
-              <div
-                className="slds-truncate"
-                title="1/31/15"
-              >
-                1/31/15
-              </div>
-            </td>
-            <td
-              className={null}
-              role="gridcell"
-              style={null}
-            >
-              <div
-                className="slds-truncate"
-                title="Prospecting"
-              >
-                Prospecting
-              </div>
-            </td>
-            <td
-              className={null}
-              role="gridcell"
-              style={null}
-            >
-              <div
-                className="slds-truncate"
-                title="30%"
-              >
-                30%
-              </div>
-            </td>
-            <td
-              className={null}
-              role="gridcell"
-              style={null}
-            >
-              <div
-                className="slds-truncate"
-                title="$5,000,000"
-              >
-                $5,000,000
-              </div>
-            </td>
-            <td
-              className={null}
-              role="gridcell"
-              style={null}
-            >
-              <div
-                className="slds-truncate"
-                title="bob@acme.com"
-              >
-                <a
-                  href="javascript:void(0);"
-                  onClick={[Function]}
-                >
-                  bob@acme.com
-                </a>
-              </div>
-            </td>
-            <td
-              className=""
-              data-label="Actions"
-              onClick={[Function]}
-              style={
-                Object {
-                  "width": "3.25rem",
-                }
-              }
-            >
-              <div
-                className="slds-dropdown-trigger slds-dropdown-trigger_click"
-                id="DataTableExample-SingleRequiredSelect-SLDSDataTableRow-5GJOOOPWU7-SLDSDataTableRowActions"
+              <a
+                href="javascript:void(0);"
                 onClick={[Function]}
-                onFocus={null}
-                onKeyDown={[Function]}
-                onMouseEnter={null}
-                onMouseLeave={null}
               >
-                <button
-                  aria-expanded={false}
-                  aria-haspopup={true}
-                  className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-SingleRequiredSelect-SLDSDataTableRow-5GJOOOPWU7-SLDSDataTableRowActions slds-button_icon-x-small"
-                  disabled={false}
-                  onClick={[Function]}
-                  tabIndex="0"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden="true"
-                    className="slds-button__icon slds-button__icon_hint"
-                  >
-                    <use
-                      xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
-                    />
-                  </svg>
-                  <span
-                    className="slds-assistive-text"
-                  >
-                    Actions
-                  </span>
-                </button>
-              </div>
-            </td>
-          </tr>
-          <tr
-            aria-selected="false"
-            className="slds-hint-parent"
+                salesforce.com - 1,000 Widgets
+              </a>
+            </div>
+          </th>
+          <td
+            className={null}
+            role="gridcell"
+            style={
+              Object {
+                "width": "8rem",
+              }
+            }
           >
-            <td
-              className="slds-text-align_right"
-              role="gridcell"
-              style={
-                Object {
-                  "width": "3.25rem",
-                }
-              }
+            <div
+              className="slds-truncate"
+              title="salesforce.com"
             >
-              <span
-                className="slds-radio slds-m-right_x-small"
-              >
-                <input
-                  checked={false}
-                  id="DataTableExample-SingleRequiredSelect-SLDSDataTableRow-8IKZHZZV81-SelectRow"
-                  name="DataTableExample-SingleRequiredSelect-SelectRow"
-                  onChange={[Function]}
-                  onClick={[Function]}
-                  onKeyPress={[Function]}
-                  type="radio"
-                />
-                <label
-                  className="slds-radio__label"
-                  htmlFor="DataTableExample-SingleRequiredSelect-SLDSDataTableRow-8IKZHZZV81-SelectRow"
-                >
-                  <span
-                    className="slds-radio_faux"
-                  />
-                  <span
-                    className="slds-form-element__label"
-                  >
-                    
-                  </span>
-                </label>
-              </span>
-            </td>
-            <th
-              className={null}
-              role="gridcell"
-              style={
-                Object {
-                  "width": "10rem",
-                }
-              }
+              salesforce.com
+            </div>
+          </td>
+          <td
+            className={null}
+            role="gridcell"
+            style={null}
+          >
+            <div
+              className="slds-truncate"
+              title="1/31/15 3:45PM"
             >
-              <div
-                className="slds-truncate"
-                title="salesforce.com - 1,000 Widgets"
-              >
-                <a
-                  href="javascript:void(0);"
-                  onClick={[Function]}
-                >
-                  salesforce.com - 1,000 Widgets
-                </a>
-              </div>
-            </th>
-            <td
-              className={null}
-              role="gridcell"
-              style={
-                Object {
-                  "width": "8rem",
-                }
-              }
+              1/31/15 3:45PM
+            </div>
+          </td>
+          <td
+            className={null}
+            role="gridcell"
+            style={null}
+          >
+            <div
+              className="slds-truncate"
+              title="Id. Decision Makers"
             >
-              <div
-                className="slds-truncate"
-                title="salesforce.com"
-              >
-                salesforce.com
-              </div>
-            </td>
-            <td
-              className={null}
-              role="gridcell"
-              style={null}
+              Id. Decision Makers
+            </div>
+          </td>
+          <td
+            className={null}
+            role="gridcell"
+            style={null}
+          >
+            <div
+              className="slds-truncate"
+              title="60%"
             >
-              <div
-                className="slds-truncate"
-                title="1/31/15 3:45PM"
-              >
-                1/31/15 3:45PM
-              </div>
-            </td>
-            <td
-              className={null}
-              role="gridcell"
-              style={null}
+              60%
+            </div>
+          </td>
+          <td
+            className={null}
+            role="gridcell"
+            style={null}
+          >
+            <div
+              className="slds-truncate"
+              title="$25,000"
             >
-              <div
-                className="slds-truncate"
-                title="Id. Decision Makers"
-              >
-                Id. Decision Makers
-              </div>
-            </td>
-            <td
-              className={null}
-              role="gridcell"
-              style={null}
+              $25,000
+            </div>
+          </td>
+          <td
+            className={null}
+            role="gridcell"
+            style={null}
+          >
+            <div
+              className="slds-truncate"
+              title="nathan@salesforce.com"
             >
-              <div
-                className="slds-truncate"
-                title="60%"
-              >
-                60%
-              </div>
-            </td>
-            <td
-              className={null}
-              role="gridcell"
-              style={null}
-            >
-              <div
-                className="slds-truncate"
-                title="$25,000"
-              >
-                $25,000
-              </div>
-            </td>
-            <td
-              className={null}
-              role="gridcell"
-              style={null}
-            >
-              <div
-                className="slds-truncate"
-                title="nathan@salesforce.com"
-              >
-                <a
-                  href="javascript:void(0);"
-                  onClick={[Function]}
-                >
-                  nathan@salesforce.com
-                </a>
-              </div>
-            </td>
-            <td
-              className=""
-              data-label="Actions"
-              onClick={[Function]}
-              style={
-                Object {
-                  "width": "3.25rem",
-                }
-              }
-            >
-              <div
-                className="slds-dropdown-trigger slds-dropdown-trigger_click"
-                id="DataTableExample-SingleRequiredSelect-SLDSDataTableRow-8IKZHZZV81-SLDSDataTableRowActions"
+              <a
+                href="javascript:void(0);"
                 onClick={[Function]}
-                onFocus={null}
-                onKeyDown={[Function]}
-                onMouseEnter={null}
-                onMouseLeave={null}
               >
-                <button
-                  aria-expanded={false}
-                  aria-haspopup={true}
-                  className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-SingleRequiredSelect-SLDSDataTableRow-8IKZHZZV81-SLDSDataTableRowActions slds-button_icon-x-small"
-                  disabled={false}
-                  onClick={[Function]}
-                  tabIndex="0"
-                  type="button"
+                nathan@salesforce.com
+              </a>
+            </div>
+          </td>
+          <td
+            className=""
+            data-label="Actions"
+            onClick={[Function]}
+            style={
+              Object {
+                "width": "3.25rem",
+              }
+            }
+          >
+            <div
+              className="slds-dropdown-trigger slds-dropdown-trigger_click"
+              id="DataTableExample-SingleRequiredSelect-SLDSDataTableRow-8IKZHZZV81-SLDSDataTableRowActions"
+              onClick={[Function]}
+              onFocus={null}
+              onKeyDown={[Function]}
+              onMouseEnter={null}
+              onMouseLeave={null}
+            >
+              <button
+                aria-expanded={false}
+                aria-haspopup={true}
+                className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-SingleRequiredSelect-SLDSDataTableRow-8IKZHZZV81-SLDSDataTableRowActions slds-button_icon-x-small"
+                disabled={false}
+                onClick={[Function]}
+                tabIndex="0"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="slds-button__icon slds-button__icon_hint"
                 >
-                  <svg
-                    aria-hidden="true"
-                    className="slds-button__icon slds-button__icon_hint"
-                  >
-                    <use
-                      xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
-                    />
-                  </svg>
-                  <span
-                    className="slds-assistive-text"
-                  >
-                    Actions
-                  </span>
-                </button>
-              </div>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+                  <use
+                    xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
+                  />
+                </svg>
+                <span
+                  className="slds-assistive-text"
+                >
+                  Actions
+                </span>
+              </button>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </div>
 `;
@@ -18437,56 +18421,111 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
 <div
   className="slds-p-around_medium"
 >
-  <div>
+  <div
+    style={
+      Object {
+        "height": "200px",
+        "width": "100%",
+      }
+    }
+  >
     <h3
       className="slds-text-heading_medium slds-m-vertical_medium"
     >
-      Fixed Header
+      Fixed Header Layout
     </h3>
     <div
+      className="slds-table_header-fixed_container"
       style={
         Object {
-          "height": "200px",
-          "width": "100%",
+          "borderTop": "1px solid rgb(221, 219, 218)",
+          "height": "100%",
         }
       }
     >
       <div
-        className="slds-table_header-fixed_container"
+        className="slds-table_header-fixed_scroller"
         style={
           Object {
-            "borderTop": "1px solid rgb(221, 219, 218)",
             "height": "100%",
+            "overflow": "auto",
           }
         }
       >
-        <div
-          className="slds-table_header-fixed_scroller"
-          style={
-            Object {
-              "height": "100%",
-              "overflow": "auto",
-            }
-          }
+        <table
+          aria-multiselectable="true"
+          className="slds-table slds-table_fixed-layout slds-table_header-fixed slds-table_resizable-cols slds-table_bordered"
+          id="DataTableExample-FixedHeaders"
+          role="grid"
         >
-          <table
-            aria-multiselectable="true"
-            className="slds-table slds-table_fixed-layout slds-table_header-fixed slds-table_resizable-cols slds-table_bordered"
-            id="DataTableExample-FixedHeaders"
-            role="grid"
-          >
-            <thead>
-              <tr
-                className="slds-line-height_reset"
+          <thead>
+            <tr
+              className="slds-line-height_reset"
+            >
+              <th
+                className="slds-text-align_right"
+                scope="col"
+                style={
+                  Object {
+                    "height": 0,
+                    "lineHeight": 0,
+                    "width": "3.25rem",
+                  }
+                }
               >
-                <th
-                  className="slds-text-align_right"
-                  scope="col"
+                <div
+                  className="slds-th__action slds-th__action_form"
                   style={
                     Object {
+                      "display": "flex",
                       "height": 0,
-                      "lineHeight": 0,
-                      "width": "3.25rem",
+                      "overflow": "hidden",
+                      "paddingBottom": 0,
+                      "paddingTop": 0,
+                      "visibility": "hidden",
+                    }
+                  }
+                >
+                  <div
+                    className="slds-form-element"
+                  >
+                    <div
+                      className="slds-form-element__control"
+                    >
+                      <span
+                        className="slds-checkbox"
+                      >
+                        <input
+                          checked={false}
+                          id="DataTableExample-FixedHeaders-SLDSDataTableHead-SelectAll"
+                          name="SelectAll"
+                          onChange={[Function]}
+                          type="checkbox"
+                        />
+                        <label
+                          className="slds-checkbox__label"
+                          htmlFor="DataTableExample-FixedHeaders-SLDSDataTableHead-SelectAll"
+                        >
+                          <span
+                            className="slds-checkbox_faux"
+                          />
+                          <span
+                            className="slds-assistive-text"
+                          >
+                            all rows
+                          </span>
+                        </label>
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="slds-cell-fixed"
+                  style={
+                    Object {
+                      "display": "flex",
+                      "flexDirection": "row",
+                      "flexWrap": "nowrap",
                     }
                   }
                 >
@@ -18495,11 +18534,9 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                     style={
                       Object {
                         "display": "flex",
-                        "height": 0,
-                        "overflow": "hidden",
-                        "paddingBottom": 0,
-                        "paddingTop": 0,
-                        "visibility": "hidden",
+                        "justifyContent": "flex-end",
+                        "lineHeight": 1,
+                        "width": "100%",
                       }
                     }
                   >
@@ -18514,14 +18551,14 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                         >
                           <input
                             checked={false}
-                            id="DataTableExample-FixedHeaders-SLDSDataTableHead-SelectAll"
+                            id="DataTableExample-FixedHeaders-SLDSDataTableHead-SelectAll-fixedHeader"
                             name="SelectAll"
                             onChange={[Function]}
                             type="checkbox"
                           />
                           <label
                             className="slds-checkbox__label"
-                            htmlFor="DataTableExample-FixedHeaders-SLDSDataTableHead-SelectAll"
+                            htmlFor="DataTableExample-FixedHeaders-SLDSDataTableHead-SelectAll-fixedHeader"
                           >
                             <span
                               className="slds-checkbox_faux"
@@ -18536,72 +18573,76 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                       </div>
                     </div>
                   </div>
-                  <div
-                    className="slds-cell-fixed"
-                    style={
-                      Object {
-                        "display": "flex",
-                        "flexDirection": "row",
-                        "flexWrap": "nowrap",
-                      }
-                    }
-                  >
-                    <div
-                      className="slds-th__action slds-th__action_form"
-                      style={
-                        Object {
-                          "display": "flex",
-                          "justifyContent": "flex-end",
-                          "lineHeight": 1,
-                          "width": "100%",
-                        }
-                      }
-                    >
-                      <div
-                        className="slds-form-element"
-                      >
-                        <div
-                          className="slds-form-element__control"
-                        >
-                          <span
-                            className="slds-checkbox"
-                          >
-                            <input
-                              checked={false}
-                              id="DataTableExample-FixedHeaders-SLDSDataTableHead-SelectAll-fixedHeader"
-                              name="SelectAll"
-                              onChange={[Function]}
-                              type="checkbox"
-                            />
-                            <label
-                              className="slds-checkbox__label"
-                              htmlFor="DataTableExample-FixedHeaders-SLDSDataTableHead-SelectAll-fixedHeader"
-                            >
-                              <span
-                                className="slds-checkbox_faux"
-                              />
-                              <span
-                                className="slds-assistive-text"
-                              >
-                                all rows
-                              </span>
-                            </label>
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </th>
-                <th
-                  aria-label="Name"
-                  aria-sort="ascending"
-                  className="slds-is-sortable slds-is-sorted slds-text-title_caps"
-                  scope="col"
+                </div>
+              </th>
+              <th
+                aria-label="Name"
+                aria-sort="ascending"
+                className="slds-is-sortable slds-is-sorted slds-text-title_caps"
+                scope="col"
+                style={
+                  Object {
+                    "height": 0,
+                    "lineHeight": 0,
+                    "width": null,
+                  }
+                }
+              >
+                <a
+                  className="slds-th__action slds-text-link_reset"
+                  href="javascript:void(0)"
+                  onClick={[Function]}
+                  role="button"
                   style={
                     Object {
+                      "display": "flex",
                       "height": 0,
-                      "lineHeight": 0,
-                      "width": null,
+                      "overflow": "hidden",
+                      "paddingBottom": 0,
+                      "paddingTop": 0,
+                      "visibility": "hidden",
+                    }
+                  }
+                  tabIndex="0"
+                >
+                  <span
+                    className="slds-assistive-text"
+                  >
+                    sort this column
+                     
+                  </span>
+                  <span
+                    className="slds-truncate"
+                    title="Name"
+                  >
+                    Name
+                  </span>
+                  <span>
+                    <svg
+                      aria-hidden="true"
+                      className="slds-is-sortable__icon slds-icon slds-icon_x-small slds-icon-text-default"
+                    >
+                      <use
+                        xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#arrowup"
+                      />
+                    </svg>
+                    
+                  </span>
+                  <span
+                    aria-atomic="true"
+                    aria-live="assertive"
+                    className="slds-assistive-text"
+                  >
+                    asc
+                  </span>
+                </a>
+                <div
+                  className="slds-cell-fixed"
+                  style={
+                    Object {
+                      "display": "flex",
+                      "flexDirection": "row",
+                      "flexWrap": "nowrap",
                     }
                   }
                 >
@@ -18612,15 +18653,13 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                     role="button"
                     style={
                       Object {
+                        "alignItems": "center",
                         "display": "flex",
-                        "height": 0,
-                        "overflow": "hidden",
-                        "paddingBottom": 0,
-                        "paddingTop": 0,
-                        "visibility": "hidden",
+                        "flex": "1 1 auto",
+                        "lineHeight": 1.25,
                       }
                     }
-                    tabIndex="0"
+                    tabIndex={0}
                   >
                     <span
                       className="slds-assistive-text"
@@ -18653,74 +18692,48 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                       asc
                     </span>
                   </a>
-                  <div
-                    className="slds-cell-fixed"
-                    style={
-                      Object {
-                        "display": "flex",
-                        "flexDirection": "row",
-                        "flexWrap": "nowrap",
-                      }
-                    }
-                  >
-                    <a
-                      className="slds-th__action slds-text-link_reset"
-                      href="javascript:void(0)"
-                      onClick={[Function]}
-                      role="button"
-                      style={
-                        Object {
-                          "alignItems": "center",
-                          "display": "flex",
-                          "flex": "1 1 auto",
-                          "lineHeight": 1.25,
-                        }
-                      }
-                      tabIndex={0}
-                    >
-                      <span
-                        className="slds-assistive-text"
-                      >
-                        sort this column
-                         
-                      </span>
-                      <span
-                        className="slds-truncate"
-                        title="Name"
-                      >
-                        Name
-                      </span>
-                      <span>
-                        <svg
-                          aria-hidden="true"
-                          className="slds-is-sortable__icon slds-icon slds-icon_x-small slds-icon-text-default"
-                        >
-                          <use
-                            xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#arrowup"
-                          />
-                        </svg>
-                        
-                      </span>
-                      <span
-                        aria-atomic="true"
-                        aria-live="assertive"
-                        className="slds-assistive-text"
-                      >
-                        asc
-                      </span>
-                    </a>
-                  </div>
-                </th>
-                <th
-                  aria-label="Account Name"
-                  aria-sort="none"
-                  className="slds-text-title_caps"
-                  scope="col"
+                </div>
+              </th>
+              <th
+                aria-label="Account Name"
+                aria-sort="none"
+                className="slds-text-title_caps"
+                scope="col"
+                style={
+                  Object {
+                    "height": 0,
+                    "lineHeight": 0,
+                    "width": null,
+                  }
+                }
+              >
+                <span
+                  className="slds-p-horizontal_x-small"
                   style={
                     Object {
+                      "display": "flex",
                       "height": 0,
-                      "lineHeight": 0,
-                      "width": null,
+                      "overflow": "hidden",
+                      "paddingBottom": 0,
+                      "paddingTop": 0,
+                      "visibility": "hidden",
+                    }
+                  }
+                >
+                  <span
+                    className="slds-truncate"
+                    title="Account Name"
+                  >
+                    Account Name
+                  </span>
+                </span>
+                <div
+                  className="slds-cell-fixed"
+                  style={
+                    Object {
+                      "display": "flex",
+                      "flexDirection": "row",
+                      "flexWrap": "nowrap",
                     }
                   }
                 >
@@ -18728,14 +18741,13 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                     className="slds-p-horizontal_x-small"
                     style={
                       Object {
+                        "alignItems": "center",
                         "display": "flex",
-                        "height": 0,
-                        "overflow": "hidden",
-                        "paddingBottom": 0,
-                        "paddingTop": 0,
-                        "visibility": "hidden",
+                        "flex": "1 1 auto",
+                        "lineHeight": 1.25,
                       }
                     }
+                    tabIndex={null}
                   >
                     <span
                       className="slds-truncate"
@@ -18744,47 +18756,48 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                       Account Name
                     </span>
                   </span>
-                  <div
-                    className="slds-cell-fixed"
-                    style={
-                      Object {
-                        "display": "flex",
-                        "flexDirection": "row",
-                        "flexWrap": "nowrap",
-                      }
-                    }
-                  >
-                    <span
-                      className="slds-p-horizontal_x-small"
-                      style={
-                        Object {
-                          "alignItems": "center",
-                          "display": "flex",
-                          "flex": "1 1 auto",
-                          "lineHeight": 1.25,
-                        }
-                      }
-                      tabIndex={null}
-                    >
-                      <span
-                        className="slds-truncate"
-                        title="Account Name"
-                      >
-                        Account Name
-                      </span>
-                    </span>
-                  </div>
-                </th>
-                <th
-                  aria-label="Close Date"
-                  aria-sort="none"
-                  className="slds-text-title_caps"
-                  scope="col"
+                </div>
+              </th>
+              <th
+                aria-label="Close Date"
+                aria-sort="none"
+                className="slds-text-title_caps"
+                scope="col"
+                style={
+                  Object {
+                    "height": 0,
+                    "lineHeight": 0,
+                    "width": null,
+                  }
+                }
+              >
+                <span
+                  className="slds-p-horizontal_x-small"
                   style={
                     Object {
+                      "display": "flex",
                       "height": 0,
-                      "lineHeight": 0,
-                      "width": null,
+                      "overflow": "hidden",
+                      "paddingBottom": 0,
+                      "paddingTop": 0,
+                      "visibility": "hidden",
+                    }
+                  }
+                >
+                  <span
+                    className="slds-truncate"
+                    title="Close Date"
+                  >
+                    Close Date
+                  </span>
+                </span>
+                <div
+                  className="slds-cell-fixed"
+                  style={
+                    Object {
+                      "display": "flex",
+                      "flexDirection": "row",
+                      "flexWrap": "nowrap",
                     }
                   }
                 >
@@ -18792,14 +18805,13 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                     className="slds-p-horizontal_x-small"
                     style={
                       Object {
+                        "alignItems": "center",
                         "display": "flex",
-                        "height": 0,
-                        "overflow": "hidden",
-                        "paddingBottom": 0,
-                        "paddingTop": 0,
-                        "visibility": "hidden",
+                        "flex": "1 1 auto",
+                        "lineHeight": 1.25,
                       }
                     }
+                    tabIndex={null}
                   >
                     <span
                       className="slds-truncate"
@@ -18808,47 +18820,48 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                       Close Date
                     </span>
                   </span>
-                  <div
-                    className="slds-cell-fixed"
-                    style={
-                      Object {
-                        "display": "flex",
-                        "flexDirection": "row",
-                        "flexWrap": "nowrap",
-                      }
-                    }
-                  >
-                    <span
-                      className="slds-p-horizontal_x-small"
-                      style={
-                        Object {
-                          "alignItems": "center",
-                          "display": "flex",
-                          "flex": "1 1 auto",
-                          "lineHeight": 1.25,
-                        }
-                      }
-                      tabIndex={null}
-                    >
-                      <span
-                        className="slds-truncate"
-                        title="Close Date"
-                      >
-                        Close Date
-                      </span>
-                    </span>
-                  </div>
-                </th>
-                <th
-                  aria-label="Stage"
-                  aria-sort="none"
-                  className="slds-text-title_caps"
-                  scope="col"
+                </div>
+              </th>
+              <th
+                aria-label="Stage"
+                aria-sort="none"
+                className="slds-text-title_caps"
+                scope="col"
+                style={
+                  Object {
+                    "height": 0,
+                    "lineHeight": 0,
+                    "width": null,
+                  }
+                }
+              >
+                <span
+                  className="slds-p-horizontal_x-small"
                   style={
                     Object {
+                      "display": "flex",
                       "height": 0,
-                      "lineHeight": 0,
-                      "width": null,
+                      "overflow": "hidden",
+                      "paddingBottom": 0,
+                      "paddingTop": 0,
+                      "visibility": "hidden",
+                    }
+                  }
+                >
+                  <span
+                    className="slds-truncate"
+                    title="Stage"
+                  >
+                    Stage
+                  </span>
+                </span>
+                <div
+                  className="slds-cell-fixed"
+                  style={
+                    Object {
+                      "display": "flex",
+                      "flexDirection": "row",
+                      "flexWrap": "nowrap",
                     }
                   }
                 >
@@ -18856,14 +18869,13 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                     className="slds-p-horizontal_x-small"
                     style={
                       Object {
+                        "alignItems": "center",
                         "display": "flex",
-                        "height": 0,
-                        "overflow": "hidden",
-                        "paddingBottom": 0,
-                        "paddingTop": 0,
-                        "visibility": "hidden",
+                        "flex": "1 1 auto",
+                        "lineHeight": 1.25,
                       }
                     }
+                    tabIndex={null}
                   >
                     <span
                       className="slds-truncate"
@@ -18872,47 +18884,69 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                       Stage
                     </span>
                   </span>
-                  <div
-                    className="slds-cell-fixed"
-                    style={
-                      Object {
-                        "display": "flex",
-                        "flexDirection": "row",
-                        "flexWrap": "nowrap",
-                      }
-                    }
-                  >
-                    <span
-                      className="slds-p-horizontal_x-small"
-                      style={
-                        Object {
-                          "alignItems": "center",
-                          "display": "flex",
-                          "flex": "1 1 auto",
-                          "lineHeight": 1.25,
-                        }
-                      }
-                      tabIndex={null}
-                    >
-                      <span
-                        className="slds-truncate"
-                        title="Stage"
-                      >
-                        Stage
-                      </span>
-                    </span>
-                  </div>
-                </th>
-                <th
-                  aria-label="Confidence"
-                  aria-sort="none"
-                  className="slds-is-sortable slds-text-title_caps"
-                  scope="col"
+                </div>
+              </th>
+              <th
+                aria-label="Confidence"
+                aria-sort="none"
+                className="slds-is-sortable slds-text-title_caps"
+                scope="col"
+                style={
+                  Object {
+                    "height": 0,
+                    "lineHeight": 0,
+                    "width": null,
+                  }
+                }
+              >
+                <a
+                  className="slds-th__action slds-text-link_reset"
+                  href="javascript:void(0)"
+                  onClick={[Function]}
+                  role="button"
                   style={
                     Object {
+                      "display": "flex",
                       "height": 0,
-                      "lineHeight": 0,
-                      "width": null,
+                      "overflow": "hidden",
+                      "paddingBottom": 0,
+                      "paddingTop": 0,
+                      "visibility": "hidden",
+                    }
+                  }
+                  tabIndex="0"
+                >
+                  <span
+                    className="slds-assistive-text"
+                  >
+                    sort this column
+                     
+                  </span>
+                  <span
+                    className="slds-truncate"
+                    title="Confidence"
+                  >
+                    Confidence
+                  </span>
+                  <span>
+                    <svg
+                      aria-hidden="true"
+                      className="slds-is-sortable__icon slds-icon slds-icon_x-small slds-icon-text-default"
+                    >
+                      <use
+                        xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#arrowup"
+                      />
+                    </svg>
+                    
+                  </span>
+                </a>
+                <div
+                  className="slds-cell-fixed"
+                  style={
+                    Object {
+                      "display": "flex",
+                      "flexDirection": "row",
+                      "flexWrap": "nowrap",
                     }
                   }
                 >
@@ -18923,15 +18957,13 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                     role="button"
                     style={
                       Object {
+                        "alignItems": "center",
                         "display": "flex",
-                        "height": 0,
-                        "overflow": "hidden",
-                        "paddingBottom": 0,
-                        "paddingTop": 0,
-                        "visibility": "hidden",
+                        "flex": "1 1 auto",
+                        "lineHeight": 1.25,
                       }
                     }
-                    tabIndex="0"
+                    tabIndex={0}
                   >
                     <span
                       className="slds-assistive-text"
@@ -18957,67 +18989,48 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                       
                     </span>
                   </a>
-                  <div
-                    className="slds-cell-fixed"
-                    style={
-                      Object {
-                        "display": "flex",
-                        "flexDirection": "row",
-                        "flexWrap": "nowrap",
-                      }
-                    }
-                  >
-                    <a
-                      className="slds-th__action slds-text-link_reset"
-                      href="javascript:void(0)"
-                      onClick={[Function]}
-                      role="button"
-                      style={
-                        Object {
-                          "alignItems": "center",
-                          "display": "flex",
-                          "flex": "1 1 auto",
-                          "lineHeight": 1.25,
-                        }
-                      }
-                      tabIndex={0}
-                    >
-                      <span
-                        className="slds-assistive-text"
-                      >
-                        sort this column
-                         
-                      </span>
-                      <span
-                        className="slds-truncate"
-                        title="Confidence"
-                      >
-                        Confidence
-                      </span>
-                      <span>
-                        <svg
-                          aria-hidden="true"
-                          className="slds-is-sortable__icon slds-icon slds-icon_x-small slds-icon-text-default"
-                        >
-                          <use
-                            xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#arrowup"
-                          />
-                        </svg>
-                        
-                      </span>
-                    </a>
-                  </div>
-                </th>
-                <th
-                  aria-label="Amount"
-                  aria-sort="none"
-                  className="slds-text-title_caps"
-                  scope="col"
+                </div>
+              </th>
+              <th
+                aria-label="Amount"
+                aria-sort="none"
+                className="slds-text-title_caps"
+                scope="col"
+                style={
+                  Object {
+                    "height": 0,
+                    "lineHeight": 0,
+                    "width": null,
+                  }
+                }
+              >
+                <span
+                  className="slds-p-horizontal_x-small"
                   style={
                     Object {
+                      "display": "flex",
                       "height": 0,
-                      "lineHeight": 0,
-                      "width": null,
+                      "overflow": "hidden",
+                      "paddingBottom": 0,
+                      "paddingTop": 0,
+                      "visibility": "hidden",
+                    }
+                  }
+                >
+                  <span
+                    className="slds-truncate"
+                    title="Amount"
+                  >
+                    Amount
+                  </span>
+                </span>
+                <div
+                  className="slds-cell-fixed"
+                  style={
+                    Object {
+                      "display": "flex",
+                      "flexDirection": "row",
+                      "flexWrap": "nowrap",
                     }
                   }
                 >
@@ -19025,14 +19038,13 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                     className="slds-p-horizontal_x-small"
                     style={
                       Object {
+                        "alignItems": "center",
                         "display": "flex",
-                        "height": 0,
-                        "overflow": "hidden",
-                        "paddingBottom": 0,
-                        "paddingTop": 0,
-                        "visibility": "hidden",
+                        "flex": "1 1 auto",
+                        "lineHeight": 1.25,
                       }
                     }
+                    tabIndex={null}
                   >
                     <span
                       className="slds-truncate"
@@ -19041,47 +19053,48 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                       Amount
                     </span>
                   </span>
-                  <div
-                    className="slds-cell-fixed"
-                    style={
-                      Object {
-                        "display": "flex",
-                        "flexDirection": "row",
-                        "flexWrap": "nowrap",
-                      }
-                    }
-                  >
-                    <span
-                      className="slds-p-horizontal_x-small"
-                      style={
-                        Object {
-                          "alignItems": "center",
-                          "display": "flex",
-                          "flex": "1 1 auto",
-                          "lineHeight": 1.25,
-                        }
-                      }
-                      tabIndex={null}
-                    >
-                      <span
-                        className="slds-truncate"
-                        title="Amount"
-                      >
-                        Amount
-                      </span>
-                    </span>
-                  </div>
-                </th>
-                <th
-                  aria-label="Contact"
-                  aria-sort="none"
-                  className="slds-text-title_caps"
-                  scope="col"
+                </div>
+              </th>
+              <th
+                aria-label="Contact"
+                aria-sort="none"
+                className="slds-text-title_caps"
+                scope="col"
+                style={
+                  Object {
+                    "height": 0,
+                    "lineHeight": 0,
+                    "width": null,
+                  }
+                }
+              >
+                <span
+                  className="slds-p-horizontal_x-small"
                   style={
                     Object {
+                      "display": "flex",
                       "height": 0,
-                      "lineHeight": 0,
-                      "width": null,
+                      "overflow": "hidden",
+                      "paddingBottom": 0,
+                      "paddingTop": 0,
+                      "visibility": "hidden",
+                    }
+                  }
+                >
+                  <span
+                    className="slds-truncate"
+                    title="Contact"
+                  >
+                    Contact
+                  </span>
+                </span>
+                <div
+                  className="slds-cell-fixed"
+                  style={
+                    Object {
+                      "display": "flex",
+                      "flexDirection": "row",
+                      "flexWrap": "nowrap",
                     }
                   }
                 >
@@ -19089,14 +19102,13 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                     className="slds-p-horizontal_x-small"
                     style={
                       Object {
+                        "alignItems": "center",
                         "display": "flex",
-                        "height": 0,
-                        "overflow": "hidden",
-                        "paddingBottom": 0,
-                        "paddingTop": 0,
-                        "visibility": "hidden",
+                        "flex": "1 1 auto",
+                        "lineHeight": 1.25,
                       }
                     }
+                    tabIndex={null}
                   >
                     <span
                       className="slds-truncate"
@@ -19105,44 +19117,43 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                       Contact
                     </span>
                   </span>
-                  <div
-                    className="slds-cell-fixed"
-                    style={
-                      Object {
-                        "display": "flex",
-                        "flexDirection": "row",
-                        "flexWrap": "nowrap",
-                      }
-                    }
-                  >
-                    <span
-                      className="slds-p-horizontal_x-small"
-                      style={
-                        Object {
-                          "alignItems": "center",
-                          "display": "flex",
-                          "flex": "1 1 auto",
-                          "lineHeight": 1.25,
-                        }
-                      }
-                      tabIndex={null}
-                    >
-                      <span
-                        className="slds-truncate"
-                        title="Contact"
-                      >
-                        Contact
-                      </span>
-                    </span>
-                  </div>
-                </th>
-                <th
-                  scope="col"
+                </div>
+              </th>
+              <th
+                scope="col"
+                style={
+                  Object {
+                    "height": 0,
+                    "lineHeight": 0,
+                    "width": "3.25rem",
+                  }
+                }
+              >
+                <div
+                  className="slds-th__action"
                   style={
                     Object {
                       "height": 0,
-                      "lineHeight": 0,
-                      "width": "3.25rem",
+                      "overflow": "hidden",
+                      "paddingBottom": 0,
+                      "paddingTop": 0,
+                      "visibility": "hidden",
+                    }
+                  }
+                >
+                  <span
+                    className="slds-assistive-text"
+                  >
+                    actions
+                  </span>
+                </div>
+                <div
+                  className="slds-cell-fixed"
+                  style={
+                    Object {
+                      "display": "flex",
+                      "flexDirection": "row",
+                      "flexWrap": "nowrap",
                     }
                   }
                 >
@@ -19150,11 +19161,8 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                     className="slds-th__action"
                     style={
                       Object {
-                        "height": 0,
-                        "overflow": "hidden",
-                        "paddingBottom": 0,
-                        "paddingTop": 0,
-                        "visibility": "hidden",
+                        "lineHeight": 1,
+                        "width": "100%",
                       }
                     }
                   >
@@ -19164,2259 +19172,2233 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                       actions
                     </span>
                   </div>
-                  <div
-                    className="slds-cell-fixed"
-                    style={
-                      Object {
-                        "display": "flex",
-                        "flexDirection": "row",
-                        "flexWrap": "nowrap",
-                      }
-                    }
-                  >
-                    <div
-                      className="slds-th__action"
-                      style={
-                        Object {
-                          "lineHeight": 1,
-                          "width": "100%",
-                        }
-                      }
-                    >
-                      <span
-                        className="slds-assistive-text"
-                      >
-                        actions
-                      </span>
-                    </div>
-                  </div>
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr
-                aria-selected="false"
-                className="slds-hint-parent"
+                </div>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              aria-selected="false"
+              className="slds-hint-parent"
+            >
+              <td
+                className="slds-text-align_right"
+                role="gridcell"
+                style={
+                  Object {
+                    "width": "3.25rem",
+                  }
+                }
               >
-                <td
-                  className="slds-text-align_right"
-                  role="gridcell"
-                  style={
-                    Object {
-                      "width": "3.25rem",
-                    }
-                  }
+                <div
+                  className="slds-form-element"
                 >
                   <div
-                    className="slds-form-element"
+                    className="slds-form-element__control"
                   >
-                    <div
-                      className="slds-form-element__control"
+                    <span
+                      className="slds-checkbox"
                     >
-                      <span
-                        className="slds-checkbox"
+                      <input
+                        checked={false}
+                        id="DataTableExample-FixedHeaders-SLDSDataTableRow-896a6a60-SelectRow"
+                        name="SelectRow"
+                        onChange={[Function]}
+                        type="checkbox"
+                      />
+                      <label
+                        className="slds-checkbox__label"
+                        htmlFor="DataTableExample-FixedHeaders-SLDSDataTableRow-896a6a60-SelectRow"
                       >
-                        <input
-                          checked={false}
-                          id="DataTableExample-FixedHeaders-SLDSDataTableRow-896a6a60-SelectRow"
-                          name="SelectRow"
-                          onChange={[Function]}
-                          type="checkbox"
+                        <span
+                          className="slds-checkbox_faux"
                         />
-                        <label
-                          className="slds-checkbox__label"
-                          htmlFor="DataTableExample-FixedHeaders-SLDSDataTableRow-896a6a60-SelectRow"
+                        <span
+                          className="slds-assistive-text"
                         >
-                          <span
-                            className="slds-checkbox_faux"
-                          />
-                          <span
-                            className="slds-assistive-text"
-                          >
-                            select this row
-                          </span>
-                        </label>
-                      </span>
-                    </div>
+                          select this row
+                        </span>
+                      </label>
+                    </span>
                   </div>
-                </td>
-                <th
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="Acme - 1,200 Widgets"
-                  >
-                    <a
-                      href="javascript:void(0);"
-                      onClick={[Function]}
-                    >
-                      Acme - 1,200 Widgets
-                    </a>
-                  </div>
-                </th>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="Acme"
-                  >
-                    Acme
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="4/10/15"
-                  >
-                    4/10/15
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="Value Proposition"
-                  >
-                    Value Proposition
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="70%"
-                  >
-                    70%
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="$25,000,000"
-                  >
-                    $25,000,000
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="jrogers@acme.com"
-                  >
-                    <a
-                      href="javascript:void(0);"
-                      onClick={[Function]}
-                    >
-                      jrogers@acme.com
-                    </a>
-                  </div>
-                </td>
-                <td
-                  className=""
-                  data-label="Actions"
-                  onClick={[Function]}
-                  style={
-                    Object {
-                      "width": "3.25rem",
-                    }
-                  }
-                >
-                  <div
-                    className="slds-dropdown-trigger slds-dropdown-trigger_click"
-                    id="DataTableExample-FixedHeaders-SLDSDataTableRow-896a6a60-SLDSDataTableRowActions"
-                    onClick={[Function]}
-                    onFocus={null}
-                    onKeyDown={[Function]}
-                    onMouseEnter={null}
-                    onMouseLeave={null}
-                  >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-FixedHeaders-SLDSDataTableRow-896a6a60-SLDSDataTableRowActions slds-button_icon-x-small"
-                      disabled={false}
-                      onClick={[Function]}
-                      tabIndex="0"
-                      type="button"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        className="slds-button__icon slds-button__icon_hint"
-                      >
-                        <use
-                          xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
-                        />
-                      </svg>
-                      <span
-                        className="slds-assistive-text"
-                      >
-                        Actions
-                      </span>
-                    </button>
-                  </div>
-                </td>
-              </tr>
-              <tr
-                aria-selected="false"
-                className="slds-hint-parent"
+                </div>
+              </td>
+              <th
+                className={null}
+                role="gridcell"
+                style={null}
               >
-                <td
-                  className="slds-text-align_right"
-                  role="gridcell"
-                  style={
-                    Object {
-                      "width": "3.25rem",
-                    }
-                  }
+                <div
+                  className="slds-truncate"
+                  title="Acme - 1,200 Widgets"
                 >
-                  <div
-                    className="slds-form-element"
-                  >
-                    <div
-                      className="slds-form-element__control"
-                    >
-                      <span
-                        className="slds-checkbox"
-                      >
-                        <input
-                          checked={false}
-                          id="DataTableExample-FixedHeaders-SLDSDataTableRow-44da9dcd-SelectRow"
-                          name="SelectRow"
-                          onChange={[Function]}
-                          type="checkbox"
-                        />
-                        <label
-                          className="slds-checkbox__label"
-                          htmlFor="DataTableExample-FixedHeaders-SLDSDataTableRow-44da9dcd-SelectRow"
-                        >
-                          <span
-                            className="slds-checkbox_faux"
-                          />
-                          <span
-                            className="slds-assistive-text"
-                          >
-                            select this row
-                          </span>
-                        </label>
-                      </span>
-                    </div>
-                  </div>
-                </td>
-                <th
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="Acme - 200 Widgets"
-                  >
-                    <a
-                      href="javascript:void(0);"
-                      onClick={[Function]}
-                    >
-                      Acme - 200 Widgets
-                    </a>
-                  </div>
-                </th>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="Acme"
-                  >
-                    Acme
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="1/31/15"
-                  >
-                    1/31/15
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="Prospecting"
-                  >
-                    Prospecting
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="30%"
-                  >
-                    30%
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="$5,000,000"
-                  >
-                    $5,000,000
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="bob@acme.com"
-                  >
-                    <a
-                      href="javascript:void(0);"
-                      onClick={[Function]}
-                    >
-                      bob@acme.com
-                    </a>
-                  </div>
-                </td>
-                <td
-                  className=""
-                  data-label="Actions"
-                  onClick={[Function]}
-                  style={
-                    Object {
-                      "width": "3.25rem",
-                    }
-                  }
-                >
-                  <div
-                    className="slds-dropdown-trigger slds-dropdown-trigger_click"
-                    id="DataTableExample-FixedHeaders-SLDSDataTableRow-44da9dcd-SLDSDataTableRowActions"
+                  <a
+                    href="javascript:void(0);"
                     onClick={[Function]}
-                    onFocus={null}
-                    onKeyDown={[Function]}
-                    onMouseEnter={null}
-                    onMouseLeave={null}
                   >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-FixedHeaders-SLDSDataTableRow-44da9dcd-SLDSDataTableRowActions slds-button_icon-x-small"
-                      disabled={false}
-                      onClick={[Function]}
-                      tabIndex="0"
-                      type="button"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        className="slds-button__icon slds-button__icon_hint"
-                      >
-                        <use
-                          xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
-                        />
-                      </svg>
-                      <span
-                        className="slds-assistive-text"
-                      >
-                        Actions
-                      </span>
-                    </button>
-                  </div>
-                </td>
-              </tr>
-              <tr
-                aria-selected="false"
-                className="slds-hint-parent"
+                    Acme - 1,200 Widgets
+                  </a>
+                </div>
+              </th>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
               >
-                <td
-                  className="slds-text-align_right"
-                  role="gridcell"
-                  style={
-                    Object {
-                      "width": "3.25rem",
-                    }
-                  }
+                <div
+                  className="slds-truncate"
+                  title="Acme"
                 >
-                  <div
-                    className="slds-form-element"
-                  >
-                    <div
-                      className="slds-form-element__control"
-                    >
-                      <span
-                        className="slds-checkbox"
-                      >
-                        <input
-                          checked={false}
-                          id="DataTableExample-FixedHeaders-SLDSDataTableRow-f988a721-SelectRow"
-                          name="SelectRow"
-                          onChange={[Function]}
-                          type="checkbox"
-                        />
-                        <label
-                          className="slds-checkbox__label"
-                          htmlFor="DataTableExample-FixedHeaders-SLDSDataTableRow-f988a721-SelectRow"
-                        >
-                          <span
-                            className="slds-checkbox_faux"
-                          />
-                          <span
-                            className="slds-assistive-text"
-                          >
-                            select this row
-                          </span>
-                        </label>
-                      </span>
-                    </div>
-                  </div>
-                </td>
-                <th
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="salesforce.com - 1,000 Widgets"
-                  >
-                    <a
-                      href="javascript:void(0);"
-                      onClick={[Function]}
-                    >
-                      salesforce.com - 1,000 Widgets
-                    </a>
-                  </div>
-                </th>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="salesforce.com"
-                  >
-                    salesforce.com
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="1/31/15 3:45PM"
-                  >
-                    1/31/15 3:45PM
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="Id. Decision Makers"
-                  >
-                    Id. Decision Makers
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="60%"
-                  >
-                    60%
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="$25,000"
-                  >
-                    $25,000
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="nathan@salesforce.com"
-                  >
-                    <a
-                      href="javascript:void(0);"
-                      onClick={[Function]}
-                    >
-                      nathan@salesforce.com
-                    </a>
-                  </div>
-                </td>
-                <td
-                  className=""
-                  data-label="Actions"
-                  onClick={[Function]}
-                  style={
-                    Object {
-                      "width": "3.25rem",
-                    }
-                  }
-                >
-                  <div
-                    className="slds-dropdown-trigger slds-dropdown-trigger_click"
-                    id="DataTableExample-FixedHeaders-SLDSDataTableRow-f988a721-SLDSDataTableRowActions"
-                    onClick={[Function]}
-                    onFocus={null}
-                    onKeyDown={[Function]}
-                    onMouseEnter={null}
-                    onMouseLeave={null}
-                  >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-FixedHeaders-SLDSDataTableRow-f988a721-SLDSDataTableRowActions slds-button_icon-x-small"
-                      disabled={false}
-                      onClick={[Function]}
-                      tabIndex="0"
-                      type="button"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        className="slds-button__icon slds-button__icon_hint"
-                      >
-                        <use
-                          xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
-                        />
-                      </svg>
-                      <span
-                        className="slds-assistive-text"
-                      >
-                        Actions
-                      </span>
-                    </button>
-                  </div>
-                </td>
-              </tr>
-              <tr
-                aria-selected="false"
-                className="slds-hint-parent"
+                  Acme
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
               >
-                <td
-                  className="slds-text-align_right"
-                  role="gridcell"
-                  style={
-                    Object {
-                      "width": "3.25rem",
-                    }
-                  }
+                <div
+                  className="slds-truncate"
+                  title="4/10/15"
                 >
-                  <div
-                    className="slds-form-element"
-                  >
-                    <div
-                      className="slds-form-element__control"
-                    >
-                      <span
-                        className="slds-checkbox"
-                      >
-                        <input
-                          checked={false}
-                          id="DataTableExample-FixedHeaders-SLDSDataTableRow-d7679cdd-SelectRow"
-                          name="SelectRow"
-                          onChange={[Function]}
-                          type="checkbox"
-                        />
-                        <label
-                          className="slds-checkbox__label"
-                          htmlFor="DataTableExample-FixedHeaders-SLDSDataTableRow-d7679cdd-SelectRow"
-                        >
-                          <span
-                            className="slds-checkbox_faux"
-                          />
-                          <span
-                            className="slds-assistive-text"
-                          >
-                            select this row
-                          </span>
-                        </label>
-                      </span>
-                    </div>
-                  </div>
-                </td>
-                <th
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="Acme - 800 Widgets"
-                  >
-                    <a
-                      href="javascript:void(0);"
-                      onClick={[Function]}
-                    >
-                      Acme - 800 Widgets
-                    </a>
-                  </div>
-                </th>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="Acme"
-                  >
-                    Acme
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="6/11/18"
-                  >
-                    6/11/18
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="Value Proposition"
-                  >
-                    Value Proposition
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="85%"
-                  >
-                    85%
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="$970,000"
-                  >
-                    $970,000
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="jrogers@acme.com"
-                  >
-                    <a
-                      href="javascript:void(0);"
-                      onClick={[Function]}
-                    >
-                      jrogers@acme.com
-                    </a>
-                  </div>
-                </td>
-                <td
-                  className=""
-                  data-label="Actions"
-                  onClick={[Function]}
-                  style={
-                    Object {
-                      "width": "3.25rem",
-                    }
-                  }
-                >
-                  <div
-                    className="slds-dropdown-trigger slds-dropdown-trigger_click"
-                    id="DataTableExample-FixedHeaders-SLDSDataTableRow-d7679cdd-SLDSDataTableRowActions"
-                    onClick={[Function]}
-                    onFocus={null}
-                    onKeyDown={[Function]}
-                    onMouseEnter={null}
-                    onMouseLeave={null}
-                  >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-FixedHeaders-SLDSDataTableRow-d7679cdd-SLDSDataTableRowActions slds-button_icon-x-small"
-                      disabled={false}
-                      onClick={[Function]}
-                      tabIndex="0"
-                      type="button"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        className="slds-button__icon slds-button__icon_hint"
-                      >
-                        <use
-                          xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
-                        />
-                      </svg>
-                      <span
-                        className="slds-assistive-text"
-                      >
-                        Actions
-                      </span>
-                    </button>
-                  </div>
-                </td>
-              </tr>
-              <tr
-                aria-selected="false"
-                className="slds-hint-parent"
+                  4/10/15
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
               >
-                <td
-                  className="slds-text-align_right"
-                  role="gridcell"
-                  style={
-                    Object {
-                      "width": "3.25rem",
-                    }
-                  }
+                <div
+                  className="slds-truncate"
+                  title="Value Proposition"
                 >
-                  <div
-                    className="slds-form-element"
-                  >
-                    <div
-                      className="slds-form-element__control"
-                    >
-                      <span
-                        className="slds-checkbox"
-                      >
-                        <input
-                          checked={false}
-                          id="DataTableExample-FixedHeaders-SLDSDataTableRow-0085f7a0-SelectRow"
-                          name="SelectRow"
-                          onChange={[Function]}
-                          type="checkbox"
-                        />
-                        <label
-                          className="slds-checkbox__label"
-                          htmlFor="DataTableExample-FixedHeaders-SLDSDataTableRow-0085f7a0-SelectRow"
-                        >
-                          <span
-                            className="slds-checkbox_faux"
-                          />
-                          <span
-                            className="slds-assistive-text"
-                          >
-                            select this row
-                          </span>
-                        </label>
-                      </span>
-                    </div>
-                  </div>
-                </td>
-                <th
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="Acme - 744 Widgets"
-                  >
-                    <a
-                      href="javascript:void(0);"
-                      onClick={[Function]}
-                    >
-                      Acme - 744 Widgets
-                    </a>
-                  </div>
-                </th>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="Acme"
-                  >
-                    Acme
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="4/15/17"
-                  >
-                    4/15/17
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="Prospecting"
-                  >
-                    Prospecting
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="56%"
-                  >
-                    56%
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="$3,110,000"
-                  >
-                    $3,110,000
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="bob@acme.com"
-                  >
-                    <a
-                      href="javascript:void(0);"
-                      onClick={[Function]}
-                    >
-                      bob@acme.com
-                    </a>
-                  </div>
-                </td>
-                <td
-                  className=""
-                  data-label="Actions"
-                  onClick={[Function]}
-                  style={
-                    Object {
-                      "width": "3.25rem",
-                    }
-                  }
-                >
-                  <div
-                    className="slds-dropdown-trigger slds-dropdown-trigger_click"
-                    id="DataTableExample-FixedHeaders-SLDSDataTableRow-0085f7a0-SLDSDataTableRowActions"
-                    onClick={[Function]}
-                    onFocus={null}
-                    onKeyDown={[Function]}
-                    onMouseEnter={null}
-                    onMouseLeave={null}
-                  >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-FixedHeaders-SLDSDataTableRow-0085f7a0-SLDSDataTableRowActions slds-button_icon-x-small"
-                      disabled={false}
-                      onClick={[Function]}
-                      tabIndex="0"
-                      type="button"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        className="slds-button__icon slds-button__icon_hint"
-                      >
-                        <use
-                          xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
-                        />
-                      </svg>
-                      <span
-                        className="slds-assistive-text"
-                      >
-                        Actions
-                      </span>
-                    </button>
-                  </div>
-                </td>
-              </tr>
-              <tr
-                aria-selected="false"
-                className="slds-hint-parent"
+                  Value Proposition
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
               >
-                <td
-                  className="slds-text-align_right"
-                  role="gridcell"
-                  style={
-                    Object {
-                      "width": "3.25rem",
-                    }
-                  }
+                <div
+                  className="slds-truncate"
+                  title="70%"
                 >
-                  <div
-                    className="slds-form-element"
-                  >
-                    <div
-                      className="slds-form-element__control"
-                    >
-                      <span
-                        className="slds-checkbox"
-                      >
-                        <input
-                          checked={false}
-                          id="DataTableExample-FixedHeaders-SLDSDataTableRow-b7acc778-SelectRow"
-                          name="SelectRow"
-                          onChange={[Function]}
-                          type="checkbox"
-                        />
-                        <label
-                          className="slds-checkbox__label"
-                          htmlFor="DataTableExample-FixedHeaders-SLDSDataTableRow-b7acc778-SelectRow"
-                        >
-                          <span
-                            className="slds-checkbox_faux"
-                          />
-                          <span
-                            className="slds-assistive-text"
-                          >
-                            select this row
-                          </span>
-                        </label>
-                      </span>
-                    </div>
-                  </div>
-                </td>
-                <th
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="salesforce.com - 847 Widgets"
-                  >
-                    <a
-                      href="javascript:void(0);"
-                      onClick={[Function]}
-                    >
-                      salesforce.com - 847 Widgets
-                    </a>
-                  </div>
-                </th>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="salesforce.com"
-                  >
-                    salesforce.com
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="5/23/18 1:02PM"
-                  >
-                    5/23/18 1:02PM
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="Id. Decision Makers"
-                  >
-                    Id. Decision Makers
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="62%"
-                  >
-                    62%
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="$18,000"
-                  >
-                    $18,000
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="nathan@salesforce.com"
-                  >
-                    <a
-                      href="javascript:void(0);"
-                      onClick={[Function]}
-                    >
-                      nathan@salesforce.com
-                    </a>
-                  </div>
-                </td>
-                <td
-                  className=""
-                  data-label="Actions"
-                  onClick={[Function]}
-                  style={
-                    Object {
-                      "width": "3.25rem",
-                    }
-                  }
-                >
-                  <div
-                    className="slds-dropdown-trigger slds-dropdown-trigger_click"
-                    id="DataTableExample-FixedHeaders-SLDSDataTableRow-b7acc778-SLDSDataTableRowActions"
-                    onClick={[Function]}
-                    onFocus={null}
-                    onKeyDown={[Function]}
-                    onMouseEnter={null}
-                    onMouseLeave={null}
-                  >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-FixedHeaders-SLDSDataTableRow-b7acc778-SLDSDataTableRowActions slds-button_icon-x-small"
-                      disabled={false}
-                      onClick={[Function]}
-                      tabIndex="0"
-                      type="button"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        className="slds-button__icon slds-button__icon_hint"
-                      >
-                        <use
-                          xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
-                        />
-                      </svg>
-                      <span
-                        className="slds-assistive-text"
-                      >
-                        Actions
-                      </span>
-                    </button>
-                  </div>
-                </td>
-              </tr>
-              <tr
-                aria-selected="false"
-                className="slds-hint-parent"
+                  70%
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
               >
-                <td
-                  className="slds-text-align_right"
-                  role="gridcell"
-                  style={
-                    Object {
-                      "width": "3.25rem",
-                    }
-                  }
+                <div
+                  className="slds-truncate"
+                  title="$25,000,000"
                 >
-                  <div
-                    className="slds-form-element"
-                  >
-                    <div
-                      className="slds-form-element__control"
-                    >
-                      <span
-                        className="slds-checkbox"
-                      >
-                        <input
-                          checked={false}
-                          id="DataTableExample-FixedHeaders-SLDSDataTableRow-17991de5-SelectRow"
-                          name="SelectRow"
-                          onChange={[Function]}
-                          type="checkbox"
-                        />
-                        <label
-                          className="slds-checkbox__label"
-                          htmlFor="DataTableExample-FixedHeaders-SLDSDataTableRow-17991de5-SelectRow"
-                        >
-                          <span
-                            className="slds-checkbox_faux"
-                          />
-                          <span
-                            className="slds-assistive-text"
-                          >
-                            select this row
-                          </span>
-                        </label>
-                      </span>
-                    </div>
-                  </div>
-                </td>
-                <th
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="Acme - 1,621 Widgets"
-                  >
-                    <a
-                      href="javascript:void(0);"
-                      onClick={[Function]}
-                    >
-                      Acme - 1,621 Widgets
-                    </a>
-                  </div>
-                </th>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="Acme"
-                  >
-                    Acme
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="5/16/17"
-                  >
-                    5/16/17
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="Value Proposition"
-                  >
-                    Value Proposition
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="70%"
-                  >
-                    70%
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="$23,600,000"
-                  >
-                    $23,600,000
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="jrogers@acme.com"
-                  >
-                    <a
-                      href="javascript:void(0);"
-                      onClick={[Function]}
-                    >
-                      jrogers@acme.com
-                    </a>
-                  </div>
-                </td>
-                <td
-                  className=""
-                  data-label="Actions"
-                  onClick={[Function]}
-                  style={
-                    Object {
-                      "width": "3.25rem",
-                    }
-                  }
-                >
-                  <div
-                    className="slds-dropdown-trigger slds-dropdown-trigger_click"
-                    id="DataTableExample-FixedHeaders-SLDSDataTableRow-17991de5-SLDSDataTableRowActions"
-                    onClick={[Function]}
-                    onFocus={null}
-                    onKeyDown={[Function]}
-                    onMouseEnter={null}
-                    onMouseLeave={null}
-                  >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-FixedHeaders-SLDSDataTableRow-17991de5-SLDSDataTableRowActions slds-button_icon-x-small"
-                      disabled={false}
-                      onClick={[Function]}
-                      tabIndex="0"
-                      type="button"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        className="slds-button__icon slds-button__icon_hint"
-                      >
-                        <use
-                          xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
-                        />
-                      </svg>
-                      <span
-                        className="slds-assistive-text"
-                      >
-                        Actions
-                      </span>
-                    </button>
-                  </div>
-                </td>
-              </tr>
-              <tr
-                aria-selected="false"
-                className="slds-hint-parent"
+                  $25,000,000
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
               >
-                <td
-                  className="slds-text-align_right"
-                  role="gridcell"
-                  style={
-                    Object {
-                      "width": "3.25rem",
-                    }
-                  }
+                <div
+                  className="slds-truncate"
+                  title="jrogers@acme.com"
                 >
-                  <div
-                    className="slds-form-element"
-                  >
-                    <div
-                      className="slds-form-element__control"
-                    >
-                      <span
-                        className="slds-checkbox"
-                      >
-                        <input
-                          checked={false}
-                          id="DataTableExample-FixedHeaders-SLDSDataTableRow-09b2cee9-SelectRow"
-                          name="SelectRow"
-                          onChange={[Function]}
-                          type="checkbox"
-                        />
-                        <label
-                          className="slds-checkbox__label"
-                          htmlFor="DataTableExample-FixedHeaders-SLDSDataTableRow-09b2cee9-SelectRow"
-                        >
-                          <span
-                            className="slds-checkbox_faux"
-                          />
-                          <span
-                            className="slds-assistive-text"
-                          >
-                            select this row
-                          </span>
-                        </label>
-                      </span>
-                    </div>
-                  </div>
-                </td>
-                <th
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="Acme - 430 Widgets"
-                  >
-                    <a
-                      href="javascript:void(0);"
-                      onClick={[Function]}
-                    >
-                      Acme - 430 Widgets
-                    </a>
-                  </div>
-                </th>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="Acme"
-                  >
-                    Acme
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="6/12/18"
-                  >
-                    6/12/18
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="Prospecting"
-                  >
-                    Prospecting
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="42%"
-                  >
-                    42%
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="$4,222,222"
-                  >
-                    $4,222,222
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="bob@acme.com"
-                  >
-                    <a
-                      href="javascript:void(0);"
-                      onClick={[Function]}
-                    >
-                      bob@acme.com
-                    </a>
-                  </div>
-                </td>
-                <td
-                  className=""
-                  data-label="Actions"
-                  onClick={[Function]}
-                  style={
-                    Object {
-                      "width": "3.25rem",
-                    }
-                  }
-                >
-                  <div
-                    className="slds-dropdown-trigger slds-dropdown-trigger_click"
-                    id="DataTableExample-FixedHeaders-SLDSDataTableRow-09b2cee9-SLDSDataTableRowActions"
+                  <a
+                    href="javascript:void(0);"
                     onClick={[Function]}
-                    onFocus={null}
-                    onKeyDown={[Function]}
-                    onMouseEnter={null}
-                    onMouseLeave={null}
                   >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-FixedHeaders-SLDSDataTableRow-09b2cee9-SLDSDataTableRowActions slds-button_icon-x-small"
-                      disabled={false}
-                      onClick={[Function]}
-                      tabIndex="0"
-                      type="button"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        className="slds-button__icon slds-button__icon_hint"
-                      >
-                        <use
-                          xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
-                        />
-                      </svg>
-                      <span
-                        className="slds-assistive-text"
-                      >
-                        Actions
-                      </span>
-                    </button>
-                  </div>
-                </td>
-              </tr>
-              <tr
-                aria-selected="false"
-                className="slds-hint-parent"
+                    jrogers@acme.com
+                  </a>
+                </div>
+              </td>
+              <td
+                className=""
+                data-label="Actions"
+                onClick={[Function]}
+                style={
+                  Object {
+                    "width": "3.25rem",
+                  }
+                }
               >
-                <td
-                  className="slds-text-align_right"
-                  role="gridcell"
-                  style={
-                    Object {
-                      "width": "3.25rem",
-                    }
-                  }
-                >
-                  <div
-                    className="slds-form-element"
-                  >
-                    <div
-                      className="slds-form-element__control"
-                    >
-                      <span
-                        className="slds-checkbox"
-                      >
-                        <input
-                          checked={false}
-                          id="DataTableExample-FixedHeaders-SLDSDataTableRow-d0035700-SelectRow"
-                          name="SelectRow"
-                          onChange={[Function]}
-                          type="checkbox"
-                        />
-                        <label
-                          className="slds-checkbox__label"
-                          htmlFor="DataTableExample-FixedHeaders-SLDSDataTableRow-d0035700-SelectRow"
-                        >
-                          <span
-                            className="slds-checkbox_faux"
-                          />
-                          <span
-                            className="slds-assistive-text"
-                          >
-                            select this row
-                          </span>
-                        </label>
-                      </span>
-                    </div>
-                  </div>
-                </td>
-                <th
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="salesforce.com - 677 Widgets"
-                  >
-                    <a
-                      href="javascript:void(0);"
-                      onClick={[Function]}
-                    >
-                      salesforce.com - 677 Widgets
-                    </a>
-                  </div>
-                </th>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="salesforce.com"
-                  >
-                    salesforce.com
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="7/21/17 10:11AM"
-                  >
-                    7/21/17 10:11AM
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="Id. Decision Makers"
-                  >
-                    Id. Decision Makers
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="42%"
-                  >
-                    42%
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="$24,200"
-                  >
-                    $24,200
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="nathan@salesforce.com"
-                  >
-                    <a
-                      href="javascript:void(0);"
-                      onClick={[Function]}
-                    >
-                      nathan@salesforce.com
-                    </a>
-                  </div>
-                </td>
-                <td
-                  className=""
-                  data-label="Actions"
+                <div
+                  className="slds-dropdown-trigger slds-dropdown-trigger_click"
+                  id="DataTableExample-FixedHeaders-SLDSDataTableRow-896a6a60-SLDSDataTableRowActions"
                   onClick={[Function]}
-                  style={
-                    Object {
-                      "width": "3.25rem",
-                    }
-                  }
+                  onFocus={null}
+                  onKeyDown={[Function]}
+                  onMouseEnter={null}
+                  onMouseLeave={null}
                 >
-                  <div
-                    className="slds-dropdown-trigger slds-dropdown-trigger_click"
-                    id="DataTableExample-FixedHeaders-SLDSDataTableRow-d0035700-SLDSDataTableRowActions"
+                  <button
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-FixedHeaders-SLDSDataTableRow-896a6a60-SLDSDataTableRowActions slds-button_icon-x-small"
+                    disabled={false}
                     onClick={[Function]}
-                    onFocus={null}
-                    onKeyDown={[Function]}
-                    onMouseEnter={null}
-                    onMouseLeave={null}
+                    tabIndex="0"
+                    type="button"
                   >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-FixedHeaders-SLDSDataTableRow-d0035700-SLDSDataTableRowActions slds-button_icon-x-small"
-                      disabled={false}
-                      onClick={[Function]}
-                      tabIndex="0"
-                      type="button"
+                    <svg
+                      aria-hidden="true"
+                      className="slds-button__icon slds-button__icon_hint"
                     >
-                      <svg
-                        aria-hidden="true"
-                        className="slds-button__icon slds-button__icon_hint"
-                      >
-                        <use
-                          xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
-                        />
-                      </svg>
-                      <span
-                        className="slds-assistive-text"
-                      >
-                        Actions
-                      </span>
-                    </button>
-                  </div>
-                </td>
-              </tr>
-              <tr
-                aria-selected="false"
-                className="slds-hint-parent"
+                      <use
+                        xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
+                      />
+                    </svg>
+                    <span
+                      className="slds-assistive-text"
+                    >
+                      Actions
+                    </span>
+                  </button>
+                </div>
+              </td>
+            </tr>
+            <tr
+              aria-selected="false"
+              className="slds-hint-parent"
+            >
+              <td
+                className="slds-text-align_right"
+                role="gridcell"
+                style={
+                  Object {
+                    "width": "3.25rem",
+                  }
+                }
               >
-                <td
-                  className="slds-text-align_right"
-                  role="gridcell"
-                  style={
-                    Object {
-                      "width": "3.25rem",
-                    }
-                  }
+                <div
+                  className="slds-form-element"
                 >
                   <div
-                    className="slds-form-element"
+                    className="slds-form-element__control"
                   >
-                    <div
-                      className="slds-form-element__control"
+                    <span
+                      className="slds-checkbox"
                     >
-                      <span
-                        className="slds-checkbox"
+                      <input
+                        checked={false}
+                        id="DataTableExample-FixedHeaders-SLDSDataTableRow-44da9dcd-SelectRow"
+                        name="SelectRow"
+                        onChange={[Function]}
+                        type="checkbox"
+                      />
+                      <label
+                        className="slds-checkbox__label"
+                        htmlFor="DataTableExample-FixedHeaders-SLDSDataTableRow-44da9dcd-SelectRow"
                       >
-                        <input
-                          checked={false}
-                          id="DataTableExample-FixedHeaders-SLDSDataTableRow-4a526f0c-SelectRow"
-                          name="SelectRow"
-                          onChange={[Function]}
-                          type="checkbox"
+                        <span
+                          className="slds-checkbox_faux"
                         />
-                        <label
-                          className="slds-checkbox__label"
-                          htmlFor="DataTableExample-FixedHeaders-SLDSDataTableRow-4a526f0c-SelectRow"
+                        <span
+                          className="slds-assistive-text"
                         >
-                          <span
-                            className="slds-checkbox_faux"
-                          />
-                          <span
-                            className="slds-assistive-text"
-                          >
-                            select this row
-                          </span>
-                        </label>
-                      </span>
-                    </div>
+                          select this row
+                        </span>
+                      </label>
+                    </span>
                   </div>
-                </td>
-                <th
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="Acme - 1,444 Widgets"
-                  >
-                    <a
-                      href="javascript:void(0);"
-                      onClick={[Function]}
-                    >
-                      Acme - 1,444 Widgets
-                    </a>
-                  </div>
-                </th>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="Acme"
-                  >
-                    Acme
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="3/18/18"
-                  >
-                    3/18/18
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="Value Proposition"
-                  >
-                    Value Proposition
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="66%"
-                  >
-                    66%
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="$22,000,000"
-                  >
-                    $22,000,000
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="jrogers@acme.com"
-                  >
-                    <a
-                      href="javascript:void(0);"
-                      onClick={[Function]}
-                    >
-                      jrogers@acme.com
-                    </a>
-                  </div>
-                </td>
-                <td
-                  className=""
-                  data-label="Actions"
-                  onClick={[Function]}
-                  style={
-                    Object {
-                      "width": "3.25rem",
-                    }
-                  }
-                >
-                  <div
-                    className="slds-dropdown-trigger slds-dropdown-trigger_click"
-                    id="DataTableExample-FixedHeaders-SLDSDataTableRow-4a526f0c-SLDSDataTableRowActions"
-                    onClick={[Function]}
-                    onFocus={null}
-                    onKeyDown={[Function]}
-                    onMouseEnter={null}
-                    onMouseLeave={null}
-                  >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-FixedHeaders-SLDSDataTableRow-4a526f0c-SLDSDataTableRowActions slds-button_icon-x-small"
-                      disabled={false}
-                      onClick={[Function]}
-                      tabIndex="0"
-                      type="button"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        className="slds-button__icon slds-button__icon_hint"
-                      >
-                        <use
-                          xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
-                        />
-                      </svg>
-                      <span
-                        className="slds-assistive-text"
-                      >
-                        Actions
-                      </span>
-                    </button>
-                  </div>
-                </td>
-              </tr>
-              <tr
-                aria-selected="false"
-                className="slds-hint-parent"
+                </div>
+              </td>
+              <th
+                className={null}
+                role="gridcell"
+                style={null}
               >
-                <td
-                  className="slds-text-align_right"
-                  role="gridcell"
-                  style={
-                    Object {
-                      "width": "3.25rem",
-                    }
-                  }
+                <div
+                  className="slds-truncate"
+                  title="Acme - 200 Widgets"
                 >
-                  <div
-                    className="slds-form-element"
-                  >
-                    <div
-                      className="slds-form-element__control"
-                    >
-                      <span
-                        className="slds-checkbox"
-                      >
-                        <input
-                          checked={false}
-                          id="DataTableExample-FixedHeaders-SLDSDataTableRow-9a5dbdb2-SelectRow"
-                          name="SelectRow"
-                          onChange={[Function]}
-                          type="checkbox"
-                        />
-                        <label
-                          className="slds-checkbox__label"
-                          htmlFor="DataTableExample-FixedHeaders-SLDSDataTableRow-9a5dbdb2-SelectRow"
-                        >
-                          <span
-                            className="slds-checkbox_faux"
-                          />
-                          <span
-                            className="slds-assistive-text"
-                          >
-                            select this row
-                          </span>
-                        </label>
-                      </span>
-                    </div>
-                  </div>
-                </td>
-                <th
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="Acme - 320 Widgets"
-                  >
-                    <a
-                      href="javascript:void(0);"
-                      onClick={[Function]}
-                    >
-                      Acme - 320 Widgets
-                    </a>
-                  </div>
-                </th>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="Acme"
-                  >
-                    Acme
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="1/31/18"
-                  >
-                    1/31/18
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="Prospecting"
-                  >
-                    Prospecting
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="36%"
-                  >
-                    36%
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="$4,322,000"
-                  >
-                    $4,322,000
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="bob@acme.com"
-                  >
-                    <a
-                      href="javascript:void(0);"
-                      onClick={[Function]}
-                    >
-                      bob@acme.com
-                    </a>
-                  </div>
-                </td>
-                <td
-                  className=""
-                  data-label="Actions"
-                  onClick={[Function]}
-                  style={
-                    Object {
-                      "width": "3.25rem",
-                    }
-                  }
-                >
-                  <div
-                    className="slds-dropdown-trigger slds-dropdown-trigger_click"
-                    id="DataTableExample-FixedHeaders-SLDSDataTableRow-9a5dbdb2-SLDSDataTableRowActions"
+                  <a
+                    href="javascript:void(0);"
                     onClick={[Function]}
-                    onFocus={null}
-                    onKeyDown={[Function]}
-                    onMouseEnter={null}
-                    onMouseLeave={null}
                   >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-FixedHeaders-SLDSDataTableRow-9a5dbdb2-SLDSDataTableRowActions slds-button_icon-x-small"
-                      disabled={false}
-                      onClick={[Function]}
-                      tabIndex="0"
-                      type="button"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        className="slds-button__icon slds-button__icon_hint"
-                      >
-                        <use
-                          xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
-                        />
-                      </svg>
-                      <span
-                        className="slds-assistive-text"
-                      >
-                        Actions
-                      </span>
-                    </button>
-                  </div>
-                </td>
-              </tr>
-              <tr
-                aria-selected="false"
-                className="slds-hint-parent"
+                    Acme - 200 Widgets
+                  </a>
+                </div>
+              </th>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
               >
-                <td
-                  className="slds-text-align_right"
-                  role="gridcell"
-                  style={
-                    Object {
-                      "width": "3.25rem",
-                    }
-                  }
+                <div
+                  className="slds-truncate"
+                  title="Acme"
                 >
-                  <div
-                    className="slds-form-element"
-                  >
-                    <div
-                      className="slds-form-element__control"
-                    >
-                      <span
-                        className="slds-checkbox"
-                      >
-                        <input
-                          checked={false}
-                          id="DataTableExample-FixedHeaders-SLDSDataTableRow-356dbb52-SelectRow"
-                          name="SelectRow"
-                          onChange={[Function]}
-                          type="checkbox"
-                        />
-                        <label
-                          className="slds-checkbox__label"
-                          htmlFor="DataTableExample-FixedHeaders-SLDSDataTableRow-356dbb52-SelectRow"
-                        >
-                          <span
-                            className="slds-checkbox_faux"
-                          />
-                          <span
-                            className="slds-assistive-text"
-                          >
-                            select this row
-                          </span>
-                        </label>
-                      </span>
-                    </div>
-                  </div>
-                </td>
-                <th
-                  className={null}
-                  role="gridcell"
-                  style={null}
+                  Acme
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="1/31/15"
                 >
-                  <div
-                    className="slds-truncate"
-                    title="salesforce.com - 4,000 Widgets"
-                  >
-                    <a
-                      href="javascript:void(0);"
-                      onClick={[Function]}
-                    >
-                      salesforce.com - 4,000 Widgets
-                    </a>
-                  </div>
-                </th>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
+                  1/31/15
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="Prospecting"
                 >
-                  <div
-                    className="slds-truncate"
-                    title="salesforce.com"
-                  >
-                    salesforce.com
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
+                  Prospecting
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="30%"
                 >
-                  <div
-                    className="slds-truncate"
-                    title="2/21/17 8:33PM"
-                  >
-                    2/21/17 8:33PM
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
+                  30%
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="$5,000,000"
                 >
-                  <div
-                    className="slds-truncate"
-                    title="Id. Decision Makers"
-                  >
-                    Id. Decision Makers
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
+                  $5,000,000
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="bob@acme.com"
                 >
-                  <div
-                    className="slds-truncate"
-                    title="72%"
-                  >
-                    72%
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="$15,000"
-                  >
-                    $15,000
-                  </div>
-                </td>
-                <td
-                  className={null}
-                  role="gridcell"
-                  style={null}
-                >
-                  <div
-                    className="slds-truncate"
-                    title="nathan@salesforce.com"
-                  >
-                    <a
-                      href="javascript:void(0);"
-                      onClick={[Function]}
-                    >
-                      nathan@salesforce.com
-                    </a>
-                  </div>
-                </td>
-                <td
-                  className=""
-                  data-label="Actions"
-                  onClick={[Function]}
-                  style={
-                    Object {
-                      "width": "3.25rem",
-                    }
-                  }
-                >
-                  <div
-                    className="slds-dropdown-trigger slds-dropdown-trigger_click"
-                    id="DataTableExample-FixedHeaders-SLDSDataTableRow-356dbb52-SLDSDataTableRowActions"
+                  <a
+                    href="javascript:void(0);"
                     onClick={[Function]}
-                    onFocus={null}
-                    onKeyDown={[Function]}
-                    onMouseEnter={null}
-                    onMouseLeave={null}
                   >
-                    <button
-                      aria-expanded={false}
-                      aria-haspopup={true}
-                      className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-FixedHeaders-SLDSDataTableRow-356dbb52-SLDSDataTableRowActions slds-button_icon-x-small"
-                      disabled={false}
-                      onClick={[Function]}
-                      tabIndex="0"
-                      type="button"
+                    bob@acme.com
+                  </a>
+                </div>
+              </td>
+              <td
+                className=""
+                data-label="Actions"
+                onClick={[Function]}
+                style={
+                  Object {
+                    "width": "3.25rem",
+                  }
+                }
+              >
+                <div
+                  className="slds-dropdown-trigger slds-dropdown-trigger_click"
+                  id="DataTableExample-FixedHeaders-SLDSDataTableRow-44da9dcd-SLDSDataTableRowActions"
+                  onClick={[Function]}
+                  onFocus={null}
+                  onKeyDown={[Function]}
+                  onMouseEnter={null}
+                  onMouseLeave={null}
+                >
+                  <button
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-FixedHeaders-SLDSDataTableRow-44da9dcd-SLDSDataTableRowActions slds-button_icon-x-small"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex="0"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="slds-button__icon slds-button__icon_hint"
                     >
-                      <svg
-                        aria-hidden="true"
-                        className="slds-button__icon slds-button__icon_hint"
+                      <use
+                        xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
+                      />
+                    </svg>
+                    <span
+                      className="slds-assistive-text"
+                    >
+                      Actions
+                    </span>
+                  </button>
+                </div>
+              </td>
+            </tr>
+            <tr
+              aria-selected="false"
+              className="slds-hint-parent"
+            >
+              <td
+                className="slds-text-align_right"
+                role="gridcell"
+                style={
+                  Object {
+                    "width": "3.25rem",
+                  }
+                }
+              >
+                <div
+                  className="slds-form-element"
+                >
+                  <div
+                    className="slds-form-element__control"
+                  >
+                    <span
+                      className="slds-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        id="DataTableExample-FixedHeaders-SLDSDataTableRow-f988a721-SelectRow"
+                        name="SelectRow"
+                        onChange={[Function]}
+                        type="checkbox"
+                      />
+                      <label
+                        className="slds-checkbox__label"
+                        htmlFor="DataTableExample-FixedHeaders-SLDSDataTableRow-f988a721-SelectRow"
                       >
-                        <use
-                          xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
+                        <span
+                          className="slds-checkbox_faux"
                         />
-                      </svg>
-                      <span
-                        className="slds-assistive-text"
-                      >
-                        Actions
-                      </span>
-                    </button>
+                        <span
+                          className="slds-assistive-text"
+                        >
+                          select this row
+                        </span>
+                      </label>
+                    </span>
                   </div>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+                </div>
+              </td>
+              <th
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="salesforce.com - 1,000 Widgets"
+                >
+                  <a
+                    href="javascript:void(0);"
+                    onClick={[Function]}
+                  >
+                    salesforce.com - 1,000 Widgets
+                  </a>
+                </div>
+              </th>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="salesforce.com"
+                >
+                  salesforce.com
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="1/31/15 3:45PM"
+                >
+                  1/31/15 3:45PM
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="Id. Decision Makers"
+                >
+                  Id. Decision Makers
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="60%"
+                >
+                  60%
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="$25,000"
+                >
+                  $25,000
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="nathan@salesforce.com"
+                >
+                  <a
+                    href="javascript:void(0);"
+                    onClick={[Function]}
+                  >
+                    nathan@salesforce.com
+                  </a>
+                </div>
+              </td>
+              <td
+                className=""
+                data-label="Actions"
+                onClick={[Function]}
+                style={
+                  Object {
+                    "width": "3.25rem",
+                  }
+                }
+              >
+                <div
+                  className="slds-dropdown-trigger slds-dropdown-trigger_click"
+                  id="DataTableExample-FixedHeaders-SLDSDataTableRow-f988a721-SLDSDataTableRowActions"
+                  onClick={[Function]}
+                  onFocus={null}
+                  onKeyDown={[Function]}
+                  onMouseEnter={null}
+                  onMouseLeave={null}
+                >
+                  <button
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-FixedHeaders-SLDSDataTableRow-f988a721-SLDSDataTableRowActions slds-button_icon-x-small"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex="0"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="slds-button__icon slds-button__icon_hint"
+                    >
+                      <use
+                        xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
+                      />
+                    </svg>
+                    <span
+                      className="slds-assistive-text"
+                    >
+                      Actions
+                    </span>
+                  </button>
+                </div>
+              </td>
+            </tr>
+            <tr
+              aria-selected="false"
+              className="slds-hint-parent"
+            >
+              <td
+                className="slds-text-align_right"
+                role="gridcell"
+                style={
+                  Object {
+                    "width": "3.25rem",
+                  }
+                }
+              >
+                <div
+                  className="slds-form-element"
+                >
+                  <div
+                    className="slds-form-element__control"
+                  >
+                    <span
+                      className="slds-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        id="DataTableExample-FixedHeaders-SLDSDataTableRow-d7679cdd-SelectRow"
+                        name="SelectRow"
+                        onChange={[Function]}
+                        type="checkbox"
+                      />
+                      <label
+                        className="slds-checkbox__label"
+                        htmlFor="DataTableExample-FixedHeaders-SLDSDataTableRow-d7679cdd-SelectRow"
+                      >
+                        <span
+                          className="slds-checkbox_faux"
+                        />
+                        <span
+                          className="slds-assistive-text"
+                        >
+                          select this row
+                        </span>
+                      </label>
+                    </span>
+                  </div>
+                </div>
+              </td>
+              <th
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="Acme - 800 Widgets"
+                >
+                  <a
+                    href="javascript:void(0);"
+                    onClick={[Function]}
+                  >
+                    Acme - 800 Widgets
+                  </a>
+                </div>
+              </th>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="Acme"
+                >
+                  Acme
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="6/11/18"
+                >
+                  6/11/18
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="Value Proposition"
+                >
+                  Value Proposition
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="85%"
+                >
+                  85%
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="$970,000"
+                >
+                  $970,000
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="jrogers@acme.com"
+                >
+                  <a
+                    href="javascript:void(0);"
+                    onClick={[Function]}
+                  >
+                    jrogers@acme.com
+                  </a>
+                </div>
+              </td>
+              <td
+                className=""
+                data-label="Actions"
+                onClick={[Function]}
+                style={
+                  Object {
+                    "width": "3.25rem",
+                  }
+                }
+              >
+                <div
+                  className="slds-dropdown-trigger slds-dropdown-trigger_click"
+                  id="DataTableExample-FixedHeaders-SLDSDataTableRow-d7679cdd-SLDSDataTableRowActions"
+                  onClick={[Function]}
+                  onFocus={null}
+                  onKeyDown={[Function]}
+                  onMouseEnter={null}
+                  onMouseLeave={null}
+                >
+                  <button
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-FixedHeaders-SLDSDataTableRow-d7679cdd-SLDSDataTableRowActions slds-button_icon-x-small"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex="0"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="slds-button__icon slds-button__icon_hint"
+                    >
+                      <use
+                        xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
+                      />
+                    </svg>
+                    <span
+                      className="slds-assistive-text"
+                    >
+                      Actions
+                    </span>
+                  </button>
+                </div>
+              </td>
+            </tr>
+            <tr
+              aria-selected="false"
+              className="slds-hint-parent"
+            >
+              <td
+                className="slds-text-align_right"
+                role="gridcell"
+                style={
+                  Object {
+                    "width": "3.25rem",
+                  }
+                }
+              >
+                <div
+                  className="slds-form-element"
+                >
+                  <div
+                    className="slds-form-element__control"
+                  >
+                    <span
+                      className="slds-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        id="DataTableExample-FixedHeaders-SLDSDataTableRow-0085f7a0-SelectRow"
+                        name="SelectRow"
+                        onChange={[Function]}
+                        type="checkbox"
+                      />
+                      <label
+                        className="slds-checkbox__label"
+                        htmlFor="DataTableExample-FixedHeaders-SLDSDataTableRow-0085f7a0-SelectRow"
+                      >
+                        <span
+                          className="slds-checkbox_faux"
+                        />
+                        <span
+                          className="slds-assistive-text"
+                        >
+                          select this row
+                        </span>
+                      </label>
+                    </span>
+                  </div>
+                </div>
+              </td>
+              <th
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="Acme - 744 Widgets"
+                >
+                  <a
+                    href="javascript:void(0);"
+                    onClick={[Function]}
+                  >
+                    Acme - 744 Widgets
+                  </a>
+                </div>
+              </th>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="Acme"
+                >
+                  Acme
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="4/15/17"
+                >
+                  4/15/17
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="Prospecting"
+                >
+                  Prospecting
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="56%"
+                >
+                  56%
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="$3,110,000"
+                >
+                  $3,110,000
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="bob@acme.com"
+                >
+                  <a
+                    href="javascript:void(0);"
+                    onClick={[Function]}
+                  >
+                    bob@acme.com
+                  </a>
+                </div>
+              </td>
+              <td
+                className=""
+                data-label="Actions"
+                onClick={[Function]}
+                style={
+                  Object {
+                    "width": "3.25rem",
+                  }
+                }
+              >
+                <div
+                  className="slds-dropdown-trigger slds-dropdown-trigger_click"
+                  id="DataTableExample-FixedHeaders-SLDSDataTableRow-0085f7a0-SLDSDataTableRowActions"
+                  onClick={[Function]}
+                  onFocus={null}
+                  onKeyDown={[Function]}
+                  onMouseEnter={null}
+                  onMouseLeave={null}
+                >
+                  <button
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-FixedHeaders-SLDSDataTableRow-0085f7a0-SLDSDataTableRowActions slds-button_icon-x-small"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex="0"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="slds-button__icon slds-button__icon_hint"
+                    >
+                      <use
+                        xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
+                      />
+                    </svg>
+                    <span
+                      className="slds-assistive-text"
+                    >
+                      Actions
+                    </span>
+                  </button>
+                </div>
+              </td>
+            </tr>
+            <tr
+              aria-selected="false"
+              className="slds-hint-parent"
+            >
+              <td
+                className="slds-text-align_right"
+                role="gridcell"
+                style={
+                  Object {
+                    "width": "3.25rem",
+                  }
+                }
+              >
+                <div
+                  className="slds-form-element"
+                >
+                  <div
+                    className="slds-form-element__control"
+                  >
+                    <span
+                      className="slds-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        id="DataTableExample-FixedHeaders-SLDSDataTableRow-b7acc778-SelectRow"
+                        name="SelectRow"
+                        onChange={[Function]}
+                        type="checkbox"
+                      />
+                      <label
+                        className="slds-checkbox__label"
+                        htmlFor="DataTableExample-FixedHeaders-SLDSDataTableRow-b7acc778-SelectRow"
+                      >
+                        <span
+                          className="slds-checkbox_faux"
+                        />
+                        <span
+                          className="slds-assistive-text"
+                        >
+                          select this row
+                        </span>
+                      </label>
+                    </span>
+                  </div>
+                </div>
+              </td>
+              <th
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="salesforce.com - 847 Widgets"
+                >
+                  <a
+                    href="javascript:void(0);"
+                    onClick={[Function]}
+                  >
+                    salesforce.com - 847 Widgets
+                  </a>
+                </div>
+              </th>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="salesforce.com"
+                >
+                  salesforce.com
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="5/23/18 1:02PM"
+                >
+                  5/23/18 1:02PM
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="Id. Decision Makers"
+                >
+                  Id. Decision Makers
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="62%"
+                >
+                  62%
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="$18,000"
+                >
+                  $18,000
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="nathan@salesforce.com"
+                >
+                  <a
+                    href="javascript:void(0);"
+                    onClick={[Function]}
+                  >
+                    nathan@salesforce.com
+                  </a>
+                </div>
+              </td>
+              <td
+                className=""
+                data-label="Actions"
+                onClick={[Function]}
+                style={
+                  Object {
+                    "width": "3.25rem",
+                  }
+                }
+              >
+                <div
+                  className="slds-dropdown-trigger slds-dropdown-trigger_click"
+                  id="DataTableExample-FixedHeaders-SLDSDataTableRow-b7acc778-SLDSDataTableRowActions"
+                  onClick={[Function]}
+                  onFocus={null}
+                  onKeyDown={[Function]}
+                  onMouseEnter={null}
+                  onMouseLeave={null}
+                >
+                  <button
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-FixedHeaders-SLDSDataTableRow-b7acc778-SLDSDataTableRowActions slds-button_icon-x-small"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex="0"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="slds-button__icon slds-button__icon_hint"
+                    >
+                      <use
+                        xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
+                      />
+                    </svg>
+                    <span
+                      className="slds-assistive-text"
+                    >
+                      Actions
+                    </span>
+                  </button>
+                </div>
+              </td>
+            </tr>
+            <tr
+              aria-selected="false"
+              className="slds-hint-parent"
+            >
+              <td
+                className="slds-text-align_right"
+                role="gridcell"
+                style={
+                  Object {
+                    "width": "3.25rem",
+                  }
+                }
+              >
+                <div
+                  className="slds-form-element"
+                >
+                  <div
+                    className="slds-form-element__control"
+                  >
+                    <span
+                      className="slds-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        id="DataTableExample-FixedHeaders-SLDSDataTableRow-17991de5-SelectRow"
+                        name="SelectRow"
+                        onChange={[Function]}
+                        type="checkbox"
+                      />
+                      <label
+                        className="slds-checkbox__label"
+                        htmlFor="DataTableExample-FixedHeaders-SLDSDataTableRow-17991de5-SelectRow"
+                      >
+                        <span
+                          className="slds-checkbox_faux"
+                        />
+                        <span
+                          className="slds-assistive-text"
+                        >
+                          select this row
+                        </span>
+                      </label>
+                    </span>
+                  </div>
+                </div>
+              </td>
+              <th
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="Acme - 1,621 Widgets"
+                >
+                  <a
+                    href="javascript:void(0);"
+                    onClick={[Function]}
+                  >
+                    Acme - 1,621 Widgets
+                  </a>
+                </div>
+              </th>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="Acme"
+                >
+                  Acme
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="5/16/17"
+                >
+                  5/16/17
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="Value Proposition"
+                >
+                  Value Proposition
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="70%"
+                >
+                  70%
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="$23,600,000"
+                >
+                  $23,600,000
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="jrogers@acme.com"
+                >
+                  <a
+                    href="javascript:void(0);"
+                    onClick={[Function]}
+                  >
+                    jrogers@acme.com
+                  </a>
+                </div>
+              </td>
+              <td
+                className=""
+                data-label="Actions"
+                onClick={[Function]}
+                style={
+                  Object {
+                    "width": "3.25rem",
+                  }
+                }
+              >
+                <div
+                  className="slds-dropdown-trigger slds-dropdown-trigger_click"
+                  id="DataTableExample-FixedHeaders-SLDSDataTableRow-17991de5-SLDSDataTableRowActions"
+                  onClick={[Function]}
+                  onFocus={null}
+                  onKeyDown={[Function]}
+                  onMouseEnter={null}
+                  onMouseLeave={null}
+                >
+                  <button
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-FixedHeaders-SLDSDataTableRow-17991de5-SLDSDataTableRowActions slds-button_icon-x-small"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex="0"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="slds-button__icon slds-button__icon_hint"
+                    >
+                      <use
+                        xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
+                      />
+                    </svg>
+                    <span
+                      className="slds-assistive-text"
+                    >
+                      Actions
+                    </span>
+                  </button>
+                </div>
+              </td>
+            </tr>
+            <tr
+              aria-selected="false"
+              className="slds-hint-parent"
+            >
+              <td
+                className="slds-text-align_right"
+                role="gridcell"
+                style={
+                  Object {
+                    "width": "3.25rem",
+                  }
+                }
+              >
+                <div
+                  className="slds-form-element"
+                >
+                  <div
+                    className="slds-form-element__control"
+                  >
+                    <span
+                      className="slds-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        id="DataTableExample-FixedHeaders-SLDSDataTableRow-09b2cee9-SelectRow"
+                        name="SelectRow"
+                        onChange={[Function]}
+                        type="checkbox"
+                      />
+                      <label
+                        className="slds-checkbox__label"
+                        htmlFor="DataTableExample-FixedHeaders-SLDSDataTableRow-09b2cee9-SelectRow"
+                      >
+                        <span
+                          className="slds-checkbox_faux"
+                        />
+                        <span
+                          className="slds-assistive-text"
+                        >
+                          select this row
+                        </span>
+                      </label>
+                    </span>
+                  </div>
+                </div>
+              </td>
+              <th
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="Acme - 430 Widgets"
+                >
+                  <a
+                    href="javascript:void(0);"
+                    onClick={[Function]}
+                  >
+                    Acme - 430 Widgets
+                  </a>
+                </div>
+              </th>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="Acme"
+                >
+                  Acme
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="6/12/18"
+                >
+                  6/12/18
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="Prospecting"
+                >
+                  Prospecting
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="42%"
+                >
+                  42%
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="$4,222,222"
+                >
+                  $4,222,222
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="bob@acme.com"
+                >
+                  <a
+                    href="javascript:void(0);"
+                    onClick={[Function]}
+                  >
+                    bob@acme.com
+                  </a>
+                </div>
+              </td>
+              <td
+                className=""
+                data-label="Actions"
+                onClick={[Function]}
+                style={
+                  Object {
+                    "width": "3.25rem",
+                  }
+                }
+              >
+                <div
+                  className="slds-dropdown-trigger slds-dropdown-trigger_click"
+                  id="DataTableExample-FixedHeaders-SLDSDataTableRow-09b2cee9-SLDSDataTableRowActions"
+                  onClick={[Function]}
+                  onFocus={null}
+                  onKeyDown={[Function]}
+                  onMouseEnter={null}
+                  onMouseLeave={null}
+                >
+                  <button
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-FixedHeaders-SLDSDataTableRow-09b2cee9-SLDSDataTableRowActions slds-button_icon-x-small"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex="0"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="slds-button__icon slds-button__icon_hint"
+                    >
+                      <use
+                        xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
+                      />
+                    </svg>
+                    <span
+                      className="slds-assistive-text"
+                    >
+                      Actions
+                    </span>
+                  </button>
+                </div>
+              </td>
+            </tr>
+            <tr
+              aria-selected="false"
+              className="slds-hint-parent"
+            >
+              <td
+                className="slds-text-align_right"
+                role="gridcell"
+                style={
+                  Object {
+                    "width": "3.25rem",
+                  }
+                }
+              >
+                <div
+                  className="slds-form-element"
+                >
+                  <div
+                    className="slds-form-element__control"
+                  >
+                    <span
+                      className="slds-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        id="DataTableExample-FixedHeaders-SLDSDataTableRow-d0035700-SelectRow"
+                        name="SelectRow"
+                        onChange={[Function]}
+                        type="checkbox"
+                      />
+                      <label
+                        className="slds-checkbox__label"
+                        htmlFor="DataTableExample-FixedHeaders-SLDSDataTableRow-d0035700-SelectRow"
+                      >
+                        <span
+                          className="slds-checkbox_faux"
+                        />
+                        <span
+                          className="slds-assistive-text"
+                        >
+                          select this row
+                        </span>
+                      </label>
+                    </span>
+                  </div>
+                </div>
+              </td>
+              <th
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="salesforce.com - 677 Widgets"
+                >
+                  <a
+                    href="javascript:void(0);"
+                    onClick={[Function]}
+                  >
+                    salesforce.com - 677 Widgets
+                  </a>
+                </div>
+              </th>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="salesforce.com"
+                >
+                  salesforce.com
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="7/21/17 10:11AM"
+                >
+                  7/21/17 10:11AM
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="Id. Decision Makers"
+                >
+                  Id. Decision Makers
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="42%"
+                >
+                  42%
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="$24,200"
+                >
+                  $24,200
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="nathan@salesforce.com"
+                >
+                  <a
+                    href="javascript:void(0);"
+                    onClick={[Function]}
+                  >
+                    nathan@salesforce.com
+                  </a>
+                </div>
+              </td>
+              <td
+                className=""
+                data-label="Actions"
+                onClick={[Function]}
+                style={
+                  Object {
+                    "width": "3.25rem",
+                  }
+                }
+              >
+                <div
+                  className="slds-dropdown-trigger slds-dropdown-trigger_click"
+                  id="DataTableExample-FixedHeaders-SLDSDataTableRow-d0035700-SLDSDataTableRowActions"
+                  onClick={[Function]}
+                  onFocus={null}
+                  onKeyDown={[Function]}
+                  onMouseEnter={null}
+                  onMouseLeave={null}
+                >
+                  <button
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-FixedHeaders-SLDSDataTableRow-d0035700-SLDSDataTableRowActions slds-button_icon-x-small"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex="0"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="slds-button__icon slds-button__icon_hint"
+                    >
+                      <use
+                        xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
+                      />
+                    </svg>
+                    <span
+                      className="slds-assistive-text"
+                    >
+                      Actions
+                    </span>
+                  </button>
+                </div>
+              </td>
+            </tr>
+            <tr
+              aria-selected="false"
+              className="slds-hint-parent"
+            >
+              <td
+                className="slds-text-align_right"
+                role="gridcell"
+                style={
+                  Object {
+                    "width": "3.25rem",
+                  }
+                }
+              >
+                <div
+                  className="slds-form-element"
+                >
+                  <div
+                    className="slds-form-element__control"
+                  >
+                    <span
+                      className="slds-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        id="DataTableExample-FixedHeaders-SLDSDataTableRow-4a526f0c-SelectRow"
+                        name="SelectRow"
+                        onChange={[Function]}
+                        type="checkbox"
+                      />
+                      <label
+                        className="slds-checkbox__label"
+                        htmlFor="DataTableExample-FixedHeaders-SLDSDataTableRow-4a526f0c-SelectRow"
+                      >
+                        <span
+                          className="slds-checkbox_faux"
+                        />
+                        <span
+                          className="slds-assistive-text"
+                        >
+                          select this row
+                        </span>
+                      </label>
+                    </span>
+                  </div>
+                </div>
+              </td>
+              <th
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="Acme - 1,444 Widgets"
+                >
+                  <a
+                    href="javascript:void(0);"
+                    onClick={[Function]}
+                  >
+                    Acme - 1,444 Widgets
+                  </a>
+                </div>
+              </th>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="Acme"
+                >
+                  Acme
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="3/18/18"
+                >
+                  3/18/18
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="Value Proposition"
+                >
+                  Value Proposition
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="66%"
+                >
+                  66%
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="$22,000,000"
+                >
+                  $22,000,000
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="jrogers@acme.com"
+                >
+                  <a
+                    href="javascript:void(0);"
+                    onClick={[Function]}
+                  >
+                    jrogers@acme.com
+                  </a>
+                </div>
+              </td>
+              <td
+                className=""
+                data-label="Actions"
+                onClick={[Function]}
+                style={
+                  Object {
+                    "width": "3.25rem",
+                  }
+                }
+              >
+                <div
+                  className="slds-dropdown-trigger slds-dropdown-trigger_click"
+                  id="DataTableExample-FixedHeaders-SLDSDataTableRow-4a526f0c-SLDSDataTableRowActions"
+                  onClick={[Function]}
+                  onFocus={null}
+                  onKeyDown={[Function]}
+                  onMouseEnter={null}
+                  onMouseLeave={null}
+                >
+                  <button
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-FixedHeaders-SLDSDataTableRow-4a526f0c-SLDSDataTableRowActions slds-button_icon-x-small"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex="0"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="slds-button__icon slds-button__icon_hint"
+                    >
+                      <use
+                        xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
+                      />
+                    </svg>
+                    <span
+                      className="slds-assistive-text"
+                    >
+                      Actions
+                    </span>
+                  </button>
+                </div>
+              </td>
+            </tr>
+            <tr
+              aria-selected="false"
+              className="slds-hint-parent"
+            >
+              <td
+                className="slds-text-align_right"
+                role="gridcell"
+                style={
+                  Object {
+                    "width": "3.25rem",
+                  }
+                }
+              >
+                <div
+                  className="slds-form-element"
+                >
+                  <div
+                    className="slds-form-element__control"
+                  >
+                    <span
+                      className="slds-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        id="DataTableExample-FixedHeaders-SLDSDataTableRow-9a5dbdb2-SelectRow"
+                        name="SelectRow"
+                        onChange={[Function]}
+                        type="checkbox"
+                      />
+                      <label
+                        className="slds-checkbox__label"
+                        htmlFor="DataTableExample-FixedHeaders-SLDSDataTableRow-9a5dbdb2-SelectRow"
+                      >
+                        <span
+                          className="slds-checkbox_faux"
+                        />
+                        <span
+                          className="slds-assistive-text"
+                        >
+                          select this row
+                        </span>
+                      </label>
+                    </span>
+                  </div>
+                </div>
+              </td>
+              <th
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="Acme - 320 Widgets"
+                >
+                  <a
+                    href="javascript:void(0);"
+                    onClick={[Function]}
+                  >
+                    Acme - 320 Widgets
+                  </a>
+                </div>
+              </th>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="Acme"
+                >
+                  Acme
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="1/31/18"
+                >
+                  1/31/18
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="Prospecting"
+                >
+                  Prospecting
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="36%"
+                >
+                  36%
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="$4,322,000"
+                >
+                  $4,322,000
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="bob@acme.com"
+                >
+                  <a
+                    href="javascript:void(0);"
+                    onClick={[Function]}
+                  >
+                    bob@acme.com
+                  </a>
+                </div>
+              </td>
+              <td
+                className=""
+                data-label="Actions"
+                onClick={[Function]}
+                style={
+                  Object {
+                    "width": "3.25rem",
+                  }
+                }
+              >
+                <div
+                  className="slds-dropdown-trigger slds-dropdown-trigger_click"
+                  id="DataTableExample-FixedHeaders-SLDSDataTableRow-9a5dbdb2-SLDSDataTableRowActions"
+                  onClick={[Function]}
+                  onFocus={null}
+                  onKeyDown={[Function]}
+                  onMouseEnter={null}
+                  onMouseLeave={null}
+                >
+                  <button
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-FixedHeaders-SLDSDataTableRow-9a5dbdb2-SLDSDataTableRowActions slds-button_icon-x-small"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex="0"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="slds-button__icon slds-button__icon_hint"
+                    >
+                      <use
+                        xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
+                      />
+                    </svg>
+                    <span
+                      className="slds-assistive-text"
+                    >
+                      Actions
+                    </span>
+                  </button>
+                </div>
+              </td>
+            </tr>
+            <tr
+              aria-selected="false"
+              className="slds-hint-parent"
+            >
+              <td
+                className="slds-text-align_right"
+                role="gridcell"
+                style={
+                  Object {
+                    "width": "3.25rem",
+                  }
+                }
+              >
+                <div
+                  className="slds-form-element"
+                >
+                  <div
+                    className="slds-form-element__control"
+                  >
+                    <span
+                      className="slds-checkbox"
+                    >
+                      <input
+                        checked={false}
+                        id="DataTableExample-FixedHeaders-SLDSDataTableRow-356dbb52-SelectRow"
+                        name="SelectRow"
+                        onChange={[Function]}
+                        type="checkbox"
+                      />
+                      <label
+                        className="slds-checkbox__label"
+                        htmlFor="DataTableExample-FixedHeaders-SLDSDataTableRow-356dbb52-SelectRow"
+                      >
+                        <span
+                          className="slds-checkbox_faux"
+                        />
+                        <span
+                          className="slds-assistive-text"
+                        >
+                          select this row
+                        </span>
+                      </label>
+                    </span>
+                  </div>
+                </div>
+              </td>
+              <th
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="salesforce.com - 4,000 Widgets"
+                >
+                  <a
+                    href="javascript:void(0);"
+                    onClick={[Function]}
+                  >
+                    salesforce.com - 4,000 Widgets
+                  </a>
+                </div>
+              </th>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="salesforce.com"
+                >
+                  salesforce.com
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="2/21/17 8:33PM"
+                >
+                  2/21/17 8:33PM
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="Id. Decision Makers"
+                >
+                  Id. Decision Makers
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="72%"
+                >
+                  72%
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="$15,000"
+                >
+                  $15,000
+                </div>
+              </td>
+              <td
+                className={null}
+                role="gridcell"
+                style={null}
+              >
+                <div
+                  className="slds-truncate"
+                  title="nathan@salesforce.com"
+                >
+                  <a
+                    href="javascript:void(0);"
+                    onClick={[Function]}
+                  >
+                    nathan@salesforce.com
+                  </a>
+                </div>
+              </td>
+              <td
+                className=""
+                data-label="Actions"
+                onClick={[Function]}
+                style={
+                  Object {
+                    "width": "3.25rem",
+                  }
+                }
+              >
+                <div
+                  className="slds-dropdown-trigger slds-dropdown-trigger_click"
+                  id="DataTableExample-FixedHeaders-SLDSDataTableRow-356dbb52-SLDSDataTableRowActions"
+                  onClick={[Function]}
+                  onFocus={null}
+                  onKeyDown={[Function]}
+                  onMouseEnter={null}
+                  onMouseLeave={null}
+                >
+                  <button
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-FixedHeaders-SLDSDataTableRow-356dbb52-SLDSDataTableRowActions slds-button_icon-x-small"
+                    disabled={false}
+                    onClick={[Function]}
+                    tabIndex="0"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="slds-button__icon slds-button__icon_hint"
+                    >
+                      <use
+                        xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
+                      />
+                    </svg>
+                    <span
+                      className="slds-assistive-text"
+                    >
+                      Actions
+                    </span>
+                  </button>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Fixes #1743

**All work in these commits was done by @kevinparkerson **

### Additional description
Testing squashed version of #1817 without any snapshot image updates except `DataTable`

Travis has been a pain with the fluid layout data table image snapshots so I added a script to upload image diffs found only on travis to transfer.sh so we can see what it's yelling about. Thanks @cormacmccarthy for the bulk of that work! He created the diff uploader for UVD some time ago and helped me port it over 👍 