### PR TITLE
Toast: Focus on dialog container on render instead of close button

### DIFF
--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -16507,12 +16507,12 @@
                 "returns": null
             },
             {
-                "name": "saveButtonRef",
+                "name": "saveToastRef",
                 "docblock": null,
                 "modifiers": [],
                 "params": [
                     {
-                        "name": "component",
+                        "name": "toast",
                         "type": null
                     }
                 ],

--- a/components/toast/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/toast/__docs__/__snapshots__/storybook-stories.storyshot
@@ -30,6 +30,7 @@ exports[`DOM snapshots SLDSToast Custom Class Names 1`] = `
     <div
       className="slds-notify slds-notify_toast slds-theme_info this-is-the-alert"
       role="status"
+      tabIndex={0}
     >
       <span
         className="slds-assistive-text"
@@ -105,6 +106,7 @@ exports[`DOM snapshots SLDSToast Custom Style 1`] = `
           "backgroundColor": "rgb(18, 49, 35)",
         }
       }
+      tabIndex={0}
     >
       <span
         className="slds-assistive-text"
@@ -176,6 +178,7 @@ exports[`DOM snapshots SLDSToast Duration Toast 1`] = `
       <div
         className="slds-notify slds-notify_toast slds-theme_info"
         role="status"
+        tabIndex={0}
       >
         <span
           className="slds-assistive-text"
@@ -256,6 +259,7 @@ exports[`DOM snapshots SLDSToast Error 1`] = `
     <div
       className="slds-notify slds-notify_toast slds-theme_error"
       role="status"
+      tabIndex={0}
     >
       <span
         className="slds-assistive-text"
@@ -321,6 +325,7 @@ exports[`DOM snapshots SLDSToast Error With Details 1`] = `
     <div
       className="slds-notify slds-notify_toast slds-theme_error"
       role="status"
+      tabIndex={0}
     >
       <span
         className="slds-assistive-text"
@@ -389,6 +394,7 @@ exports[`DOM snapshots SLDSToast Info 1`] = `
     <div
       className="slds-notify slds-notify_toast slds-theme_info"
       role="status"
+      tabIndex={0}
     >
       <span
         className="slds-assistive-text"
@@ -460,6 +466,7 @@ exports[`DOM snapshots SLDSToast Success 1`] = `
     <div
       className="slds-notify slds-notify_toast slds-theme_success"
       role="status"
+      tabIndex={0}
     >
       <span
         className="slds-assistive-text"
@@ -531,6 +538,7 @@ exports[`DOM snapshots SLDSToast Warning 1`] = `
     <div
       className="slds-notify slds-notify_toast slds-theme_warning"
       role="status"
+      tabIndex={0}
     >
       <span
         className="slds-assistive-text"

--- a/components/toast/index.jsx
+++ b/components/toast/index.jsx
@@ -109,6 +109,7 @@ class Toast extends React.Component {
 			isInitialRender: true,
 		};
 		this.timeout = null;
+		this.toast = null;
 
 		// `checkProps` issues warnings to developers about properties (similar to React's built in development tools)
 		checkProps(TOAST, props, componentDoc);
@@ -142,12 +143,12 @@ class Toast extends React.Component {
 		}
 	};
 
-	saveButtonRef = (component) => {
-		this.closeButton = component;
+	saveToastRef = (toast) => {
+		this.toast = toast;
 		if (this.state.isInitialRender) {
 			DOMElementFocus.storeActiveElement();
-			if (this.closeButton) {
-				this.closeButton.focus();
+			if (this.toast) {
+				this.toast.focus();
 			}
 			this.setState({ isInitialRender: false });
 		}
@@ -200,8 +201,10 @@ class Toast extends React.Component {
 					},
 					this.props.className
 				)}
+				ref={this.saveToastRef}
 				role="status"
 				style={this.props.style}
+				tabIndex={0} // eslint-disable-line jsx-a11y/no-noninteractive-tabindex
 			>
 				<span className="slds-assistive-text">
 					{assistiveTextVariant[this.props.variant]}
@@ -223,7 +226,6 @@ class Toast extends React.Component {
 				</div>
 				<Button
 					assistiveText={{ icon: assistiveText.closeButton }}
-					buttonRef={this.saveButtonRef}
 					className="slds-notify__close"
 					iconCategory="utility"
 					iconName="close"


### PR DESCRIPTION
Fixes #2336

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [ ] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [ ] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
