### PR TITLE
Fix for ProgressRing layout issue on IE11

### DIFF
--- a/components/progress-ring/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/progress-ring/__docs__/__snapshots__/storybook-stories.storyshot
@@ -19,7 +19,11 @@ exports[`DOM snapshots SLDSProgressRing Base 1`] = `
           aria-valuenow={0}
           className="slds-progress-ring__progress"
           role="progressbar"
-          style={Object {}}
+          style={
+            Object {
+              "height": "2rem",
+            }
+          }
         >
           <svg
             viewBox="-1 -1 2 2"
@@ -49,7 +53,11 @@ exports[`DOM snapshots SLDSProgressRing Base 1`] = `
           aria-valuenow={20}
           className="slds-progress-ring__progress"
           role="progressbar"
-          style={Object {}}
+          style={
+            Object {
+              "height": "2rem",
+            }
+          }
         >
           <svg
             viewBox="-1 -1 2 2"
@@ -81,6 +89,7 @@ exports[`DOM snapshots SLDSProgressRing Base 1`] = `
           role="progressbar"
           style={
             Object {
+              "height": "2rem",
               "transform": "scaleX(1) rotate(-90deg)",
             }
           }
@@ -113,7 +122,11 @@ exports[`DOM snapshots SLDSProgressRing Base 1`] = `
           aria-valuenow={100}
           className="slds-progress-ring__progress"
           role="progressbar"
-          style={Object {}}
+          style={
+            Object {
+              "height": "2rem",
+            }
+          }
         >
           <svg
             viewBox="-1 -1 2 2"
@@ -154,7 +167,11 @@ exports[`DOM snapshots SLDSProgressRing Custom Icon 1`] = `
           aria-valuenow={20}
           className="slds-progress-ring__progress"
           role="progressbar"
-          style={Object {}}
+          style={
+            Object {
+              "height": "2rem",
+            }
+          }
         >
           <svg
             viewBox="-1 -1 2 2"
@@ -196,6 +213,7 @@ exports[`DOM snapshots SLDSProgressRing Custom Icon 1`] = `
           role="progressbar"
           style={
             Object {
+              "height": "2rem",
               "transform": "scaleX(1) rotate(-90deg)",
             }
           }
@@ -249,7 +267,11 @@ exports[`DOM snapshots SLDSProgressRing Snapshot Test Examples 1`] = `
           aria-valuenow={0}
           className="slds-progress-ring__progress"
           role="progressbar"
-          style={Object {}}
+          style={
+            Object {
+              "height": "2rem",
+            }
+          }
         >
           <svg
             viewBox="-1 -1 2 2"
@@ -281,6 +303,7 @@ exports[`DOM snapshots SLDSProgressRing Snapshot Test Examples 1`] = `
           role="progressbar"
           style={
             Object {
+              "height": "2rem",
               "transform": "scaleX(1) rotate(-90deg)",
             }
           }
@@ -313,7 +336,11 @@ exports[`DOM snapshots SLDSProgressRing Snapshot Test Examples 1`] = `
           aria-valuenow={0}
           className="slds-progress-ring__progress"
           role="progressbar"
-          style={Object {}}
+          style={
+            Object {
+              "height": "2rem",
+            }
+          }
         >
           <svg
             viewBox="-1 -1 2 2"
@@ -353,7 +380,11 @@ exports[`DOM snapshots SLDSProgressRing Snapshot Test Examples 1`] = `
           aria-valuenow={0}
           className="slds-progress-ring__progress"
           role="progressbar"
-          style={Object {}}
+          style={
+            Object {
+              "height": "2rem",
+            }
+          }
         >
           <svg
             viewBox="-1 -1 2 2"
@@ -393,7 +424,11 @@ exports[`DOM snapshots SLDSProgressRing Snapshot Test Examples 1`] = `
           aria-valuenow={20}
           className="slds-progress-ring__progress"
           role="progressbar"
-          style={Object {}}
+          style={
+            Object {
+              "height": "2rem",
+            }
+          }
         >
           <svg
             viewBox="-1 -1 2 2"
@@ -425,6 +460,7 @@ exports[`DOM snapshots SLDSProgressRing Snapshot Test Examples 1`] = `
           role="progressbar"
           style={
             Object {
+              "height": "2rem",
               "transform": "scaleX(1) rotate(-90deg)",
             }
           }
