### PR TITLE
Added support for aria-* to StatefulButton.

### DIFF
--- a/components/button-stateful/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/button-stateful/__docs__/__snapshots__/storybook-stories.storyshot
@@ -56,6 +56,62 @@ exports[`DOM snapshots SLDSButtonStateful Base 1`] = `
 </div>
 `;
 
+exports[`DOM snapshots SLDSButtonStateful Base With aria-pressed 1`] = `
+<div
+  className="slds-p-around_medium"
+>
+  <button
+    aria-pressed={true}
+    className="slds-button slds-button_neutral slds-not-selected"
+    disabled={false}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onMouseLeave={[Function]}
+    type="button"
+  >
+    <span
+      className="slds-text-not-selected"
+    >
+      <svg
+        aria-hidden="true"
+        className="slds-button__icon slds-button__icon_small slds-button__icon_left slds-button__icon_stateful"
+      >
+        <use
+          href="/assets/icons/utility-sprite/svg/symbols.svg#add"
+        />
+      </svg>
+      Follow
+    </span>
+    <span
+      className="slds-text-selected"
+    >
+      <svg
+        aria-hidden="true"
+        className="slds-button__icon slds-button__icon_small slds-button__icon_left slds-button__icon_stateful"
+      >
+        <use
+          href="/assets/icons/utility-sprite/svg/symbols.svg#check"
+        />
+      </svg>
+      Following
+    </span>
+    <span
+      className="slds-text-selected-focus"
+    >
+      <svg
+        aria-hidden="true"
+        className="slds-button__icon slds-button__icon_small slds-button__icon_left slds-button__icon_stateful"
+      >
+        <use
+          href="/assets/icons/utility-sprite/svg/symbols.svg#close"
+        />
+      </svg>
+      Unfollow
+    </span>
+  </button>
+</div>
+`;
+
 exports[`DOM snapshots SLDSButtonStateful Disabled 1`] = `
 <div
   className="slds-p-around_medium"

--- a/components/button-stateful/__docs__/storybook-stories.jsx
+++ b/components/button-stateful/__docs__/storybook-stories.jsx
@@ -24,4 +24,5 @@ storiesOf(BUTTON_STATEFUL, module)
 	.add('Base', () => getButtonStateful())
 	.add('Disabled', () => getButtonStateful({ disabled: true }))
 	.add('Icon Text Button', () => <IconTextButton />)
-	.add('Icon Button', () => <IconButton />);
+	.add('Icon Button', () => <IconButton />)
+	.add('Base With aria-pressed', () => getButtonStateful({ 'aria-pressed': true}));

--- a/components/button-stateful/__tests__/button-stateful.browser-test.jsx
+++ b/components/button-stateful/__tests__/button-stateful.browser-test.jsx
@@ -11,10 +11,13 @@ chai.should();
 
 describe('Button Stateful: ', () => {
 	// Base defaults
-	const requiredProps = {
+	const requiredPropsNoVariant = {
 		assistiveText: { icon: 'like' },
 		iconName: 'like',
 		iconSize: 'large',
+	};
+	const requiredProps = {
+		...requiredPropsNoVariant,
 		variant: 'icon',
 	};
 
@@ -54,7 +57,7 @@ describe('Button Stateful: ', () => {
 	});
 
 	describe('External active props works', () => {
-		const propsWithActive = assign(requiredProps, { active: true });
+		const propsWithActive = assign({ active: true }, requiredProps);
 
 		beforeEach(renderButton(<ButtonStateful {...propsWithActive} />));
 		afterEach(removeButton);
@@ -62,6 +65,55 @@ describe('Button Stateful: ', () => {
 		it('renders active prop', function() {
 			const button = getButton(this.dom);
 			button.className.should.include('slds-is-selected');
+		});
+	});
+
+	describe('Aria-* is supported', () => {
+
+		const propsWithAria = assign({ 'aria-pressed': true, 'aria-label': 'abc', 'aria-live': null }, requiredProps);
+		beforeEach(renderButton(<ButtonStateful {...propsWithAria} />));
+		afterEach(removeButton);
+
+		it('honors aria override', function () {
+
+			const button = getButton(this.dom);
+			button.getAttribute('aria-pressed').should.equal('true');
+			button.getAttribute('aria-label').should.equal('abc');
+			chai.expect(button.getAttribute('aria-live')).to.be.null;
+		});
+	});
+
+	describe('Aria default for icon button', () => {
+
+		const propsToUse = assign({ variant: 'icon' }, requiredPropsNoVariant);
+		beforeEach(renderButton(<ButtonStateful {...propsToUse} />));
+		afterEach(removeButton);
+
+		it('gives correct aria default for buttons with icon', function () {
+			const button = getButton(this.dom);
+			button.getAttribute('aria-live').should.equal('polite');
+		});
+	});
+
+	describe('Aria default for icon-filled button', () => {
+		const propsToUse = assign({ variant: 'icon-filled' }, requiredPropsNoVariant);
+		beforeEach(renderButton(<ButtonStateful {...propsToUse} />));
+		afterEach(removeButton);
+
+		it('gives correct aria default for buttons with icon-filled', function () {
+			const button = getButton(this.dom);
+			button.getAttribute('aria-live').should.equal('polite');
+		});
+	});
+
+	describe('Aria default for non-icon button', () => {
+		const propsToUse = assign({ variant: 'base' }, requiredPropsNoVariant);
+		beforeEach(renderButton(<ButtonStateful {...propsToUse} />));
+		afterEach(removeButton);
+
+		it('gives correct aria default for non-icon buttons', function () {
+			const button = getButton(this.dom);
+			button.getAttribute('aria-live').should.equal('assertive');
 		});
 	});
 

--- a/components/button-stateful/index.jsx
+++ b/components/button-stateful/index.jsx
@@ -23,6 +23,7 @@ import componentDoc from './component.json';
 // ## Children
 import ButtonIcon from '../icon/button-icon';
 
+import getAriaProps from '../../utilities/get-aria-props';
 import { BUTTON_STATEFUL } from '../../utilities/constants';
 
 const propTypes = {
@@ -125,6 +126,8 @@ const defaultProps = {
 /**
  * The ButtonStateful component is a variant of the Lightning Design System Button component. It is used for buttons that have a state of unselected or selected.
  * For icon buttons, use <code>variant='icon'</code>. For buttons with labels or buttons with labels and icons, pass data to the state props (ie. <code>stateOne={{iconName: 'add', label: 'Join'}}</code>).
+ * Although not listed in the prop table, all `aria-*` will be added to the button element if passed in.
+ * If no `aria-*` is being passed, <code>aria-live='polite'</code> will be used for `icon` and `icon-filled` variant <code>aria-live='assertive'</code> will be used for other variants.
  */
 class ButtonStateful extends React.Component {
 	constructor(props) {
@@ -196,10 +199,19 @@ class ButtonStateful extends React.Component {
 
 		const isActive = typeof active === 'boolean' ? active : this.state.active;
 
+		// Accept aria-* props
+		let ariaProps = getAriaProps(this.props);
+
 		if (variant === 'icon' || variant === 'icon-filled') {
+
+			// Default aria attribute for stateful button with icon, if none is specified
+			if (!ariaProps || Object.keys(ariaProps).length === 0) {
+				ariaProps = { 'aria-live': 'polite' };
+			}
+
 			return (
 				<button
-					aria-live="polite"
+					{...ariaProps}
 					className={this.getClassName(isActive)}
 					disabled={disabled}
 					id={id}
@@ -237,9 +249,14 @@ class ButtonStateful extends React.Component {
 
 		defaultIconProps.position = 'left';
 
+		// Default aria attribute for stateful button, if none is specified
+		if (!ariaProps || Object.keys(ariaProps).length === 0) {
+			ariaProps = { 'aria-live': 'assertive' };
+		}
+
 		return (
 			<button
-				aria-live="assertive"
+				{...ariaProps}
 				className={this.getClassName(isActive)}
 				disabled={disabled}
 				id={id}

--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -1721,7 +1721,7 @@
         "dependencies": []
     },
     "button-stateful": {
-        "description": "The ButtonStateful component is a variant of the Lightning Design System Button component. It is used for buttons that have a state of unselected or selected.\nFor icon buttons, use <code>variant='icon'</code>. For buttons with labels or buttons with labels and icons, pass data to the state props (ie. <code>stateOne={{iconName: 'add', label: 'Join'}}</code>).",
+        "description": "The ButtonStateful component is a variant of the Lightning Design System Button component. It is used for buttons that have a state of unselected or selected.\nFor icon buttons, use <code>variant='icon'</code>. For buttons with labels or buttons with labels and icons, pass data to the state props (ie. <code>stateOne={{iconName: 'add', label: 'Join'}}</code>).\nAlthough not listed in the prop table, all `aria-*` will be added to the button element if passed in.\nIf no `aria-*` is being passed, <code>aria-live='polite'</code> will be used for `icon` and `icon-filled` variant <code>aria-live='assertive'</code> will be used for other variants.",
         "methods": [
             {
                 "name": "getClassName",


### PR DESCRIPTION
This is to add support for aria-* in StatefulButton, similar to Button's support for aria-*.  To preserve the original behavior, the default aria-live attribute will be added if no aria-* is provided in props. 

Fixes #2502

### Additional description

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [x] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [x] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [x] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
