### PR TITLE
ButtonGroup label support for all variants

### DIFF
--- a/components/button-group/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/button-group/__docs__/__snapshots__/storybook-stories.storyshot
@@ -299,7 +299,7 @@ exports[`DOM snapshots SLDSButtonGroup Icon Group 1`] = `
     </button>
     <div
       className="slds-dropdown-trigger slds-dropdown-trigger_click slds-button_last"
-      id="icon-dropdown-example"
+      id="icon-dropdown-example-1"
       onClick={[Function]}
       onFocus={null}
       onKeyDown={[Function]}
@@ -309,7 +309,7 @@ exports[`DOM snapshots SLDSButtonGroup Icon Group 1`] = `
       <button
         aria-expanded={false}
         aria-haspopup={true}
-        className="slds-button slds-button_icon-more ignore-click-icon-dropdown-example"
+        className="slds-button slds-button_icon-more ignore-click-icon-dropdown-example-1"
         disabled={false}
         onClick={[Function]}
         tabIndex="0"
@@ -339,6 +339,113 @@ exports[`DOM snapshots SLDSButtonGroup Icon Group 1`] = `
       </button>
     </div>
   </div>
+  <br />
+  <br />
+  <fieldset
+    className="slds-form-element"
+  >
+    <legend
+      className="slds-form-element__legend slds-form-element__label"
+    >
+      Actions
+    </legend>
+    <div
+      className="slds-form-element__control"
+    >
+      <div
+        className="slds-button-group"
+        role="group"
+      >
+        <button
+          aria-live="polite"
+          className="slds-button slds-not-selected slds-button_icon-border"
+          disabled={false}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onMouseLeave={[Function]}
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            className="slds-button__icon slds-button__icon_stateful"
+          >
+            <use
+              xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#chart"
+            />
+          </svg>
+          <span
+            className="slds-assistive-text"
+          >
+            Show Chart
+          </span>
+        </button>
+        <button
+          aria-live="polite"
+          className="slds-button slds-not-selected slds-button_icon-border"
+          disabled={false}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onMouseLeave={[Function]}
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            className="slds-button__icon slds-button__icon_stateful"
+          >
+            <use
+              xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#filterList"
+            />
+          </svg>
+          <span
+            className="slds-assistive-text"
+          >
+            Filter List
+          </span>
+        </button>
+        <div
+          className="slds-dropdown-trigger slds-dropdown-trigger_click slds-button_last"
+          id="icon-dropdown-example-2"
+          onClick={[Function]}
+          onFocus={null}
+          onKeyDown={[Function]}
+          onMouseEnter={null}
+          onMouseLeave={null}
+        >
+          <button
+            aria-expanded={false}
+            aria-haspopup={true}
+            className="slds-button slds-button_icon-more ignore-click-icon-dropdown-example-2"
+            disabled={false}
+            onClick={[Function]}
+            tabIndex="0"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              className="slds-button__icon"
+            >
+              <use
+                xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#settings"
+              />
+            </svg>
+            <svg
+              aria-hidden="true"
+              className="slds-button__icon slds-button__icon_x-small"
+            >
+              <use
+                xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
+              />
+            </svg>
+            <span
+              className="slds-assistive-text"
+            >
+              Settings
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </fieldset>
 </div>
 `;
 
@@ -353,7 +460,7 @@ exports[`DOM snapshots SLDSButtonGroup List Variant 1`] = `
       <button
         className="slds-button slds-button_neutral"
         disabled={false}
-        id="refresh-button"
+        id="refresh-button-1"
         onClick={[Function]}
         type="button"
       >
@@ -364,7 +471,7 @@ exports[`DOM snapshots SLDSButtonGroup List Variant 1`] = `
       <button
         className="slds-button slds-button_neutral"
         disabled={false}
-        id="edit-button"
+        id="edit-button-1"
         onClick={[Function]}
         type="button"
       >
@@ -374,7 +481,7 @@ exports[`DOM snapshots SLDSButtonGroup List Variant 1`] = `
     <li>
       <div
         className="slds-dropdown-trigger slds-dropdown-trigger_click"
-        id="options"
+        id="options-1"
         onClick={[Function]}
         onFocus={null}
         onKeyDown={[Function]}
@@ -384,7 +491,7 @@ exports[`DOM snapshots SLDSButtonGroup List Variant 1`] = `
         <button
           aria-expanded={false}
           aria-haspopup={true}
-          className="slds-button slds-button_icon-border-filled ignore-click-options"
+          className="slds-button slds-button_icon-border-filled ignore-click-options-1"
           disabled={false}
           onClick={[Function]}
           tabIndex="0"
