### PR TITLE
Use onClickOutside wrapper for Edit Dialog, add docs for BuilderHeaderMisc

### DIFF
--- a/components/builder-header/index.jsx
+++ b/components/builder-header/index.jsx
@@ -26,11 +26,12 @@ const propTypes = {
 		icon: PropTypes.string,
 	}),
 	/**
-	 * Provide children of the types `<BuilderHeaderNav />` or `<BuilderHeaderToolbar />` to define the structure of the header.
+	 * Provide children of the types `<BuilderHeaderNav />`, `<BuilderHeaderToolbar />`, or `<BuilderHeaderMisc />` to define the structure of the header.
 	 * ```
 	 * <BuilderHeader>
 	 *   <BuilderHeaderNav />
 	 *   <BuilderHeaderToolbar />
+	 * 	 <BuilderHeaderMisc />
 	 * </BuilderHeader>
 	 * ```
 	 */

--- a/components/builder-header/index.jsx
+++ b/components/builder-header/index.jsx
@@ -31,7 +31,7 @@ const propTypes = {
 	 * <BuilderHeader>
 	 *   <BuilderHeaderNav />
 	 *   <BuilderHeaderToolbar />
-	 * 	 <BuilderHeaderMisc />
+	 *   <BuilderHeaderMisc />
 	 * </BuilderHeader>
 	 * ```
 	 */

--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -1385,7 +1385,7 @@
                     "name": "node"
                 },
                 "required": false,
-                "description": "Provide children of the types `<BuilderHeaderNav />` or `<BuilderHeaderToolbar />` to define the structure of the header.\n```\n<BuilderHeader>\n  <BuilderHeaderNav />\n  <BuilderHeaderToolbar />\n</BuilderHeader>\n```"
+                "description": "Provide children of the types `<BuilderHeaderNav />`, `<BuilderHeaderToolbar />`, or `<BuilderHeaderMisc />` to define the structure of the header.\n```\n<BuilderHeader>\n  <BuilderHeaderNav />\n  <BuilderHeaderToolbar />\n\t <BuilderHeaderMisc />\n</BuilderHeader>\n```"
             },
             "className": {
                 "type": {
@@ -1610,6 +1610,23 @@
                     },
                     "name": "toolbar",
                     "source": "/components/builder-header/toolbar.jsx"
+                }
+            },
+            {
+                "misc": {
+                    "description": "The miscellaneous section of the header.",
+                    "methods": [],
+                    "props": {
+                        "children": {
+                            "type": {
+                                "name": "node"
+                            },
+                            "required": false,
+                            "description": "Provide custom content in place of Page Type label\n```\n<BuilderHeader>\n  <BuilderHeaderMisc>\n    Custom content\n  </BuilderHeaderMisc>\n</BuilderHeader>\n```"
+                        }
+                    },
+                    "name": "misc",
+                    "source": "/components/builder-header/misc.jsx"
                 }
             }
         ]

--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -1385,7 +1385,7 @@
                     "name": "node"
                 },
                 "required": false,
-                "description": "Provide children of the types `<BuilderHeaderNav />`, `<BuilderHeaderToolbar />`, or `<BuilderHeaderMisc />` to define the structure of the header.\n```\n<BuilderHeader>\n  <BuilderHeaderNav />\n  <BuilderHeaderToolbar />\n\t <BuilderHeaderMisc />\n</BuilderHeader>\n```"
+                "description": "Provide children of the types `<BuilderHeaderNav />`, `<BuilderHeaderToolbar />`, or `<BuilderHeaderMisc />` to define the structure of the header.\n```\n<BuilderHeader>\n  <BuilderHeaderNav />\n  <BuilderHeaderToolbar />\n  <BuilderHeaderMisc />\n</BuilderHeader>\n```"
             },
             "className": {
                 "type": {
@@ -11079,7 +11079,7 @@
                     "name": "array"
                 },
                 "required": false,
-                "description": "An array of menu item objects. `className` and `id` object keys are applied to the `li` DOM node. `divider` key can have a value of `top` or `bottom`. `rightIcon` and `leftIcon` are not actually `Icon` components, but prop objects that get passed to an `Icon` component. The `href` key will be added to the `a` and its default click event will be prevented. Here is a sample:\n```\n[{\n  className: 'custom-li-class',\n    divider: 'bottom',\n    label: 'A Header',\n    type: 'header'\n }, {\n    href: 'http://sfdc.co/',\n    id: 'custom-li-id',\n    label: 'Has a value',\n  leftIcon: {\n   name: 'settings',\n   category: 'utility'\n  },\n  rightIcon: {\n   name: 'settings',\n   category: 'utility'\n  },\n    type: 'item',\n    value: 'B0'\n }, {\n  tooltipContent: 'Displays a tooltip when hovered over with this content. The `tooltipMenuItem` prop must be set for this to work.'\n  type: 'divider'\n}]\n```"
+                "description": "An array of menu item objects. `className` and `id` object keys are applied to the `li` DOM node. `divider` key can have a value of `top` or `bottom`. `rightIcon` and `leftIcon` are not actually `Icon` components, but prop objects that get passed to an `Icon` component. The `href` key will be added to the `a` and its default click event will be prevented. Here is a sample:\n```\n[{\n  className: 'custom-li-class',\n    divider: 'bottom',\n    label: 'A Header',\n    type: 'header'\n }, {\n    href: 'http://sfdc.co/',\n    id: 'custom-li-id',\n    label: 'Has a value',\n  leftIcon: {\n   name: 'settings',\n   category: 'utility'\n  },\n  rightIcon: {\n   name: 'settings',\n   category: 'utility'\n  },\n    type: 'item',\n    value: 'B0'\n }, {\n  tooltipContent: 'Displays a tooltip when hovered over with this content. The `tooltipMenuItem` prop must be set for this to work.',\n  type: 'divider'\n}]\n```"
             },
             "style": {
                 "type": {
@@ -17501,7 +17501,7 @@
                     }
                 },
                 "required": true,
-                "description": "Array of items starting at the top of the tree. The shape each node in the array is:\n```\n{\n  expanded: string,\n  id: string,\n  label: string or node,\n  selected: string,\n  type: string,\n  nodes: array\n}\n```\n`assistiveText: string` is optional and helpful if the label is not a string. Only `id` and `label` are required. Use `type: 'branch'` for folder and categories."
+                "description": "Array of items starting at the top of the tree. The shape each node in the array is:\n```\n{\n  expanded: boolean,\n  id: string,\n  label: string or node,\n  selected: boolean,\n  type: string,\n  nodes: array\n}\n```\n`assistiveText: string` is optional and helpful if the label is not a string. Only `id` and `label` are required. Use `type: 'branch'` for folder and categories."
             },
             "onClick": {
                 "type": {

--- a/components/menu-dropdown/menu-dropdown.jsx
+++ b/components/menu-dropdown/menu-dropdown.jsx
@@ -348,7 +348,7 @@ const propTypes = {
 	 *     type: 'item',
 	 *     value: 'B0'
 	 *  }, {
-	 *   tooltipContent: 'Displays a tooltip when hovered over with this content. The `tooltipMenuItem` prop must be set for this to work.'
+	 *   tooltipContent: 'Displays a tooltip when hovered over with this content. The `tooltipMenuItem` prop must be set for this to work.',
 	 *   type: 'divider'
 	 * }]
 	 * ```

--- a/components/popover/edit-dialog.jsx
+++ b/components/popover/edit-dialog.jsx
@@ -11,7 +11,7 @@ import assign from 'lodash.assign';
 import { POPOVER_EDIT_DIALOG } from '../../utilities/constants';
 
 import Button from '../button';
-import Popover from './popover';
+import Popover from './index';
 
 const defaultProps = {
 	labels: {

--- a/components/tree/index.jsx
+++ b/components/tree/index.jsx
@@ -60,10 +60,10 @@ const propTypes = {
 	 * Array of items starting at the top of the tree. The shape each node in the array is:
 	 * ```
 	 * {
-	 *   expanded: string,
+	 *   expanded: boolean,
 	 *   id: string,
 	 *   label: string or node,
-	 *   selected: string,
+	 *   selected: boolean,
 	 *   type: string,
 	 *   nodes: array
 	 * }

--- a/package.json
+++ b/package.json
@@ -443,6 +443,10 @@
 				{
 					"component": "toolbar",
 					"classKey": "BuilderHeaderToolbar"
+				},
+				{
+					"component": "misc",
+					"classKey": "BuilderHeaderMisc"
 				}
 			],
 			"site-stories": [


### PR DESCRIPTION
Fixes #

-  The Edit Dialog now closes when a user clicks outside the component. All of the other popover variations implement this behavior already. This was done by importing from `index.js` (an onClickOutside wrapper for `popover.js` instead of `popover.js` itself. 

- Added documentation for the BuilderHeaderMisc component. It was added in https://github.com/salesforce/design-system-react/pull/2287, but the docs were never updated.

### Additional description

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [x] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
