### PR TITLE
Remove Padding from Inline Edit Dialog

### DIFF
--- a/components/date-picker/date-picker.jsx
+++ b/components/date-picker/date-picker.jsx
@@ -432,7 +432,7 @@ class Datepicker extends React.Component {
 		const childrenPropInputProps = {
 			...childrenProps,
 			onClick: () => {
-				this.openDialog();
+				this.preventDefault();
 				if (childrenProps && childrenProps.onClick) {
 					childrenProps.onClick();
 				}

--- a/components/date-picker/date-picker.jsx
+++ b/components/date-picker/date-picker.jsx
@@ -432,7 +432,7 @@ class Datepicker extends React.Component {
 		const childrenPropInputProps = {
 			...childrenProps,
 			onClick: () => {
-				this.preventDefault();
+				this.openDialog();
 				if (childrenProps && childrenProps.onClick) {
 					childrenProps.onClick();
 				}

--- a/components/popover/__examples__/edit-dialog.jsx
+++ b/components/popover/__examples__/edit-dialog.jsx
@@ -63,7 +63,7 @@ class Example extends React.Component {
 	render() {
 		// Body of Edit Dialog that is shown when clicking on edit button (pencil icon)
 		const editDialogPopoverBody = (
-			<div className="slds-form slds-form_stacked slds-p-top_medium slds-p-right_small slds-p-left_small">
+			<div className="slds-form slds-form_stacked slds-p-top_medium">
 				<h2 id="edit-name" className="slds-assistive-text">
 					Edit Name
 				</h2>

--- a/components/popover/edit-dialog.jsx
+++ b/components/popover/edit-dialog.jsx
@@ -93,8 +93,8 @@ class EditDialog extends React.Component {
 			<Popover
 				classNameFooter={[
 					'slds-p-top_xxx-small',
-					'slds-p-bottom_xx-small',
-					'slds-p-right_large',
+					'slds-p-bottom_xx-small'
+				
 				]}
 				classNameBody={['slds-p-bottom_xx-small']}
 				footer={


### PR DESCRIPTION
Fixes #2296 

### Additional description
padding is removed from bttuon and dialog box : 
![Screenshot from 2019-10-07 09-44-11](https://user-images.githubusercontent.com/49001649/66301869-9121b080-e915-11e9-93e5-6a6bcfada716.png)
![Screenshot from 2019-10-07 09-44-15](https://user-images.githubusercontent.com/49001649/66301870-91ba4700-e915-11e9-9d85-8821b8a23850.png)


---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [ ] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [ ] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
