### PR TITLE
Popover: Pass aria-haspopup to triggering component

### DIFF
--- a/components/builder-header/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/builder-header/__docs__/__snapshots__/storybook-stories.storyshot
@@ -1966,6 +1966,7 @@ exports[`DOM snapshots SLDSBuilderHeader Failed Save 1`] = `
               }
             >
               <button
+                aria-haspopup="dialog"
                 className="slds-button slds-button_icon-container"
                 disabled={false}
                 id="popover-error"

--- a/components/color-picker/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/color-picker/__docs__/__snapshots__/storybook-stories.storyshot
@@ -25,6 +25,7 @@ exports[`DOM snapshots SLDSColorPicker Color Picker Disabled 1`] = `
         }
       >
         <button
+          aria-haspopup="dialog"
           className="slds-button slds-button_icon-more slds-color-picker__summary-button"
           disabled={true}
           id="slds-color-picker__summary-button-color-picker"
@@ -107,6 +108,7 @@ exports[`DOM snapshots SLDSColorPicker ColorPicker Menu Open 1`] = `
         }
       >
         <button
+          aria-haspopup="dialog"
           className="slds-button slds-button_icon-more slds-color-picker__summary-button"
           disabled={false}
           id="slds-color-picker__summary-button-color-picker"
@@ -1421,6 +1423,7 @@ exports[`DOM snapshots SLDSColorPicker Custom Only 1`] = `
         }
       >
         <button
+          aria-haspopup="dialog"
           className="slds-button slds-button_icon-more slds-color-picker__summary-button"
           disabled={false}
           id="slds-color-picker__summary-button-custom-only-color-picker"
@@ -1502,6 +1505,7 @@ exports[`DOM snapshots SLDSColorPicker Custom Tab Selected 1`] = `
         }
       >
         <button
+          aria-haspopup="dialog"
           className="slds-button slds-button_icon-more slds-color-picker__summary-button"
           disabled={false}
           id="slds-color-picker__summary-button-Custom-tab-default-color-picker"
@@ -1583,6 +1587,7 @@ exports[`DOM snapshots SLDSColorPicker Custom Validator 1`] = `
         }
       >
         <button
+          aria-haspopup="dialog"
           className="slds-button slds-button_icon-more slds-color-picker__summary-button"
           disabled={false}
           id="slds-color-picker__summary-button-custom-validator-color-picker"
@@ -1667,6 +1672,7 @@ exports[`DOM snapshots SLDSColorPicker Default - Right to Left (RTL) 1`] = `
           }
         >
           <button
+            aria-haspopup="dialog"
             className="slds-button slds-button_icon-more slds-color-picker__summary-button"
             disabled={false}
             id="slds-color-picker__summary-button-default-color-picker"
@@ -1749,6 +1755,7 @@ exports[`DOM snapshots SLDSColorPicker Default 1`] = `
         }
       >
         <button
+          aria-haspopup="dialog"
           className="slds-button slds-button_icon-more slds-color-picker__summary-button"
           disabled={false}
           id="slds-color-picker__summary-button-default-color-picker"
@@ -1830,6 +1837,7 @@ exports[`DOM snapshots SLDSColorPicker Doc site Default 1`] = `
         }
       >
         <button
+          aria-haspopup="dialog"
           className="slds-button slds-button_icon-more slds-color-picker__summary-button"
           disabled={false}
           id="slds-color-picker__summary-button-default-color-picker"
@@ -1910,6 +1918,7 @@ exports[`DOM snapshots SLDSColorPicker Hidden Input 1`] = `
         }
       >
         <button
+          aria-haspopup="dialog"
           className="slds-button slds-button_icon-more slds-color-picker__summary-button"
           disabled={false}
           id="slds-color-picker__summary-button-hidden-input-color-picker"
@@ -1976,6 +1985,7 @@ exports[`DOM snapshots SLDSColorPicker Outer Input in Error State 1`] = `
         }
       >
         <button
+          aria-haspopup="dialog"
           className="slds-button slds-button_icon-more slds-color-picker__summary-button"
           disabled={false}
           id="slds-color-picker__summary-button-outer-input-error-state-color-picker"
@@ -2062,6 +2072,7 @@ exports[`DOM snapshots SLDSColorPicker Predefined Colors 1`] = `
         }
       >
         <button
