### PR TITLE
Divide Image snapshot tests into chunks

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,1 +1,9 @@
- <link rel="stylesheet" href="assets/styles/salesforce-lightning-design-system.css">
+<link
+	rel="stylesheet"
+	href="assets/styles/salesforce-lightning-design-system.css"
+/>
+<style type="text/css">
+	html {
+		background-color: #fafaf9;
+	}
+</style>

--- a/tests/index.html
+++ b/tests/index.html
@@ -1,24 +1,33 @@
 <!DOCTYPE html>
 <html>
-<head>
-	<meta charset="utf-8">
-	<title>Design System React :: In-Browser Tests</title>
-	<link rel="stylesheet" media="all" href="/node_modules/mocha/mocha.css">
-	<link href="/assets/styles/salesforce-lightning-design-system.css" rel="stylesheet" type="text/css">
-</head>
-<body>
-	<div id="mocha"></div>
-	<div id="messages"></div>
-	<div id="fixtures"></div>
-	<script src="/node_modules/mocha/mocha.js"></script>
-	<script src="/node_modules/chai/chai.js"></script>
-	<script src="/node_modules/sinon/pkg/sinon.js"></script>
-	<script>
-		mocha.setup('bdd'); // eslint-disable-line no-undef, indent
-	</script>
-	<script src="/test-build/browser-tests.bundle.js"></script>
-	<script>
-		mocha.run(); // eslint-disable-line no-undef, indent
-	</script>
-</body>
+	<head>
+		<meta charset="utf-8" />
+		<title>Design System React :: In-Browser Tests</title>
+		<link rel="stylesheet" media="all" href="/node_modules/mocha/mocha.css" />
+		<link
+			href="/assets/styles/salesforce-lightning-design-system.css"
+			rel="stylesheet"
+			type="text/css"
+		/>
+		<style type="text/css">
+			html {
+				background-color: #fafaf9;
+			}
+		</style>
+	</head>
+	<body>
+		<div id="mocha"></div>
+		<div id="messages"></div>
+		<div id="fixtures"></div>
+		<script src="/node_modules/mocha/mocha.js"></script>
+		<script src="/node_modules/chai/chai.js"></script>
+		<script src="/node_modules/sinon/pkg/sinon.js"></script>
+		<script>
+			mocha.setup('bdd'); // eslint-disable-line no-undef, indent
+		</script>
+		<script src="/test-build/browser-tests.bundle.js"></script>
+		<script>
+			mocha.run(); // eslint-disable-line no-undef, indent
+		</script>
+	</body>
 </html>

--- a/tests/story-based-tests.snapshot-test.js
+++ b/tests/story-based-tests.snapshot-test.js
@@ -31,6 +31,7 @@ app.use(
 		`${rootPath}/node_modules/@salesforce-ux/design-system/assets/`
 	)
 );
