### PR TITLE
More A11y Audit Fixes

### DIFF
--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -14124,13 +14124,17 @@
                         "label": {
                             "name": "string",
                             "required": false
+                        },
+                        "required": {
+                            "name": "string",
+                            "required": false
                         }
                     }
                 },
                 "required": false,
-                "description": "**Assistive text for accessibility**\n* `label`: This label appears in the legend.",
+                "description": "**Assistive text for accessibility**\n* `label`: This label appears in the legend.\n* `required`: Text to help identify the group as required",
                 "defaultValue": {
-                    "value": "{}",
+                    "value": "{ required: 'Required' }",
                     "computed": false
                 }
             },
@@ -14898,6 +14902,10 @@
                 "type": {
                     "name": "shape",
                     "value": {
+                        "disabled": {
+                            "name": "string",
+                            "required": false
+                        },
                         "label": {
                             "name": "string",
                             "required": false
@@ -14905,7 +14913,11 @@
                     }
                 },
                 "required": false,
-                "description": "Assistive text for accessibility**\n`label`: Visually hidden label but read out loud by screen readers."
+                "description": "Assistive text for accessibility**\n`disabled`: Read by screen readers to indicate a disabled slider\n`label`: Visually hidden label but read out loud by screen readers.",
+                "defaultValue": {
+                    "value": "{ disabled: 'Disabled' }",
+                    "computed": false
+                }
             },
             "classNameContainer": {
                 "type": {
@@ -16612,9 +16624,9 @@
                     }
                 },
                 "required": false,
-                "description": "**Assistive text for accessibility**\nThis object is merged with the default props object on every render.\n* `closeButton`: This is a visually hidden label for the close button.\n_Tested with snapshot testing._",
+                "description": "**Assistive text for accessibility**\nThis object is merged with the default props object on every render.\n* `closeButton`: This is a visually hidden label for the close button.\n* `error`: This is a visually hidden label to mark the toast as an error variant\n* `info`: This is a visually hidden label to mark the toast as an info variant\n* `success`: This is a visually hidden label to mark the toast as an success variant\n* `warning`: This is a visually hidden label to mark the toast as an warning variant\n_Tested with snapshot testing._",
                 "defaultValue": {
-                    "value": "{\n    closeButton: 'Close',\n}",
+                    "value": "{\n    closeButton: 'Close',\n    error: 'error',\n    info: 'info',\n    success: 'success',\n    warning: 'warning',\n}",
                     "computed": false
                 }
             },

--- a/components/radio-button-group/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/radio-button-group/__docs__/__snapshots__/storybook-stories.storyshot
@@ -636,6 +636,12 @@ exports[`DOM snapshots SLDSRadioButtonGroup Required 1`] = `
           title="required"
         >
           *
+          <div
+            className="slds-assistive-text"
+          >
+            Required
+             
+          </div>
         </abbr>
         Day of week
       </legend>

--- a/components/radio-button-group/__tests__/radio-button-group.browser-test.jsx
+++ b/components/radio-button-group/__tests__/radio-button-group.browser-test.jsx
@@ -108,7 +108,7 @@ describe('RadioButtonGroup', function() {
 			attachTo: mountNode,
 		});
 		const abbr = wrapper.find('abbr');
-		expect(abbr.text()).to.equal('*', 'there is a required indicator');
+		expect(abbr.text()).to.equal('*Required ', 'there is a required indicator');
 	});
 
 	it('triggers a change callback', () => {

--- a/components/radio-group/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/radio-group/__docs__/__snapshots__/storybook-stories.storyshot
@@ -350,6 +350,12 @@ exports[`DOM snapshots SLDSRadioGroup Required 1`] = `
           title="required"
         >
           *
+          <div
+            className="slds-assistive-text"
+          >
+            Required
+             
+          </div>
         </abbr>
         Radio Group Label
       </legend>