+          aria-haspopup="dialog"
           className="slds-button slds-button_icon-more slds-color-picker__summary-button"
           disabled={false}
           id="slds-color-picker__summary-button-predefined-color-picker"
@@ -2142,6 +2153,7 @@ exports[`DOM snapshots SLDSColorPicker Predefined Colors Only 1`] = `
         }
       >
         <button
+          aria-haspopup="dialog"
           className="slds-button slds-button_icon-more slds-color-picker__summary-button"
           disabled={false}
           id="slds-color-picker__summary-button-predefined-only-color-picker"
@@ -2222,6 +2234,7 @@ exports[`DOM snapshots SLDSColorPicker Swatch Only 1`] = `
         }
       >
         <button
+          aria-haspopup="dialog"
           className="slds-button slds-button_icon-more slds-color-picker__summary-button"
           disabled={false}
           id="slds-color-picker__summary-button-swatch-only-color-picker"
@@ -2303,6 +2316,7 @@ exports[`DOM snapshots SLDSColorPicker Working Color Input in Error State 1`] = 
         }
       >
         <button
+          aria-haspopup="dialog"
           className="slds-button slds-button_icon-more slds-color-picker__summary-button"
           disabled={false}
           id="slds-color-picker__summary-button-working-color-error-state-color-picker"

--- a/components/combobox/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/combobox/__docs__/__snapshots__/storybook-stories.storyshot
@@ -2516,6 +2516,7 @@ exports[`DOM snapshots SLDSCombobox Dialog 1`] = `
               <input
                 aria-autocomplete="none"
                 aria-describedby={null}
+                aria-haspopup="dialog"
                 autoComplete="off"
                 className="slds-input slds-combobox__input"
                 id="combobox-dialog"
@@ -5183,6 +5184,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Dialog Open 1`] = `
               <input
                 aria-autocomplete="none"
                 aria-controls="combobox-unique-id-popover"
+                aria-haspopup="dialog"
                 autoComplete="off"
                 className="slds-input slds-combobox__input"
                 id="combobox-unique-id"

--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -1616,7 +1616,15 @@
     },
     "button-group": {
         "description": "The ButtonGroup component wraps other components (ie. Button, MenuDropdown, PopoverTooltip, Checkboxes, etc).",
-        "methods": [],
+        "methods": [
+            {
+                "name": "getId",
+                "docblock": null,
+                "modifiers": [],
+                "params": [],
+                "returns": null
+            }
+        ],
         "props": {
             "children": {
                 "type": {
@@ -1660,6 +1668,13 @@
                 },
                 "required": false,
                 "description": "If the `labels.label` prop is set, a `.slds-form-element` classed fieldset element is added as a container. This prop applies classes to that element"
+            },
+            "id": {
+                "type": {
+                    "name": "string"
+                },
+                "required": false,
+                "description": "HTML id for component."
             },
             "labels": {
                 "type": {

--- a/components/filter/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/filter/__docs__/__snapshots__/storybook-stories.storyshot
@@ -27,6 +27,7 @@ exports[`DOM snapshots SLDSFilter AssistiveTextFilter 1`] = `
           }
         >
           <button
+            aria-haspopup="dialog"
             className="slds-button_reset slds-grow slds-has-blur-focus"
             id="sample-panel-filtering-show-me"
             onClick={[Function]}
@@ -107,6 +108,7 @@ exports[`DOM snapshots SLDSFilter ErrorFilter 1`] = `
           >
             <button
               aria-describedby="sample-panel-filtering-show-me-error"
+              aria-haspopup="dialog"
               className="slds-button_reset slds-grow slds-has-blur-focus"
               id="sample-panel-filtering-show-me"
               onClick={[Function]}
@@ -192,6 +194,7 @@ exports[`DOM snapshots SLDSFilter Filter 1`] = `
           }
         >
           <button
+            aria-haspopup="dialog"
             className="slds-button_reset slds-grow slds-has-blur-focus"
             id="sample-panel-filtering-show-me"
             onClick={[Function]}
@@ -270,6 +273,7 @@ exports[`DOM snapshots SLDSFilter Filter Align Right 1`] = `
           }
         >
           <button
+            aria-haspopup="dialog"
             className="slds-button_reset slds-grow slds-has-blur-focus"
             id="sample-panel-filtering-show-me"
             onClick={[Function]}
@@ -386,6 +390,7 @@ exports[`DOM snapshots SLDSFilter New Filter 1`] = `
           }
         >
           <button