@@ -407,6 +514,82 @@ exports[`DOM snapshots SLDSButtonGroup List Variant 1`] = `
       </div>
     </li>
   </ul>
+  <br />
+  <br />
+  <fieldset
+    className="slds-form-element custom-container-class"
+  >
+    <legend
+      className="slds-form-element__legend slds-form-element__label"
+    >
+      Actions
+    </legend>
+    <div
+      className="slds-form-element__control"
+    >
+      <ul
+        className="slds-button-group-list"
+      >
+        <li>
+          <button
+            className="slds-button slds-button_neutral"
+            disabled={false}
+            id="refresh-button-2"
+            onClick={[Function]}
+            type="button"
+          >
+            Refresh
+          </button>
+        </li>
+        <li>
+          <button
+            className="slds-button slds-button_neutral"
+            disabled={false}
+            id="edit-button-2"
+            onClick={[Function]}
+            type="button"
+          >
+            Edit
+          </button>
+        </li>
+        <li>
+          <div
+            className="slds-dropdown-trigger slds-dropdown-trigger_click"
+            id="options-2"
+            onClick={[Function]}
+            onFocus={null}
+            onKeyDown={[Function]}
+            onMouseEnter={null}
+            onMouseLeave={null}
+          >
+            <button
+              aria-expanded={false}
+              aria-haspopup={true}
+              className="slds-button slds-button_icon-border-filled ignore-click-options-2"
+              disabled={false}
+              onClick={[Function]}
+              tabIndex="0"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                className="slds-button__icon"
+              >
+                <use
+                  xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#down"
+                />
+              </svg>
+              <span
+                className="slds-assistive-text"
+              >
+                More Options
+              </span>
+            </button>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </fieldset>
 </div>
 `;
 