+app.use('/assets', express.static(path.join(__dirname, `${rootPath}/assets/`)));
 app.use(express.static(`${rootPath}/storybook`));
 
 /* jest-image-snapshot
@@ -54,53 +55,68 @@ QUEUEING: STORY-BASED VISUAL REGRESSION SNAPSHOT TESTING
 EXECUTING /tests/story-based-tests.snapshot-test.js
 BASED ON STORYBOOK STORIES FOUND IN /components/storybook-stories.js
 
-This script uses Jest to call Storyshots 
-https://github.com/storybooks/storybook/tree/next/addons/storyshots on each 
-Storybook story found at http://localhost:9001. This stores a PNG on load and 
-compares it to PNGs previously captured. If you need an open menu tested, then 
+This script uses Jest to call Storyshots
+https://github.com/storybooks/storybook/tree/next/addons/storyshots on each
+Storybook story found at http://localhost:9001. This stores a PNG on load and
+compares it to PNGs previously captured. If you need an open menu tested, then
 you will need to open the menu with the \`isOpen\` prop.
 
-PLEASE DO NOT USE \`git add -A\` WHEN COMMITING PNGs. ONLY ADD IMAGES THAT 
+PLEASE DO NOT USE \`git add -A\` WHEN COMMITING PNGs. ONLY ADD IMAGES THAT
 ARE RELATED TO YOUR PULL REQUEST. Each PNG adds up and bloats the repository.
 
 For more information, please review: https://github.com/salesforce/design-system-react/blob/master/tests/README.md
 `);
 
+const chunk = (arr, size) =>
+	arr.reduce(
+		(chunks, el, i) =>
+			(i % size ? chunks[chunks.length - 1].push(el) : chunks.push([el])) &&
+			chunks,
+		[]
+	);
+
+const chunkedStories = chunk(excludeFromTests.visualRegression.storyKind, 10);
+
 // If a Storybook story should not be visual regression tested, please add
 // the suffix `NoImageTest` to the story's name.
 const skipImageStoryShotTest = 'NoImageTest';
 
-describe('Image Snapshots', function imageSnapshotFunction() {
-	beforeAll(() => {
-		// Start Express server
-		server = app.listen(port, () => {
-			console.log('Storybook server listening on port ', server.address().port);
+chunkedStories.forEach((subArrayOfStories) => {
+	describe('Image Snapshots', function imageSnapshotFunction() {
+		beforeAll(() => {
+			// Start Express server
+			server = app.listen(port, () => {
+				console.log(
+					'Storybook server listening on port ',
+					server.address().port
+				);
+			});
 		});
-	});
 
-	afterAll(() => {
-		// Stop Express server
-		server.close(() => {
-			console.log('Shutting down the server running Storybook');
+		afterAll(() => {
+			// Stop Express server
+			server.close(() => {
+				console.log('Shutting down the server running Storybook');
+			});
 		});
-	});
 
-	// Use custom storybook config that uses a subset of stories until
-	// all components have been audited for compatibility with Jest
-	// snapshot tests.
-	initStoryshots({
-		configPath: '.storybook',
-		storyNameRegex: new RegExp(
-			`^((?!.*?(${skipStoryShotTest}|${skipImageStoryShotTest})).)*$`,
-			'g'
-		),
-		storyKindRegex: getExcludeKindRegex({
-			arrayOfStoryKind: excludeFromTests.visualRegression.storyKind,
-		}),
-		suite: 'Image storyshots',
-		test: imageSnapshot({
-			storybookUrl: `http://localhost:${port}`,
-			getMatchOptions,
-		}),
+		// Use custom storybook config that uses a subset of stories until
+		// all components have been audited for compatibility with Jest
+		// snapshot tests.
+		initStoryshots({
+			configPath: '.storybook',
+			storyNameRegex: new RegExp(
+				`^((?!.*?(${skipStoryShotTest}|${skipImageStoryShotTest})).)*$`,
+				'g'
+			),
+			storyKindRegex: getExcludeKindRegex({
+				arrayOfStoryKind: subArrayOfStories,
+			}),
+			suite: 'Image storyshots',
+			test: imageSnapshot({
+				storybookUrl: `http://localhost:${port}`,
+				getMatchOptions,
+			}),
+		});
 	});
 });

--- a/tests/storyshots-helpers.js
+++ b/tests/storyshots-helpers.js
@@ -10,9 +10,15 @@ const getExcludeKindRegex = ({ arrayOfStoryKind = [] } = {}) => {
 	return new RegExp(`^(?!(${storyKindString})$)[a-z A-Z0-9s]+$`, 'g');
 };
 
+// Use with `./exclude-story-config` to create a REGEX config that adds stories instead of removing them
+const getIncludeKindRegex = ({ arrayOfStoryKind = [] } = {}) => {
+	const storyKindString = arrayOfStoryKind.join('|');
+	return new RegExp(`^(${storyKindString})$`, 'g');
+};
+
 // If a Storybook story should not be tested by Storyshots, please add
 // the suffix `NoTest` to the story's name.
 const skipStoryShotTest = 'NoTest';
 
 // eslint-disable-next-line import/prefer-default-export
-export { getExcludeKindRegex, skipStoryShotTest };
+export { getExcludeKindRegex, getIncludeKindRegex, skipStoryShotTest };


### PR DESCRIPTION
Fixes #2139

### Additional description
* Currently this is set to divide Storybook `storyKind` by 10 and use those arrays as suites with the same name.
* Adds `getIncludeKindRegex` helper. This was helpful in debugging this issue by adding a subset of stories instead of excluding them.

If passing:
<img width="304" alt="Screen Shot 2019-06-28 at 3 26 50 PM" src="https://user-images.githubusercontent.com/1290832/60374098-f46b8080-99bf-11e9-92b4-75cf39d3aeda.png">


---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [ ] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [ ] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
