### PR TITLE
Files: Add inverse classname to download button

### DIFF
--- a/components/files/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/files/__docs__/__snapshots__/storybook-stories.storyshot
@@ -437,7 +437,7 @@ exports[`DOM snapshots SLDSFiles w/ Actions 1`] = `
               role="group"
             >
               <button
-                className="slds-button slds-button_icon"
+                className="slds-button slds-button_icon slds-button_icon-inverse"
                 disabled={false}
                 onClick={[Function]}
                 title="Download"
@@ -569,7 +569,7 @@ exports[`DOM snapshots SLDSFiles w/ Actions 1`] = `
             role="group"
           >
             <button
-              className="slds-button slds-button_icon"
+              className="slds-button slds-button_icon slds-button_icon-inverse"
               disabled={false}
               onClick={[Function]}
               title="Download"

--- a/components/files/private/file-actions.jsx
+++ b/components/files/private/file-actions.jsx
@@ -26,6 +26,7 @@ const FileActions = (props) => {
 						iconSize="x-small"
 						onClick={props.onClickDownload}
 						title="Download"
+						className="slds-button_icon-inverse"
 					>
 						<Icon
 							assistiveText={{ label: props.assistiveText.download }}


### PR DESCRIPTION
Fixes #2300

### Additional description

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [ ] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [ ] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