--- a/components/button-group/__examples__/icon-group.jsx
+++ b/components/button-group/__examples__/icon-group.jsx
@@ -31,7 +31,42 @@ class Example extends React.Component {
 						iconCategory="utility"
 						iconName="settings"
 						iconVariant="more"
-						id="icon-dropdown-example"
+						id="icon-dropdown-example-1"
+						onSelect={(item) => {
+							console.log(item.label, 'selected');
+						}}
+						openOn="click"
+						options={[
+							{ label: 'Bring left panel to front', value: 'A0' },
+							{ label: 'Bring right panel to front', value: 'B0' },
+						]}
+						value="A0"
+						variant="icon"
+					/>
+				</ButtonGroup>
+				<br />
+				<br />
+				<ButtonGroup labels={{ label: 'Actions' }}>
+					<ButtonStateful
+						assistiveText={{ icon: 'Show Chart' }}
+						buttonVariant="icon"
+						iconName="chart"
+						iconVariant="border"
+						variant="icon"
+					/>
+					<ButtonStateful
+						assistiveText={{ icon: 'Filter List' }}
+						iconName="filterList"
+						iconVariant="border"
+						variant="icon"
+					/>
+					<Dropdown
+						assistiveText={{ icon: 'Settings' }}
+						checkmark
+						iconCategory="utility"
+						iconName="settings"
+						iconVariant="more"
+						id="icon-dropdown-example-2"
 						onSelect={(item) => {
 							console.log(item.label, 'selected');
 						}}

--- a/components/button-group/__examples__/list-variant.jsx
+++ b/components/button-group/__examples__/list-variant.jsx
@@ -12,10 +12,34 @@ class Example extends React.Component {
 		return (
 			<IconSettings iconPath="/assets/icons">
 				<ButtonGroup variant="list">
-					<Button id="refresh-button" label="Refresh" />
-					<Button label="Edit" id="edit-button" />
+					<Button id="refresh-button-1" label="Refresh" />
+					<Button label="Edit" id="edit-button-1" />
 					<Dropdown
-						id="options"
+						id="options-1"
+						assistiveText={{ icon: 'More Options' }}
+						buttonVariant="icon"
+						iconCategory="utility"
+						iconName="down"
+						iconVariant="border-filled"
+						onSelect={(item) => console.log('selected', item)}
+						options={[
+							{ label: 'A Option', value: 'A0' },
+							{ label: 'B Option', value: 'B0' },
+							{ label: 'C Option', value: 'C0' },
+						]}
+					/>
+				</ButtonGroup>
+				<br />
+				<br />
+				<ButtonGroup
+					classNameContainer="custom-container-class"
+					labels={{ label: 'Actions' }}
+					variant="list"
+				>
+					<Button id="refresh-button-2" label="Refresh" />
+					<Button label="Edit" id="edit-button-2" />
+					<Dropdown
+						id="options-2"
 						assistiveText={{ icon: 'More Options' }}
 						buttonVariant="icon"
 						iconCategory="utility"

--- a/components/button-group/index.jsx
+++ b/components/button-group/index.jsx
@@ -26,6 +26,14 @@ const propTypes = {
 		PropTypes.string,
 	]),
 	/**
+	 * If the `labels.label` prop is set, a `.slds-form-element` classed fieldset element is added as a container. This prop applies classes to that element
+	 */
+	classNameContainer: PropTypes.oneOfType([
+		PropTypes.array,
+		PropTypes.object,
+		PropTypes.string,
+	]),
+	/**
 	 * **Text labels for internationalization**
 	 * This object is merged with the default props object on every render.
 	 * * `error`: Message to display when any of Checkboxes are in an error state. _Tested with snapshot testing._
@@ -46,76 +54,91 @@ const defaultProps = { labels: {} };
 /**
  * The ButtonGroup component wraps other components (ie. Button, MenuDropdown, PopoverTooltip, Checkboxes, etc).
  */
-const ButtonGroup = (props = {}) => {
-	// Merge objects of strings with their default object
-	const labels = assign({}, defaultProps.labels, props.labels);
+class ButtonGroup extends React.Component {
+	render() {
+		// Merge objects of strings with their default object
+		const labels = assign({}, defaultProps.labels, this.props.labels);
 
-	const zeroIndexLength = React.Children.count(props.children) - 1;
-	let { children } = props;
-	if (zeroIndexLength > 0) {
-		children = React.Children.map(props.children, (child, index) => {
-			let newChild;
-			if (index === zeroIndexLength) {
-				newChild = React.cloneElement(child, {
-					triggerClassName: 'slds-button_last',
-				});
-			}
+		const zeroIndexLength = React.Children.count(this.props.children) - 1;
+		let { children } = this.props;
+		if (zeroIndexLength > 0) {
+			children = React.Children.map(this.props.children, (child, index) => {
+				let newChild;
+				if (index === zeroIndexLength) {
+					newChild = React.cloneElement(child, {
+						triggerClassName: 'slds-button_last',
+					});
+				}
 
-			return newChild || child;
-		});
-	}
+				return newChild || child;
+			});
+		}
 
-	if (props.variant === 'checkbox') {
-		children = React.Children.map(props.children, (child) =>
-			React.cloneElement(child, {
-				variant: 'button-group',
-			})
-		);
+		let component;
 
-		return (
-			<fieldset
-				className={classNames('slds-form-element', {
-					'slds-has-error': labels.error,
-				})}
-			>
-				<legend className="slds-form-element__legend slds-form-element__label">
-					{props.labels.label}
-				</legend>
-				<div className="slds-form-element__control">
-					<div
-						className={classNames(
-							'slds-checkbox_button-group',
-							props.className
-						)}
-					>
-						{children}
-					</div>
-					{labels.error ? (
-						<div className="slds-form-element__help">{labels.error}</div>
-					) : null}
+		if (this.props.variant === 'checkbox') {
+			children = React.Children.map(this.props.children, (child) =>
+				React.cloneElement(child, {
+					variant: 'button-group',
+				})
+			);
+
+			component = (
+				<div
+					className={classNames(
+						'slds-checkbox_button-group',
+						this.props.className
+					)}
+				>
+					{children}
 				</div>
-			</fieldset>
-		);
-	}
+			);
+		} else if (this.props.variant === 'list') {
+			component = (
+				<ul
+					className={classNames('slds-button-group-list', this.props.className)}
+				>
+					{React.Children.map(this.props.children, (child) => <li>{child}</li>)}
+				</ul>
+			);
+		} else {
+			component = (
+				<div
+					className={classNames('slds-button-group', this.props.className)}
+					role="group"
+				>
+					{children}
+				</div>
+			);
+		}
 
-	if (props.variant === 'list') {
-		return (
-			<ul className={classNames('slds-button-group-list', props.className)}>
-				{React.Children.map(props.children, (child) => <li>{child}</li>)}
-			</ul>
-		);
-	}
+		if (this.props.variant === 'checkbox' || this.props.labels.label) {
+			component = (
+				<fieldset
+					className={classNames(
+						'slds-form-element',
+						{
+							'slds-has-error': labels.error,
+						},
+						this.props.classNameContainer
+					)}
+				>
+					<legend className="slds-form-element__legend slds-form-element__label">
+						{this.props.labels.label}
+					</legend>
+					<div className="slds-form-element__control">
+						{component}
+						{labels.error ? (
+							<div className="slds-form-element__help">{labels.error}</div>
+						) : null}
+					</div>
+				</fieldset>
+			);
+		}
 
-	// default
-	return (
-		<div
-			className={classNames('slds-button-group', props.className)}
-			role="group"
-		>
-			{children}
-		</div>
-	);
-};
+		return component;
+	}
+}
 
 ButtonGroup.displayName = BUTTON_GROUP;
 ButtonGroup.propTypes = propTypes;

--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -1479,6 +1479,24 @@
                 "required": false,
                 "description": "CSS classes added to `slds-button-group` or `slds-checkbox_button-group` tag"
             },
+            "classNameContainer": {
+                "type": {
+                    "name": "union",
+                    "value": [
+                        {
+                            "name": "array"
+                        },
+                        {
+                            "name": "object"
+                        },
+                        {
+                            "name": "string"
+                        }
+                    ]
+                },
+                "required": false,
+                "description": "If the `labels.label` prop is set, a `.slds-form-element` classed fieldset element is added as a container. This prop applies classes to that element"
+            },
             "labels": {
                 "type": {
                     "name": "shape",


### PR DESCRIPTION
Fixes #2153 

Adds label support for all ButtonGroup variants. Also adds a `classNameContainer` prop that applies to the label fieldset container

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [ ] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [ ] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
