### PR TITLE
Merge Radio Button Group and Radio Group

### DIFF
--- a/components/radio-button-group/index.jsx
+++ b/components/radio-button-group/index.jsx
@@ -6,10 +6,8 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
 
-import shortid from 'shortid';
-import assign from 'lodash.assign';
+import RadioGroup from '../radio-group';
 
 import { RADIO_BUTTON_GROUP } from '../../utilities/constants';
 
@@ -71,85 +69,12 @@ const defaultProps = { labels: {}, assistiveText: {} };
  * A styled select list that can have a single entry checked at any one time.
  * The RadioButtonGroup component wraps [Radio](/components/radios) components, which should be used as children.
  */
-class RadioButtonGroup extends React.Component {
-	constructor(props) {
-		super(props);
+const RadioButtonGroup = (props) => {
+	// Separate props we care about in order to pass others along passively to the dropdown component
+	const { variant, ...rest } = props;
 
-		// Merge objects of strings with their default object
-		this.labels = this.props.labels
-			? assign({}, defaultProps.labels, this.props.labels)
-			: defaultProps.labels;
-
-		this.generatedName = shortid.generate();
-		this.generatedErrorId = this.labels.error ? shortid.generate() : null;
-	}
-
-	getErrorId() {
-		if (this.hasError()) {
-			return this.props.errorId || this.generatedErrorId;
-		}
-		return undefined;
-	}
-
-	getName() {
-		return this.props.name || this.generatedName;
-	}
-
-	hasError() {
-		return !!this.labels.error;
-	}
-
-	render() {
-		const children = React.Children.map(this.props.children, (child) =>
-			React.cloneElement(child, {
-				name: this.getName(),
-				onChange: this.props.onChange,
-				'aria-describedby': this.getErrorId(),
-				disabled: this.props.disabled,
-			})
-		);
-
-		return (
-			<fieldset
-				className={classNames('slds-form-element', {
-					'slds-has-error': this.labels.error,
-				})}
-			>
-				<legend
-					className={classNames(
-						'slds-form-element__legend',
-						'slds-form-element__label',
-						this.props.assistiveText.label ? 'slds-assistive-text' : ''
-					)}
-				>
-					{this.props.required ? (
-						<abbr className="slds-required" title="required">
-							*
-						</abbr>
-					) : null}
-					{this.props.assistiveText.label
-						? this.props.assistiveText.label
-						: this.labels.label}
-				</legend>
-				<div
-					className={classNames(
-						'slds-form-element__control',
-						this.props.className
-					)}
-				>
-					<div style={this.props.style} className="slds-radio_button-group">
-						{children}
-					</div>
-					{this.labels.error ? (
-						<div id={this.getErrorId()} className="slds-form-element__help">
-							{this.labels.error}
-						</div>
-					) : null}
-				</div>
-			</fieldset>
-		);
-	}
-}
+	return <RadioGroup variant="button-group" {...rest} />;
+};
 
 RadioButtonGroup.displayName = RADIO_BUTTON_GROUP;
 RadioButtonGroup.propTypes = propTypes;

--- a/components/radio-group/index.jsx
+++ b/components/radio-group/index.jsx
@@ -65,16 +65,9 @@ const defaultProps = { labels: {} };
  * The RadioGroup component wraps [Radio](/components/radios) components, which should be used as children.
  */
 class RadioGroup extends React.Component {
-	constructor(props) {
-		super(props);
-
-		// Merge objects of strings with their default object
-		this.labels = this.props.labels
-			? assign({}, defaultProps.labels, this.props.labels)
-			: defaultProps.labels;
-
+	componentWillMount() {
 		this.generatedName = shortid.generate();
-		this.generatedErrorId = this.labels.error ? shortid.generate() : null;
+		this.generatedErrorId = shortid.generate();
 	}
 
 	getErrorId() {
@@ -93,6 +86,11 @@ class RadioGroup extends React.Component {
 	}
 
 	render() {
+		// Merge objects of strings with their default object
+		this.labels = this.props.labels
+			? assign({}, defaultProps.labels, this.props.labels)
+			: defaultProps.labels;
+
 		const children = React.Children.map(this.props.children, (child) =>
 			React.cloneElement(child, {
 				name: this.getName(),

--- a/components/radio-group/index.jsx
+++ b/components/radio-group/index.jsx
@@ -131,7 +131,7 @@ class RadioGroup extends React.Component {
 					) : null}
 					{this.props.assistiveText.label
 						? this.props.assistiveText.label
-						: this.labels.label}{' '}
+						: this.labels.label}
 				</legend>
 				<div
 					className={classNames(

--- a/components/radio-group/index.jsx
+++ b/components/radio-group/index.jsx
@@ -15,6 +15,13 @@ import { RADIO_GROUP } from '../../utilities/constants';
 
 const propTypes = {
 	/**
+	 * **Assistive text for accessibility**
+	 * * `label`: This label appears in the legend.
+	 */
+	assistiveText: PropTypes.shape({
+		label: PropTypes.string,
+	}),
+	/**
 	 * Children are expected to be Radio components.
 	 */
 	children: PropTypes.node.isRequired,
@@ -56,9 +63,13 @@ const propTypes = {
 	 * The ID of the error message, for linking to radio inputs with aria-describedby.
 	 */
 	errorId: PropTypes.string,
+	/**
+	 * Variants of radio groups such as Radio Button Group
+	 */
+	variant: PropTypes.oneOf(['base', 'button-group']),
 };
 
-const defaultProps = { labels: {} };
+const defaultProps = { assistiveText: {}, labels: {}, variant: 'base' };
 
 /**
  * A styled select list that can have a single entry checked at any one time.
@@ -106,13 +117,21 @@ class RadioGroup extends React.Component {
 					'slds-has-error': this.labels.error,
 				})}
 			>
-				<legend className="slds-form-element__legend slds-form-element__label">
+				<legend
+					className={classNames(
+						'slds-form-element__legend',
+						'slds-form-element__label',
+						this.props.assistiveText.label ? 'slds-assistive-text' : ''
+					)}
+				>
 					{this.props.required ? (
 						<abbr className="slds-required" title="required">
 							*
 						</abbr>
 					) : null}
-					{this.labels.label}
+					{this.props.assistiveText.label
+						? this.props.assistiveText.label
+						: this.labels.label}{' '}
 				</legend>
 				<div
 					className={classNames(
@@ -120,7 +139,14 @@ class RadioGroup extends React.Component {
 						this.props.className
 					)}
 				>
-					{children}
+					{this.props.variant === 'button-group' ? (
+						<div style={this.props.style} className="slds-radio_button-group">
+							{children}
+						</div>
+					) : (
+						children
+					)}
+
 					{this.labels.error ? (
 						<div id={this.getErrorId()} className="slds-form-element__help">
 							{this.labels.error}


### PR DESCRIPTION
Fixes #2031

@kevinparkerson Merge in #2030 first

### Additional description

RadioGroup and RadioButtonGroup have most of the same code. This issue puts RadioGroup inside of ButtonGroup and integrates RadioButtonGroup render into RadioGroup.


---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [ ] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [ ] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
