### PR TITLE
Tree Buttons: Adds `aria-hidden=true` to align with SLDS

### DIFF
--- a/components/tree/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/tree/__docs__/__snapshots__/storybook-stories.storyshot
@@ -36,6 +36,7 @@ exports[`DOM snapshots SLDSTree Assistive Heading 1`] = `
             onClick={[Function]}
           >
             <button
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small slds-is-disabled"
               disabled={true}
               onClick={[Function]}
@@ -80,6 +81,7 @@ exports[`DOM snapshots SLDSTree Assistive Heading 1`] = `
           >
             <button
               aria-controls="example-tree-2"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -97,7 +99,7 @@ exports[`DOM snapshots SLDSTree Assistive Heading 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -135,6 +137,7 @@ exports[`DOM snapshots SLDSTree Assistive Heading 1`] = `
           >
             <button
               aria-controls="example-tree-3"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -152,7 +155,7 @@ exports[`DOM snapshots SLDSTree Assistive Heading 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -190,6 +193,7 @@ exports[`DOM snapshots SLDSTree Assistive Heading 1`] = `
           >
             <button
               aria-controls="example-tree-7"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -207,7 +211,7 @@ exports[`DOM snapshots SLDSTree Assistive Heading 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -270,6 +274,7 @@ exports[`DOM snapshots SLDSTree Base 1`] = `
             onClick={[Function]}
           >
             <button
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small slds-is-disabled"
               disabled={true}
               onClick={[Function]}
@@ -314,6 +319,7 @@ exports[`DOM snapshots SLDSTree Base 1`] = `
           >
             <button
               aria-controls="example-tree-2"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -331,7 +337,7 @@ exports[`DOM snapshots SLDSTree Base 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -369,6 +375,7 @@ exports[`DOM snapshots SLDSTree Base 1`] = `
           >
             <button
               aria-controls="example-tree-3"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -386,7 +393,7 @@ exports[`DOM snapshots SLDSTree Base 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -424,6 +431,7 @@ exports[`DOM snapshots SLDSTree Base 1`] = `
           >
             <button
               aria-controls="example-tree-7"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -441,7 +449,7 @@ exports[`DOM snapshots SLDSTree Base 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -504,6 +512,7 @@ exports[`DOM snapshots SLDSTree Base with stencil 1`] = `
             onClick={[Function]}
           >
             <button
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small slds-is-disabled"
               disabled={true}
               onClick={[Function]}
@@ -548,6 +557,7 @@ exports[`DOM snapshots SLDSTree Base with stencil 1`] = `
           >
             <button
               aria-controls="example-tree-2"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -565,7 +575,7 @@ exports[`DOM snapshots SLDSTree Base with stencil 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -603,6 +613,7 @@ exports[`DOM snapshots SLDSTree Base with stencil 1`] = `
           >
             <button
               aria-controls="example-tree-3"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -620,7 +631,7 @@ exports[`DOM snapshots SLDSTree Base with stencil 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -658,6 +669,7 @@ exports[`DOM snapshots SLDSTree Base with stencil 1`] = `
           >
             <button
               aria-controls="example-tree-7"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -675,7 +687,7 @@ exports[`DOM snapshots SLDSTree Base with stencil 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -771,6 +783,7 @@ exports[`DOM snapshots SLDSTree Highlighted Search 1`] = `
             onClick={[Function]}
           >
             <button
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small slds-is-disabled"
               disabled={true}
               onClick={[Function]}
@@ -819,6 +832,7 @@ exports[`DOM snapshots SLDSTree Highlighted Search 1`] = `
           >
             <button
               aria-controls="example-tree-2"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -836,7 +850,7 @@ exports[`DOM snapshots SLDSTree Highlighted Search 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -884,6 +898,7 @@ exports[`DOM snapshots SLDSTree Highlighted Search 1`] = `
           >
             <button
               aria-controls="example-tree-3"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -901,7 +916,7 @@ exports[`DOM snapshots SLDSTree Highlighted Search 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -943,6 +958,7 @@ exports[`DOM snapshots SLDSTree Highlighted Search 1`] = `
           >
             <button
               aria-controls="example-tree-7"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -960,7 +976,7 @@ exports[`DOM snapshots SLDSTree Highlighted Search 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -1027,6 +1043,7 @@ exports[`DOM snapshots SLDSTree Initial Expanded/Selected 1`] = `
             onClick={[Function]}
           >
             <button
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small slds-is-disabled"
               disabled={true}
               onClick={[Function]}
@@ -1071,6 +1088,7 @@ exports[`DOM snapshots SLDSTree Initial Expanded/Selected 1`] = `
           >
             <button
               aria-controls="example-tree-2"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -1088,7 +1106,7 @@ exports[`DOM snapshots SLDSTree Initial Expanded/Selected 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -1125,6 +1143,7 @@ exports[`DOM snapshots SLDSTree Initial Expanded/Selected 1`] = `
               >
                 <button
                   aria-controls="example-tree-4"
+                  aria-hidden={true}
                   className="slds-button slds-button_icon slds-m-right_small"
                   disabled={false}
                   onClick={[Function]}
@@ -1142,7 +1161,7 @@ exports[`DOM snapshots SLDSTree Initial Expanded/Selected 1`] = `
                   <span
                     className="slds-assistive-text"
                   >
-                    Toggle
+                    Expand Tree Branch
                   </span>
                 </button>
                 <span
@@ -1177,6 +1196,7 @@ exports[`DOM snapshots SLDSTree Initial Expanded/Selected 1`] = `
                     onClick={[Function]}
                   >
                     <button
+                      aria-hidden={true}
                       className="slds-button slds-button_icon slds-m-right_small slds-is-disabled"
                       disabled={true}
                       onClick={[Function]}
@@ -1219,6 +1239,7 @@ exports[`DOM snapshots SLDSTree Initial Expanded/Selected 1`] = `
                     onClick={[Function]}
                   >
                     <button
+                      aria-hidden={true}
                       className="slds-button slds-button_icon slds-m-right_small slds-is-disabled"
                       disabled={true}
                       onClick={[Function]}
@@ -1261,6 +1282,7 @@ exports[`DOM snapshots SLDSTree Initial Expanded/Selected 1`] = `
                     onClick={[Function]}
                   >
                     <button
+                      aria-hidden={true}
                       className="slds-button slds-button_icon slds-m-right_small slds-is-disabled"
                       disabled={true}
                       onClick={[Function]}
@@ -1307,6 +1329,7 @@ exports[`DOM snapshots SLDSTree Initial Expanded/Selected 1`] = `
               >
                 <button
                   aria-controls="example-tree-5"
+                  aria-hidden={true}
                   className="slds-button slds-button_icon slds-m-right_small"
                   disabled={false}
                   onClick={[Function]}
@@ -1324,7 +1347,7 @@ exports[`DOM snapshots SLDSTree Initial Expanded/Selected 1`] = `
                   <span
                     className="slds-assistive-text"
                   >
-                    Toggle
+                    Expand Tree Branch
                   </span>
                 </button>
                 <span
@@ -1364,6 +1387,7 @@ exports[`DOM snapshots SLDSTree Initial Expanded/Selected 1`] = `
           >
             <button
               aria-controls="example-tree-3"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -1381,7 +1405,7 @@ exports[`DOM snapshots SLDSTree Initial Expanded/Selected 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -1419,6 +1443,7 @@ exports[`DOM snapshots SLDSTree Initial Expanded/Selected 1`] = `
           >
             <button
               aria-controls="example-tree-7"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -1436,7 +1461,7 @@ exports[`DOM snapshots SLDSTree Initial Expanded/Selected 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -1499,6 +1524,7 @@ exports[`DOM snapshots SLDSTree Multiple Selection 1`] = `
             onClick={[Function]}
           >
             <button
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small slds-is-disabled"
               disabled={true}
               onClick={[Function]}
@@ -1543,6 +1569,7 @@ exports[`DOM snapshots SLDSTree Multiple Selection 1`] = `
           >
             <button
               aria-controls="example-tree-2"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -1560,7 +1587,7 @@ exports[`DOM snapshots SLDSTree Multiple Selection 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -1598,6 +1625,7 @@ exports[`DOM snapshots SLDSTree Multiple Selection 1`] = `
           >
             <button
               aria-controls="example-tree-3"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -1615,7 +1643,7 @@ exports[`DOM snapshots SLDSTree Multiple Selection 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -1653,6 +1681,7 @@ exports[`DOM snapshots SLDSTree Multiple Selection 1`] = `
           >
             <button
               aria-controls="example-tree-7"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -1670,7 +1699,7 @@ exports[`DOM snapshots SLDSTree Multiple Selection 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -1733,6 +1762,7 @@ exports[`DOM snapshots SLDSTree No Branch Select 1`] = `
             onClick={[Function]}
           >
             <button
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small slds-is-disabled"
               disabled={true}
               onClick={[Function]}
@@ -1777,6 +1807,7 @@ exports[`DOM snapshots SLDSTree No Branch Select 1`] = `
           >
             <button
               aria-controls="example-tree-2"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -1794,7 +1825,7 @@ exports[`DOM snapshots SLDSTree No Branch Select 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -1832,6 +1863,7 @@ exports[`DOM snapshots SLDSTree No Branch Select 1`] = `
           >
             <button
               aria-controls="example-tree-3"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -1849,7 +1881,7 @@ exports[`DOM snapshots SLDSTree No Branch Select 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -1887,6 +1919,7 @@ exports[`DOM snapshots SLDSTree No Branch Select 1`] = `
           >
             <button
               aria-controls="example-tree-7"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -1904,7 +1937,7 @@ exports[`DOM snapshots SLDSTree No Branch Select 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -1975,6 +2008,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4002"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -1992,7 +2026,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -2030,6 +2064,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4006"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -2047,7 +2082,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -2085,6 +2120,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4009"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -2102,7 +2138,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -2140,6 +2176,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4014"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -2157,7 +2194,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -2195,6 +2232,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4022"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -2212,7 +2250,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -2250,6 +2288,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4024"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -2267,7 +2306,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -2305,6 +2344,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4028"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -2322,7 +2362,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -2360,6 +2400,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4033"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -2377,7 +2418,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -2415,6 +2456,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4045"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -2432,7 +2474,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -2470,6 +2512,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4049"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -2487,7 +2530,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -2525,6 +2568,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4051"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -2542,7 +2586,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -2580,6 +2624,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4055"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -2597,7 +2642,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -2635,6 +2680,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4060"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -2652,7 +2698,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -2690,6 +2736,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4069"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -2707,7 +2754,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -2745,6 +2792,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4071"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -2762,7 +2810,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -2800,6 +2848,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4077"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -2817,7 +2866,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -2855,6 +2904,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4082"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -2872,7 +2922,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -2910,6 +2960,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4087"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -2927,7 +2978,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -2965,6 +3016,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4089"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -2982,7 +3034,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -3020,6 +3072,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4091"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -3037,7 +3090,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -3075,6 +3128,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4096"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -3092,7 +3146,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -3130,6 +3184,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4101"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -3147,7 +3202,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -3185,6 +3240,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4105"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -3202,7 +3258,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -3240,6 +3296,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4109"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -3257,7 +3314,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -3295,6 +3352,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4111"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -3312,7 +3370,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -3350,6 +3408,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4115"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -3367,7 +3426,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -3405,6 +3464,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4117"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -3422,7 +3482,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -3460,6 +3520,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4121"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -3477,7 +3538,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -3515,6 +3576,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4124"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -3532,7 +3594,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -3570,6 +3632,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4127"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -3587,7 +3650,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -3625,6 +3688,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4129"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -3642,7 +3706,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -3680,6 +3744,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4133"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -3697,7 +3762,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -3735,6 +3800,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4141"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -3752,7 +3818,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -3790,6 +3856,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4150"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -3807,7 +3874,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -3845,6 +3912,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4153"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -3862,7 +3930,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -3900,6 +3968,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4159"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -3917,7 +3986,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -3955,6 +4024,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4163"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -3972,7 +4042,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -4010,6 +4080,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4167"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -4027,7 +4098,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -4065,6 +4136,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4172"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -4082,7 +4154,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -4120,6 +4192,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4174"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -4137,7 +4210,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -4175,6 +4248,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4178"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -4192,7 +4266,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -4230,6 +4304,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4186"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -4247,7 +4322,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -4285,6 +4360,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4191"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -4302,7 +4378,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -4340,6 +4416,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4196"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -4357,7 +4434,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -4395,6 +4472,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4198"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -4412,7 +4490,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -4450,6 +4528,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4206"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -4467,7 +4546,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -4505,6 +4584,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4212"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -4522,7 +4602,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -4560,6 +4640,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4214"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -4577,7 +4658,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -4615,6 +4696,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4222"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -4632,7 +4714,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -4670,6 +4752,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4228"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -4687,7 +4770,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -4725,6 +4808,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4232"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -4742,7 +4826,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -4780,6 +4864,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4234"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -4797,7 +4882,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -4835,6 +4920,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4236"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -4852,7 +4938,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -4890,6 +4976,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4240"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -4907,7 +4994,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -4945,6 +5032,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4242"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -4962,7 +5050,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -5000,6 +5088,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4246"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -5017,7 +5106,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -5055,6 +5144,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4248"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -5072,7 +5162,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -5110,6 +5200,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4250"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -5127,7 +5218,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -5165,6 +5256,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4252"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -5182,7 +5274,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -5220,6 +5312,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4254"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -5237,7 +5330,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -5275,6 +5368,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4263"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -5292,7 +5386,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -5330,6 +5424,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4265"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -5347,7 +5442,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -5385,6 +5480,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4267"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -5402,7 +5498,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -5440,6 +5536,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4270"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -5457,7 +5554,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -5495,6 +5592,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4273"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -5512,7 +5610,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -5550,6 +5648,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4282"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -5567,7 +5666,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -5605,6 +5704,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4284"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -5622,7 +5722,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -5660,6 +5760,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4288"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -5677,7 +5778,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -5715,6 +5816,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4293"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -5732,7 +5834,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -5770,6 +5872,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4296"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -5787,7 +5890,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -5825,6 +5928,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4300"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -5842,7 +5946,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -5880,6 +5984,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4302"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -5897,7 +6002,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -5935,6 +6040,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4304"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -5952,7 +6058,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -5990,6 +6096,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4306"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -6007,7 +6114,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -6045,6 +6152,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4308"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -6062,7 +6170,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -6100,6 +6208,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4310"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -6117,7 +6226,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -6155,6 +6264,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4319"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -6172,7 +6282,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -6210,6 +6320,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4321"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -6227,7 +6338,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -6265,6 +6376,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4323"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -6282,7 +6394,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -6320,6 +6432,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4328"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -6337,7 +6450,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -6375,6 +6488,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4336"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -6392,7 +6506,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -6430,6 +6544,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4339"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -6447,7 +6562,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -6485,6 +6600,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4341"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -6502,7 +6618,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -6540,6 +6656,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4343"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -6557,7 +6674,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -6595,6 +6712,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4348"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -6612,7 +6730,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -6650,6 +6768,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4356"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -6667,7 +6786,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -6705,6 +6824,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4359"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -6722,7 +6842,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -6760,6 +6880,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4363"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -6777,7 +6898,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -6815,6 +6936,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4365"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -6832,7 +6954,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -6870,6 +6992,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4369"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -6887,7 +7010,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -6925,6 +7048,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4375"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -6942,7 +7066,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -6980,6 +7104,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4384"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -6997,7 +7122,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -7035,6 +7160,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4388"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -7052,7 +7178,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -7090,6 +7216,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4390"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -7107,7 +7234,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -7145,6 +7272,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4395"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -7162,7 +7290,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -7200,6 +7328,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4403"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -7217,7 +7346,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -7255,6 +7384,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4407"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -7272,7 +7402,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -7310,6 +7440,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4411"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -7327,7 +7458,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -7365,6 +7496,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4419"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -7382,7 +7514,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -7420,6 +7552,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4422"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -7437,7 +7570,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -7475,6 +7608,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4426"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -7492,7 +7626,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -7530,6 +7664,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4429"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -7547,7 +7682,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -7585,6 +7720,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4432"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -7602,7 +7738,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -7640,6 +7776,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4438"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -7657,7 +7794,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -7695,6 +7832,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4440"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -7712,7 +7850,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -7750,6 +7888,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4443"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -7767,7 +7906,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -7805,6 +7944,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4446"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -7822,7 +7962,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -7860,6 +8000,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4450"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -7877,7 +8018,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -7915,6 +8056,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4458"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -7932,7 +8074,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -7970,6 +8112,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4463"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -7987,7 +8130,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -8025,6 +8168,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4465"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -8042,7 +8186,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -8080,6 +8224,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4469"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -8097,7 +8242,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -8135,6 +8280,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4474"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -8152,7 +8298,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -8190,6 +8336,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4477"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -8207,7 +8354,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -8245,6 +8392,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4482"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -8262,7 +8410,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -8300,6 +8448,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4486"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -8317,7 +8466,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -8355,6 +8504,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4492"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -8372,7 +8522,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -8410,6 +8560,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4497"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -8427,7 +8578,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -8465,6 +8616,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4499"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -8482,7 +8634,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -8520,6 +8672,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4501"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -8537,7 +8690,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -8575,6 +8728,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4505"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -8592,7 +8746,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -8630,6 +8784,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4508"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -8647,7 +8802,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -8685,6 +8840,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4516"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -8702,7 +8858,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -8740,6 +8896,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4522"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -8757,7 +8914,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -8795,6 +8952,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4528"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -8812,7 +8970,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -8850,6 +9008,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4532"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -8867,7 +9026,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -8905,6 +9064,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4534"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -8922,7 +9082,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -8960,6 +9120,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4540"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -8977,7 +9138,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -9015,6 +9176,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4542"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -9032,7 +9194,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -9070,6 +9232,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4551"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -9087,7 +9250,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -9125,6 +9288,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4560"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -9142,7 +9306,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -9180,6 +9344,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4568"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -9197,7 +9362,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -9235,6 +9400,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4576"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -9252,7 +9418,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -9290,6 +9456,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4585"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -9307,7 +9474,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -9345,6 +9512,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4587"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -9362,7 +9530,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -9400,6 +9568,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4592"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -9417,7 +9586,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -9455,6 +9624,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4595"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -9472,7 +9642,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -9510,6 +9680,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4603"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -9527,7 +9698,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -9565,6 +9736,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4615"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -9582,7 +9754,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -9620,6 +9792,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4620"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -9637,7 +9810,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -9675,6 +9848,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4626"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -9692,7 +9866,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -9730,6 +9904,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4631"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -9747,7 +9922,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -9785,6 +9960,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4634"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -9802,7 +9978,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -9840,6 +10016,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4636"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -9857,7 +10034,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -9895,6 +10072,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4638"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -9912,7 +10090,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -9950,6 +10128,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4644"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -9967,7 +10146,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -10005,6 +10184,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4646"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -10022,7 +10202,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -10060,6 +10240,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4652"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -10077,7 +10258,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -10115,6 +10296,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4656"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -10132,7 +10314,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -10170,6 +10352,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4664"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -10187,7 +10370,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -10225,6 +10408,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4666"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -10242,7 +10426,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -10280,6 +10464,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4669"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -10297,7 +10482,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -10335,6 +10520,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4673"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -10352,7 +10538,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -10390,6 +10576,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4679"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -10407,7 +10594,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -10445,6 +10632,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4684"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -10462,7 +10650,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -10500,6 +10688,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4688"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -10517,7 +10706,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -10555,6 +10744,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4692"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -10572,7 +10762,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -10610,6 +10800,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4700"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -10627,7 +10818,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -10665,6 +10856,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4708"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -10682,7 +10874,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -10720,6 +10912,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4710"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -10737,7 +10930,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -10775,6 +10968,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4714"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -10792,7 +10986,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -10830,6 +11024,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4716"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -10847,7 +11042,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -10885,6 +11080,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4722"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -10902,7 +11098,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -10940,6 +11136,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4727"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -10957,7 +11154,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -10995,6 +11192,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4733"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -11012,7 +11210,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -11050,6 +11248,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4736"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -11067,7 +11266,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -11105,6 +11304,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4741"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -11122,7 +11322,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -11160,6 +11360,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4750"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -11177,7 +11378,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -11215,6 +11416,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4752"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -11232,7 +11434,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -11270,6 +11472,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4758"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -11287,7 +11490,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -11325,6 +11528,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4763"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -11342,7 +11546,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -11380,6 +11584,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4765"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -11397,7 +11602,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -11435,6 +11640,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4773"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -11452,7 +11658,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -11490,6 +11696,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4777"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -11507,7 +11714,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -11545,6 +11752,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4783"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -11562,7 +11770,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -11600,6 +11808,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4785"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -11617,7 +11826,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -11655,6 +11864,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4791"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -11672,7 +11882,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -11710,6 +11920,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4796"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -11727,7 +11938,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -11765,6 +11976,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4800"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -11782,7 +11994,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -11820,6 +12032,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4808"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -11837,7 +12050,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -11875,6 +12088,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4814"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -11892,7 +12106,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -11930,6 +12144,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4819"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -11947,7 +12162,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -11985,6 +12200,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4825"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -12002,7 +12218,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -12040,6 +12256,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4833"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -12057,7 +12274,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -12095,6 +12312,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4838"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -12112,7 +12330,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -12150,6 +12368,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4841"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -12167,7 +12386,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -12205,6 +12424,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4843"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -12222,7 +12442,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -12260,6 +12480,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4855"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -12277,7 +12498,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -12315,6 +12536,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4863"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -12332,7 +12554,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -12370,6 +12592,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4867"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -12387,7 +12610,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -12425,6 +12648,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4871"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -12442,7 +12666,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -12480,6 +12704,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4879"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -12497,7 +12722,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -12535,6 +12760,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4881"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -12552,7 +12778,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -12590,6 +12816,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4885"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -12607,7 +12834,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -12645,6 +12872,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4887"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -12662,7 +12890,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -12700,6 +12928,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4890"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -12717,7 +12946,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -12755,6 +12984,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4894"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -12772,7 +13002,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -12810,6 +13040,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4896"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -12827,7 +13058,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -12865,6 +13096,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4898"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -12882,7 +13114,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -12920,6 +13152,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4900"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -12937,7 +13170,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -12975,6 +13208,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4904"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -12992,7 +13226,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -13030,6 +13264,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4908"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -13047,7 +13282,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -13085,6 +13320,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4910"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -13102,7 +13338,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -13140,6 +13376,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4912"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -13157,7 +13394,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -13195,6 +13432,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4916"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -13212,7 +13450,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -13250,6 +13488,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4918"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -13267,7 +13506,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -13305,6 +13544,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4921"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -13322,7 +13562,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -13360,6 +13600,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4923"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -13377,7 +13618,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -13415,6 +13656,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4925"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -13432,7 +13674,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -13470,6 +13712,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4928"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -13487,7 +13730,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -13525,6 +13768,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4934"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -13542,7 +13786,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -13580,6 +13824,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4938"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -13597,7 +13842,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -13635,6 +13880,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4944"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -13652,7 +13898,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -13690,6 +13936,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4946"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -13707,7 +13954,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -13745,6 +13992,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4949"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -13762,7 +14010,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -13800,6 +14048,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4951"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -13817,7 +14066,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -13855,6 +14104,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4957"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -13872,7 +14122,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -13910,6 +14160,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4959"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -13927,7 +14178,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -13965,6 +14216,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4962"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -13982,7 +14234,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -14020,6 +14272,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4964"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -14037,7 +14290,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -14075,6 +14328,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4973"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -14092,7 +14346,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -14130,6 +14384,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4981"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -14147,7 +14402,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -14185,6 +14440,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4983"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -14202,7 +14458,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -14240,6 +14496,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4985"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -14257,7 +14514,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -14295,6 +14552,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4987"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -14312,7 +14570,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -14350,6 +14608,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4989"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -14367,7 +14626,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -14405,6 +14664,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4992"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -14422,7 +14682,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -14460,6 +14720,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-4996"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -14477,7 +14738,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -14515,6 +14776,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5002"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -14532,7 +14794,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -14570,6 +14832,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5004"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -14587,7 +14850,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -14625,6 +14888,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5010"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -14642,7 +14906,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -14680,6 +14944,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5013"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -14697,7 +14962,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -14735,6 +15000,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5019"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -14752,7 +15018,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -14790,6 +15056,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5023"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -14807,7 +15074,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -14845,6 +15112,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5031"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -14862,7 +15130,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -14900,6 +15168,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5036"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -14917,7 +15186,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -14955,6 +15224,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5044"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -14972,7 +15242,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -15010,6 +15280,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5047"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -15027,7 +15298,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -15065,6 +15336,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5052"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -15082,7 +15354,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -15120,6 +15392,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5064"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -15137,7 +15410,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -15175,6 +15448,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5073"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -15192,7 +15466,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -15230,6 +15504,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5077"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -15247,7 +15522,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -15285,6 +15560,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5079"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -15302,7 +15578,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -15340,6 +15616,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5081"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -15357,7 +15634,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -15395,6 +15672,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5087"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -15412,7 +15690,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -15450,6 +15728,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5091"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -15467,7 +15746,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -15505,6 +15784,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5095"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -15522,7 +15802,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -15560,6 +15840,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5098"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -15577,7 +15858,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -15615,6 +15896,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5104"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -15632,7 +15914,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -15670,6 +15952,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5109"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -15687,7 +15970,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -15725,6 +16008,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5114"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -15742,7 +16026,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -15780,6 +16064,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5116"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -15797,7 +16082,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -15835,6 +16120,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5121"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -15852,7 +16138,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -15890,6 +16176,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5127"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -15907,7 +16194,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -15945,6 +16232,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5136"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -15962,7 +16250,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -16000,6 +16288,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5140"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -16017,7 +16306,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -16055,6 +16344,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5148"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -16072,7 +16362,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -16110,6 +16400,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5156"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -16127,7 +16418,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -16165,6 +16456,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5164"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -16182,7 +16474,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -16220,6 +16512,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5168"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -16237,7 +16530,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -16275,6 +16568,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5172"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -16292,7 +16586,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -16330,6 +16624,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5178"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -16347,7 +16642,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -16385,6 +16680,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5182"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -16402,7 +16698,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -16440,6 +16736,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5186"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -16457,7 +16754,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -16495,6 +16792,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5192"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -16512,7 +16810,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -16550,6 +16848,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5194"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -16567,7 +16866,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -16605,6 +16904,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5199"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -16622,7 +16922,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -16660,6 +16960,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5205"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -16677,7 +16978,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -16715,6 +17016,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5209"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -16732,7 +17034,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -16770,6 +17072,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5217"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -16787,7 +17090,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -16825,6 +17128,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5220"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -16842,7 +17146,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -16880,6 +17184,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5228"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -16897,7 +17202,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -16935,6 +17240,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5234"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -16952,7 +17258,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -16990,6 +17296,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5242"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -17007,7 +17314,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -17045,6 +17352,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5244"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -17062,7 +17370,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -17100,6 +17408,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5248"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -17117,7 +17426,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -17155,6 +17464,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5252"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -17172,7 +17482,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -17210,6 +17520,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5256"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -17227,7 +17538,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -17265,6 +17576,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5260"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -17282,7 +17594,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -17320,6 +17632,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5268"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -17337,7 +17650,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -17375,6 +17688,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5273"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -17392,7 +17706,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -17430,6 +17744,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5282"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -17447,7 +17762,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -17485,6 +17800,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5288"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -17502,7 +17818,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -17540,6 +17856,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5290"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -17557,7 +17874,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -17595,6 +17912,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5299"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -17612,7 +17930,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -17650,6 +17968,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5302"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -17667,7 +17986,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -17705,6 +18024,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5307"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -17722,7 +18042,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -17760,6 +18080,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5309"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -17777,7 +18098,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -17815,6 +18136,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5311"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -17832,7 +18154,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -17870,6 +18192,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5317"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -17887,7 +18210,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -17925,6 +18248,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5323"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -17942,7 +18266,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -17980,6 +18304,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5325"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -17997,7 +18322,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -18035,6 +18360,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5327"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -18052,7 +18378,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -18090,6 +18416,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5329"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -18107,7 +18434,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -18145,6 +18472,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5337"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -18162,7 +18490,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -18200,6 +18528,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5341"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -18217,7 +18546,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -18255,6 +18584,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5343"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -18272,7 +18602,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -18310,6 +18640,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5349"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -18327,7 +18658,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -18365,6 +18696,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5351"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -18382,7 +18714,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span
@@ -18420,6 +18752,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
           >
             <button
               aria-controls="example-tree-5354"
+              aria-hidden={true}
               className="slds-button slds-button_icon slds-m-right_small"
               disabled={false}
               onClick={[Function]}
@@ -18437,7 +18770,7 @@ exports[`DOM snapshots SLDSTree Overflow Hidden 1`] = `
               <span
                 className="slds-assistive-text"
               >
-                Toggle
+                Expand Tree Branch
               </span>
             </button>
             <span

--- a/components/tree/private/item.jsx
+++ b/components/tree/private/item.jsx
@@ -165,6 +165,7 @@ const Item = (props) => {
 				{/* eslint-enable jsx-a11y/no-static-element-interactions */}
 				<Button
 					tabIndex="-1"
+					aria-hidden
 					assistiveText={{ icon: '' }}
 					role="presentation"
 					iconCategory="utility"

--- a/components/tree/private/render-branch.jsx
+++ b/components/tree/private/render-branch.jsx
@@ -303,7 +303,8 @@ const RenderBranch = (children, props) => {
 			>
 				{/* eslint-enable jsx-a11y/no-static-element-interactions */}
 				<Button
-					assistiveText={{ icon: 'Toggle' }}
+					aria-hidden
+					assistiveText={{ icon: 'Expand Tree Branch' }}
 					iconCategory="utility"
 					iconName="chevronright"
 					iconSize="small"


### PR DESCRIPTION
Adds `aria-hidden=true` in Tree Buttons and also, edits the assistiveText on the button to align with SLDS

Fixes #1914 

### Additional description

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [ ] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [ ] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
