### PR TITLE
Fix for: EditDialogPopover is not defined on sites

### DIFF
--- a/components/popover/__examples__/edit-dialog.jsx
+++ b/components/popover/__examples__/edit-dialog.jsx
@@ -13,8 +13,6 @@ class Example extends React.Component {
 
 	constructor(props) {
 		super(props);
-		const defaultFirstName = 'John';
-		const defaultLastName = 'Smith';
 		this.state = {
 			isOpen: this.props.isOpen,
 			firstName: DEFAULT_FIRST_NAME, // stores firstName in edit input field

--- a/components/popover/__examples__/edit-dialog.jsx
+++ b/components/popover/__examples__/edit-dialog.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import IconSettings from '~/components/icon-settings';
-import EditDialogPopover from '~/components/popover/edit-dialog'; // `~` is replaced with design-system-react at runtime
+import EditDialog from '~/components/popover/edit-dialog'; // `~` is replaced with design-system-react at runtime
 import Input from '~/components/input'; // `~` is replaced with design-system-react at runtime
 import Button from '~/components/button';
 
@@ -87,7 +87,7 @@ class Example extends React.Component {
 					<span className="slds-p-right_x-small">
 						{this.state.prevFirstName} {this.state.prevLastName}
 					</span>
-					<EditDialogPopover
+					<EditDialog
 						ariaLabelledby="Edit Name"
 						body={editDialogPopoverBody}
 						isModified={

--- a/components/popover/edit-dialog.jsx
+++ b/components/popover/edit-dialog.jsx
@@ -19,7 +19,7 @@ const defaultProps = {
 		save: 'Save',
 	},
 };
-class EditDialogPopover extends React.Component {
+class EditDialog extends React.Component {
 	// ### Display Name
 	// Always use the canonical component name as the React display name.
 	static displayName = POPOVER_EDIT_DIALOG;
@@ -110,6 +110,6 @@ class EditDialogPopover extends React.Component {
 	}
 }
 
-EditDialogPopover.defaultProps = defaultProps;
+EditDialog.defaultProps = defaultProps;
 
-export default EditDialogPopover;
+export default EditDialog;


### PR DESCRIPTION
Fixes #2064 

Looks like I had `SLDSEditDialog/EditDialog` exported in `components/index.js` but I was using a wrong name in the examples. Since it's already exported, I modified the class name to be `EditDialog`. 

### Additional description

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [ ] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [ ] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