+            aria-haspopup="dialog"
             className="slds-button_reset slds-grow slds-has-blur-focus"
             id="sample-panel-filtering-show-me"
             onClick={[Function]}
@@ -464,6 +469,7 @@ exports[`DOM snapshots SLDSFilter Permanant Filter 1`] = `
           }
         >
           <button
+            aria-haspopup="dialog"
             className="slds-button_reset slds-grow slds-has-blur-focus"
             id="sample-panel-filtering-show-me"
             onClick={[Function]}

--- a/components/global-header/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/global-header/__docs__/__snapshots__/storybook-stories.storyshot
@@ -141,6 +141,7 @@ exports[`DOM snapshots SLDSGlobalHeader Doc site Default 1`] = `
                   }
                 >
                   <button
+                    aria-haspopup="dialog"
                     className="slds-button slds-button_icon-border slds-button_icon-small slds-button_icon slds-global-actions__favorites-more"
                     disabled={false}
                     id="header-favorites-popover-id"
@@ -304,6 +305,7 @@ exports[`DOM snapshots SLDSGlobalHeader Doc site Default 1`] = `
               }
             >
               <button
+                aria-haspopup="dialog"
                 aria-live="assertive"
                 className="slds-button slds-button_icon-container slds-button_icon-small slds-button_icon slds-global-actions__notifications slds-global-actions__item-action"
                 disabled={false}
@@ -631,6 +633,7 @@ exports[`DOM snapshots SLDSGlobalHeader Search + Navigation 1`] = `
                   }
                 >
                   <button
+                    aria-haspopup="dialog"
                     className="slds-button slds-button_icon-border slds-button_icon-small slds-button_icon slds-global-actions__favorites-more"
                     disabled={false}
                     id="header-favorites-popover-id"
@@ -794,6 +797,7 @@ exports[`DOM snapshots SLDSGlobalHeader Search + Navigation 1`] = `
               }
             >
               <button
+                aria-haspopup="dialog"
                 aria-live="assertive"
                 className="slds-button slds-button_icon-container slds-button_icon-small slds-button_icon slds-global-actions__notifications slds-global-actions__item-action"
                 disabled={false}
@@ -1012,6 +1016,7 @@ exports[`DOM snapshots SLDSGlobalHeader With custom <Avatar/> 1`] = `
                   }
                 >
                   <button
+                    aria-haspopup="dialog"
                     className="slds-button slds-button_icon-border slds-button_icon-small slds-button_icon slds-global-actions__favorites-more"
                     disabled={false}
                     id="header-favorites-popover-id"
@@ -1175,6 +1180,7 @@ exports[`DOM snapshots SLDSGlobalHeader With custom <Avatar/> 1`] = `
               }
             >
               <button
+                aria-haspopup="dialog"
                 aria-live="assertive"
                 className="slds-button slds-button_icon-container slds-button_icon-small slds-button_icon slds-global-actions__notifications slds-global-actions__item-action"
                 disabled={false}

--- a/components/panel/__tests__/__snapshots__/filtering.dom-snapshot-test.jsx.snap
+++ b/components/panel/__tests__/__snapshots__/filtering.dom-snapshot-test.jsx.snap
@@ -61,6 +61,7 @@ exports[`Panel Filtering Default Snapshot DOM Snapshot 1`] = `
                 }
               >
                 <button
+                  aria-haspopup="dialog"
                   className="slds-button_reset slds-grow slds-has-blur-focus"
                   id="sample-panel-filtering-show-me"
                   onClick={[Function]}
@@ -111,6 +112,7 @@ exports[`Panel Filtering Default Snapshot DOM Snapshot 1`] = `
                 }
               >
                 <button
+                  aria-haspopup="dialog"
                   className="slds-button_reset slds-grow slds-has-blur-focus"
                   id="sample-panel-filtering-created-date"
                   onClick={[Function]}
@@ -173,6 +175,7 @@ exports[`Panel Filtering Default Snapshot DOM Snapshot 1`] = `
                 }
               >
                 <button
+                  aria-haspopup="dialog"
                   className="slds-button_reset slds-grow slds-has-blur-focus"
                   id="sample-panel-filtering-list-price"
                   onClick={[Function]}