@@ -457,7 +493,11 @@ exports[`DOM snapshots SLDSProgressRing Snapshot Test Examples 1`] = `
           aria-valuenow={100}
           className="slds-progress-ring__progress"
           role="progressbar"
-          style={Object {}}
+          style={
+            Object {
+              "height": "2rem",
+            }
+          }
         >
           <svg
             viewBox="-1 -1 2 2"
@@ -499,7 +539,11 @@ exports[`DOM snapshots SLDSProgressRing Snapshot Test Examples 1`] = `
           aria-valuenow={100}
           className="slds-progress-ring__progress"
           role="progressbar"
-          style={Object {}}
+          style={
+            Object {
+              "height": "2rem",
+            }
+          }
         >
           <svg
             viewBox="-1 -1 2 2"
@@ -529,7 +573,11 @@ exports[`DOM snapshots SLDSProgressRing Snapshot Test Examples 1`] = `
           aria-valuenow={20}
           className="slds-progress-ring__progress"
           role="progressbar"
-          style={Object {}}
+          style={
+            Object {
+              "height": "2rem",
+            }
+          }
         >
           <svg
             viewBox="-1 -1 2 2"
@@ -561,6 +609,7 @@ exports[`DOM snapshots SLDSProgressRing Snapshot Test Examples 1`] = `
           role="progressbar"
           style={
             Object {
+              "height": "2rem",
               "transform": "scaleX(1) rotate(-90deg)",
             }
           }
@@ -593,7 +642,11 @@ exports[`DOM snapshots SLDSProgressRing Snapshot Test Examples 1`] = `
           aria-valuenow={100}
           className="slds-progress-ring__progress"
           role="progressbar"
-          style={Object {}}
+          style={
+            Object {
+              "height": "2rem",
+            }
+          }
         >
           <svg
             viewBox="-1 -1 2 2"
@@ -635,7 +688,11 @@ exports[`DOM snapshots SLDSProgressRing Snapshot Test Examples 1`] = `
           aria-valuenow={100}
           className="slds-progress-ring__progress"
           role="progressbar"
-          style={Object {}}
+          style={
+            Object {
+              "height": "2rem",
+            }
+          }
         >
           <svg
             viewBox="-1 -1 2 2"
@@ -665,7 +722,11 @@ exports[`DOM snapshots SLDSProgressRing Snapshot Test Examples 1`] = `
           aria-valuenow={20}
           className="slds-progress-ring__progress"
           role="progressbar"
-          style={Object {}}
+          style={
+            Object {
+              "height": "2rem",
+            }
+          }
         >
           <svg
             viewBox="-1 -1 2 2"
@@ -697,6 +758,7 @@ exports[`DOM snapshots SLDSProgressRing Snapshot Test Examples 1`] = `
           role="progressbar"
           style={
             Object {
+              "height": "2rem",
               "transform": "scaleX(1) rotate(-90deg)",
             }
           }
@@ -729,7 +791,11 @@ exports[`DOM snapshots SLDSProgressRing Snapshot Test Examples 1`] = `
           aria-valuenow={100}
           className="slds-progress-ring__progress"
           role="progressbar"
-          style={Object {}}
+          style={
+            Object {
+              "height": "2rem",
+            }
+          }
         >
           <svg
             viewBox="-1 -1 2 2"
@@ -771,7 +837,11 @@ exports[`DOM snapshots SLDSProgressRing Snapshot Test Examples 1`] = `
           aria-valuenow={100}
           className="slds-progress-ring__progress"
           role="progressbar"
-          style={Object {}}
+          style={
+            Object {
+              "height": "2rem",
+            }
+          }
         >
           <svg
             viewBox="-1 -1 2 2"
