### PR TITLE
Added onRequestTargetElement and hasAnchoredNubbin prop to tooltip

### DIFF
--- a/components/builder-header/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/builder-header/__docs__/__snapshots__/storybook-stories.storyshot
@@ -394,6 +394,7 @@ exports[`DOM snapshots SLDSBuilderHeader After Successful Save 1`] = `
               style={
                 Object {
                   "display": "inline-block",
+                  "lineHeight": "1",
                 }
               }
             >
@@ -923,6 +924,7 @@ exports[`DOM snapshots SLDSBuilderHeader Base with Page Type Editable 1`] = `
                   style={
                     Object {
                       "display": "inline-block",
+                      "lineHeight": "1",
                     }
                   }
                 >
@@ -1003,6 +1005,7 @@ exports[`DOM snapshots SLDSBuilderHeader Base with Page Type Editable 1`] = `
                   style={
                     Object {
                       "display": "inline-block",
+                      "lineHeight": "1",
                     }
                   }
                 >
@@ -1944,6 +1947,7 @@ exports[`DOM snapshots SLDSBuilderHeader Failed Save 1`] = `
               style={
                 Object {
                   "display": "inline-block",
+                  "lineHeight": "1",
                 }
               }
             >

--- a/components/combobox/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/combobox/__docs__/__snapshots__/storybook-stories.storyshot
@@ -870,6 +870,7 @@ exports[`DOM snapshots SLDSCombobox Base Inline Help 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
             "position": "static",
           }
         }
@@ -1661,6 +1662,7 @@ exports[`DOM snapshots SLDSCombobox Base Menu Item Disabled With Tooltip Open 1`
                   style={
                     Object {
                       "display": "inline-block",
+                      "lineHeight": "1",
                       "width": "100%",
                     }
                   }
@@ -1803,6 +1805,7 @@ exports[`DOM snapshots SLDSCombobox Base Menu Item Disabled With Tooltip Open 1`
                   style={
                     Object {
                       "display": "inline-block",
+                      "lineHeight": "1",
                       "width": "100%",
                     }
                   }

--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -17090,7 +17090,7 @@
                     "name": "bool"
                 },
                 "required": false,
-                "description": "Enabling this hides the default nubbin, replacing it with one attached directly to the tooltip trigger."
+                "description": "Enabling this hides the default nubbin, replacing it with one attached directly to the tooltip trigger. Note: `hasStaticAlignment` should be set to `true` if using this feature as auto-flipping anchored nubbins are not currently supported."
             },
             "hasStaticAlignment": {
                 "type": {

--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -16884,6 +16884,13 @@
         "description": "The PopoverTooltip component is variant of the Lightning Design System Popover component. This component wraps an element that triggers it to open. It must be a focusable child element (either a button or an anchor), so that keyboard users can navigate to it.",
         "methods": [
             {
+                "name": "getAnchoredNubbinStyles",
+                "docblock": null,
+                "modifiers": [],
+                "params": [],
+                "returns": null
+            },
+            {
                 "name": "getContent",
                 "docblock": null,
                 "modifiers": [],
@@ -17078,6 +17085,13 @@
                 "required": false,
                 "description": "CSS classes to be added to the popover dialog. That is the element with `.slds-popover` on it."
             },
+            "hasAnchoredNubbin": {
+                "type": {
+                    "name": "bool"
+                },
+                "required": false,
+                "description": "Enabling this hides the default nubbin, replacing it with one attached directly to the tooltip trigger."
+            },
             "hasStaticAlignment": {
                 "type": {
                     "name": "bool"
@@ -17141,6 +17155,13 @@
                 },
                 "required": false,
                 "description": "Forces tooltip to be open. A value of `false` will disable any interaction with the tooltip."
+            },
+            "onRequestTargetElement": {
+                "type": {
+                    "name": "func"
+                },
+                "required": false,
+                "description": "Callback that returns an element or React `ref` to align the Tooltip with."
             },
             "triggerClassName": {
                 "type": {

--- a/components/input/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/input/__docs__/__snapshots__/storybook-stories.storyshot
@@ -1611,6 +1611,7 @@ exports[`DOM snapshots SLDSInput Field Level Help 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
             "position": "static",
           }
         }
