### PR TITLE
Combobox: Cancel mouseDown bubble from listbox div tag in order to help scrollbar

### DIFF
--- a/components/combobox/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/combobox/__docs__/__snapshots__/storybook-stories.storyshot
@@ -1149,6 +1149,7 @@ exports[`DOM snapshots SLDSCombobox Base Menu Item Disabled With Tooltip Open 1`
             className="absolute-positioned"
             id="combobox-base-listbox"
             onKeyDown={[Function]}
+            onMouseDown={[Function]}
             role="listbox"
             style={
               Object {
@@ -3034,6 +3035,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Custom Menu Item Open 1`] = `
           <div
             id="combobox-base-custom-menu-item-listbox"
             onKeyDown={[Function]}
+            onMouseDown={[Function]}
             role="listbox"
             style={Object {}}
           >
@@ -3394,6 +3396,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Open 1`] = `
           <div
             id="combobox-unique-id-listbox"
             onKeyDown={[Function]}
+            onMouseDown={[Function]}
             role="listbox"
             style={Object {}}
           >
@@ -3568,6 +3571,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Open Menu Sub Header Separator
           <div
             id="combobox-unique-id-listbox"
             onKeyDown={[Function]}
+            onMouseDown={[Function]}
             role="listbox"
             style={Object {}}
           >
@@ -3684,6 +3688,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Open Menu inheritWidthOf prop 
           <div
             id="combobox-unique-id-listbox"
             onKeyDown={[Function]}
+            onMouseDown={[Function]}
             role="listbox"
             style={Object {}}
           >
@@ -4772,6 +4777,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Single Selection Custom Me
           <div
             id="combobox-readonly-single-custom-item-listbox"
             onKeyDown={[Function]}
+            onMouseDown={[Function]}
             role="listbox"
             style={Object {}}
           >
@@ -5548,6 +5554,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Single Selection Selected 
           <div
             id="combobox-unique-id-listbox"
             onKeyDown={[Function]}
+            onMouseDown={[Function]}
             role="listbox"
             style={Object {}}
           >

--- a/components/combobox/combobox.jsx
+++ b/components/combobox/combobox.jsx
@@ -395,6 +395,10 @@ class Combobox extends React.Component {
 				hasStaticAlignment={this.props.hasStaticAlignment}
 				inheritWidthOf={this.props.inheritWidthOf}
 				onClose={this.handleClose}
+				onMouseDown={(event) => {
+					// prevent onBlur
+					event.preventDefault();
+				}}
 				onOpen={this.handleOpen}
 				onRequestTargetElement={this.getTargetElement}
 				position={menuPosition}
@@ -805,9 +809,9 @@ class Combobox extends React.Component {
 
 		this.handleClose();
 
-		if (this.inputRef) {
-			this.inputRef.focus();
-		}
+		// if (this.inputRef) {
+		// 	this.inputRef.focus();
+		// }
 	};
 
 	isSelected = ({ selection, option }) => !!find(selection, option);

--- a/components/utilities/dialog/index.jsx
+++ b/components/utilities/dialog/index.jsx
@@ -455,6 +455,7 @@ class Dialog extends React.Component {
 					) || undefined
 				}
 				style={style}
+				onMouseDown={this.props.onMouseDown}
 				onKeyDown={this.handleKeyDown}
 				onMouseEnter={this.props.onMouseEnter}
 				onMouseLeave={this.props.onMouseLeave}


### PR DESCRIPTION
Fixes #1818 

@Prophetess Please see if this fixes your issue. I'm thinking this should work due to the order that events fire:
* https://stackoverflow.com/questions/34804719/detect-mousedown-click-event-on-browsers-scrollbar
* https://stackoverflow.com/questions/50895064/handling-blur-click-and-focus-events-of-dropdown-input-suggestion-lists-in-react 
* https://codepen.io/mudassir0909/pen/eIHqB

I'm not seeing the issue in Chrome on my Mac at all and I am able to click the scrollbar in this example http://design-system-react-components.herokuapp.com/?selectedKind=SLDSCombobox&selectedStory=Readonly%20Multiple%20Selection&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel. Are you testing in Windows? What OS and browser are you seeing the scrollbar bug in?

I don't think this should interfere with clicks on the menu items, since this `event.preventDefault` is on the `listbox` div and not on the `listitem` themselves. I think this should work. Generally, we haven't done much testing for SLDS on touch devices, so it's difficult to tell.

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [ ] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [ ] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