@@ -801,7 +871,11 @@ exports[`DOM snapshots SLDSProgressRing Snapshot Test Examples 1`] = `
           aria-valuenow={20}
           className="slds-progress-ring__progress"
           role="progressbar"
-          style={Object {}}
+          style={
+            Object {
+              "height": "2rem",
+            }
+          }
         >
           <svg
             viewBox="-1 -1 2 2"
@@ -833,6 +907,7 @@ exports[`DOM snapshots SLDSProgressRing Snapshot Test Examples 1`] = `
           role="progressbar"
           style={
             Object {
+              "height": "2rem",
               "transform": "scaleX(1) rotate(-90deg)",
             }
           }
@@ -867,6 +942,7 @@ exports[`DOM snapshots SLDSProgressRing Snapshot Test Examples 1`] = `
           role="progressbar"
           style={
             Object {
+              "height": "2rem",
               "transform": "scaleX(1) rotate(-90deg)",
             }
           }
@@ -899,7 +975,11 @@ exports[`DOM snapshots SLDSProgressRing Snapshot Test Examples 1`] = `
           aria-valuenow={100}
           className="slds-progress-ring__progress"
           role="progressbar"
-          style={Object {}}
+          style={
+            Object {
+              "height": "2rem",
+            }
+          }
         >
           <svg
             viewBox="-1 -1 2 2"
@@ -929,7 +1009,11 @@ exports[`DOM snapshots SLDSProgressRing Snapshot Test Examples 1`] = `
           aria-valuenow={20}
           className="slds-progress-ring__progress"
           role="progressbar"
-          style={Object {}}
+          style={
+            Object {
+              "height": "2rem",
+            }
+          }
         >
           <svg
             viewBox="-1 -1 2 2"
@@ -961,6 +1045,7 @@ exports[`DOM snapshots SLDSProgressRing Snapshot Test Examples 1`] = `
           role="progressbar"
           style={
             Object {
+              "height": "2rem",
               "transform": "scaleX(1) rotate(-90deg)",
             }
           }
@@ -995,6 +1080,7 @@ exports[`DOM snapshots SLDSProgressRing Snapshot Test Examples 1`] = `
           role="progressbar"
           style={
             Object {
+              "height": "2rem",
               "transform": "scaleX(1) rotate(-90deg)",
             }
           }
@@ -1039,7 +1125,11 @@ exports[`DOM snapshots SLDSProgressRing Snapshot Test Examples 1`] = `
           aria-valuenow={100}
           className="slds-progress-ring__progress"
           role="progressbar"
-          style={Object {}}
+          style={
+            Object {
+              "height": "2rem",
+            }
+          }
         >
           <svg
             viewBox="-1 -1 2 2"
@@ -1082,6 +1172,7 @@ exports[`DOM snapshots SLDSProgressRing Theme: Active 1`] = `
           role="progressbar"
           style={
             Object {
+              "height": "2rem",
               "transform": "scaleX(1) rotate(-90deg)",
             }
           }
@@ -1114,7 +1205,11 @@ exports[`DOM snapshots SLDSProgressRing Theme: Active 1`] = `
           aria-valuenow={100}
           className="slds-progress-ring__progress"
           role="progressbar"
-          style={Object {}}
+          style={
+            Object {
+              "height": "2rem",
+            }
+          }
         >
           <svg
             viewBox="-1 -1 2 2"
@@ -1155,7 +1250,11 @@ exports[`DOM snapshots SLDSProgressRing Theme: Complete 1`] = `
           aria-valuenow={100}
           className="slds-progress-ring__progress"
           role="progressbar"
-          style={Object {}}
+          style={
+            Object {
+              "height": "2rem",
+            }
+          }
         >
           <svg
             viewBox="-1 -1 2 2"
@@ -1185,7 +1284,11 @@ exports[`DOM snapshots SLDSProgressRing Theme: Complete 1`] = `
           aria-valuenow={100}
           className="slds-progress-ring__progress"
           role="progressbar"
-          style={Object {}}
+          style={
+            Object {
+              "height": "2rem",
+            }
+          }
         >
           <svg
             viewBox="-1 -1 2 2"
