### PR TITLE
Radio Group: Update labels from props after instance construction

### DIFF
--- a/components/radio-group/index.jsx
+++ b/components/radio-group/index.jsx
@@ -65,16 +65,9 @@ const defaultProps = { labels: {} };
  * The RadioGroup component wraps [Radio](/components/radios) components, which should be used as children.
  */
 class RadioGroup extends React.Component {
-	constructor(props) {
-		super(props);
-
-		// Merge objects of strings with their default object
-		this.labels = this.props.labels
-			? assign({}, defaultProps.labels, this.props.labels)
-			: defaultProps.labels;
-
+	componentWillMount() {
 		this.generatedName = shortid.generate();
-		this.generatedErrorId = this.labels.error ? shortid.generate() : null;
+		this.generatedErrorId = shortid.generate();
 	}
 
 	getErrorId() {
@@ -93,6 +86,11 @@ class RadioGroup extends React.Component {
 	}
 
 	render() {
+		// Merge objects of strings with their default object
+		this.labels = this.props.labels
+			? assign({}, defaultProps.labels, this.props.labels)
+			: defaultProps.labels;
+
 		const children = React.Children.map(this.props.children, (child) =>
 			React.cloneElement(child, {
 				name: this.getName(),


### PR DESCRIPTION
Current RadioGroup does not update label props and uses the label set via props in the contrstructor

Fixes #2009

### Additional description

```
/* eslint-disable react/display-name */ import React from 'react';
import PropTypes from 'prop-types';
import { storiesOf } from '@storybook/react';
import { action } from '@storybook/addon-actions';
import RadioGroup from '../../radio-group';
import Radio from '../../radio-group/radio';
import { RADIO_GROUP } from '../../../utilities/constants';

import Base from '../__examples__/base';

class RadioGroupExample extends React.Component {
	constructor(props) {
		super(props);
		this.state = {
			labels: {
				label: 'Radio Group Label',
			},
		};
		this.onChange = this.onChange.bind(this);
	}

	onChange(event) {
		const { value } = event.target;
		this.setState((prevState) => ({
			checked: value,
			labels: {
				label: prevState.labels.label,
				error: 'There is an error',
			},
		}));

		action('onChange')(event);
	}

	render() {
		const values = ['Radio Label One', 'Radio Label Two'];
		return (
			<div>
				<h1 className="slds-text-title_caps slds-p-vertical_medium">
					{this.props.heading}
				</h1>
				<RadioGroup
					labels={this.state.labels}
					onChange={this.onChange}
					disabled={this.props.disabled}
					required={this.props.required}
				>
					{values.map((value) => (
						<Radio
							key={value}
							id={value}
							label={value}
							value={value}
							checked={this.state.checked === value}
							variant="base"
						/>
					))}
				</RadioGroup>
			</div>
		);
	}
}
RadioGroupExample.propTypes = {
	labels: PropTypes.shape({
		error: PropTypes.string,
		label: PropTypes.string,
	}),
	disabled: PropTypes.bool,
	required: PropTypes.bool,
	heading: PropTypes.string,
};
RadioGroupExample.defaultProps = {
	labels: {
		label: 'Radio Group Label',
	},
};
storiesOf(RADIO_GROUP, module)
	.addDecorator((getStory) => (
		<div className="slds-p-around_medium">{getStory()}</div>
	))
	.add('Base', () => <RadioGroupExample heading="Base" />)
	.add('Disabled', () => <RadioGroupExample heading="Disabled" disabled />)
	.add('Required', () => <RadioGroupExample heading="Required" required />)
	.add('Error', () => <RadioGroupExample heading="Error" />)
	.add('Docs site Base', () => <Base />);

```

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [ ] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [ ] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