@@ -258,7 +261,7 @@ exports[`Panel Filtering Default Snapshot HTML Snapshot 1`] = `
         <ol class=\\"slds-list_vertical slds-list_vertical-space\\">
           <li class=\\"slds-item slds-hint-parent\\">
             <div class=\\"slds-filters__item slds-grid slds-grid_vertical-align-center\\">
-              <div class=\\"slds-grow\\" style=\\"display:inline-block\\"><button class=\\"slds-button_reset slds-grow slds-has-blur-focus\\" type=\\"button\\" id=\\"sample-panel-filtering-show-me\\" tabindex=\\"0\\"><span class=\\"slds-assistive-text\\">Edit filter:</span><p class=\\"slds-text-body_small\\">Show Me</p><p>All Products</p></button></div>
+              <div class=\\"slds-grow\\" style=\\"display:inline-block\\"><button class=\\"slds-button_reset slds-grow slds-has-blur-focus\\" type=\\"button\\" aria-haspopup=\\"dialog\\" id=\\"sample-panel-filtering-show-me\\" tabindex=\\"0\\"><span class=\\"slds-assistive-text\\">Edit filter:</span><p class=\\"slds-text-body_small\\">Show Me</p><p>All Products</p></button></div>
             </div>
           </li>
         </ol>
@@ -266,14 +269,14 @@ exports[`Panel Filtering Default Snapshot HTML Snapshot 1`] = `
         <ol class=\\"slds-list_vertical slds-list_vertical-space\\">
           <li class=\\"slds-item slds-hint-parent\\">
             <div class=\\"slds-filters__item slds-grid slds-grid_vertical-align-center\\">
-              <div class=\\"slds-grow\\" style=\\"display:inline-block\\"><button class=\\"slds-button_reset slds-grow slds-has-blur-focus\\" type=\\"button\\" id=\\"sample-panel-filtering-created-date\\" tabindex=\\"0\\"><span class=\\"slds-assistive-text\\">Edit filter:</span><p class=\\"slds-text-body_small\\">Created Date</p><p>equals THIS WEEK</p></button></div>
+              <div class=\\"slds-grow\\" style=\\"display:inline-block\\"><button class=\\"slds-button_reset slds-grow slds-has-blur-focus\\" type=\\"button\\" aria-haspopup=\\"dialog\\" id=\\"sample-panel-filtering-created-date\\" tabindex=\\"0\\"><span class=\\"slds-assistive-text\\">Edit filter:</span><p class=\\"slds-text-body_small\\">Created Date</p><p>equals THIS WEEK</p></button></div>
               <button
                 class=\\"slds-button slds-button_icon slds-button_icon-bare slds-button_icon-small\\" title=\\"Remove Filter: Created Date equals THIS WEEK\\" type=\\"button\\"><svg aria-hidden=\\"true\\" class=\\"slds-button__icon slds-button__icon_hint\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#close\\"></use></svg><span class=\\"slds-assistive-text\\">Remove Filter: Created Date equals THIS WEEK</span></button>
             </div>
           </li>
           <li class=\\"slds-item slds-hint-parent\\">
             <div class=\\"slds-filters__item slds-grid slds-grid_vertical-align-center\\">
-              <div class=\\"slds-grow\\" style=\\"display:inline-block\\"><button class=\\"slds-button_reset slds-grow slds-has-blur-focus\\" type=\\"button\\" id=\\"sample-panel-filtering-list-price\\" tabindex=\\"0\\"><span class=\\"slds-assistive-text\\">Edit filter:</span><p class=\\"slds-text-body_small\\">List Price</p><p>greater than &quot;500&quot;</p></button></div>
+              <div class=\\"slds-grow\\" style=\\"display:inline-block\\"><button class=\\"slds-button_reset slds-grow slds-has-blur-focus\\" type=\\"button\\" aria-haspopup=\\"dialog\\" id=\\"sample-panel-filtering-list-price\\" tabindex=\\"0\\"><span class=\\"slds-assistive-text\\">Edit filter:</span><p class=\\"slds-text-body_small\\">List Price</p><p>greater than &quot;500&quot;</p></button></div>
               <button
                 class=\\"slds-button slds-button_icon slds-button_icon-bare slds-button_icon-small\\" title=\\"Remove Filter: List Price greater than &quot;500&quot;\\" type=\\"button\\"><svg aria-hidden=\\"true\\" class=\\"slds-button__icon slds-button__icon_hint\\"><use xlink:href=\\"/assets/icons/utility-sprite/svg/symbols.svg#close\\"></use></svg><span class=\\"slds-assistive-text\\">Remove Filter: List Price greater than &quot;500&quot;</span></button>
             </div>