@@ -1241,7 +1344,11 @@ exports[`DOM snapshots SLDSProgressRing Theme: Expired 1`] = `
           aria-valuenow={20}
           className="slds-progress-ring__progress"
           role="progressbar"
-          style={Object {}}
+          style={
+            Object {
+              "height": "2rem",
+            }
+          }
         >
           <svg
             viewBox="-1 -1 2 2"
@@ -1271,7 +1378,11 @@ exports[`DOM snapshots SLDSProgressRing Theme: Expired 1`] = `
           aria-valuenow={20}
           className="slds-progress-ring__progress"
           role="progressbar"
-          style={Object {}}
+          style={
+            Object {
+              "height": "2rem",
+            }
+          }
         >
           <svg
             viewBox="-1 -1 2 2"
@@ -1315,6 +1426,7 @@ exports[`DOM snapshots SLDSProgressRing Theme: Expired 1`] = `
           role="progressbar"
           style={
             Object {
+              "height": "2rem",
               "transform": "scaleX(1) rotate(-90deg)",
             }
           }
@@ -1359,7 +1471,11 @@ exports[`DOM snapshots SLDSProgressRing Theme: Expired 1`] = `
           aria-valuenow={100}
           className="slds-progress-ring__progress"
           role="progressbar"
-          style={Object {}}
+          style={
+            Object {
+              "height": "2rem",
+            }
+          }
         >
           <svg
             viewBox="-1 -1 2 2"
@@ -1400,7 +1516,11 @@ exports[`DOM snapshots SLDSProgressRing Theme: Warning 1`] = `
           aria-valuenow={20}
           className="slds-progress-ring__progress"
           role="progressbar"
-          style={Object {}}
+          style={
+            Object {
+              "height": "2rem",
+            }
+          }
         >
           <svg
             viewBox="-1 -1 2 2"
@@ -1430,7 +1550,11 @@ exports[`DOM snapshots SLDSProgressRing Theme: Warning 1`] = `
           aria-valuenow={20}
           className="slds-progress-ring__progress"
           role="progressbar"
-          style={Object {}}
+          style={
+            Object {
+              "height": "2rem",
+            }
+          }
         >
           <svg
             viewBox="-1 -1 2 2"
@@ -1474,6 +1598,7 @@ exports[`DOM snapshots SLDSProgressRing Theme: Warning 1`] = `
           role="progressbar"
           style={
             Object {
+              "height": "2rem",
               "transform": "scaleX(1) rotate(-90deg)",
             }
           }
@@ -1518,7 +1643,11 @@ exports[`DOM snapshots SLDSProgressRing Theme: Warning 1`] = `
           aria-valuenow={100}
           className="slds-progress-ring__progress"
           role="progressbar"
-          style={Object {}}
+          style={
+            Object {
+              "height": "2rem",
+            }
+          }
         >
           <svg
             viewBox="-1 -1 2 2"

