### PR TITLE
DatePicker: Close calendar when typing in input

### DIFF
--- a/components/date-picker/__tests__/date-picker.browser-test.jsx
+++ b/components/date-picker/__tests__/date-picker.browser-test.jsx
@@ -428,7 +428,7 @@ describe('SLDSDatepicker', function describeFunction() {
 
 				// Changing input value closes the calendar
 				const input = wrapper.find('input#sample-datepicker');
-				input.simulate('change', {target: {value: '1/1/2020'}});
+				input.simulate('change', { target: { value: '1/1/2020' } });
 				expect(wrapper.find('.slds-datepicker').length).to.equal(0);
 			});
 		});

--- a/components/date-picker/__tests__/date-picker.browser-test.jsx
+++ b/components/date-picker/__tests__/date-picker.browser-test.jsx
@@ -414,6 +414,23 @@ describe('SLDSDatepicker', function describeFunction() {
 					which: KEYS.TAB,
 				});
 			});
+
+			it('typing in input closes calendar', function() {
+				wrapper = mount(<DemoComponent menuPosition="relative" />);
+
+				// Calendar is closed
+				expect(wrapper.find('.slds-datepicker').length).to.equal(0);
+
+				// Click on input to open the calendar
+				const trigger = wrapper.find(triggerClassSelector);
+				trigger.simulate('click', {});
+				expect(wrapper.find('.slds-datepicker').length).to.equal(1);
+
+				// Changing input value closes the calendar
+				const input = wrapper.find('input#sample-datepicker');
+				input.simulate('change', {target: {value: '1/1/2020'}});
+				expect(wrapper.find('.slds-datepicker').length).to.equal(0);
+			});
 		});
 	});
 

--- a/components/date-picker/date-picker.jsx
+++ b/components/date-picker/date-picker.jsx
@@ -498,6 +498,11 @@ class Datepicker extends React.Component {
 	};
 
 	handleInputChange = (event) => {
+		// Typing in the input closes the calendar when it's used as an uncontrolled component
+		if (typeof this.props.isOpen !== 'boolean' && this.state.isOpen) {
+			this.setState({ isOpen: false });
+		}
+
 		this.setState({
 			formattedValue: event.target.value,
 			inputValue: event.target.value,


### PR DESCRIPTION
Typing in the DatePicker input closes the calendar when it's used as an uncontrolled component.

Fixes https://github.com/salesforce/design-system-react/issues/2489

@interactivellama Can you review when you get a chance? Thanks!