--- a/components/popover/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/popover/__docs__/__snapshots__/storybook-stories.storyshot
@@ -28,6 +28,7 @@ exports[`DOM snapshots SLDSPopover Alignment (Button) 1`] = `
         }
       >
         <button
+          aria-haspopup="dialog"
           className="slds-button slds-button_neutral"
           disabled={false}
           id="top"
@@ -57,6 +58,7 @@ exports[`DOM snapshots SLDSPopover Alignment (Button) 1`] = `
         }
       >
         <button
+          aria-haspopup="dialog"
           className="slds-button slds-button_neutral"
           disabled={false}
           id="top right"
@@ -86,6 +88,7 @@ exports[`DOM snapshots SLDSPopover Alignment (Button) 1`] = `
         }
       >
         <button
+          aria-haspopup="dialog"
           className="slds-button slds-button_neutral"
           disabled={false}
           id="top left"
@@ -115,6 +118,7 @@ exports[`DOM snapshots SLDSPopover Alignment (Button) 1`] = `
         }
       >
         <button
+          aria-haspopup="dialog"
           className="slds-button slds-button_neutral"
           disabled={false}
           id="right"
@@ -144,6 +148,7 @@ exports[`DOM snapshots SLDSPopover Alignment (Button) 1`] = `
         }
       >
         <button
+          aria-haspopup="dialog"
           className="slds-button slds-button_neutral"
           disabled={false}
           id="right top"
@@ -173,6 +178,7 @@ exports[`DOM snapshots SLDSPopover Alignment (Button) 1`] = `
         }
       >
         <button
+          aria-haspopup="dialog"
           className="slds-button slds-button_neutral"
           disabled={false}
           id="right bottom"
@@ -202,6 +208,7 @@ exports[`DOM snapshots SLDSPopover Alignment (Button) 1`] = `
         }
       >
         <button
+          aria-haspopup="dialog"
           className="slds-button slds-button_neutral"
           disabled={false}
           id="bottom"
@@ -231,6 +238,7 @@ exports[`DOM snapshots SLDSPopover Alignment (Button) 1`] = `
         }
       >
         <button
+          aria-haspopup="dialog"
           className="slds-button slds-button_neutral"
           disabled={false}
           id="bottom left"
@@ -260,6 +268,7 @@ exports[`DOM snapshots SLDSPopover Alignment (Button) 1`] = `
         }
       >
         <button
+          aria-haspopup="dialog"
           className="slds-button slds-button_neutral"
           disabled={false}
           id="bottom right"
@@ -289,6 +298,7 @@ exports[`DOM snapshots SLDSPopover Alignment (Button) 1`] = `
         }
       >
         <button
+          aria-haspopup="dialog"
           className="slds-button slds-button_neutral"
           disabled={false}
           id="left"
@@ -318,6 +328,7 @@ exports[`DOM snapshots SLDSPopover Alignment (Button) 1`] = `
         }
       >
         <button
+          aria-haspopup="dialog"
           className="slds-button slds-button_neutral"
           disabled={false}
           id="left top"
@@ -347,6 +358,7 @@ exports[`DOM snapshots SLDSPopover Alignment (Button) 1`] = `
         }
       >
         <button
+          aria-haspopup="dialog"
           className="slds-button slds-button_neutral"
           disabled={false}
           id="left bottom"
@@ -393,6 +405,7 @@ exports[`DOM snapshots SLDSPopover Alignment (ButtonIcon) 1`] = `
         }
       >
         <button
+          aria-haspopup="dialog"
           className="slds-button slds-button_icon-border slds-button_icon-small"
           disabled={false}
           id="myPopoverId"
@@ -434,6 +447,7 @@ exports[`DOM snapshots SLDSPopover Alignment (ButtonIcon) 1`] = `
         }
       >
         <button
+          aria-haspopup="dialog"
           className="slds-button slds-button_icon-border slds-button_icon-small"
           disabled={false}
           id="myPopoverId"
