### PR TITLE
Add disable prop to EditDialog and its child Button

### DIFF
--- a/components/popover/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/popover/__docs__/__snapshots__/storybook-stories.storyshot
@@ -1147,7 +1147,7 @@ exports[`DOM snapshots SLDSPopover Custom Target 1`] = `
 </div>
 `;
 
-exports[`DOM snapshots SLDSPopover Edit Dialog  - Open 1`] = `
+exports[`DOM snapshots SLDSPopover Edit Dialog - Open 1`] = `
 <div
   className="slds-p-around_medium slds-m-horizontal_x-large"
   style={

--- a/components/popover/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/popover/__docs__/__snapshots__/storybook-stories.storyshot
@@ -1147,6 +1147,67 @@ exports[`DOM snapshots SLDSPopover Custom Target 1`] = `
 </div>
 `;
 
+exports[`DOM snapshots SLDSPopover Edit Dialog - Disabled 1`] = `
+<div
+  className="slds-p-around_medium slds-m-horizontal_x-large"
+  style={
+    Object {
+      "margin": "300px auto",
+      "width": "500px",
+    }
+  }
+>
+  <div>
+    <span
+      className="slds-p-right_x-small"
+    >
+      John
+       
+      Smith
+    </span>
+    <div
+      style={
+        Object {
+          "display": "inline-block",
+        }
+      }
+    >
+      <button
+        aria-haspopup="dialog"
+        className="slds-button slds-button_icon slds-button_reset"
+        disabled={true}
+        id="edit-dialog-popover"
+        onClick={[Function]}
+        onFocus={null}
+        onMouseEnter={null}
+        onMouseLeave={null}
+        style={
+          Object {
+            "verticalAlign": "middle",
+          }
+        }
+        tabIndex="0"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          className="slds-button__icon slds-button__icon slds-button__icon_hint"
+        >
+          <use
+            href="/assets/icons/utility-sprite/svg/symbols.svg#edit"
+          />
+        </svg>
+        <span
+          className="slds-assistive-text"
+        >
+          Edit: Status
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`DOM snapshots SLDSPopover Edit Dialog - Open 1`] = `
 <div
   className="slds-p-around_medium slds-m-horizontal_x-large"

--- a/components/popover/__docs__/storybook-stories.jsx
+++ b/components/popover/__docs__/storybook-stories.jsx
@@ -149,4 +149,5 @@ storiesOf(POPOVER, module)
 	.add('Walkthrough Action', () => <WalkthroughAction />)
 	.add('Walkthrough Action - Open', () => <WalkthroughAction isOpen />)
 	.add('Edit Dialog', () => <EditDialog />)
-	.add('Edit Dialog  - Open', () => <EditDialog isOpen />);
+	.add('Edit Dialog - Open', () => <EditDialog isOpen />)
+	.add('Edit Dialog - Disabled', () => <EditDialog disabled="true" />);

--- a/components/popover/__docs__/storybook-stories.jsx
+++ b/components/popover/__docs__/storybook-stories.jsx
@@ -150,4 +150,4 @@ storiesOf(POPOVER, module)
 	.add('Walkthrough Action - Open', () => <WalkthroughAction isOpen />)
 	.add('Edit Dialog', () => <EditDialog />)
 	.add('Edit Dialog - Open', () => <EditDialog isOpen />)
-	.add('Edit Dialog - Disabled', () => <EditDialog disabled="true" />);
+	.add('Edit Dialog - Disabled', () => <EditDialog disabled />);

--- a/components/popover/__examples__/edit-dialog.jsx
+++ b/components/popover/__examples__/edit-dialog.jsx
@@ -94,6 +94,7 @@ class Example extends React.Component {
 							this.state.firstName !== this.state.prevFirstName ||
 							this.state.lastName !== this.state.prevLastName
 						}
+						disabled={this.props.disabled}
 						onCancel={this.handleRequestClose}
 						onClose={this.handleClose}
 						onRequestClose={this.handleRequestClose}

--- a/components/popover/edit-dialog.jsx
+++ b/components/popover/edit-dialog.jsx
@@ -27,6 +27,10 @@ class EditDialog extends React.Component {
 	// ### Prop Types
 	static propTypes = {
 		/**
+		 * Disables the edit dialog and prevents clicking it.
+		 */
+		disabled: PropTypes.bool,
+		/**
 		 * By default, a unique ID will be created at render to support keyboard navigation, ARIA roles, and connect the popover to the triggering button. This ID will be applied to the triggering element. `${id}-popover`, `${id}-dialog-heading`, `${id}-dialog-body` are also created.
 		 */
 		id: PropTypes.string,
@@ -78,6 +82,7 @@ class EditDialog extends React.Component {
 			<Button
 				assistiveText={{ icon: 'Edit: Status' }}
 				className="slds-button_reset"
+				disabled={this.props.disabled}
 				iconCategory="utility"
 				iconClassName="slds-button__icon slds-button__icon_hint"
 				iconName="edit"


### PR DESCRIPTION
**Bug Description**
Currently, when passing in disabled="true" to `<EditDialog>`, user can still hover over the pencil icon/ see the color change.

**Expected**
﻿In this case, the pencil icon should not seem clickable while being disabled.

**Fix**
Add `disable` as a prop to `<EditDialog>` and pass it in to its child `<Button>`.
Storybook example added for a disabled `EditDialog` popover

Fixes https://github.com/salesforce/design-system-react/issues/2521

### Additional description

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [x] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [x] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
