### PR TITLE
add iconPath and iconClassName props

### DIFF
--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -11228,6 +11228,31 @@
                 "required": false,
                 "description": "The icons category"
             },
+            "iconClassName": {
+                "type": {
+                    "name": "union",
+                    "value": [
+                        {
+                            "name": "array"
+                        },
+                        {
+                            "name": "object"
+                        },
+                        {
+                            "name": "string"
+                        }
+                    ]
+                },
+                "required": false,
+                "description": "CSS classes to be added to icon."
+            },
+            "iconPath": {
+                "type": {
+                    "name": "string"
+                },
+                "required": false,
+                "description": "Path to the icon. This will override any global icon settings."
+            },
             "iconPosition": {
                 "type": {
                     "name": "enum",

--- a/components/page-header/__docs__/storybook-stories.jsx
+++ b/components/page-header/__docs__/storybook-stories.jsx
@@ -382,6 +382,17 @@ storiesOf(PAGE_HEADER, module)
 			info: 'Mark Jaeckal • Unlimited Customer • 11/13/15',
 		})
 	)
+	.add('Base with custom icon', () =>
+		getPageHeader({
+			iconAssistiveText: 'Opportunity',
+			iconCategory: 'standard',
+			iconClassName: 'slds-icon-text-default',
+			iconName: 'opportunity',
+			iconPath: '/assets/icons/utility-sprite/svg/symbols.svg#bucket',
+			title: 'Rohde Corp - 80,000 Widgets',
+			info: 'Mark Jaeckal • Unlimited Customer • 11/13/15',
+		})
+	)
 	.add('Base with actions', () =>
 		getPageHeader({
 			iconAssistiveText: 'Opportunity',

--- a/components/page-header/index.jsx
+++ b/components/page-header/index.jsx
@@ -79,6 +79,18 @@ const propTypes = {
 		'utility',
 	]),
 	/**
+	 * CSS classes to be added to icon.
+	 */
+	iconClassName: PropTypes.oneOfType([
+		PropTypes.array,
+		PropTypes.object,
+		PropTypes.string,
+	]),
+	/**
+	 * Path to the icon. This will override any global icon settings.
+	 */
+	iconPath: PropTypes.string,
+	/**
 	 * If omitted, icon position is centered.
 	 */
 	iconPosition: PropTypes.oneOf(['left', 'right']),
@@ -154,7 +166,9 @@ class PageHeader extends Component {
 			details,
 			icon,
 			iconCategory,
+			iconClassName,
 			iconName,
+			iconPath,
 			iconPosition,
 			iconSize,
 			iconVariant,
@@ -174,11 +188,13 @@ class PageHeader extends Component {
 		 * Render the icon
 		 */
 		const renderIcon = () => {
-			if (iconName) {
+			if (iconName || iconPath) {
 				return (
 					<Icon
 						name={iconName}
 						category={iconCategory}
+						className={iconClassName}
+						path={iconPath}
 						position={iconPosition}
 						size={iconSize}
 						variant={iconVariant}


### PR DESCRIPTION
Fixes #1984 

Adding the following props:

`iconPath`: Path to the icon. This will override any global icon settings.
`iconClassName`: CSS classes to be added to [icon.]

<img width="599" alt="Screen Shot 2019-05-17 at 3 51 33 PM" src="https://user-images.githubusercontent.com/1821787/57960066-a1c88000-78bb-11e9-8f42-4644bc789d5b.png">



### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [ ] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [ ] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