@@ -475,6 +489,7 @@ exports[`DOM snapshots SLDSPopover Alignment (ButtonIcon) 1`] = `
         }
       >
         <button
+          aria-haspopup="dialog"
           className="slds-button slds-button_icon-border slds-button_icon-small"
           disabled={false}
           id="myPopoverId"
@@ -516,6 +531,7 @@ exports[`DOM snapshots SLDSPopover Alignment (ButtonIcon) 1`] = `
         }
       >
         <button
+          aria-haspopup="dialog"
           className="slds-button slds-button_icon-border slds-button_icon-small"
           disabled={false}
           id="myPopoverId"
@@ -557,6 +573,7 @@ exports[`DOM snapshots SLDSPopover Alignment (ButtonIcon) 1`] = `
         }
       >
         <button
+          aria-haspopup="dialog"
           className="slds-button slds-button_icon-border slds-button_icon-small"
           disabled={false}
           id="myPopoverId"
@@ -598,6 +615,7 @@ exports[`DOM snapshots SLDSPopover Alignment (ButtonIcon) 1`] = `
         }
       >
         <button
+          aria-haspopup="dialog"
           className="slds-button slds-button_icon-border slds-button_icon-small"
           disabled={false}
           id="myPopoverId"
@@ -639,6 +657,7 @@ exports[`DOM snapshots SLDSPopover Alignment (ButtonIcon) 1`] = `
         }
       >
         <button
+          aria-haspopup="dialog"
           className="slds-button slds-button_icon-border slds-button_icon-small"
           disabled={false}
           id="myPopoverId"
@@ -680,6 +699,7 @@ exports[`DOM snapshots SLDSPopover Alignment (ButtonIcon) 1`] = `
         }
       >
         <button
+          aria-haspopup="dialog"
           className="slds-button slds-button_icon-border slds-button_icon-small"
           disabled={false}
           id="myPopoverId"
@@ -721,6 +741,7 @@ exports[`DOM snapshots SLDSPopover Alignment (ButtonIcon) 1`] = `
         }
       >
         <button
+          aria-haspopup="dialog"
           className="slds-button slds-button_icon-border slds-button_icon-small"
           disabled={false}
           id="myPopoverId"
@@ -762,6 +783,7 @@ exports[`DOM snapshots SLDSPopover Alignment (ButtonIcon) 1`] = `
         }
       >
         <button
+          aria-haspopup="dialog"
           className="slds-button slds-button_icon-border slds-button_icon-small"
           disabled={false}
           id="myPopoverId"
@@ -803,6 +825,7 @@ exports[`DOM snapshots SLDSPopover Alignment (ButtonIcon) 1`] = `
         }
       >
         <button
+          aria-haspopup="dialog"
           className="slds-button slds-button_icon-border slds-button_icon-small"
           disabled={false}
           id="myPopoverId"
@@ -844,6 +867,7 @@ exports[`DOM snapshots SLDSPopover Alignment (ButtonIcon) 1`] = `
         }
       >
         <button
+          aria-haspopup="dialog"
           className="slds-button slds-button_icon-border slds-button_icon-small"
           disabled={false}
           id="myPopoverId"
@@ -893,6 +917,7 @@ exports[`DOM snapshots SLDSPopover AlternativeHeader 1`] = `
       }
     >
       <button
+        aria-haspopup="dialog"
         className="slds-button slds-button_neutral"
         disabled={false}
         id="popover-alternative-header"
@@ -929,6 +954,7 @@ exports[`DOM snapshots SLDSPopover Controlled w/ Footer 1`] = `
       }
     >
       <button
+        aria-haspopup="dialog"
         className="slds-button slds-button_neutral"
         disabled={false}
         id="popover-controlled-with-footer"
@@ -971,6 +997,7 @@ exports[`DOM snapshots SLDSPopover Custom Target - Open 1`] = `
       }
     >
       <button
+        aria-haspopup="dialog"
         className="slds-button slds-button_neutral"
         disabled={false}
         id="popover-custom-target"
@@ -1086,6 +1113,7 @@ exports[`DOM snapshots SLDSPopover Custom Target 1`] = `
       }
     >
       <button
+        aria-haspopup="dialog"
         className="slds-button slds-button_neutral"
         disabled={false}
         id="popover-custom-target"
