### PR TITLE
Filter and Panel markup updates

### DIFF
--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -12213,14 +12213,11 @@
                                 "name": "string"
                             },
                             "required": false,
-                            "description": "Heading for a group of filters that are locked"
-                        },
-                        "lockedLabel": {
+                            "description": "Heading for a group of filters that are locked",
                             "defaultValue": {
                                 "value": "'Locked filters'",
                                 "computed": false
-                            },
-                            "required": false
+                            }
                         }
                     },
                     "name": "filtering/list-heading",

--- a/components/filter/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/filter/__docs__/__snapshots__/storybook-stories.storyshot
@@ -42,14 +42,16 @@ exports[`DOM snapshots SLDSFilter AssistiveTextFilter 1`] = `
             >
               editFilter-TEST
             </span>
-            <p
-              className="slds-text-body_small"
+            <span
+              className="slds-show slds-text-body_small"
             >
               Show Me
-            </p>
-            <p>
+            </span>
+            <span
+              className="slds-show"
+            >
               All Products
-            </p>
+            </span>
           </button>
         </div>
         <button
@@ -64,7 +66,7 @@ exports[`DOM snapshots SLDSFilter AssistiveTextFilter 1`] = `
             className="slds-button__icon slds-button__icon_hint"
           >
             <use
-              href="/assets/icons/utility-sprite/svg/symbols.svg#close"
+              href="/assets/icons/utility-sprite/svg/symbols.svg#delete"
             />
           </svg>
           <span
@@ -123,14 +125,16 @@ exports[`DOM snapshots SLDSFilter ErrorFilter 1`] = `
               >
                 Edit filter:
               </span>
-              <p
-                className="slds-text-body_small"
+              <span
+                className="slds-show slds-text-body_small"
               >
                 Show Me
-              </p>
-              <p>
+              </span>
+              <span
+                className="slds-show"
+              >
                 All Products
-              </p>
+              </span>
             </button>
           </div>
           <button
@@ -145,7 +149,7 @@ exports[`DOM snapshots SLDSFilter ErrorFilter 1`] = `
               className="slds-button__icon slds-button__icon_hint"
             >
               <use
-                href="/assets/icons/utility-sprite/svg/symbols.svg#close"
+                href="/assets/icons/utility-sprite/svg/symbols.svg#delete"
               />
             </svg>
             <span
@@ -209,14 +213,16 @@ exports[`DOM snapshots SLDSFilter Filter 1`] = `
             >
               Edit filter:
             </span>
-            <p
-              className="slds-text-body_small"
+            <span
+              className="slds-show slds-text-body_small"
             >
               Show Me
-            </p>
-            <p>
+            </span>
+            <span
+              className="slds-show"
+            >
               All Products
-            </p>
+            </span>
           </button>
         </div>
         <button
@@ -231,7 +237,7 @@ exports[`DOM snapshots SLDSFilter Filter 1`] = `
             className="slds-button__icon slds-button__icon_hint"
           >
             <use
-              href="/assets/icons/utility-sprite/svg/symbols.svg#close"
+              href="/assets/icons/utility-sprite/svg/symbols.svg#delete"
             />
           </svg>
           <span
@@ -288,14 +294,16 @@ exports[`DOM snapshots SLDSFilter Filter Align Right 1`] = `
             >
               Edit filter:
             </span>
-            <p
-              className="slds-text-body_small"
+            <span
+              className="slds-show slds-text-body_small"
             >
               Show Me
-            </p>
-            <p>
+            </span>
+            <span
+              className="slds-show"
+            >
               All Products
-            </p>
+            </span>
           </button>
         </div>
         <button
@@ -310,7 +318,7 @@ exports[`DOM snapshots SLDSFilter Filter Align Right 1`] = `
             className="slds-button__icon slds-button__icon_hint"
           >
             <use
-              href="/assets/icons/utility-sprite/svg/symbols.svg#close"
+              href="/assets/icons/utility-sprite/svg/symbols.svg#delete"
             />
           </svg>
           <span
