### PR TITLE
Tooltip `hasAnchoredNubbin` behavior fix

### DIFF
--- a/components/tooltip/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/tooltip/__docs__/__snapshots__/storybook-stories.storyshot
@@ -2248,6 +2248,32 @@ exports[`DOM snapshots SLDSPopoverTooltip With Anchored Nubbin 1`] = `
 	display: none;
 }
       </style>
+      <div
+        style={
+          Object {
+            "height": "0",
+            "left": "0px",
+            "position": "relative",
+            "top": "0",
+            "width": "0",
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "backgroundColor": "#16325c",
+              "content": "",
+              "height": "1rem",
+              "left": "-8px",
+              "position": "absolute",
+              "top": "-19px",
+              "transform": "rotate(45deg)",
+              "width": "1rem",
+            }
+          }
+        />
+      </div>
       <button
         aria-describedby="anchored-nubbin-top"
         aria-disabled={true}
@@ -2316,6 +2342,32 @@ exports[`DOM snapshots SLDSPopoverTooltip With Anchored Nubbin 1`] = `
 	display: none;
 }
       </style>
+      <div
+        style={
+          Object {
+            "height": "0",
+            "left": "0px",
+            "position": "relative",
+            "top": "0px",
+            "width": "0",
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "backgroundColor": "#16325c",
+              "content": "",
+              "height": "1rem",
+              "left": "3px",
+              "position": "absolute",
+              "top": "-9px",
+              "transform": "rotate(45deg)",
+              "width": "1rem",
+            }
+          }
+        />
+      </div>
       <button
         aria-describedby="anchored-nubbin-right"
         aria-disabled={true}
@@ -2384,6 +2436,32 @@ exports[`DOM snapshots SLDSPopoverTooltip With Anchored Nubbin 1`] = `
 	display: none;
 }
       </style>
+      <div
+        style={
+          Object {
+            "height": "0",
+            "left": "0",
+            "position": "relative",
+            "top": "0px",
+            "width": "0",
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "backgroundColor": "#16325c",
+              "content": "",
+              "height": "1rem",
+              "left": "-19px",
+              "position": "absolute",
+              "top": "-9px",
+              "transform": "rotate(45deg)",
+              "width": "1rem",
+            }
+          }
+        />
+      </div>
       <button
         aria-describedby="anchored-nubbin-left"
         aria-disabled={true}
@@ -2452,6 +2530,32 @@ exports[`DOM snapshots SLDSPopoverTooltip With Anchored Nubbin 1`] = `
 	display: none;
 }
       </style>
+      <div
+        style={
+          Object {
+            "height": "0",
+            "left": "0px",
+            "position": "relative",
+            "top": "0px",
+            "width": "0",
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "backgroundColor": "#16325c",
+              "content": "",
+              "height": "1rem",
+              "left": "-8px",
+              "position": "absolute",
+              "top": "3px",
+              "transform": "rotate(45deg)",
+              "width": "1rem",
+            }
+          }
+        />
+      </div>
       <button
         aria-describedby="anchored-nubbin-bottom"
         aria-disabled={true}

--- a/components/tooltip/index.jsx
+++ b/components/tooltip/index.jsx
@@ -241,7 +241,7 @@ class Tooltip extends React.Component {
 					<style>{`#${this.getId()}:after, #${this.getId()}:before {
 	display: none;
 }`}</style>
-					{this.state.isOpen ? (
+					{this.getIsOpen() ? (
 						<div style={nubbinContainerStyles}>
 							<div style={nubbinStyles} />
 						</div>


### PR DESCRIPTION
Fixes #2423

Small tweak to make `hasAnchoredNubbin` behave reliably when using a controlled `isOpen` Tooltip prop

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [ ] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [ ] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
