### PR TITLE
Prevent literal strings in component source code

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,6 +37,7 @@ module.exports = {
 				// TODO: This should be removed.
 				'no-unused-vars': 'off',
 				'react/no-access-state-in-setstate': 'off',
+				'react/jsx-no-literals': ['off'],
 			},
 		},
 		{
@@ -77,6 +78,7 @@ module.exports = {
 				// TODO: This should be removed.
 				'react/display-name': 'off',
 				'react/no-access-state-in-setstate': 'off',
+				'react/jsx-no-literals': ['off'],
 			},
 		},
 		{
@@ -127,6 +129,11 @@ module.exports = {
 
 		// Can't be used because it doesn't currently recognize props used in functions
 		'react/no-unused-prop-types': 'off',
+
+		// https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-literals.md
+		// All text should be able to be changed by the consumer due to internationalisation
+		// See https://github.com/salesforce/design-system-react/blob/master/docs/codebase-overview.md#rendered-text-needs-a-prop-group-assistive-text-and-labels
+		'react/jsx-no-literals': ['error', { noStrings: false }],
 
 		//
 		// THE FOLLOWING RULES NEED REVIEW IN THE FUTURE (and possibly removed)

--- a/components/checkbox/index.jsx
+++ b/components/checkbox/index.jsx
@@ -275,7 +275,7 @@ class Checkbox extends React.Component {
 				<span className="slds-checkbox">
 					{props.required ? (
 						<abbr className="slds-required" title="required">
-							*
+							{'*'}
 						</abbr>
 					) : null}
 					<input
@@ -338,7 +338,7 @@ class Checkbox extends React.Component {
 			<label className="slds-checkbox_toggle slds-grid" htmlFor={this.getId()}>
 				{props.required ? (
 					<abbr className="slds-required" title="required">
-						*
+						{'*'}
 					</abbr>
 				) : null}
 				{labels.label ? (

--- a/components/date-picker/private/day.jsx
+++ b/components/date-picker/private/day.jsx
@@ -138,7 +138,7 @@ const DatepickerCalendarDay = (props) => {
 			{/* eslint-enable jsx-a11y/no-static-element-interactions */}
 			<span className="slds-day">
 				{isToday ? (
-					<span className="slds-assistive-text">{props.todayLabel}: </span>
+					<span className="slds-assistive-text">{`${props.todayLabel}: `}</span>
 				) : null}
 				{props.date.getDate()}
 			</span>

--- a/components/forms/private/label.jsx
+++ b/components/forms/private/label.jsx
@@ -49,7 +49,7 @@ const Label = (props) => {
 			>
 				{props.required && (
 					<abbr className="slds-required" title="required">
-						*
+						{'*'}
 					</abbr>
 				)}
 				{labelText}

--- a/components/lookup/lookup.jsx
+++ b/components/lookup/lookup.jsx
@@ -723,7 +723,8 @@ const Lookup = class extends React.Component {
 	renderLabel = () => {
 		let inputLabel;
 		const required = this.props.required ? (
-			<span className="slds-required">*</span>
+			// eslint-disable-next-line react/jsx-curly-brace-presence
+			<span className="slds-required">{'*'}</span>
 		) : null;
 		if (this.isSelected()) {
 			// inline style override

--- a/components/menu-picklist/index.jsx
+++ b/components/menu-picklist/index.jsx
@@ -673,7 +673,8 @@ const MenuPicklist = createReactClass({
 		const { className, errorText, label, required } = this.props;
 
 		const requiredElem = required ? (
-			<span style={{ color: 'red' }}>* </span>
+			// eslint-disable-next-line react/jsx-curly-brace-presence
+			<span style={{ color: 'red' }}>{'* '}</span>
 		) : null;
 
 		return (

--- a/components/modal/private/manager.jsx
+++ b/components/modal/private/manager.jsx
@@ -95,6 +95,8 @@ class Manager extends React.Component {
 						onClick={this.closeModal}
 					>
 						<Icon name="close" category="utility" size="small" />
+						{/* This file is an example file and should not be used */}
+						{/* eslint-disable-next-line react/jsx-no-literals */}
 						<span className="slds-assistive-text">Close</span>
 					</Button>
 				</div>

--- a/components/progress-bar/index.jsx
+++ b/components/progress-bar/index.jsx
@@ -16,6 +16,13 @@ import { PROGRESS_BAR } from '../../utilities/constants';
 
 const propTypes = {
 	/**
+	 * **Assistive text for accessibility**
+	 * This object is merged with the default props object on every render.
+	 * * `progress`: This is a visually hidden label for the percent of progress.
+	 * _Tested with snapshot testing._
+	 */
+	assistiveText: PropTypes.shape({ progress: PropTypes.string }),
+	/**
 	 * HTML id for component.
 	 */
 	id: PropTypes.string,
@@ -61,6 +68,9 @@ const propTypes = {
 };
 
 const defaultProps = {
+	assistiveText: {
+		progress: 'Progress',
+	},
 	labels: {
 		complete: 'Complete',
 	},
@@ -100,7 +110,9 @@ class ProgressBar extends React.Component {
 					<span>{labels.label}</span>
 					<span aria-hidden="true">
 						<strong>
-							{this.props.value}% {labels.complete}
+							{this.props.value}
+							{'% '}
+							{labels.complete}
 						</strong>
 					</span>
 				</div>
@@ -111,6 +123,11 @@ class ProgressBar extends React.Component {
 
 	render() {
 		const labels = assign({}, defaultProps.labels, this.props.labels);
+		const assistiveText = assign(
+			{},
+			defaultProps.assistiveText,
+			this.props.assistiveText
+		);
 		const style = assign({}, defaultProps.style, this.props.style);
 		return (
 			<div id={this.getId()} style={style}>
@@ -152,7 +169,8 @@ class ProgressBar extends React.Component {
 						}
 					>
 						<span className="slds-assistive-text">
-							Progress: {`${this.props.value}%`}
+							{`${assistiveText.progress}: `}
+							{`${this.props.value}%`}
 						</span>
 					</span>
 				</div>

--- a/components/radio-group/index.jsx
+++ b/components/radio-group/index.jsx
@@ -126,7 +126,7 @@ class RadioGroup extends React.Component {
 				>
 					{this.props.required ? (
 						<abbr className="slds-required" title="required">
-							*
+							{'*'}
 						</abbr>
 					) : null}
 					{this.props.assistiveText.label

--- a/components/slider/index.jsx
+++ b/components/slider/index.jsx
@@ -178,7 +178,9 @@ class Slider extends React.Component {
 							<span className="slds-slider-label__label">{labelText}</span>
 						) : null}
 						<span className="slds-slider-label__range">
-							{this.props.min} - {this.props.max}
+							{this.props.min}
+							{' - '}
+							{this.props.max}
 						</span>
 					</span>
 				</label>

--- a/components/split-view/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/split-view/__docs__/__snapshots__/storybook-stories.storyshot
@@ -420,7 +420,7 @@ exports[`DOM snapshots SLDSSplitView Base: Multiple 1`] = `
                   className="slds-assistive-text"
                 >
                   Sorted by
-                  :
+                  : 
                 </span>
                 <span>
                   Lead Score
@@ -439,8 +439,7 @@ exports[`DOM snapshots SLDSSplitView Base: Multiple 1`] = `
                 <span
                   className="slds-assistive-text"
                 >
-                  -
-                   
+                  - 
                   Descending
                 </span>
               </span>
@@ -1274,7 +1273,7 @@ exports[`DOM snapshots SLDSSplitView Base: Open 1`] = `
                   className="slds-assistive-text"
                 >
                   Sorted by
-                  :
+                  : 
                 </span>
                 <span>
                   Lead Score
@@ -1293,8 +1292,7 @@ exports[`DOM snapshots SLDSSplitView Base: Open 1`] = `
                 <span
                   className="slds-assistive-text"
                 >
-                  -
-                   
+                  - 
                   Descending
                 </span>
               </span>
@@ -2127,7 +2125,7 @@ exports[`DOM snapshots SLDSSplitView Custom List 1`] = `
                   className="slds-assistive-text"
                 >
                   Sorted by
-                  :
+                  : 
                 </span>
                 <span>
                   Lead Score
@@ -2146,8 +2144,7 @@ exports[`DOM snapshots SLDSSplitView Custom List 1`] = `
                 <span
                   className="slds-assistive-text"
                 >
-                  -
-                   
+                  - 
                   Descending
                 </span>
               </span>
@@ -2744,7 +2741,7 @@ exports[`DOM snapshots SLDSSplitView External State 1`] = `
                     className="slds-assistive-text"
                   >
                     Sorted by
-                    :
+                    : 
                   </span>
                   <span>
                     Lead Score
@@ -2763,8 +2760,7 @@ exports[`DOM snapshots SLDSSplitView External State 1`] = `
                   <span
                     className="slds-assistive-text"
                   >
-                    -
-                     
+                    - 
                     Descending
                   </span>
                 </span>

--- a/components/split-view/__tests__/split-view.listbox.header.browser-test.jsx
+++ b/components/split-view/__tests__/split-view.listbox.header.browser-test.jsx
@@ -102,7 +102,7 @@ describe('SLDSSplitView - Listbox header', () => {
 				.find('.slds-split-view__list-header > span > span')
 				.at(0)
 				.text()
-		).to.equal('test sort by:');
+		).to.equal('test sort by: ');
 	});
 
 	describe('sort', () => {

--- a/components/split-view/listbox.jsx
+++ b/components/split-view/listbox.jsx
@@ -322,14 +322,15 @@ class SplitViewListbox extends React.Component {
 			? this.headerWrapper(
 					<span>
 						<span className="slds-assistive-text">
-							{this.props.assistiveText.sort.sortedBy}:
+							{this.props.assistiveText.sort.sortedBy}
+							{': '}
 						</span>
 						<span>
 							{this.props.labels.header}
 							{this.sortDirection()}
 						</span>
 						<span className="slds-assistive-text">
-							-{' '}
+							{'- '}
 							{this.props.sortDirection === SORT_OPTIONS.DOWN
 								? this.props.assistiveText.sort.descending
 								: this.props.assistiveText.sort.ascending}

--- a/components/split-view/private/list-item-with-content.jsx
+++ b/components/split-view/private/list-item-with-content.jsx
@@ -92,7 +92,8 @@ const listItemWithContent = (ListItemContent) => {
 					title={this.props.assistiveText.unreadItem}
 					aria-label={this.props.assistiveText.unreadItem}
 				>
-					<span className="slds-assistive-text">●</span>
+					{/* eslint-disable-next-line react/jsx-curly-brace-presence */}
+					<span className="slds-assistive-text">{'●'}</span>
 				</abbr>
 			) : null;
 		}

--- a/components/textarea/index.jsx
+++ b/components/textarea/index.jsx
@@ -284,7 +284,7 @@ class Textarea extends React.Component {
 					>
 						{required && (
 							<abbr className="slds-required" title="required">
-								*
+								{'*'}
 							</abbr>
 						)}
 						{labelText}

--- a/components/tooltip/index.jsx
+++ b/components/tooltip/index.jsx
@@ -137,7 +137,8 @@ const defaultProps = {
 		triggerLearnMoreIcon: 'Help',
 	},
 	align: 'top',
-	content: <span>Tooltip</span>,
+	// eslint-disable-next-line react/jsx-curly-brace-presence
+	content: <span>{'Tooltip'}</span>,
 	labels: {
 		learnMoreAfter: 'to learn more.',
 		learnMoreBefore: 'Click',

--- a/components/trial-bar/index.jsx
+++ b/components/trial-bar/index.jsx
@@ -7,6 +7,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
+import assign from 'lodash.assign';
+
 import { TRIAL_BAR } from '../../utilities/constants';
 
 const propTypes = {
@@ -30,13 +32,16 @@ const propTypes = {
 		PropTypes.string,
 	]),
 	/**
-	 * Renders the labels in the trial bar.
+	 * **Text labels for internationalization**
+	 * This object is merged with the default props object on every render.
+	 * * `learnMoreAfter`: Amount of time left in trial, e.g. `30`
+	 * * `learnMoreBefore`: Unit of the amount of time left, e.g. `days`
+	 * * `timeLeftUnitAfter`: String after `timeLeftUnit`
 	 */
 	labels: PropTypes.shape({
-		/** Amount of time left in trial, e.g. `30` */
 		timeLeft: PropTypes.string,
-		/** Unit of the amount of time left, e.g. `days` */
 		timeLeftUnit: PropTypes.string,
+		timeLeftUnitAfter: PropTypes.string,
 	}),
 	/**
 	 * Renders the actions section of the trial bar.
@@ -48,28 +53,39 @@ const propTypes = {
 	style: PropTypes.object,
 };
 
+const defaultProps = {
+	labels: {
+		timeLeftUnitAfter: 'left in trial',
+	},
+};
+
 /**
  * Trial bar components are used to provide an interactive and educational prospect experience for setup.
  */
-const TrialBar = (props) => (
-	<div
-		className={classNames('slds-trial-header slds-grid', props.className)}
-		style={props.style}
-	>
-		<div className="slds-grid">{props.children}</div>
-		<div className="slds-grid slds-grid_vertical-align-center slds-col_bump-left">
-			<span className="slds-box slds-box_xx-small slds-theme_default">
-				{props.labels.timeLeft}
-			</span>
-			<span className="slds-m-horizontal_x-small">
-				{props.labels.timeLeftUnit} left in trial
-			</span>
-			{props.onRenderActions()}
+const TrialBar = (props) => {
+	const labels = assign({}, defaultProps.labels, props.labels);
+	return (
+		<div
+			className={classNames('slds-trial-header slds-grid', props.className)}
+			style={props.style}
+		>
+			<div className="slds-grid">{props.children}</div>
+			<div className="slds-grid slds-grid_vertical-align-center slds-col_bump-left">
+				<span className="slds-box slds-box_xx-small slds-theme_default">
+					{labels.timeLeft}
+				</span>
+				<span className="slds-m-horizontal_x-small">
+					{labels.timeLeftUnit}
+					{` ${labels.timeLeftUnitAfter}`}
+				</span>
+				{props.onRenderActions()}
+			</div>
 		</div>
-	</div>
-);
+	);
+};
 
 TrialBar.displayName = TRIAL_BAR;
 TrialBar.propTypes = propTypes;
+TrialBar.defaultProps = defaultProps;
 
 export default TrialBar;

--- a/components/utilities/deprecated-warning/index.jsx
+++ b/components/utilities/deprecated-warning/index.jsx
@@ -1,6 +1,8 @@
 /* Copyright (c) 2015-present, salesforce.com, inc. All rights reserved */
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 
+/* eslint-disable react/jsx-no-literals */
+
 // ### React
 import React from 'react';
 

--- a/components/utilities/label/index.jsx
+++ b/components/utilities/label/index.jsx
@@ -61,7 +61,7 @@ const Label = (props) => {
 			>
 				{props.required && (
 					<abbr className="slds-required" title="required">
-						*
+						{'*'}
 					</abbr>
 				)}
 				{labelText}

--- a/components/welcome-mat/index.jsx
+++ b/components/welcome-mat/index.jsx
@@ -11,6 +11,8 @@ import classNames from 'classnames';
 // shortid is a short, non-sequential, url-friendly, unique id generator
 import shortid from 'shortid';
 
+import assign from 'lodash.assign';
+
 import Modal from '../modal';
 import ProgressBar from '../progress-bar';
 
@@ -40,10 +42,12 @@ const propTypes = {
 	 * This object is merged with the default props object on every render.
 	 * * `title`: Title for the Welcome Mat
 	 * * `description`: Label for the radio input
+	 * * `unitsCompletedAfter`: Label for the radio input
 	 */
 	labels: PropTypes.shape({
 		title: PropTypes.string,
 		description: PropTypes.string,
+		unitsCompletedAfter: PropTypes.string,
 	}),
 	/**
 	 *	Variant of the WelcomeMat
@@ -73,6 +77,9 @@ const propTypes = {
 };
 
 const defaultProps = {
+	labels: {
+		unitsCompletedAfter: 'units completed',
+	},
 	variant: 'steps',
 	isOpen: true,
 };
@@ -116,6 +123,7 @@ class WelcomeMat extends React.Component {
 	}
 
 	render() {
+		const labels = assign({}, defaultProps.labels, this.props.labels);
 		const splash = (
 			<div
 				className={classNames(
@@ -128,10 +136,10 @@ class WelcomeMat extends React.Component {
 					className="slds-welcome-mat__info-title"
 					id={`${this.getId()}-label`}
 				>
-					{this.props.labels.title}
+					{labels.title}
 				</h2>
 				<div className="slds-welcome-mat__info-description slds-text-longform">
-					<p>{this.props.labels.description}</p>
+					<p>{labels.description}</p>
 				</div>
 				{this.props.variant === 'info-only' ||
 				this.props.variant === 'splash' ? (
@@ -173,14 +181,18 @@ class WelcomeMat extends React.Component {
 								<React.Fragment>
 									{this.props.variant === 'trailhead-connected' ? (
 										<p>
-											{this.state.completedSteps}/{this.state.totalSteps} units
-											completed
+											{this.state.completedSteps}
+											{`/`}
+											{this.state.totalSteps}
+											{` ${labels.unitsCompletedAfter}`}
 										</p>
 									) : (
 										<p>
 											<strong>
-												{this.state.completedSteps}/{this.state.totalSteps}{' '}
-												units completed
+												{this.state.completedSteps}
+												{`/`}
+												{this.state.totalSteps}
+												{` ${labels.unitsCompletedAfter}`}
 											</strong>
 										</p>
 									)}

--- a/utilities/sample-data/global-navigation-bar/index.jsx
+++ b/utilities/sample-data/global-navigation-bar/index.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-no-literals */
 /* eslint-disable react/prop-types */
 /* eslint-disable react/display-name */
 

--- a/utilities/sample-data/tree/nodes-base.jsx
+++ b/utilities/sample-data/tree/nodes-base.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-no-literals */
 import React from 'react';
 
 const sampleNodesDefault = {


### PR DESCRIPTION
Fixes #2184

### Additional description
* Adds `assistiveText` and `labels` strings
* Wraps non-words in `{ }`

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [ ] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [ ] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
