### PR TITLE
Welcome mat: Doc site compatibility, Icon prop updates

### DIFF
--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -16039,6 +16039,232 @@
         "route": "welcome-mat",
         "display-name": "Welcome Mat",
         "SLDS-component-path": "/components/welcome-mat",
-        "dependencies": []
+        "dependencies": [
+            {
+                "info-badge": {
+                    "description": "InfoBadge component item represents a tile in a Welcome Mat",
+                    "methods": [
+                        {
+                            "name": "getId",
+                            "docblock": "Get the Welcome Mat Info Badge's HTML id. Generate a new one if no ID present.",
+                            "modifiers": [],
+                            "params": [],
+                            "returns": null,
+                            "description": "Get the Welcome Mat Info Badge's HTML id. Generate a new one if no ID present."
+                        },
+                        {
+                            "name": "getCompletedText",
+                            "docblock": null,
+                            "modifiers": [],
+                            "params": [],
+                            "returns": null
+                        }
+                    ],
+                    "props": {
+                        "assistiveText": {
+                            "type": {
+                                "name": "shape",
+                                "value": {
+                                    "completed": {
+                                        "name": "string",
+                                        "required": false
+                                    }
+                                }
+                            },
+                            "required": false,
+                            "description": "**Assistive text for accessibility.**\n* `completed` : For users of assistive technology, assistive text for completed icon."
+                        },
+                        "className": {
+                            "type": {
+                                "name": "union",
+                                "value": [
+                                    {
+                                        "name": "array"
+                                    },
+                                    {
+                                        "name": "object"
+                                    },
+                                    {
+                                        "name": "string"
+                                    }
+                                ]
+                            },
+                            "required": false,
+                            "description": "CSS class names to be added to the container element. `array`, `object`, or `string` are accepted."
+                        },
+                        "id": {
+                            "type": {
+                                "name": "string"
+                            },
+                            "required": false,
+                            "description": "HTML id for component."
+                        },
+                        "image": {
+                            "type": {
+                                "name": "string"
+                            },
+                            "required": false,
+                            "description": "Icon for the tile"
+                        },
+                        "isComplete": {
+                            "type": {
+                                "name": "bool"
+                            },
+                            "required": false,
+                            "description": "Whether the trail is completed",
+                            "defaultValue": {
+                                "value": "false",
+                                "computed": false
+                            }
+                        },
+                        "onCompleteRenderActions": {
+                            "type": {
+                                "name": "func"
+                            },
+                            "required": false,
+                            "description": "Actions to be rendered on completion of the trail"
+                        },
+                        "variant": {
+                            "defaultValue": {
+                                "value": "'steps'",
+                                "computed": false
+                            },
+                            "required": false
+                        }
+                    },
+                    "name": "info-badge",
+                    "source": "/components/welcome-mat/info-badge.jsx"
+                }
+            },
+            {
+                "tile": {
+                    "description": "Tile component item represents a tile in a Welcome Mat",
+                    "methods": [
+                        {
+                            "name": "getId",
+                            "docblock": "Get the Welcome Mat Tile's HTML id. Generate a new one if no ID present.",
+                            "modifiers": [],
+                            "params": [],
+                            "returns": null,
+                            "description": "Get the Welcome Mat Tile's HTML id. Generate a new one if no ID present."
+                        }
+                    ],
+                    "props": {
+                        "assistiveText": {
+                            "type": {
+                                "name": "shape",
+                                "value": {
+                                    "completedIcon": {
+                                        "name": "string",
+                                        "required": false
+                                    }
+                                }
+                            },
+                            "required": false,
+                            "description": "**Assistive text for accessibility.**\nThis object is merged with the default props object on every render.\n* `completeIcon`: Text that is visually hidden but read aloud by screenreaders to tell the user what the complete icon means.",
+                            "defaultValue": {
+                                "value": "{\n    completedIcon: 'Completed',\n}",
+                                "computed": false
+                            }
+                        },
+                        "className": {
+                            "type": {
+                                "name": "union",
+                                "value": [
+                                    {
+                                        "name": "array"
+                                    },
+                                    {
+                                        "name": "object"
+                                    },
+                                    {
+                                        "name": "string"
+                                    }
+                                ]
+                            },
+                            "required": false,
+                            "description": "CSS class names to be added to the container element. `array`, `object`, or `string` are accepted."
+                        },
+                        "id": {
+                            "type": {
+                                "name": "string"
+                            },
+                            "required": false,
+                            "description": "HTML id for component."
+                        },
+                        "title": {
+                            "type": {
+                                "name": "string"
+                            },
+                            "required": false,
+                            "description": "Title for the tile component."
+                        },
+                        "description": {
+                            "type": {
+                                "name": "string"
+                            },
+                            "required": false,
+                            "description": "Description for the tile component."
+                        },
+                        "href": {
+                            "type": {
+                                "name": "string"
+                            },
+                            "required": false,
+                            "description": "Href for the tile link"
+                        },
+                        "icon": {
+                            "type": {
+                                "name": "node"
+                            },
+                            "required": false,
+                            "description": "Icon for the tile"
+                        },
+                        "isComplete": {
+                            "type": {
+                                "name": "bool"
+                            },
+                            "required": false,
+                            "description": "Whether the tile is completed",
+                            "defaultValue": {
+                                "value": "false",
+                                "computed": false
+                            }
+                        },
+                        "variant": {
+                            "type": {
+                                "name": "enum",
+                                "value": [
+                                    {
+                                        "value": "'steps'",
+                                        "computed": false
+                                    },
+                                    {
+                                        "value": "'info-only'",
+                                        "computed": false
+                                    },
+                                    {
+                                        "value": "'splash'",
+                                        "computed": false
+                                    },
+                                    {
+                                        "value": "'trailhead-connected'",
+                                        "computed": false
+                                    }
+                                ]
+                            },
+                            "required": false,
+                            "description": "Variant of the Welcome Mat Tile",
+                            "defaultValue": {
+                                "value": "'steps'",
+                                "computed": false
+                            }
+                        }
+                    },
+                    "name": "tile",
+                    "source": "/components/welcome-mat/tile.jsx"
+                }
+            }
+        ]
     }
 }

