### PR TITLE
Button: Fixes assistive text in small icon hint inverse example

### DIFF
--- a/components/button/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/button/__docs__/__snapshots__/storybook-stories.storyshot
@@ -608,6 +608,11 @@ exports[`DOM snapshots SLDSButton Small Icon Hint inverse 1`] = `
             xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
           />
         </svg>
+        <span
+          className="slds-assistive-text"
+        >
+          Small icon hint inverse
+        </span>
       </button>
     </div>
   </div>

--- a/components/button/__docs__/storybook-stories.jsx
+++ b/components/button/__docs__/storybook-stories.jsx
@@ -92,7 +92,9 @@ storiesOf(BUTTON, module)
 	))
 	.add('Small Icon Hint inverse', () =>
 		getIconButton({
-			assistiveTest: 'Hint',
+			assistiveText: {
+				icon: 'Small icon hint inverse',
+			},
 			iconCategory: 'utility',
 			iconName: 'down',
 			iconVariant: 'border',


### PR DESCRIPTION
There was a slight spell error in sending the prop to the button.
This commit fixes that and sends the correct name in `assistiveText`.

Fixes #1894

### Additional description

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [x] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