@@ -348,14 +356,16 @@ exports[`DOM snapshots SLDSFilter Locked Filter 1`] = `
           disabled={true}
           type="button"
         >
-          <p
-            className="slds-text-body_small"
+          <span
+            className="slds-show slds-text-body_small"
           >
             Show Me
-          </p>
-          <p>
+          </span>
+          <span
+            className="slds-show"
+          >
             All Products
-          </p>
+          </span>
         </button>
       </div>
     </div>
@@ -405,14 +415,16 @@ exports[`DOM snapshots SLDSFilter New Filter 1`] = `
             >
               Edit filter:
             </span>
-            <p
-              className="slds-text-body_small"
+            <span
+              className="slds-show slds-text-body_small"
             >
               Show Me
-            </p>
-            <p>
+            </span>
+            <span
+              className="slds-show"
+            >
               All Products
-            </p>
+            </span>
           </button>
         </div>
         <button
@@ -427,7 +439,7 @@ exports[`DOM snapshots SLDSFilter New Filter 1`] = `
             className="slds-button__icon slds-button__icon_hint"
           >
             <use
-              href="/assets/icons/utility-sprite/svg/symbols.svg#close"
+              href="/assets/icons/utility-sprite/svg/symbols.svg#delete"
             />
           </svg>
           <span
@@ -484,14 +496,16 @@ exports[`DOM snapshots SLDSFilter Permanant Filter 1`] = `
             >
               Edit filter:
             </span>
-            <p
-              className="slds-text-body_small"
+            <span
+              className="slds-show slds-text-body_small"
             >
               Show Me
-            </p>
-            <p>
+            </span>
+            <span
+              className="slds-show"
+            >
               All Products
-            </p>
+            </span>
           </button>
         </div>
       </div>