@@ -1681,6 +1682,7 @@ exports[`DOM snapshots SLDSInput Field Level Help, Tooltip Open 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
             "position": "static",
           }
         }

--- a/components/menu-dropdown/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/menu-dropdown/__docs__/__snapshots__/storybook-stories.storyshot
@@ -4837,6 +4837,7 @@ exports[`DOM snapshots SLDSMenuDropdown With tooltips (open) 1`] = `
             style={
               Object {
                 "display": "inline-block",
+                "lineHeight": "1",
                 "width": "100%",
               }
             }
@@ -4920,6 +4921,7 @@ exports[`DOM snapshots SLDSMenuDropdown With tooltips (open) 1`] = `
             style={
               Object {
                 "display": "inline-block",
+                "lineHeight": "1",
                 "width": "100%",
               }
             }

--- a/components/page-header/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/page-header/__docs__/__snapshots__/storybook-stories.storyshot
@@ -1651,6 +1651,7 @@ exports[`DOM snapshots SLDSPageHeader Record Home (truncates) 1`] = `
               style={
                 Object {
                   "display": "inline",
+                  "lineHeight": "1",
                 }
               }
             >

--- a/components/progress-indicator/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/progress-indicator/__docs__/__snapshots__/storybook-stories.storyshot
@@ -27,6 +27,7 @@ exports[`DOM snapshots SLDSProgressIndicator Base 1`] = `
             style={
               Object {
                 "display": "flex",
+                "lineHeight": "1",
               }
             }
           >
@@ -57,6 +58,7 @@ exports[`DOM snapshots SLDSProgressIndicator Base 1`] = `
             style={
               Object {
                 "display": "flex",
+                "lineHeight": "1",
               }
             }
           >
@@ -89,6 +91,7 @@ exports[`DOM snapshots SLDSProgressIndicator Base 1`] = `
             style={
               Object {
                 "display": "flex",
+                "lineHeight": "1",
               }
             }
           >
@@ -128,6 +131,7 @@ exports[`DOM snapshots SLDSProgressIndicator Base 1`] = `
             style={
               Object {
                 "display": "flex",
+                "lineHeight": "1",
               }
             }
           >
@@ -165,6 +169,7 @@ exports[`DOM snapshots SLDSProgressIndicator Base 1`] = `
             style={
               Object {
                 "display": "flex",
+                "lineHeight": "1",
               }
             }
           >
@@ -248,6 +253,7 @@ exports[`DOM snapshots SLDSProgressIndicator Base With Disabled Steps 1`] = `
             style={
               Object {
                 "display": "",
+                "lineHeight": "1",
               }
             }
           >
@@ -286,6 +292,7 @@ exports[`DOM snapshots SLDSProgressIndicator Base With Disabled Steps 1`] = `
             style={
               Object {
                 "display": "",
+                "lineHeight": "1",
               }
             }
           >
@@ -326,6 +333,7 @@ exports[`DOM snapshots SLDSProgressIndicator Base With Disabled Steps 1`] = `
             style={
               Object {
                 "display": "flex",
+                "lineHeight": "1",
               }
             }
           >
@@ -360,6 +368,7 @@ exports[`DOM snapshots SLDSProgressIndicator Base With Disabled Steps 1`] = `
             style={
               Object {
                 "display": "flex",
+                "lineHeight": "1",
               }
             }
           >
@@ -397,6 +406,7 @@ exports[`DOM snapshots SLDSProgressIndicator Base With Disabled Steps 1`] = `
             style={
               Object {
                 "display": "flex",
+                "lineHeight": "1",
               }
             }
           >
@@ -480,6 +490,7 @@ exports[`DOM snapshots SLDSProgressIndicator Base With Many Steps 1`] = `
             style={
               Object {
                 "display": "",
+                "lineHeight": "1",
               }
             }
           >
@@ -520,6 +531,7 @@ exports[`DOM snapshots SLDSProgressIndicator Base With Many Steps 1`] = `
             style={
               Object {
                 "display": "",
+                "lineHeight": "1",
               }
             }
           >
@@ -560,6 +572,7 @@ exports[`DOM snapshots SLDSProgressIndicator Base With Many Steps 1`] = `
             style={
               Object {
                 "display": "",
+                "lineHeight": "1",
               }
             }
           >
@@ -600,6 +613,7 @@ exports[`DOM snapshots SLDSProgressIndicator Base With Many Steps 1`] = `
             style={
               Object {
                 "display": "",
+                "lineHeight": "1",
               }
             }
           >
@@ -640,6 +654,7 @@ exports[`DOM snapshots SLDSProgressIndicator Base With Many Steps 1`] = `
             style={
               Object {
                 "display": "flex",
+                "lineHeight": "1",
               }
             }
           >
@@ -672,6 +687,7 @@ exports[`DOM snapshots SLDSProgressIndicator Base With Many Steps 1`] = `
             style={
               Object {
                 "display": "flex",
+                "lineHeight": "1",
               }
             }
           >
@@ -704,6 +720,7 @@ exports[`DOM snapshots SLDSProgressIndicator Base With Many Steps 1`] = `
             style={
               Object {
                 "display": "flex",
+                "lineHeight": "1",
               }
             }
           >
@@ -736,6 +753,7 @@ exports[`DOM snapshots SLDSProgressIndicator Base With Many Steps 1`] = `
             style={
               Object {
                 "display": "flex",
+                "lineHeight": "1",
               }
             }
           >
@@ -768,6 +786,7 @@ exports[`DOM snapshots SLDSProgressIndicator Base With Many Steps 1`] = `
             style={
               Object {
                 "display": "flex",
+                "lineHeight": "1",
               }
             }
           >
@@ -846,6 +865,7 @@ exports[`DOM snapshots SLDSProgressIndicator Completed Progress 1`] = `
             style={
               Object {
                 "display": "",
+                "lineHeight": "1",
               }
             }
           >
@@ -884,6 +904,7 @@ exports[`DOM snapshots SLDSProgressIndicator Completed Progress 1`] = `
             style={
               Object {
                 "display": "",
+                "lineHeight": "1",
               }
             }
           >
@@ -924,6 +945,7 @@ exports[`DOM snapshots SLDSProgressIndicator Completed Progress 1`] = `
             style={
               Object {
                 "display": "",
+                "lineHeight": "1",
               }
             }
           >
@@ -966,6 +988,7 @@ exports[`DOM snapshots SLDSProgressIndicator Completed Progress 1`] = `
             style={
               Object {
                 "display": "flex",
+                "lineHeight": "1",
               }
             }
           >
@@ -998,6 +1021,7 @@ exports[`DOM snapshots SLDSProgressIndicator Completed Progress 1`] = `
             style={
               Object {
                 "display": "flex",
+                "lineHeight": "1",
               }
             }
           >
@@ -1321,6 +1345,7 @@ exports[`DOM snapshots SLDSProgressIndicator Step Error 1`] = `
             style={
               Object {
                 "display": "",
+                "lineHeight": "1",
               }
             }
           >
@@ -1359,6 +1384,7 @@ exports[`DOM snapshots SLDSProgressIndicator Step Error 1`] = `
             style={
               Object {
                 "display": "",
+                "lineHeight": "1",
               }
             }
           >
@@ -1399,6 +1425,7 @@ exports[`DOM snapshots SLDSProgressIndicator Step Error 1`] = `
             style={
               Object {
                 "display": "flex",
+                "lineHeight": "1",
               }
             }
           >
@@ -1438,6 +1465,7 @@ exports[`DOM snapshots SLDSProgressIndicator Step Error 1`] = `
             style={
               Object {
                 "display": "flex",
+                "lineHeight": "1",
               }
             }
           >
@@ -1475,6 +1503,7 @@ exports[`DOM snapshots SLDSProgressIndicator Step Error 1`] = `
             style={
               Object {
                 "display": "flex",
+                "lineHeight": "1",
               }
             }
           >

--- a/components/tooltip/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/tooltip/__docs__/__snapshots__/storybook-stories.storyshot
@@ -24,6 +24,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Alignment (Button) 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
           }
         }
       >
@@ -74,6 +75,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Alignment (Button) 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
           }
         }
       >
@@ -124,6 +126,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Alignment (Button) 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
           }
         }
       >
@@ -174,6 +177,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Alignment (Button) 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
           }
         }
       >
@@ -224,6 +228,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Alignment (Button) 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
           }
         }
       >
@@ -274,6 +279,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Alignment (Button) 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
           }
         }
       >
@@ -324,6 +330,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Alignment (Button) 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
           }
         }
       >
@@ -374,6 +381,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Alignment (Button) 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
           }
         }
       >
@@ -424,6 +432,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Alignment (Button) 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
           }
         }
       >
@@ -474,6 +483,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Alignment (Button) 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
           }
         }
       >
@@ -524,6 +534,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Alignment (Button) 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
           }
         }
       >
@@ -574,6 +585,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Alignment (Button) 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
           }
         }
       >
@@ -639,6 +651,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Alignment (icon) 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
           }
         }
       >
@@ -695,6 +708,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Alignment (icon) 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
           }
         }
       >
@@ -751,6 +765,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Alignment (icon) 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
           }
         }
       >
@@ -807,6 +822,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Alignment (icon) 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
           }
         }
       >
@@ -863,6 +879,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Alignment (icon) 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
           }
         }
       >
@@ -919,6 +936,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Alignment (icon) 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
           }
         }
       >
@@ -975,6 +993,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Alignment (icon) 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
           }
         }
       >
@@ -1031,6 +1050,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Alignment (icon) 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
           }
         }
       >
@@ -1087,6 +1107,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Alignment (icon) 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
           }
         }
       >
@@ -1143,6 +1164,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Alignment (icon) 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
           }
         }
       >
@@ -1199,6 +1221,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Alignment (icon) 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
           }
         }
       >
@@ -1255,6 +1278,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Alignment (icon) 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
           }
         }
       >
@@ -1326,6 +1350,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Alignment (span) 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
           }
         }
       >
@@ -1373,6 +1398,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Alignment (span) 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
           }
         }
       >
@@ -1420,6 +1446,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Alignment (span) 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
           }
         }
       >
@@ -1467,6 +1494,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Alignment (span) 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
           }
         }
       >
@@ -1514,6 +1542,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Alignment (span) 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
           }
         }
       >
@@ -1561,6 +1590,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Alignment (span) 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
           }
         }
       >
@@ -1608,6 +1638,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Alignment (span) 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
           }
         }
       >
@@ -1655,6 +1686,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Alignment (span) 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
           }
         }
       >
@@ -1702,6 +1734,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Alignment (span) 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
           }
         }
       >
@@ -1749,6 +1782,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Alignment (span) 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
           }
         }
       >
@@ -1796,6 +1830,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Alignment (span) 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
           }
         }
       >
@@ -1843,6 +1878,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Alignment (span) 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
           }
         }
       >
@@ -1896,6 +1932,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Base 1`] = `
     style={
       Object {
         "display": "inline-block",
+        "lineHeight": "1",
       }
     }
   >
@@ -1944,6 +1981,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Button 1`] = `
     style={
       Object {
         "display": "inline-block",
+        "lineHeight": "1",
       }
     }
   >
@@ -1985,6 +2023,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Button Group 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
           }
         }
       >
@@ -2010,6 +2049,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Button Group 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
           }
         }
       >
@@ -2035,6 +2075,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Button Group 1`] = `
         style={
           Object {
             "display": "inline-block",
+            "lineHeight": "1",
           }
         }
       >
@@ -2094,6 +2135,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Learn More 1`] = `
     style={
       Object {
         "display": "inline-block",
+        "lineHeight": "1",
       }
     }
   >
@@ -2141,6 +2183,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Open 1`] = `
     style={
       Object {
         "display": "inline-block",
+        "lineHeight": "1",
       }
     }
   >
@@ -2180,6 +2223,285 @@ exports[`DOM snapshots SLDSPopoverTooltip Open 1`] = `
 </div>
 `;
 
+exports[`DOM snapshots SLDSPopoverTooltip With Anchored Nubbin 1`] = `
+<div
+  className="slds-p-around_medium slds-m-horizontal_x-large"
+  style={
+    Object {
+      "margin": "150px auto",
+      "width": "500px",
+    }
+  }
+>
+  <div>
+    <div
+      className="slds-tooltip-trigger"
+      style={
+        Object {
+          "display": "inline-block",
+          "lineHeight": "1",
+        }
+      }
+    >
+      <style>
+        #anchored-nubbin-top:after, #anchored-nubbin-top:before {
+	display: none;
+}
+      </style>
+      <button
+        aria-describedby="anchored-nubbin-top"
+        aria-disabled={true}
+        className="slds-button slds-button_icon"
+        disabled={false}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          className="slds-button__icon"
+        >
+          <use
+            xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#info"
+          />
+        </svg>
+        <span
+          className="slds-assistive-text"
+        >
+          Help
+        </span>
+      </button>
+      <div
+        className="absolute-positioned slds-nubbin_bottom-left slds-popover slds-popover_tooltip"
+        id="anchored-nubbin-top"
+        onKeyDown={[Function]}
+        role="tooltip"
+        style={
+          Object {
+            "outline": 0,
+            "pointerEvents": "none",
+            "position": "absolute",
+          }
+        }
+      >
+        <div
+          className="slds-popover__body"
+        >
+          Sit nulla est ex deserunt exercitation anim occaecat. Nostrud ullamco deserunt aute id consequat veniam incididunt duis in sint irure nisi.
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    style={
+      Object {
+        "marginTop": "1rem",
+      }
+    }
+  >
+    <div
+      className="slds-tooltip-trigger"
+      style={
+        Object {
+          "display": "inline-block",
+          "lineHeight": "1",
+        }
+      }
+    >
+      <style>
+        #anchored-nubbin-right:after, #anchored-nubbin-right:before {
+	display: none;
+}
+      </style>
+      <button
+        aria-describedby="anchored-nubbin-right"
+        aria-disabled={true}
+        className="slds-button slds-button_icon"
+        disabled={false}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          className="slds-button__icon"
+        >
+          <use
+            xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#info"
+          />
+        </svg>
+        <span
+          className="slds-assistive-text"
+        >
+          Help
+        </span>
+      </button>
+      <div
+        className="absolute-positioned slds-nubbin_left slds-popover slds-popover_tooltip"
+        id="anchored-nubbin-right"
+        onKeyDown={[Function]}
+        role="tooltip"
+        style={
+          Object {
+            "outline": 0,
+            "pointerEvents": "none",
+            "position": "absolute",
+          }
+        }
+      >
+        <div
+          className="slds-popover__body"
+        >
+          Sit nulla est ex deserunt exercitation anim occaecat. Nostrud ullamco deserunt aute id consequat veniam incididunt duis in sint irure nisi.
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    style={
+      Object {
+        "marginTop": "1rem",
+      }
+    }
+  >
+    <div
+      className="slds-tooltip-trigger"
+      style={
+        Object {
+          "display": "inline-block",
+          "lineHeight": "1",
+        }
+      }
+    >
+      <style>
+        #anchored-nubbin-left:after, #anchored-nubbin-left:before {
+	display: none;
+}
+      </style>
+      <button
+        aria-describedby="anchored-nubbin-left"
+        aria-disabled={true}
+        className="slds-button slds-button_icon"
+        disabled={false}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          className="slds-button__icon"
+        >
+          <use
+            xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#info"
+          />
+        </svg>
+        <span
+          className="slds-assistive-text"
+        >
+          Help
+        </span>
+      </button>
+      <div
+        className="absolute-positioned slds-nubbin_right slds-popover slds-popover_tooltip"
+        id="anchored-nubbin-left"
+        onKeyDown={[Function]}
+        role="tooltip"
+        style={
+          Object {
+            "outline": 0,
+            "pointerEvents": "none",
+            "position": "absolute",
+          }
+        }
+      >
+        <div
+          className="slds-popover__body"
+        >
+          Sit nulla est ex deserunt exercitation anim occaecat. Nostrud ullamco deserunt aute id consequat veniam incididunt duis in sint irure nisi.
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    style={
+      Object {
+        "marginTop": "1rem",
+      }
+    }
+  >
+    <div
+      className="slds-tooltip-trigger"
+      style={
+        Object {
+          "display": "inline-block",
+          "lineHeight": "1",
+        }
+      }
+    >
+      <style>
+        #anchored-nubbin-bottom:after, #anchored-nubbin-bottom:before {
+	display: none;
+}
+      </style>
+      <button
+        aria-describedby="anchored-nubbin-bottom"
+        aria-disabled={true}
+        className="slds-button slds-button_icon"
+        disabled={false}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          className="slds-button__icon"
+        >
+          <use
+            xlinkHref="/assets/icons/utility-sprite/svg/symbols.svg#info"
+          />
+        </svg>
+        <span
+          className="slds-assistive-text"
+        >
+          Help
+        </span>
+      </button>
+      <div
+        className="absolute-positioned slds-nubbin_top-right slds-popover slds-popover_tooltip"
+        id="anchored-nubbin-bottom"
+        onKeyDown={[Function]}
+        role="tooltip"
+        style={
+          Object {
+            "outline": 0,
+            "pointerEvents": "none",
+            "position": "absolute",
+          }
+        }
+      >
+        <div
+          className="slds-popover__body"
+        >
+          Sit nulla est ex deserunt exercitation anim occaecat. Nostrud ullamco deserunt aute id consequat veniam incididunt duis in sint irure nisi.
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`DOM snapshots SLDSPopoverTooltip With Delay 1`] = `
 <div
   className="slds-p-around_medium slds-m-horizontal_x-large"
@@ -2195,6 +2517,7 @@ exports[`DOM snapshots SLDSPopoverTooltip With Delay 1`] = `
     style={
       Object {
         "display": "inline-block",
+        "lineHeight": "1",
       }
     }
   >

