### PR TITLE
illustration component minor bugfix for style object

### DIFF
--- a/components/illustration/index.jsx
+++ b/components/illustration/index.jsx
@@ -52,7 +52,14 @@ const Illustration = ({
 		componentDoc
 	);
 	const kababCaseName = name ? name.replace(/_| /g, '-').toLowerCase() : '';
+	const styles = { ...style };
 	let illustrationSvg;
+
+	// large illustration svg should have a default height of 400px if not already specified
+	if (size === 'large' && !styles.height) {
+		styles.height = '400px';
+	}
+
 	if (illustration) {
 		// Use SVG data passed in with `illustration` prop
 		illustrationSvg = (
@@ -61,7 +68,7 @@ const Illustration = ({
 				aria-hidden="true"
 				data={illustration}
 				name={kababCaseName}
-				style={style}
+				style={styles}
 			/>
 		);
 	} else if (path) {
@@ -70,16 +77,13 @@ const Illustration = ({
 				className="slds-illustration__svg"
 				aria-hidden="true"
 				name={kababCaseName}
-				style={style}
+				style={styles}
 			>
 				<use xlinkHref={path} />
 			</svg>
 		);
 	}
-	// large illustration svg should have a default height of 400px if not already specified
-	if (illustrationSvg && size === 'large' && !style.height) {
-		style.height = '400px';
-	}
+
 	return (
 		<div
 			className={classNames(className, 'slds-illustration', {


### PR DESCRIPTION
Fixes #1912

A simple fix for a bug where the illustration component directly manipulates incoming props. Very obscure and not a huge issue unless running in Storybook / dev mode, but worth correcting now since it's simple.

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [x] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [x] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [x] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
