### PR TITLE
Resolve console warns and errors

### DIFF
--- a/components/combobox/private/menu.jsx
+++ b/components/combobox/private/menu.jsx
@@ -2,6 +2,7 @@
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 
 /* eslint-disable jsx-a11y/interactive-supports-focus */
+/* eslint-disable jsx-a11y/no-noninteractive-tabindex */
 
 import React from 'react';
 import PropTypes from 'prop-types';
@@ -189,6 +190,7 @@ const Menu = (props) => {
 								}
 					}
 					role="option"
+					tabIndex="0"
 				>
 					{optionData.icon && !props.menuItem ? (
 						<span className="slds-media__figure">{optionData.icon}</span>

--- a/components/filter/__examples__/default.jsx
+++ b/components/filter/__examples__/default.jsx
@@ -9,8 +9,8 @@ import Combobox from '~/components/combobox';
 
 const options = {
 	'show-me': [
-		{ id: 1, label: 'All Products', value: 'all-products' },
-		{ id: 2, label: 'All Wackamoles', value: 'all-Wackamoles' },
+		{ id: '1', label: 'All Products', value: 'all-products' },
+		{ id: '2', label: 'All Wackamoles', value: 'all-Wackamoles' },
 	],
 };
 

--- a/components/filter/index.jsx
+++ b/components/filter/index.jsx
@@ -166,8 +166,6 @@ class Filter extends React.Component {
 			heading: '',
 			id: this.getId(),
 			isOpen: this.state.popoverIsOpen,
-			// MAGIC NUMBERS - REMOVE/REDESIGN WHEN DESIGN FOR RIGHT-ALIGNED FILTERS ARE ADDED TO SLDS
-			offset: this.props.align === 'right' ? '0px -35px' : undefined,
 			onClose: this.handleClose,
 			onRequestClose: this.handleClose,
 			position: 'overflowBoundaryElement',

--- a/components/menu-picklist/__examples__/tooltip-list-item.jsx
+++ b/components/menu-picklist/__examples__/tooltip-list-item.jsx
@@ -1,3 +1,5 @@
+/* eslint-disable jsx-a11y/no-noninteractive-tabindex */
+
 import React from 'react';
 
 import IconSettings from '~/components/icon-settings';
@@ -10,7 +12,9 @@ const ListItemRenderer = (props) => (
 		align="bottom left"
 		content={`${props.label} tooltip on bottom left`}
 	>
-		<p className="slds-truncate">{props.label} (Hover for tooltip)</p>
+		<p className="slds-truncate" tabIndex="0">
+			{props.label} (Hover for tooltip)
+		</p>
 	</Tooltip>
 );
 


### PR DESCRIPTION
Fixes #1849 

@interactivellama @futuremint, Can you review it and guide me through some problems I am facing while resolving the issue.
 
* [x] Resolve PopoverTooltip warning which expects the element to be tabbable and id in Filter example needed in type `string`
* [ ] Resolve warning due to use of `offset`

### Additional description

The problem was not only with the examples but with the components that were using those components in it. Other components(here Combobox) were not accordingly updated when changes were made in the props of PopoverTooltip.

Now upper two errors don't appear while running `npm test` as shown following

![image](https://user-images.githubusercontent.com/34851451/54883283-5204a400-4e8a-11e9-8b4d-498046252da8.png)

`offset` warning is due to the following code [here](https://github.com/salesforce/design-system-react/blob/44cc2624cd0edb0d88408e514a544541ddb92a95/components/filter/index.jsx#L170). Is there any alternative to produce the same result?

![image](https://user-images.githubusercontent.com/34851451/54883284-5204a400-4e8a-11e9-9776-7cbee514af1b.png)
![image](https://user-images.githubusercontent.com/34851451/54883285-529d3a80-4e8a-11e9-8e18-f41d3e8a522a.png)

While, resolving this I came across the following console warning in an example that is corrected in the change.

![image](https://user-images.githubusercontent.com/34851451/54883166-e837ca80-4e88-11e9-9468-1d177fa467a9.png)

Also, should I update the tests according to these changes also?

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