--- a/components/filter/index.jsx
+++ b/components/filter/index.jsx
@@ -252,9 +252,11 @@ class Filter extends React.Component {
 								{assistiveText.editFilter}
 							</span>
 							{this.props.property ? (
-								<p className="slds-text-body_small">{this.props.property}</p>
+								<span className="slds-show slds-text-body_small">
+									{this.props.property}
+								</span>
 							) : null}
-							<p>{this.props.predicate}</p>
+							<span className="slds-show">{this.props.predicate}</span>
 						</button>
 					</Popover>
 				) : (
@@ -266,8 +268,10 @@ class Filter extends React.Component {
 						disabled
 						type="button"
 					>
-						<p className="slds-text-body_small">{this.props.property}</p>
-						<p>{this.props.predicate}</p>
+						<span className="slds-show slds-text-body_small">
+							{this.props.property}
+						</span>
+						<span className="slds-show">{this.props.predicate}</span>
 					</button>
 				)}
 				{// Remove button
@@ -276,7 +280,7 @@ class Filter extends React.Component {
 						assistiveText={{ icon: assistiveText.removeFilter }}
 						hint
 						iconCategory="utility"
-						iconName="close"
+						iconName="delete"
 						iconSize="small"
 						iconVariant="bare"
 						onClick={this.handleRemove}

--- a/components/panel/__tests__/__snapshots__/filtering.dom-snapshot-test.jsx.snap
+++ b/components/panel/__tests__/__snapshots__/filtering.dom-snapshot-test.jsx.snap
@@ -76,14 +76,16 @@ exports[`Panel Filtering Default Snapshot DOM Snapshot 1`] = `
                   >
                     Edit filter:
                   </span>
-                  <p
-                    className="slds-text-body_small"
+                  <span
+                    className="slds-show slds-text-body_small"
                   >
                     Show Me
-                  </p>
-                  <p>
+                  </span>
+                  <span
+                    className="slds-show"
+                  >
                     All Products
-                  </p>
+                  </span>
                 </button>
               </div>
             </div>
@@ -127,14 +129,16 @@ exports[`Panel Filtering Default Snapshot DOM Snapshot 1`] = `
                   >
                     Edit filter:
                   </span>
-                  <p
-                    className="slds-text-body_small"
+                  <span
+                    className="slds-show slds-text-body_small"
                   >
                     Created Date
-                  </p>
-                  <p>
+                  </span>
+                  <span
+                    className="slds-show"
+                  >
                     equals THIS WEEK
-                  </p>
+                  </span>
                 </button>
               </div>
               <button
@@ -149,7 +153,7 @@ exports[`Panel Filtering Default Snapshot DOM Snapshot 1`] = `
                   className="slds-button__icon slds-button__icon_hint"
                 >
                   <use
-                    href="/assets/icons/utility-sprite/svg/symbols.svg#close"
+                    href="/assets/icons/utility-sprite/svg/symbols.svg#delete"
                   />
                 </svg>
                 <span
@@ -190,14 +194,16 @@ exports[`Panel Filtering Default Snapshot DOM Snapshot 1`] = `
                   >
                     Edit filter:
                   </span>
-                  <p
-                    className="slds-text-body_small"
+                  <span
+                    className="slds-show slds-text-body_small"
                   >
                     List Price
-                  </p>
-                  <p>
+                  </span>
+                  <span
+                    className="slds-show"
+                  >
                     greater than "500"
-                  </p>
+                  </span>
                 </button>
               </div>
               <button
@@ -212,7 +218,7 @@ exports[`Panel Filtering Default Snapshot DOM Snapshot 1`] = `
                   className="slds-button__icon slds-button__icon_hint"
                 >
                   <use
-                    href="/assets/icons/utility-sprite/svg/symbols.svg#close"
+                    href="/assets/icons/utility-sprite/svg/symbols.svg#delete"
                   />
                 </svg>
                 <span
@@ -261,7 +267,7 @@ exports[`Panel Filtering Default Snapshot HTML Snapshot 1`] = `
         <ol class=\\"slds-list_vertical slds-list_vertical-space\\">
           <li class=\\"slds-item slds-hint-parent\\">
             <div class=\\"slds-filters__item slds-grid slds-grid_vertical-align-center\\">
-              <div class=\\"slds-grow\\" style=\\"display:inline-block\\"><button class=\\"slds-button_reset slds-grow slds-has-blur-focus\\" type=\\"button\\" aria-haspopup=\\"dialog\\" id=\\"sample-panel-filtering-show-me\\" tabindex=\\"0\\"><span class=\\"slds-assistive-text\\">Edit filter:</span><p class=\\"slds-text-body_small\\">Show Me</p><p>All Products</p></button></div>
+              <div class=\\"slds-grow\\" style=\\"display:inline-block\\"><button class=\\"slds-button_reset slds-grow slds-has-blur-focus\\" type=\\"button\\" aria-haspopup=\\"dialog\\" id=\\"sample-panel-filtering-show-me\\" tabindex=\\"0\\"><span class=\\"slds-assistive-text\\">Edit filter:</span><span class=\\"slds-show slds-text-body_small\\">Show Me</span><span class=\\"slds-show\\">All Products</span></button></div>
             </div>
           </li>
         </ol>
@@ -269,16 +275,16 @@ exports[`Panel Filtering Default Snapshot HTML Snapshot 1`] = `
         <ol class=\\"slds-list_vertical slds-list_vertical-space\\">
           <li class=\\"slds-item slds-hint-parent\\">
             <div class=\\"slds-filters__item slds-grid slds-grid_vertical-align-center\\">
-              <div class=\\"slds-grow\\" style=\\"display:inline-block\\"><button class=\\"slds-button_reset slds-grow slds-has-blur-focus\\" type=\\"button\\" aria-haspopup=\\"dialog\\" id=\\"sample-panel-filtering-created-date\\" tabindex=\\"0\\"><span class=\\"slds-assistive-text\\">Edit filter:</span><p class=\\"slds-text-body_small\\">Created Date</p><p>equals THIS WEEK</p></button></div>
+              <div class=\\"slds-grow\\" style=\\"display:inline-block\\"><button class=\\"slds-button_reset slds-grow slds-has-blur-focus\\" type=\\"button\\" aria-haspopup=\\"dialog\\" id=\\"sample-panel-filtering-created-date\\" tabindex=\\"0\\"><span class=\\"slds-assistive-text\\">Edit filter:</span><span class=\\"slds-show slds-text-body_small\\">Created Date</span><span class=\\"slds-show\\">equals THIS WEEK</span></button></div>
               <button
-                class=\\"slds-button slds-button_icon slds-button_icon-bare slds-button_icon-small\\" title=\\"Remove Filter: Created Date equals THIS WEEK\\" type=\\"button\\"><svg aria-hidden=\\"true\\" class=\\"slds-button__icon slds-button__icon_hint\\"><use href=\\"/assets/icons/utility-sprite/svg/symbols.svg#close\\"></use></svg><span class=\\"slds-assistive-text\\">Remove Filter: Created Date equals THIS WEEK</span></button>
+                class=\\"slds-button slds-button_icon slds-button_icon-bare slds-button_icon-small\\" title=\\"Remove Filter: Created Date equals THIS WEEK\\" type=\\"button\\"><svg aria-hidden=\\"true\\" class=\\"slds-button__icon slds-button__icon_hint\\"><use href=\\"/assets/icons/utility-sprite/svg/symbols.svg#delete\\"></use></svg><span class=\\"slds-assistive-text\\">Remove Filter: Created Date equals THIS WEEK</span></button>
             </div>
           </li>
           <li class=\\"slds-item slds-hint-parent\\">
             <div class=\\"slds-filters__item slds-grid slds-grid_vertical-align-center\\">
-              <div class=\\"slds-grow\\" style=\\"display:inline-block\\"><button class=\\"slds-button_reset slds-grow slds-has-blur-focus\\" type=\\"button\\" aria-haspopup=\\"dialog\\" id=\\"sample-panel-filtering-list-price\\" tabindex=\\"0\\"><span class=\\"slds-assistive-text\\">Edit filter:</span><p class=\\"slds-text-body_small\\">List Price</p><p>greater than &quot;500&quot;</p></button></div>
+              <div class=\\"slds-grow\\" style=\\"display:inline-block\\"><button class=\\"slds-button_reset slds-grow slds-has-blur-focus\\" type=\\"button\\" aria-haspopup=\\"dialog\\" id=\\"sample-panel-filtering-list-price\\" tabindex=\\"0\\"><span class=\\"slds-assistive-text\\">Edit filter:</span><span class=\\"slds-show slds-text-body_small\\">List Price</span><span class=\\"slds-show\\">greater than &quot;500&quot;</span></button></div>
               <button
-                class=\\"slds-button slds-button_icon slds-button_icon-bare slds-button_icon-small\\" title=\\"Remove Filter: List Price greater than &quot;500&quot;\\" type=\\"button\\"><svg aria-hidden=\\"true\\" class=\\"slds-button__icon slds-button__icon_hint\\"><use href=\\"/assets/icons/utility-sprite/svg/symbols.svg#close\\"></use></svg><span class=\\"slds-assistive-text\\">Remove Filter: List Price greater than &quot;500&quot;</span></button>
+                class=\\"slds-button slds-button_icon slds-button_icon-bare slds-button_icon-small\\" title=\\"Remove Filter: List Price greater than &quot;500&quot;\\" type=\\"button\\"><svg aria-hidden=\\"true\\" class=\\"slds-button__icon slds-button__icon_hint\\"><use href=\\"/assets/icons/utility-sprite/svg/symbols.svg#delete\\"></use></svg><span class=\\"slds-assistive-text\\">Remove Filter: List Price greater than &quot;500&quot;</span></button>
             </div>
           </li>
         </ol>

--- a/components/panel/filtering/list-heading.jsx
+++ b/components/panel/filtering/list-heading.jsx
@@ -61,7 +61,7 @@ PanelFilterListHeading.propTypes = {
 
 PanelFilterListHeading.defaultProps = {
 	heading: 'Matching all these filters',
-	lockedLabel: 'Locked filters',
+	lockedHeading: 'Locked filters',
 };
 
 export default PanelFilterListHeading;


### PR DESCRIPTION
Some minor updates to Filter and Panel markup to bring them up-to-date with the latest from SLDS.

The only visible change is the "x" icon changing into a trash can icon:

<img width="401" alt="Screen Shot 2020-04-10 at 3 10 08 PM" src="https://user-images.githubusercontent.com/7608505/79027335-aedc0680-7b40-11ea-977b-c1ed56468fe6.png">

Fixes https://github.com/salesforce/design-system-react/issues/2490

@interactivellama Can you please review?  Thanks!