--- a/components/tooltip/__docs__/storybook-stories.jsx
+++ b/components/tooltip/__docs__/storybook-stories.jsx
@@ -7,6 +7,7 @@ import IconSettings from '../../icon-settings';
 import { POPOVER_TOOLTIP } from '../../../utilities/constants';
 import Tooltip from '../../tooltip';
 
+import AnchoredNubbin from '../__examples__/anchored-nubbin';
 import Base from '../__examples__/base';
 import ButtonGroupExample from '../__examples__/button-group';
 import ButtonExample from '../__examples__/button';
@@ -122,4 +123,5 @@ storiesOf(POPOVER_TOOLTIP, module)
 			),
 		})
 	)
-	.add('With Delay', () => <WithDelay />);
+	.add('With Delay', () => <WithDelay />)
+	.add('With Anchored Nubbin', () => <AnchoredNubbin />);

--- a/components/tooltip/__examples__/anchored-nubbin.jsx
+++ b/components/tooltip/__examples__/anchored-nubbin.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+import IconSettings from '~/components/icon-settings';
+import Tooltip from '~/components/tooltip'; // `~` is replaced with design-system-react at runtime
+
+class Example extends React.Component {
+	static displayName = 'TooltipAnchoredNubbinExample';
+
+	render() {
+		return (
+			<IconSettings iconPath="/assets/icons">
+				<div>
+					<Tooltip
+						id="anchored-nubbin-top"
+						align="top left"
+						content="Sit nulla est ex deserunt exercitation anim occaecat. Nostrud ullamco deserunt aute id consequat veniam incididunt duis in sint irure nisi."
+						hasAnchoredNubbin
+						isOpen
+					/>
+				</div>
+				<div style={{ marginTop: '1rem' }}>
+					<Tooltip
+						id="anchored-nubbin-right"
+						align="right"
+						content="Sit nulla est ex deserunt exercitation anim occaecat. Nostrud ullamco deserunt aute id consequat veniam incididunt duis in sint irure nisi."
+						hasAnchoredNubbin
+						isOpen
+					/>
+				</div>
+				<div style={{ marginTop: '1rem' }}>
+					<Tooltip
+						id="anchored-nubbin-left"
+						align="left"
+						content="Sit nulla est ex deserunt exercitation anim occaecat. Nostrud ullamco deserunt aute id consequat veniam incididunt duis in sint irure nisi."
+						hasAnchoredNubbin
+						isOpen
+					/>
+				</div>
+				<div style={{ marginTop: '1rem' }}>
+					<Tooltip
+						id="anchored-nubbin-bottom"
+						align="bottom right"
+						content="Sit nulla est ex deserunt exercitation anim occaecat. Nostrud ullamco deserunt aute id consequat veniam incididunt duis in sint irure nisi."
+						hasAnchoredNubbin
+						isOpen
+					/>
+				</div>
+			</IconSettings>
+		);
+	}
+}
+
+export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/tooltip/index.jsx
+++ b/components/tooltip/index.jsx
@@ -73,6 +73,10 @@ const propTypes = {
 		PropTypes.string,
 	]),
 	/**
+	 * Enabling this hides the default nubbin, replacing it with one attached directly to the tooltip trigger.
+	 */
+	hasAnchoredNubbin: PropTypes.bool,
+	/**
 	 * By default, dialogs will flip their alignment (such as bottom to top) if they extend beyond a boundary element such as a scrolling parent or a window/viewpoint. `hasStaticAlignment` disables this behavior and allows this component to extend beyond boundary elements. _Not tested._
 	 */
 	hasStaticAlignment: PropTypes.bool,
