### PR TITLE
Added "center" `align` prop value to menu-dropdown

### DIFF
--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -6474,7 +6474,7 @@
             },
             {
                 "more-files": {
-                    "description": "",
+                    "description": "MoreFiles is a component that represents multiple uploaded attachments",
                     "methods": [
                         {
                             "name": "getId",
@@ -9223,6 +9223,10 @@
                     "name": "enum",
                     "value": [
                         {
+                            "value": "'center'",
+                            "computed": false
+                        },
+                        {
                             "value": "'left'",
                             "computed": false
                         },
@@ -9233,7 +9237,7 @@
                     ]
                 },
                 "required": false,
-                "description": "Aligns the right or left side of the menu with the respective side of the trigger. This is not intended for use with `nubbinPosition`.",
+                "description": "Aligns the menu center, right, or left respective to the trigger. This is not intended for use with `nubbinPosition`.",
                 "defaultValue": {
                     "value": "'left'",
                     "computed": false

--- a/components/files/more-files.jsx
+++ b/components/files/more-files.jsx
@@ -67,6 +67,9 @@ const defaultProps = {
 	href: 'javascript:void(0);',
 };
 
+/**
+ * MoreFiles is a component that represents multiple uploaded attachments
+ */
 class MoreFiles extends React.Component {
 	componentWillMount() {
 		this.generatedId = shortid.generate();

--- a/components/menu-dropdown/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/menu-dropdown/__docs__/__snapshots__/storybook-stories.storyshot
@@ -28,6 +28,34 @@ exports[`DOM snapshots SLDSMenuDropdown Base 1`] = `
 </div>
 `;
 
+exports[`DOM snapshots SLDSMenuDropdown Base center-aligned 1`] = `
+<div
+  className="slds-p-around_medium slds-text-align_center"
+>
+  <div
+    className="slds-dropdown-trigger slds-dropdown-trigger_click"
+    id="base-center"
+    onClick={[Function]}
+    onFocus={null}
+    onKeyDown={[Function]}
+    onMouseEnter={null}
+    onMouseLeave={null}
+  >
+    <button
+      aria-expanded={false}
+      aria-haspopup={true}
+      className="slds-button slds-button_neutral ignore-click-base-center"
+      disabled={false}
+      onClick={[Function]}
+      tabIndex="0"
+      type="button"
+    >
+      Dropdown Click
+    </button>
+  </div>
+</div>
+`;
+
 exports[`DOM snapshots SLDSMenuDropdown Base with icon, dropdown left-aligned 1`] = `
 <div
   className="slds-p-around_medium slds-text-align_center"

--- a/components/menu-dropdown/__docs__/storybook-stories.jsx
+++ b/components/menu-dropdown/__docs__/storybook-stories.jsx
@@ -237,6 +237,20 @@ storiesOf(MENU_DROPDOWN, module)
 			options,
 		})
 	)
+	.add('Base center-aligned', () =>
+		getDropdown({
+			align: 'center',
+			id: 'base-center',
+			label: 'Dropdown Click',
+			onClick: (...rest) => {
+				action('Clicked')(...rest);
+			},
+			onSelect: (...rest) => {
+				action('Selected')(...rest);
+			},
+			options,
+		})
+	)
 	.add('Base with icon, dropdown right-aligned', () =>
 		getDropdown({
 			align: 'right',

--- a/components/menu-dropdown/menu-dropdown.jsx
+++ b/components/menu-dropdown/menu-dropdown.jsx
@@ -129,9 +129,9 @@ const DropdownToDialogNubbinMapping = {
 
 const propTypes = {
 	/**
-	 * Aligns the right or left side of the menu with the respective side of the trigger. This is not intended for use with `nubbinPosition`.
+	 * Aligns the menu center, right, or left respective to the trigger. This is not intended for use with `nubbinPosition`.
 	 */
-	align: PropTypes.oneOf(['left', 'right']),
+	align: PropTypes.oneOf(['center', 'left', 'right']),
 	/**
 	 * This prop is passed onto the triggering `Button`. Text that is visually hidden but read aloud by screenreaders to tell the user what the icon means. You can omit this prop if you are using the `label` prop.
 	 */
@@ -903,7 +903,8 @@ class MenuDropdown extends React.Component {
 			hasNubbin = true;
 			align = DropdownToDialogNubbinMapping[this.props.nubbinPosition];
 		} else if (this.props.align) {
-			align = `bottom ${this.props.align}`;
+			align =
+				this.props.align === 'center' ? 'bottom' : `bottom ${this.props.align}`;
 		}
 
 		const positions = DropdownToDialogNubbinMapping[align].split(' ');
@@ -915,6 +916,11 @@ class MenuDropdown extends React.Component {
 		const menuPosition = this.props.isInline
 			? 'relative'
 			: this.props.menuPosition; // eslint-disable-line react/prop-types
+
+		const menuStylesBase = {};
+		if (this.props.align === 'center' && !hasNubbin) {
+			menuStylesBase.transform = 'none';
+		}
 
 		return isOpen ? (
 			<Dialog
@@ -946,7 +952,10 @@ class MenuDropdown extends React.Component {
 				}
 				outsideClickIgnoreClass={outsideClickIgnoreClass}
 				position={menuPosition}
-				style={this.props.menuStyle}
+				style={{
+					...menuStylesBase,
+					...this.props.menuStyle,
+				}}
 				onRequestTargetElement={() => this.trigger}
 			>
 				{this.renderMenuContent(customContent)}


### PR DESCRIPTION
Fixes #2221 

Simple feature add and solution, but wow did this take me a while to figure out the positioning issue that was occurring. Basically I have to set the `transform` value to `'none'` when `align` is equal to `'center'` and no nubbin is present, otherwise the `slds-dropdown` class breaks the popper's natural positioning.

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [ ] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [ ] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
