### PR TITLE
Fix for Invalid prop `direction` of value `[object Object]` supplied to `SLDSDialog`, expected one of ["ltr","rtl"]

### DIFF
--- a/components/utilities/UNSAFE_direction/private/language-direction.jsx
+++ b/components/utilities/UNSAFE_direction/private/language-direction.jsx
@@ -8,8 +8,6 @@ const LanguageDirectionHOC = (WrappedComponent) => {
 		WrappedComponent.displayName || WrappedComponent.name || 'Component';
 	return class LanguageDirection extends Component {
 		static displayName = `LanguageDirection(${componentName})`;
-		// eslint-disable-next-line camelcase
-		// static contextType = UNSAFE_DirectionSettings;
 
 		getWrappedComponent = (state) => {
 			return <WrappedComponent {...this.props} direction={state} />;

--- a/components/utilities/UNSAFE_direction/private/language-direction.jsx
+++ b/components/utilities/UNSAFE_direction/private/language-direction.jsx
@@ -1,5 +1,5 @@
-import React, { Component } from 'react';
-
+import React, { Component, useContext } from 'react';
+import PropTypes from 'prop-types';
 // eslint-disable-next-line camelcase
 import UNSAFE_DirectionSettings from '..';
 
@@ -8,14 +8,15 @@ const LanguageDirectionHOC = (WrappedComponent) => {
 		WrappedComponent.displayName || WrappedComponent.name || 'Component';
 	return class LanguageDirection extends Component {
 		static displayName = `LanguageDirection(${componentName})`;
-
 		// eslint-disable-next-line camelcase
-		static contextType = UNSAFE_DirectionSettings;
+		// static contextType = UNSAFE_DirectionSettings;
+
+		languageDirectionWrapper = (state) => {
+			return <WrappedComponent {...this.props} direction={state} />;
+		};
 
 		render() {
-			const props = { ...this.props };
-			props.direction = this.context;
-			return React.createElement(WrappedComponent, props);
+			return <UNSAFE_DirectionSettings.Consumer>{this.languageDirectionWrapper}</UNSAFE_DirectionSettings.Consumer>
 		}
 	};
 };

--- a/components/utilities/UNSAFE_direction/private/language-direction.jsx
+++ b/components/utilities/UNSAFE_direction/private/language-direction.jsx
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import PropTypes from 'prop-types';
 // eslint-disable-next-line camelcase
 import UNSAFE_DirectionSettings from '..';
 

--- a/components/utilities/UNSAFE_direction/private/language-direction.jsx
+++ b/components/utilities/UNSAFE_direction/private/language-direction.jsx
@@ -8,12 +8,17 @@ const LanguageDirectionHOC = (WrappedComponent) => {
 	return class LanguageDirection extends Component {
 		static displayName = `LanguageDirection(${componentName})`;
 
-		getWrappedComponent = (value) => {
-			return <WrappedComponent {...this.props} direction={value} />;
-		};
+		getWrappedComponent = (value) => (
+			<WrappedComponent {...this.props} direction={value} />
+		);
 
 		render() {
-			return <UNSAFE_DirectionSettings.Consumer>{this.getWrappedComponent}</UNSAFE_DirectionSettings.Consumer>
+			return (
+				// eslint-disable-next-line react/jsx-pascal-case
+				<UNSAFE_DirectionSettings.Consumer>
+					{this.getWrappedComponent}
+				</UNSAFE_DirectionSettings.Consumer>
+			);
 		}
 	};
 };

--- a/components/utilities/UNSAFE_direction/private/language-direction.jsx
+++ b/components/utilities/UNSAFE_direction/private/language-direction.jsx
@@ -1,4 +1,4 @@
-import React, { Component, useContext } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 // eslint-disable-next-line camelcase
 import UNSAFE_DirectionSettings from '..';
@@ -11,12 +11,12 @@ const LanguageDirectionHOC = (WrappedComponent) => {
 		// eslint-disable-next-line camelcase
 		// static contextType = UNSAFE_DirectionSettings;
 
-		languageDirectionWrapper = (state) => {
+		getWrappedComponent = (state) => {
 			return <WrappedComponent {...this.props} direction={state} />;
 		};
 
 		render() {
-			return <UNSAFE_DirectionSettings.Consumer>{this.languageDirectionWrapper}</UNSAFE_DirectionSettings.Consumer>
+			return <UNSAFE_DirectionSettings.Consumer>{this.getWrappedComponent}</UNSAFE_DirectionSettings.Consumer>
 		}
 	};
 };

--- a/components/utilities/UNSAFE_direction/private/language-direction.jsx
+++ b/components/utilities/UNSAFE_direction/private/language-direction.jsx
@@ -8,8 +8,8 @@ const LanguageDirectionHOC = (WrappedComponent) => {
 	return class LanguageDirection extends Component {
 		static displayName = `LanguageDirection(${componentName})`;
 
-		getWrappedComponent = (state) => {
-			return <WrappedComponent {...this.props} direction={state} />;
+		getWrappedComponent = (value) => {
+			return <WrappedComponent {...this.props} direction={value} />;
 		};
 
 		render() {


### PR DESCRIPTION
Fixes #2108

Use `Consumer` instead of `contextType` to subscribe to context change. I also noticed that `contextType` is only available in 16.6 so we can't use this since we support >= 16.3. 

https://reactjs.org/docs/context.html#classcontexttype

### Additional description

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [ ] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [ ] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
