### PR TITLE
Removed Padding

### DIFF
--- a/components/popover/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/popover/__docs__/__snapshots__/storybook-stories.storyshot
@@ -1246,7 +1246,7 @@ exports[`DOM snapshots SLDSPopover Edit Dialog  - Open 1`] = `
           id="edit-dialog-popover-dialog-body"
         >
           <div
-            className="slds-form slds-form_stacked slds-p-top_medium slds-p-right_small slds-p-left_small"
+            className="slds-form slds-form_stacked slds-p-top_medium"
           >
             <h2
               className="slds-assistive-text"
@@ -1299,7 +1299,7 @@ exports[`DOM snapshots SLDSPopover Edit Dialog  - Open 1`] = `
           </div>
         </div>
         <footer
-          className="slds-popover__footer slds-p-top_xxx-small slds-p-bottom_xx-small slds-p-right_large"
+          className="slds-popover__footer slds-p-top_xxx-small slds-p-bottom_xx-small"
           style={
             Object {
               "borderTop": "0px",

--- a/components/popover/__examples__/edit-dialog.jsx
+++ b/components/popover/__examples__/edit-dialog.jsx
@@ -63,7 +63,7 @@ class Example extends React.Component {
 	render() {
 		// Body of Edit Dialog that is shown when clicking on edit button (pencil icon)
 		const editDialogPopoverBody = (
-			<div className="slds-form slds-form_stacked slds-p-top_medium slds-p-right_small slds-p-left_small">
+			<div className="slds-form slds-form_stacked slds-p-top_medium">
 				<h2 id="edit-name" className="slds-assistive-text">
 					Edit Name
 				</h2>

--- a/components/popover/edit-dialog.jsx
+++ b/components/popover/edit-dialog.jsx
@@ -91,11 +91,7 @@ class EditDialog extends React.Component {
 
 		return (
 			<Popover
-				classNameFooter={[
-					'slds-p-top_xxx-small',
-					'slds-p-bottom_xx-small',
-					'slds-p-right_large',
-				]}
+				classNameFooter={['slds-p-top_xxx-small', 'slds-p-bottom_xx-small']}
 				classNameBody={['slds-p-bottom_xx-small']}
 				footer={
 					<div className="slds-text-align_right slds-text-align_right slds-p-bottom_x-small slds-p-right_xx-small">


### PR DESCRIPTION
Fixes #2296 

### Additional description

Removed Padding

After Fix:
![image](https://user-images.githubusercontent.com/10993808/71777013-6a443c00-2f4f-11ea-8f2c-0b295d666b49.png)


---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [x] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [x] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [x] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