--- a/components/radio-group/__tests__/radio-group.browser-test.jsx
+++ b/components/radio-group/__tests__/radio-group.browser-test.jsx
@@ -105,7 +105,7 @@ describe('RadioGroup', function() {
 	it('renders a required indicator', () => {
 		wrapper = mount(<RadioGroupExample required />, { attachTo: mountNode });
 		const abbr = wrapper.find('abbr');
-		expect(abbr.text()).to.equal('*', 'there is a required indicator');
+		expect(abbr.text()).to.equal('*Required ', 'there is a required indicator');
 	});
 
 	it('triggers a change callback', () => {

--- a/components/radio-group/index.jsx
+++ b/components/radio-group/index.jsx
@@ -17,9 +17,11 @@ const propTypes = {
 	/**
 	 * **Assistive text for accessibility**
 	 * * `label`: This label appears in the legend.
+	 * * `required`: Text to help identify the group as required
 	 */
 	assistiveText: PropTypes.shape({
 		label: PropTypes.string,
+		required: PropTypes.string,
 	}),
 	/**
 	 * Children are expected to be Radio components.
@@ -69,7 +71,11 @@ const propTypes = {
 	variant: PropTypes.oneOf(['base', 'button-group']),
 };
 
-const defaultProps = { assistiveText: {}, labels: {}, variant: 'base' };
+const defaultProps = {
+	assistiveText: { required: 'Required' },
+	labels: {},
+	variant: 'base',
+};
 
 /**
  * A styled select list that can have a single entry checked at any one time.
@@ -104,6 +110,10 @@ class RadioGroup extends React.Component {
 			? assign({}, defaultProps.labels, this.props.labels)
 			: defaultProps.labels;
 
+		const assistiveText = {
+			...defaultProps.assistiveText,
+			...this.props.assistiveText,
+		};
 		const children = React.Children.map(this.props.children, (child) =>
 			React.cloneElement(child, {
 				name: this.getName(),
@@ -123,17 +133,18 @@ class RadioGroup extends React.Component {
 					className={classNames(
 						'slds-form-element__legend',
 						'slds-form-element__label',
-						this.props.assistiveText.label ? 'slds-assistive-text' : ''
+						assistiveText.label ? 'slds-assistive-text' : ''
 					)}
 				>
 					{this.props.required ? (
 						<abbr className="slds-required" title="required">
 							{'*'}
+							<div className="slds-assistive-text">
+								{assistiveText.required}{' '}
+							</div>
 						</abbr>
 					) : null}
-					{this.props.assistiveText.label
-						? this.props.assistiveText.label
-						: this.labels.label}
+					{assistiveText.label ? assistiveText.label : this.labels.label}
 				</legend>
 				<div
 					className={classNames(

--- a/components/slider/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/slider/__docs__/__snapshots__/storybook-stories.storyshot
@@ -26,6 +26,12 @@ exports[`DOM snapshots SLDSSlider Disabled 1`] = `
            - 
           100
         </span>
+        <span
+          className="slds-assistive-text"
+        >
+           
+          Disabled
+        </span>
       </span>
     </label>
     <div

--- a/components/slider/index.jsx
+++ b/components/slider/index.jsx
@@ -31,10 +31,11 @@ const propTypes = {
 	'aria-describedby': PropTypes.string,
 	/**
 	 * Assistive text for accessibility**
+	 * `disabled`: Read by screen readers to indicate a disabled slider
 	 * `label`: Visually hidden label but read out loud by screen readers.
-	 *
 	 */
 	assistiveText: PropTypes.shape({
+		disabled: PropTypes.string,
 		label: PropTypes.string,
 	}),
 	/**
@@ -108,6 +109,7 @@ const propTypes = {
 };
 
 const defaultProps = {
+	assistiveText: { disabled: 'Disabled' },
 	min: 0,
 	max: 100,
 	step: 1,
@@ -157,6 +159,10 @@ class Slider extends React.Component {
 		const ariaProps = getAriaProps(this.props);
 		ariaProps['aria-describedby'] = this.getErrorId();
 
+		const assistiveText = {
+			...defaultProps.assistiveText,
+			...this.props.assistiveText,
+		};
 		const labelText =
 			this.props.label ||
 			(this.props.assistiveText && this.props.assistiveText.label);
@@ -187,6 +193,12 @@ class Slider extends React.Component {
 							{' - '}
 							{this.props.max}
 						</span>
+						{this.props.disabled ? (
+							<span className="slds-assistive-text">
+								{' '}
+								{assistiveText.disabled}
+							</span>
+						) : null}
 					</span>
 				</label>
 				<div className="slds-form-element__control">

--- a/components/spinner/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/spinner/__docs__/__snapshots__/storybook-stories.storyshot
@@ -107,7 +107,7 @@ exports[`DOM snapshots SLDSSpinner Docs site Default 1`] = `
         <span
           className="slds-assistive-text"
         >
-          Small spinner
+          Main Frame Loading...
         </span>
         <div
           className="slds-spinner__dot-a"
@@ -337,7 +337,7 @@ exports[`DOM snapshots SLDSSpinner Small 1`] = `
       <span
         className="slds-assistive-text"
       >
-        Small spinner
+        Main Frame Loading...
       </span>
       <div
         className="slds-spinner__dot-a"

--- a/components/spinner/__docs__/storybook-stories.jsx
+++ b/components/spinner/__docs__/storybook-stories.jsx
@@ -29,7 +29,7 @@ storiesOf(SPINNER, module)
 			size: 'small',
 			variant: 'base',
 			assistiveText: {
-				label: 'Small spinner',
+				label: 'Main Frame Loading...',
 			},
 		})
 	)

--- a/components/spinner/__examples__/default.jsx
+++ b/components/spinner/__examples__/default.jsx
@@ -10,7 +10,7 @@ class Example extends React.Component {
 				<Spinner
 					size="small"
 					variant="base"
-					assistiveText={{ label: 'Small spinner' }}
+					assistiveText={{ label: 'Main Frame Loading...' }}
 				/>
 			</div>
 		);

--- a/components/split-view/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/split-view/__docs__/__snapshots__/storybook-stories.storyshot
@@ -411,6 +411,7 @@ exports[`DOM snapshots SLDSSplitView Base: Multiple 1`] = `
             className="slds-grid slds-grid_vertical slds-scrollable_none"
           >
             <a
+              aria-live="polite"
               className="slds-split-view__list-header slds-grid slds-text-link_reset"
               href="javascript:void(0);"
               onClick={[Function]}
@@ -421,7 +422,9 @@ exports[`DOM snapshots SLDSSplitView Base: Multiple 1`] = `
                 }
               }
             >
-              <span>
+              <span
+                aria-sort="Descending"
+              >
                 <span
                   className="slds-assistive-text"
                 >
@@ -1265,6 +1268,7 @@ exports[`DOM snapshots SLDSSplitView Base: Open 1`] = `
             className="slds-grid slds-grid_vertical slds-scrollable_none"
           >
             <a
+              aria-live="polite"
               className="slds-split-view__list-header slds-grid slds-text-link_reset"
               href="javascript:void(0);"
               onClick={[Function]}
@@ -1275,7 +1279,9 @@ exports[`DOM snapshots SLDSSplitView Base: Open 1`] = `
                 }
               }
             >
-              <span>
+              <span
+                aria-sort="Descending"
+              >
                 <span
                   className="slds-assistive-text"
                 >
@@ -2118,6 +2124,7 @@ exports[`DOM snapshots SLDSSplitView Custom List 1`] = `
             className="slds-grid slds-grid_vertical slds-scrollable_none"
           >
             <a
+              aria-live="polite"
               className="slds-split-view__list-header slds-grid slds-text-link_reset"
               href="javascript:void(0);"
               onClick={[Function]}
@@ -2128,7 +2135,9 @@ exports[`DOM snapshots SLDSSplitView Custom List 1`] = `
                 }
               }
             >
-              <span>
+              <span
+                aria-sort="Descending"
+              >
                 <span
                   className="slds-assistive-text"
                 >
@@ -2735,6 +2744,7 @@ exports[`DOM snapshots SLDSSplitView External State 1`] = `
               className="slds-grid slds-grid_vertical slds-scrollable_none"
             >
               <a
+                aria-live="polite"
                 className="slds-split-view__list-header slds-grid slds-text-link_reset"
                 href="javascript:void(0);"
                 onClick={[Function]}
@@ -2745,7 +2755,9 @@ exports[`DOM snapshots SLDSSplitView External State 1`] = `
                   }
                 }
               >
-                <span>
+                <span
+                  aria-sort="Descending"
+                >
                   <span
                     className="slds-assistive-text"
                   >

--- a/components/split-view/listbox.jsx
+++ b/components/split-view/listbox.jsx
@@ -295,6 +295,7 @@ class SplitViewListbox extends React.Component {
 	headerWrapper(children) {
 		return this.props.events.onSort ? (
 			<a
+				aria-live="polite"
 				style={{ borderTop: '0' }}
 				href="javascript:void(0);" // eslint-disable-line no-script-url
 				role="button"
@@ -316,7 +317,13 @@ class SplitViewListbox extends React.Component {
 	header() {
 		return this.props.labels.header
 			? this.headerWrapper(
-					<span>
+					<span
+						aria-sort={
+							this.props.sortDirection === SORT_OPTIONS.DOWN
+								? this.props.assistiveText.sort.descending
+								: this.props.assistiveText.sort.ascending
+						}
+					>
 						<span className="slds-assistive-text">
 							{this.props.assistiveText.sort.sortedBy}
 							{': '}

--- a/components/toast/__examples__/duration-toast.jsx
+++ b/components/toast/__examples__/duration-toast.jsx
@@ -20,7 +20,7 @@ class Example extends React.Component {
 					<ToastContainer>
 						{this.state.isOpen ? (
 							<Toast
-								duration={1000}
+								duration={10000}
 								labels={{
 									heading: '26 potential duplicate leads were found.',
 									headingLink: 'Select Leads to Merge',

--- a/components/toast/index.jsx
+++ b/components/toast/index.jsx
@@ -23,6 +23,10 @@ const propTypes = {
 	 * **Assistive text for accessibility**
 	 * This object is merged with the default props object on every render.
 	 * * `closeButton`: This is a visually hidden label for the close button.
+	 * * `error`: This is a visually hidden label to mark the toast as an error variant
+	 * * `info`: This is a visually hidden label to mark the toast as an info variant
+	 * * `success`: This is a visually hidden label to mark the toast as an success variant
+	 * * `warning`: This is a visually hidden label to mark the toast as an warning variant
 	 * _Tested with snapshot testing._
 	 */
 	assistiveText: PropTypes.shape({
@@ -86,6 +90,10 @@ const propTypes = {
 const defaultProps = {
 	assistiveText: {
 		closeButton: 'Close',
+		error: 'error',
+		info: 'info',
+		success: 'success',
+		warning: 'warning',
 	},
 	variant: 'info',
 };
@@ -156,10 +164,10 @@ class Toast extends React.Component {
 		const heading = labels.heading || this.props.content; // eslint-disable-line react/prop-types
 
 		const assistiveTextVariant = {
-			info: 'info',
-			success: 'success',
-			warning: 'warning',
-			error: 'error',
+			info: assistiveText.info,
+			success: assistiveText.success,
+			warning: assistiveText.warning,
+			error: assistiveText.error,
 		};
 
 		const defaultIcons = {


### PR DESCRIPTION
Fixes #2336

Corrects the following:

- [x] Radio Group: "Required" is not read
- [x] Slider: Needs to read as disabled
- [x] SplitView: Sorting needs to read when toggled
- [x] Spinner: Small needs to read "Main Frame Loading..."
- [x] Toast: Needs to read when displayed, also duration leaves too quickly

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [ ] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [ ] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