@@ -1145,6 +1173,7 @@ exports[`DOM snapshots SLDSPopover Edit Dialog  - Open 1`] = `
       }
     >
       <button
+        aria-haspopup="dialog"
         className="slds-button slds-button_icon slds-button_reset"
         disabled={false}
         id="edit-dialog-popover"
@@ -1330,6 +1359,7 @@ exports[`DOM snapshots SLDSPopover Edit Dialog 1`] = `
       }
     >
       <button
+        aria-haspopup="dialog"
         className="slds-button slds-button_icon slds-button_reset"
         disabled={false}
         id="edit-dialog-popover"
@@ -1382,6 +1412,7 @@ exports[`DOM snapshots SLDSPopover Error - Open 1`] = `
     }
   >
     <button
+      aria-haspopup="dialog"
       className="slds-button slds-button_neutral"
       disabled={false}
       id="popover-error"
@@ -1540,6 +1571,7 @@ exports[`DOM snapshots SLDSPopover Error 1`] = `
     }
   >
     <button
+      aria-haspopup="dialog"
       className="slds-button slds-button_neutral"
       disabled={false}
       id="popover-error"
@@ -1574,6 +1606,7 @@ exports[`DOM snapshots SLDSPopover Feature - Open 1`] = `
     }
   >
     <button
+      aria-haspopup="dialog"
       className="slds-button slds-button_neutral"
       disabled={false}
       id="popover-feature"
@@ -1713,6 +1746,7 @@ exports[`DOM snapshots SLDSPopover Feature 1`] = `
     }
   >
     <button
+      aria-haspopup="dialog"
       className="slds-button slds-button_neutral"
       disabled={false}
       id="popover-feature"
@@ -1748,6 +1782,7 @@ exports[`DOM snapshots SLDSPopover Header 1`] = `
       }
     >
       <button
+        aria-haspopup="dialog"
         className="slds-button slds-button_neutral"
         disabled={false}
         id="popover-heading"
@@ -1784,6 +1819,7 @@ exports[`DOM snapshots SLDSPopover Styling (dev-only) 1`] = `
       }
     >
       <button
+        aria-haspopup="dialog"
         className="slds-button slds-button_neutral"
         disabled={false}
         id="myPopoverId"
@@ -1875,6 +1911,7 @@ exports[`DOM snapshots SLDSPopover Walkthrough - Open 1`] = `
     }
   >
     <button
+      aria-haspopup="dialog"
       className="slds-button slds-button_neutral"
       disabled={false}
       id="popover-walkthrough"
@@ -1996,6 +2033,7 @@ exports[`DOM snapshots SLDSPopover Walkthrough 1`] = `
     }
   >
     <button
+      aria-haspopup="dialog"
       className="slds-button slds-button_neutral"
       disabled={false}
       id="popover-walkthrough"
@@ -2030,6 +2068,7 @@ exports[`DOM snapshots SLDSPopover Walkthrough Action - Open 1`] = `
     }
   >
     <button
+      aria-haspopup="dialog"
       className="slds-button slds-button_neutral"
       disabled={false}
       id="popover-walkthrough"
@@ -2145,6 +2184,7 @@ exports[`DOM snapshots SLDSPopover Walkthrough Action 1`] = `
     }
   >
     <button
+      aria-haspopup="dialog"
       className="slds-button slds-button_neutral"
       disabled={false}
       id="popover-walkthrough"
@@ -2179,6 +2219,7 @@ exports[`DOM snapshots SLDSPopover Warning  - Open 1`] = `
     }
   >
     <button
+      aria-haspopup="dialog"
       className="slds-button slds-button_neutral"
       disabled={false}
       id="popover-error"
@@ -2337,6 +2378,7 @@ exports[`DOM snapshots SLDSPopover Warning 1`] = `
     }
   >
     <button
+      aria-haspopup="dialog"
       className="slds-button slds-button_neutral"
       disabled={false}
       id="popover-error"

--- a/components/popover/popover.jsx
+++ b/components/popover/popover.jsx
@@ -785,6 +785,7 @@ class Popover extends React.Component {
 		React.Children.forEach(this.props.children, (child, index) => {
 			if (index === 0) {
 				clonedTrigger = React.cloneElement(child, {
+					'aria-haspopup': 'dialog',
 					id: this.getId(),
 					onClick:
 						this.props.openOn === 'click' || this.props.openOn === 'hybrid'


### PR DESCRIPTION
Fixes #2302

Short, sweet, and simple

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [ ] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [ ] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
