### PR TITLE
Modal: Refactor border-radius render logic

### DIFF
--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -8855,6 +8855,13 @@
                 "returns": null
             },
             {
+                "name": "getBorderRadius",
+                "docblock": null,
+                "modifiers": [],
+                "params": [],
+                "returns": null
+            },
+            {
                 "name": "getModal",
                 "docblock": null,
                 "modifiers": [],

--- a/components/modal/__docs__/storybook-stories.jsx
+++ b/components/modal/__docs__/storybook-stories.jsx
@@ -281,7 +281,7 @@ storiesOf(MODAL, module)
 			children: modalContent,
 			onRequestClose: action('modal closed'),
 			portalClassName: 'portal-class-name-test',
-			footer: modalFooter
+			footer: modalFooter,
 		})
 	)
 	.add('Large with directional footer', () =>

--- a/components/modal/__docs__/storybook-stories.jsx
+++ b/components/modal/__docs__/storybook-stories.jsx
@@ -275,6 +275,15 @@ storiesOf(MODAL, module)
 			portalClassName: 'portal-class-name-test',
 		})
 	)
+	.add('Small no header and custom footer', () =>
+		getModal({
+			isOpen: true,
+			children: modalContent,
+			onRequestClose: action('modal closed'),
+			portalClassName: 'portal-class-name-test',
+			footer: modalFooter
+		})
+	)
 	.add('Large with directional footer', () =>
 		getModal({
 			directional: true,

--- a/components/modal/index.jsx
+++ b/components/modal/index.jsx
@@ -235,13 +235,26 @@ class Modal extends React.Component {
 		return this.props.id || this.generatedId;
 	}
 
+	getBorderRadius() {
+		const borderRadiusValue = '.25rem';
+		const borderTopRadius =
+			this.props.title || this.props.heading || this.props.header
+				? {}
+				: { borderTopLeftRadius: borderRadiusValue, borderTopRightRadius: borderRadiusValue };
+		const borderBottomRadius =
+			this.props.footer
+				? {}
+				: { borderBottomLeftRadius: borderRadiusValue, borderBottomRightRadius: borderRadiusValue };
+		return {
+			...borderTopRadius,
+			...borderBottomRadius
+		}
+	}
+
 	getModal() {
 		const modalStyle =
 			this.props.align === 'top' ? { justifyContent: 'flex-start' } : null;
-		const borderRadius =
-			this.props.title || this.props.heading || this.props.header
-				? {}
-				: { borderRadius: '.25rem' };
+		const borderRadius = this.getBorderRadius();
 		const contentStyleFromProps = this.props.contentStyle || {};
 		const contentStyle = {
 			...borderRadius,

--- a/components/modal/index.jsx
+++ b/components/modal/index.jsx
@@ -240,15 +240,20 @@ class Modal extends React.Component {
 		const borderTopRadius =
 			this.props.title || this.props.heading || this.props.header
 				? {}
-				: { borderTopLeftRadius: borderRadiusValue, borderTopRightRadius: borderRadiusValue };
-		const borderBottomRadius =
-			this.props.footer
-				? {}
-				: { borderBottomLeftRadius: borderRadiusValue, borderBottomRightRadius: borderRadiusValue };
+				: {
+						borderTopLeftRadius: borderRadiusValue,
+						borderTopRightRadius: borderRadiusValue,
+					};
+		const borderBottomRadius = this.props.footer
+			? {}
+			: {
+					borderBottomLeftRadius: borderRadiusValue,
+					borderBottomRightRadius: borderRadiusValue,
+				};
 		return {
 			...borderTopRadius,
-			...borderBottomRadius
-		}
+			...borderBottomRadius,
+		};
 	}
 
 	getModal() {


### PR DESCRIPTION
Fixes #

1. Updated the Modal Component to fix a "border-radius" style problem when the modal has a footer but not a header. Now only apply the style to the top or bottom corners as appropriate.
2. Added Storybook case "Small no header and custom footer".

### Additional description

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [x] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [x] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [x] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