--- a/components/index.js
+++ b/components/index.js
@@ -329,6 +329,9 @@ export VisualPickerLink from './visual-picker/link';
 export SLDSWelcomeMat from './welcome-mat';
 export WelcomeMat from './welcome-mat';
 
+export SLDSWelcomeMatInfoBadge from './welcome-mat/info-badge';
+export WelcomeMatInfoBadge from './welcome-mat/info-badge';
+
 export SLDSWelcomeMatTile from './welcome-mat/tile';
 export WelcomeMatTile from './welcome-mat/tile';
 

--- a/components/welcome-mat/__examples__/default.jsx
+++ b/components/welcome-mat/__examples__/default.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import WelcomeMat from '~/components/welcome-mat';
 import WelcomeMatTile from '~/components/welcome-mat/tile';
+import Icon from '~/components/icon';
 import IconSettings from '~/components/icon-settings';
 
 class Example extends React.Component {
@@ -23,7 +24,7 @@ class Example extends React.Component {
 							<WelcomeMatTile
 								title="Welcome to Salesforce!"
 								description="Lorem ipsum dolor sit amet, lorem ipsum dolor sit amet."
-								icon="animal_and_nature"
+								icon={<Icon category="utility" name="animal_and_nature" />}
 								id="welcome-mat-tile-1"
 								href="javascript:void(0);"
 								isComplete
@@ -31,7 +32,7 @@ class Example extends React.Component {
 							<WelcomeMatTile
 								title="Learn About OpenCTI!"
 								description="Lorem ipsum dolor sit amet, lorem ipsum dolor sit amet."
-								icon="call"
+								icon={<Icon category="utility" name="call" />}
 								id="welcome-mat-tile-2"
 								href="javascript:void(0);"
 								isComplete
@@ -41,21 +42,21 @@ class Example extends React.Component {
 								description="Tap into case history or share notes with fellow agents—it all happens on the utility bar."
 								id="welcome-mat-tile-3"
 								href="javascript:void(0);"
-								icon="call"
+								icon={<Icon category="utility" name="call" />}
 							/>
 							<WelcomeMatTile
 								title="Customize your view"
 								description="Tailor your cases to your team&#x27;s workflow with custom list views."
 								id="welcome-mat-tile-4"
 								href="javascript:void(0);"
-								icon="upload"
+								icon={<Icon category="utility" name="upload" />}
 							/>
 							<WelcomeMatTile
 								title="Share the Knowledge"
 								description="Harness your team&#x27;s collective know-how with our powerful knowledge base."
 								id="welcome-mat-tile-5"
 								href="javascript:void(0);"
-								icon="knowledge_base"
+								icon={<Icon category="utility" name="knowledge_base" />}
 							/>
 						</WelcomeMat>
 					</div>

--- a/components/welcome-mat/__examples__/info-only.jsx
+++ b/components/welcome-mat/__examples__/info-only.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import WelcomeMat from '~/components/welcome-mat';
 import WelcomeMatTile from '~/components/welcome-mat/tile';
 import Button from '~/components/button';
+import Icon from '~/components/icon';
 import IconSettings from '~/components/icon-settings';
 import Checkbox from '~/components/checkbox';
 
@@ -45,35 +46,35 @@ class Example extends React.Component {
 							<WelcomeMatTile
 								title="Welcome to Salesforce!"
 								description="Lorem ipsum dolor sit amet, lorem ipsum dolor sit amet."
-								icon="animal_and_nature"
+								icon={<Icon category="utility" name="animal_and_nature" />}
 								id="welcome-mat-tile-1"
 								href="javascript:void(0);"
 							/>
 							<WelcomeMatTile
 								title="Learn About OpenCTI!"
 								description="Lorem ipsum dolor sit amet, lorem ipsum dolor sit amet."
-								icon="call"
+								icon={<Icon category="utility" name="call" />}
 								id="welcome-mat-tile-2"
 								href="javascript:void(0);"
 							/>
 							<WelcomeMatTile
 								title="Power Up the Utility Bar"
 								description="Tap into case history or share notes with fellow agents—it all happens on the utility bar."
-								icon="call"
+								icon={<Icon category="utility" name="call" />}
 								id="welcome-mat-tile-3"
 								href="javascript:void(0);"
 							/>
 							<WelcomeMatTile
 								title="Customize your view"
 								description="Tailor your cases to your team&#x27;s workflow with custom list views."
-								icon="upload"
+								icon={<Icon category="utility" name="upload" />}
 								href="javascript:void(0);"
 								id="welcome-mat-tile-4"
 							/>
 							<WelcomeMatTile
 								title="Share the Knowledge"
 								description="Harness your team&#x27;s collective know-how with our powerful knowledge base."
-								icon="knowledge_base"
+								icon={<Icon category="utility" name="knowledge_base" />}
 								href="javascript:void(0);"
 								id="welcome-mat-tile-5"
 							/>

--- a/components/welcome-mat/__examples__/steps-complete.jsx
+++ b/components/welcome-mat/__examples__/steps-complete.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import WelcomeMat from '~/components/welcome-mat';
 import WelcomeMatTile from '~/components/welcome-mat/tile';
+import Icon from '~/components/icon';
 import IconSettings from '~/components/icon-settings';
 
 class Example extends React.Component {
@@ -23,7 +24,7 @@ class Example extends React.Component {
 							<WelcomeMatTile
 								title="Welcome to Salesforce!"
 								description="Lorem ipsum dolor sit amet, lorem ipsum dolor sit amet."
-								icon="animal_and_nature"
+								icon={<Icon category="utility" name="animal_and_nature" />}
 								href="javascript:void(0);"
 								id="welcome-mat-steps-tile-1"
 								isComplete
@@ -31,7 +32,7 @@ class Example extends React.Component {
 							<WelcomeMatTile
 								title="Learn About OpenCTI!"
 								description="Lorem ipsum dolor sit amet, lorem ipsum dolor sit amet."
-								icon="call"
+								icon={<Icon category="utility" name="call" />}
 								href="javascript:void(0);"
 								id="welcome-mat-steps-tile-2"
 								isComplete
@@ -41,7 +42,7 @@ class Example extends React.Component {
 								description="Tap into case history or share notes with fellow agents—it all happens on the utility bar."
 								href="javascript:void(0);"
 								id="welcome-mat-steps-tile-3"
-								icon="call"
+								icon={<Icon category="utility" name="call" />}
 								isComplete
 							/>
 							<WelcomeMatTile
@@ -49,7 +50,7 @@ class Example extends React.Component {
 								description="Tailor your cases to your team&#x27;s workflow with custom list views."
 								href="javascript:void(0);"
 								id="welcome-mat-steps-tile-4"
-								icon="upload"
+								icon={<Icon category="utility" name="upload" />}
 								isComplete
 							/>
 							<WelcomeMatTile
@@ -57,7 +58,7 @@ class Example extends React.Component {
 								description="Harness your team&#x27;s collective know-how with our powerful knowledge base."
 								href="javascript:void(0);"
 								id="welcome-mat-steps-tile-5"
-								icon="knowledge_base"
+								icon={<Icon category="utility" name="knowledge_base" />}
 								isComplete
 							/>
 						</WelcomeMat>

--- a/components/welcome-mat/__examples__/trailhead-complete.jsx
+++ b/components/welcome-mat/__examples__/trailhead-complete.jsx
@@ -3,6 +3,7 @@ import WelcomeMat from '~/components/welcome-mat';
 import WelcomeMatTile from '~/components/welcome-mat/tile';
 import WelcomeMatInfoBadge from '~/components/welcome-mat/info-badge';
 import Button from '~/components/button';
+import Icon from '~/components/icon';
 import IconSettings from '~/components/icon-settings';
 
 class Example extends React.Component {
@@ -47,7 +48,7 @@ class Example extends React.Component {
 							<WelcomeMatTile
 								title="Welcome to Salesforce!"
 								description="Lorem ipsum dolor sit amet, lorem ipsum dolor sit amet."
-								icon="animal_and_nature"
+								icon={<Icon category="utility" name="animal_and_nature" />}
 								href="javascript:void(0);"
 								id="welcome-mat-tile-1"
 								isComplete
@@ -55,7 +56,7 @@ class Example extends React.Component {
 							<WelcomeMatTile
 								title="Learn About OpenCTI!"
 								description="Lorem ipsum dolor sit amet, lorem ipsum dolor sit amet."
-								icon="call"
+								icon={<Icon category="utility" name="call" />}
 								href="javascript:void(0);"
 								id="welcome-mat-tile-2"
 								isComplete
@@ -65,7 +66,7 @@ class Example extends React.Component {
 								description="Tap into case history or share notes with fellow agents—it all happens on the utility bar."
 								href="javascript:void(0);"
 								id="welcome-mat-tile-3"
-								icon="call"
+								icon={<Icon category="utility" name="call" />}
 								isComplete
 							/>
 							<WelcomeMatTile
@@ -73,7 +74,7 @@ class Example extends React.Component {
 								description="Tailor your cases to your team&#x27;s workflow with custom list views."
 								href="javascript:void(0);"
 								id="welcome-mat-tile-4"
-								icon="upload"
+								icon={<Icon category="utility" name="upload" />}
 								isComplete
 							/>
 							<WelcomeMatTile
@@ -81,7 +82,7 @@ class Example extends React.Component {
 								description="Harness your team&#x27;s collective know-how with our powerful knowledge base."
 								href="javascript:void(0);"
 								id="welcome-mat-tile-5"
-								icon="knowledge_base"
+								icon={<Icon category="utility" name="knowledge_base" />}
 								isComplete
 							/>
 						</WelcomeMat>

--- a/components/welcome-mat/__examples__/trailhead.jsx
+++ b/components/welcome-mat/__examples__/trailhead.jsx
@@ -3,6 +3,7 @@ import WelcomeMat from '~/components/welcome-mat';
 import WelcomeMatTile from '~/components/welcome-mat/tile';
 import WelcomeMatInfoBadge from '~/components/welcome-mat/info-badge';
 import Button from '~/components/button';
+import Icon from '~/components/icon';
 import IconSettings from '~/components/icon-settings';
 
 class Example extends React.Component {
@@ -47,7 +48,7 @@ class Example extends React.Component {
 							<WelcomeMatTile
 								title="Welcome to Salesforce!"
 								description="Lorem ipsum dolor sit amet, lorem ipsum dolor sit amet."
-								icon="animal_and_nature"
+								icon={<Icon category="utility" name="animal_and_nature" />}
 								href="javascript:void(0);"
 								id="welcome-mat-tile-1"
 								isComplete
@@ -55,7 +56,7 @@ class Example extends React.Component {
 							<WelcomeMatTile
 								title="Learn About OpenCTI!"
 								description="Lorem ipsum dolor sit amet, lorem ipsum dolor sit amet."
-								icon="call"
+								icon={<Icon category="utility" name="call" />}
 								href="javascript:void(0);"
 								id="welcome-mat-tile-2"
 								isComplete
@@ -65,21 +66,21 @@ class Example extends React.Component {
 								description="Tap into case history or share notes with fellow agents—it all happens on the utility bar."
 								href="javascript:void(0);"
 								id="welcome-mat-tile-3"
-								icon="call"
+								icon={<Icon category="utility" name="call" />}
 							/>
 							<WelcomeMatTile
 								title="Customize your view"
 								description="Tailor your cases to your team&#x27;s workflow with custom list views."
 								href="javascript:void(0);"
 								id="welcome-mat-tile-4"
-								icon="upload"
+								icon={<Icon category="utility" name="upload" />}
 							/>
 							<WelcomeMatTile
 								title="Share the Knowledge"
 								description="Harness your team&#x27;s collective know-how with our powerful knowledge base."
 								href="javascript:void(0);"
 								id="welcome-mat-tile-5"
-								icon="knowledge_base"
+								icon={<Icon category="utility" name="knowledge_base" />}
 							/>
 						</WelcomeMat>
 					</div>

--- a/components/welcome-mat/docs.json
+++ b/components/welcome-mat/docs.json
@@ -3,5 +3,13 @@
   "status": "prod",
   "display-name": "Welcome Mat",
   "SLDS-component-path": "/components/welcome-mat",
-  "url-slug": "welcome-mat"
+  "url-slug": "welcome-mat",
+  "dependencies": [
+	{
+	  "component": "info-badge"
+	},
+	{
+	  "component": "tile"
+	}
+  ]
 }

--- a/components/welcome-mat/index.jsx
+++ b/components/welcome-mat/index.jsx
@@ -191,6 +191,9 @@ class WelcomeMat extends React.Component {
 
 		return (
 			<Modal
+				assistiveText={{
+					dialogLabelledBy: `${this.getId()}-label`,
+				}}
 				isOpen={this.props.isOpen}
 				size="small"
 				id={`${this.getId()}-modal`}

--- a/components/welcome-mat/tile.jsx
+++ b/components/welcome-mat/tile.jsx
@@ -19,6 +19,14 @@ const displayName = WELCOME_MAT_TILE;
 
 const propTypes = {
 	/**
+	 * **Assistive text for accessibility.**
+	 * This object is merged with the default props object on every render.
+	 * * `completeIcon`: Text that is visually hidden but read aloud by screenreaders to tell the user what the complete icon means.
+	 */
+	assistiveText: PropTypes.shape({
+		completedIcon: PropTypes.string,
+	}),
+	/**
 	 * CSS class names to be added to the container element. `array`, `object`, or `string` are accepted.
 	 */
 	className: PropTypes.oneOfType([
@@ -45,7 +53,7 @@ const propTypes = {
 	/**
 	 * Icon for the tile
 	 */
-	icon: PropTypes.string,
+	icon: PropTypes.node,
 	/**
 	 * Whether the tile is completed
 	 */
@@ -62,6 +70,9 @@ const propTypes = {
 };
 
 const defaultProps = {
+	assistiveText: {
+		completedIcon: 'Completed',
+	},
 	isComplete: false,
 	variant: 'steps',
 };
@@ -82,6 +93,10 @@ class Tile extends React.Component {
 	}
 
 	render() {
+		const assistiveText = {
+			...defaultProps.assistiveText,
+			...this.props.assistiveText,
+		};
 		const body = (
 			<React.Fragment>
 				<div
@@ -93,9 +108,16 @@ class Tile extends React.Component {
 				>
 					<div className="slds-welcome-mat__tile-figure">
 						<div className="slds-welcome-mat__tile-icon-container">
-							<Icon category="utility" name={this.props.icon} />
+							{this.props.icon}
 							{this.props.isComplete && this.props.variant !== 'info-only' ? (
-								<Icon category="action" name="check" />
+								<Icon
+									assistiveText={{
+										label: assistiveText.completedIcon,
+									}}
+									category="action"
+									name="check"
+									title={assistiveText.completedIcon}
+								/>
 							) : null}
 						</div>
 					</div>

--- a/package.json
+++ b/package.json
@@ -834,7 +834,15 @@
 			"status": "prod",
 			"display-name": "Welcome Mat",
 			"SLDS-component-path": "/components/welcome-mat",
-			"url-slug": "welcome-mat"
+			"url-slug": "welcome-mat",
+			"dependencies": [
+				{
+					"component": "info-badge"
+				},
+				{
+					"component": "tile"
+				}
+			]
 		}
 	],
 	"documentation": {


### PR DESCRIPTION
Patches up a few overlooked items for welcome mat

* Doc site compatibility
* Icon prop now takes `Icon` component

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [ ] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [ ] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
