### PR TITLE
BuilderHeader: Use Error Popover in Utility Bar

### DIFF
--- a/components/builder-header/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/builder-header/__docs__/__snapshots__/storybook-stories.storyshot
@@ -1953,7 +1953,6 @@ exports[`DOM snapshots SLDSBuilderHeader Failed Save 1`] = `
               <span />
             </div>
             <div
-              className="slds-tooltip-trigger"
               style={
                 Object {
                   "display": "inline-block",
@@ -1963,11 +1962,12 @@ exports[`DOM snapshots SLDSBuilderHeader Failed Save 1`] = `
               <button
                 className="slds-button slds-button_icon-container"
                 disabled={false}
-                onBlur={[Function]}
+                id="popover-error"
                 onClick={[Function]}
-                onFocus={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
+                onFocus={null}
+                onMouseEnter={null}
+                onMouseLeave={null}
+                tabIndex="0"
                 type="button"
               >
                 <svg
@@ -1984,7 +1984,6 @@ exports[`DOM snapshots SLDSBuilderHeader Failed Save 1`] = `
                   Error
                 </span>
               </button>
-              <span />
             </div>
             <button
               className="slds-button slds-button_neutral"

--- a/components/builder-header/__examples__/failed-save.jsx
+++ b/components/builder-header/__examples__/failed-save.jsx
@@ -1,13 +1,14 @@
 import React from 'react';
-import IconSettings from '../../icon-settings';
-import Button from '../../button';
-import ButtonGroup from '../../button-group';
-import Tooltip from '../../tooltip';
-import BuilderHeader from '..';
-import BuilderHeaderNav from '../nav';
-import BuilderHeaderNavLink from '../nav-link';
-import BuilderHeaderNavDropdown from '../nav-dropdown';
-import BuilderHeaderToolbar from '../toolbar';
+import IconSettings from '~/components/icon-settings';
+import Button from '~/components/button';
+import ButtonGroup from '~/components/button-group';
+import Popover from '~/components/popover'; // `~` is replaced with design-system-react at runtime
+import Tooltip from '~/components/tooltip';
+import BuilderHeader from '~/components/builder-header';
+import BuilderHeaderNav from '~/components/builder-header/nav';
+import BuilderHeaderNavLink from '~/components/builder-header/nav-link';
+import BuilderHeaderNavDropdown from '~/components/builder-header/nav-dropdown';
+import BuilderHeaderToolbar from '~/components/builder-header/toolbar';
 
 const Example = (props) => (
 	<IconSettings iconPath="/assets/icons">
@@ -62,10 +63,22 @@ const Example = (props) => (
 								Saved 45 mins ago
 							</button>
 						</Tooltip>
-						<Tooltip
-							id="error-tooltip"
-							align="bottom"
-							content="There has been an error."
+						<Popover
+							align="top left"
+							body={
+								<div>
+									<p className="slds-p-bottom_x-small">
+										Pellentesque magna tellus, dapibus vitae placerat nec,
+										viverra vel mi.{' '}
+										<a href="javascript:void(0);" title="Learn More">
+											Learn More
+										</a>
+									</p>
+								</div>
+							}
+							heading="Review warning"
+							id="popover-error"
+							variant="error"
 						>
 							<Button
 								assistiveText={{ icon: 'Error' }}
@@ -77,7 +90,7 @@ const Example = (props) => (
 								colorVariant="error"
 								variant="icon"
 							/>
-						</Tooltip>
+						</Popover>
 						<Button
 							iconCategory="utility"
 							iconName="right"


### PR DESCRIPTION
Builder Header example "Error on save" icon currently uses a tooltip. This should use an Error themed Popover instead.

### Additional description

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [ ] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [ ] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
