### PR TITLE
Added Error Prop to Radio Group Component

### DIFF
--- a/components/radio-group/index.jsx
+++ b/components/radio-group/index.jsx
@@ -35,7 +35,11 @@ const propTypes = {
 	labels: PropTypes.shape({
 		error: PropTypes.string,
 		label: PropTypes.string,
-	}),
+    }),
+    /**
+     * `error`: Alternative way to display an error message
+     */
+    error: PropTypes.string,
 	/**
 	 * This event fires when the radio selection changes.
 	 */
@@ -58,7 +62,7 @@ const propTypes = {
 	errorId: PropTypes.string,
 };
 
-const defaultProps = { labels: {} };
+const defaultProps = { labels: {}, error: ''};
 
 /**
  * A styled select list that can have a single entry checked at any one time.
@@ -89,8 +93,12 @@ class RadioGroup extends React.Component {
 	}
 
 	hasError() {
-		return !!this.labels.error;
-	}
+		return !!this.labels.error || !!this.props.error;
+    }
+    
+    getError() {
+        return !!this.labels.error ? this.labels.error : this.props.error
+    }
 
 	render() {
 		const children = React.Children.map(this.props.children, (child) =>
@@ -105,7 +113,7 @@ class RadioGroup extends React.Component {
 		return (
 			<fieldset
 				className={classNames('slds-form-element', {
-					'slds-has-error': this.labels.error,
+					'slds-has-error': this.hasError(),
 				})}
 			>
 				<legend className="slds-form-element__legend slds-form-element__label">
@@ -123,9 +131,9 @@ class RadioGroup extends React.Component {
 					)}
 				>
 					{children}
-					{this.labels.error ? (
+					{this.hasError() ? (
 						<div id={this.getErrorId()} className="slds-form-element__help">
-							{this.labels.error}
+							{this.getError()}
 						</div>
 					) : null}
 				</div>


### PR DESCRIPTION
Fixes #2009

### Additional description
This error prop is easily updated and controlled by a parent component.
Please tell me how I might write a test for this that passes.  I will then write tests for all other changes to the codebase.
---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