--- a/components/progress-ring/private/ring-shape.jsx
+++ b/components/progress-ring/private/ring-shape.jsx
@@ -61,7 +61,7 @@ const calculateD = (fillPercent) => {
  * Displays the progress ring shape.
  */
 const ProgressRingShape = (props) => {
-	const progressStyles = {};
+	const progressStyles = { height: '2rem' };
 
 	if (props.flowDirection === 'fill') {
 		progressStyles.transform = 'scaleX(1) rotate(-90deg)';

--- a/components/setup-assistant/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/setup-assistant/__docs__/__snapshots__/storybook-stories.storyshot
@@ -317,6 +317,7 @@ exports[`DOM snapshots SLDSSetupAssistant Hub with Expandable Steps 1`] = `
                         role="progressbar"
                         style={
                           Object {
+                            "height": "2rem",
                             "transform": "scaleX(1) rotate(-90deg)",
                           }
                         }
@@ -581,6 +582,7 @@ exports[`DOM snapshots SLDSSetupAssistant Hub with Expandable Steps 1`] = `
                         role="progressbar"
                         style={
                           Object {
+                            "height": "2rem",
                             "transform": "scaleX(1) rotate(-90deg)",
                           }
                         }
@@ -875,6 +877,7 @@ exports[`DOM snapshots SLDSSetupAssistant Hub with Expandable Steps 1`] = `
                         role="progressbar"
                         style={
                           Object {
+                            "height": "2rem",
                             "transform": "scaleX(1) rotate(-90deg)",
                           }
                         }
@@ -1139,6 +1142,7 @@ exports[`DOM snapshots SLDSSetupAssistant Hub with Expandable Steps 1`] = `
                         role="progressbar"
                         style={
                           Object {
+                            "height": "2rem",
                             "transform": "scaleX(1) rotate(-90deg)",
                           }
                         }
@@ -1366,6 +1370,7 @@ exports[`DOM snapshots SLDSSetupAssistant Hub with Expandable Steps 1`] = `
                         role="progressbar"
                         style={
                           Object {
+                            "height": "2rem",
                             "transform": "scaleX(1) rotate(-90deg)",
                           }
                         }
@@ -1661,6 +1666,7 @@ exports[`DOM snapshots SLDSSetupAssistant In a Card 1`] = `
                           role="progressbar"
                           style={
                             Object {
+                              "height": "2rem",
                               "transform": "scaleX(1) rotate(-90deg)",
                             }
                           }
@@ -1925,6 +1931,7 @@ exports[`DOM snapshots SLDSSetupAssistant In a Card 1`] = `
                           role="progressbar"
                           style={
                             Object {
+                              "height": "2rem",
                               "transform": "scaleX(1) rotate(-90deg)",
                             }
                           }
@@ -2232,6 +2239,7 @@ exports[`DOM snapshots SLDSSetupAssistant In a Card 1`] = `
                           role="progressbar"
                           style={
                             Object {
+                              "height": "2rem",
                               "transform": "scaleX(1) rotate(-90deg)",
                             }
                           }
@@ -2496,6 +2504,7 @@ exports[`DOM snapshots SLDSSetupAssistant In a Card 1`] = `
                           role="progressbar"
                           style={
                             Object {
+                              "height": "2rem",
                               "transform": "scaleX(1) rotate(-90deg)",
                             }
                           }
@@ -2723,6 +2732,7 @@ exports[`DOM snapshots SLDSSetupAssistant In a Card 1`] = `
                           role="progressbar"
                           style={
                             Object {
+                              "height": "2rem",
                               "transform": "scaleX(1) rotate(-90deg)",
                             }
                           }
@@ -2938,6 +2948,7 @@ exports[`DOM snapshots SLDSSetupAssistant With Step Progress 1`] = `
                   role="progressbar"
                   style={
                     Object {
+                      "height": "2rem",
                       "transform": "scaleX(1) rotate(-90deg)",
                     }
                   }
@@ -3039,6 +3050,7 @@ exports[`DOM snapshots SLDSSetupAssistant With Step Progress 1`] = `
                   role="progressbar"
                   style={
                     Object {
+                      "height": "2rem",
                       "transform": "scaleX(1) rotate(-90deg)",
                     }
                   }
@@ -3123,6 +3135,7 @@ exports[`DOM snapshots SLDSSetupAssistant With Step Progress 1`] = `
                   role="progressbar"
                   style={
                     Object {
+                      "height": "2rem",
                       "transform": "scaleX(1) rotate(-90deg)",
                     }
                   }
@@ -3224,6 +3237,7 @@ exports[`DOM snapshots SLDSSetupAssistant With Step Progress 1`] = `
                   role="progressbar"
                   style={
                     Object {
+                      "height": "2rem",
                       "transform": "scaleX(1) rotate(-90deg)",
                     }
                   }
@@ -3333,6 +3347,7 @@ exports[`DOM snapshots SLDSSetupAssistant With Step Progress 1`] = `
                   role="progressbar"
                   style={
                     Object {
+                      "height": "2rem",
                       "transform": "scaleX(1) rotate(-90deg)",
                     }
                   }


### PR DESCRIPTION
To fix this issue, I added an inline style height of 2rem to "slds-progress-ring_progress" class.
### Additional description

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [ ] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [ ] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