@@ -102,6 +106,10 @@ const propTypes = {
 	 * Forces tooltip to be open. A value of `false` will disable any interaction with the tooltip.
 	 */
 	isOpen: PropTypes.bool,
+	/**
+	 * Callback that returns an element or React `ref` to align the Tooltip with.
+	 */
+	onRequestTargetElement: PropTypes.func,
 	/**
 	 * CSS classes to be added to tag with `slds-tooltip-trigger`.
 	 */
@@ -175,6 +183,74 @@ class Tooltip extends React.Component {
 
 	componentWillUnmount() {
 		this.isUnmounting = true;
+	}
+
+	getAnchoredNubbinStyles() {
+		if (this.props.hasAnchoredNubbin) {
+			const alignment = this.props.align.split(' ')[0];
+			const nubbinContainerStyles = {
+				height: '0',
+				position: 'relative',
+				width: '0',
+			};
+			const nubbinStyles = {
+				backgroundColor: '#16325c',
+				content: '',
+				height: '1rem',
+				position: 'absolute',
+				transform: 'rotate(45deg)',
+				width: '1rem',
+			};
+			const triggerDimensions = {
+				height: this.trigger ? this.trigger.getBoundingClientRect().height : 0,
+				width: this.trigger ? this.trigger.getBoundingClientRect().width : 0,
+			};
+
+			switch (alignment) {
+				case 'bottom': {
+					nubbinContainerStyles.left = `${triggerDimensions.width / 2}px`;
+					nubbinContainerStyles.top = `${triggerDimensions.height}px`;
+					nubbinStyles.left = '-8px';
+					nubbinStyles.top = '3px';
+					break;
+				}
+				case 'left': {
+					nubbinContainerStyles.left = '0';
+					nubbinContainerStyles.top = `${triggerDimensions.height / 2}px`;
+					nubbinStyles.left = '-19px';
+					nubbinStyles.top = '-9px';
+					break;
+				}
+				case 'right': {
+					nubbinContainerStyles.left = `${triggerDimensions.width}px`;
+					nubbinContainerStyles.top = `${triggerDimensions.height / 2}px`;
+					nubbinStyles.left = '3px';
+					nubbinStyles.top = '-9px';
+					break;
+				}
+				default: {
+					nubbinContainerStyles.left = `${triggerDimensions.width / 2}px`;
+					nubbinContainerStyles.top = '0';
+					nubbinStyles.left = '-8px';
+					nubbinStyles.top = '-19px';
+				}
+			}
+
+			return (
+				<React.Fragment>
+					<style>{`#${this.getId()}:after, #${this.getId()}:before {
+	display: none;
+}`}</style>
+					{this.state.isOpen ? (
+						<div style={nubbinContainerStyles}>
+							<div style={nubbinStyles} />
+						</div>
+					) : null}
+				</React.Fragment>
+			);
+		}
+
+		return null;
 	}
 
 	getContent() {
@@ -294,7 +370,16 @@ class Tooltip extends React.Component {
 	}
 
 	getTooltipTarget() {
-		return this.props.target ? this.props.target : this.trigger;
+		if (this.props.onRequestTargetElement) {
+			return this.props.onRequestTargetElement();
+		}
+
+		// for backwards compatibility
+		if (this.props.target) {
+			return this.props.target;
+		}
+
+		return this.trigger;
 	}
 
 	handleCancel = () => {
@@ -344,6 +429,7 @@ class Tooltip extends React.Component {
 	render() {
 		const containerStyles = {
 			display: 'inline-block',
+			lineHeight: '1',
 			...this.props.triggerStyle,
 		};
 
@@ -356,6 +442,7 @@ class Tooltip extends React.Component {
 				style={containerStyles}
 				ref={this.saveTriggerRef}
 			>
+				{this.getAnchoredNubbinStyles()}
 				{this.getContent()}
 				{this.getTooltip()}
 			</div>

--- a/components/tooltip/index.jsx
+++ b/components/tooltip/index.jsx
@@ -73,7 +73,7 @@ const propTypes = {
 		PropTypes.string,
 	]),
 	/**
-	 * Enabling this hides the default nubbin, replacing it with one attached directly to the tooltip trigger.
+	 * Enabling this hides the default nubbin, replacing it with one attached directly to the tooltip trigger. Note: `hasStaticAlignment` should be set to `true` if using this feature as auto-flipping anchored nubbins are not currently supported.
 	 */
 	hasAnchoredNubbin: PropTypes.bool,
 	/**


### PR DESCRIPTION
Fixes #2400 & #2401

NOTE: currently the anchored nubbin does not flip with the tooltip... @interactivellama is there a solid way for me to detect when this happens in the current dialog component? If it's unnecessary I might just make `hasStaticAlignment` true when `hasAnchoredNubbin` is true (or recommend that in the comment description)

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [ ] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [ ] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
