### PR TITLE
Custom title icon for Builder Header

### DIFF
--- a/components/builder-header/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/builder-header/__docs__/__snapshots__/storybook-stories.storyshot
@@ -1553,6 +1553,269 @@ exports[`DOM snapshots SLDSBuilderHeader Base with Toolbar 1`] = `
 </div>
 `;
 
+exports[`DOM snapshots SLDSBuilderHeader Custom Icon 1`] = `
+<div
+  className="slds-p-around_medium"
+>
+  <div
+    style={
+      Object {
+        "height": "100px",
+        "position": "relative",
+      }
+    }
+  >
+    <div
+      className="slds-builder-header_container"
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
+    >
+      <header
+        className="slds-builder-header"
+      >
+        <div
+          className="slds-builder-header__item"
+        >
+          <div
+            className="slds-builder-header__item-label slds-media slds-media_center"
+          >
+            <div
+              className="slds-media__figure"
+            >
+              <span
+                className="slds-icon_container slds-icon-utility-builder slds-current-color"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="slds-icon slds-icon_x-small slds-icon-text-default"
+                >
+                  <use
+                    href="/assets/icons/utility-sprite/svg/symbols.svg#world"
+                  />
+                </svg>
+                <span
+                  className="slds-assistive-text"
+                >
+                  Builder
+                </span>
+              </span>
+            </div>
+            <div
+              className="slds-media__body"
+            >
+              App Name
+            </div>
+          </div>
+        </div>
+        <nav
+          className="slds-builder-header__item slds-builder-header__nav"
+        >
+          <ul
+            className="slds-builder-header__nav-list"
+          >
+            <li
+              className="slds-builder-header__nav-item"
+            >
+              <a
+                className="slds-builder-header__item-action slds-media slds-media_center"
+                href="javascript:void(0)"
+              >
+                <span
+                  className="slds-media__figure"
+                >
+                  <span
+                    className="slds-icon_container slds-icon-utility-settings slds-current-color"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="slds-icon slds-icon_x-small slds-icon-text-default"
+                    >
+                      <use
+                        href="/assets/icons/utility-sprite/svg/symbols.svg#settings"
+                      />
+                    </svg>
+                    
+                  </span>
+                </span>
+                <span
+                  className="slds-media__body"
+                >
+                  <span
+                    className="slds-truncate"
+                    title="Link"
+                  >
+                    Link
+                  </span>
+                </span>
+              </a>
+            </li>
+            <li
+              className="slds-builder-header__nav-item"
+            >
+              <div
+                className="slds-dropdown-trigger slds-dropdown-trigger_click"
+                id="dropdown"
+                onClick={[Function]}
+                onFocus={null}
+                onKeyDown={[Function]}
+                onMouseEnter={null}
+                onMouseLeave={null}
+              >
+                <button
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="slds-button slds-builder-header__item-action slds-media slds-media_center"
+                  disabled={false}
+                  onClick={[Function]}
+                  tabIndex="0"
+                  type="button"
+                >
+                  <span
+                    className="slds-media__figure"
+                  >
+                    <span
+                      className="slds-icon_container slds-icon-utility-page slds-current-color"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        className="slds-icon slds-icon_x-small slds-icon-text-default"
+                      >
+                        <use
+                          href="/assets/icons/utility-sprite/svg/symbols.svg#page"
+                        />
+                      </svg>
+                      <span
+                        className="slds-assistive-text"
+                      >
+                        Dropdown
+                      </span>
+                    </span>
+                  </span>
+                  <span
+                    className="slds-media__body"
+                  >
+                    <span
+                      className="slds-truncate"
+                      title="Dropdown"
+                    >
+                      Dropdown
+                    </span>
+                    <span
+                      className="slds-icon_container slds-icon-utility-chevrondown slds-current-color slds-m-left_small"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        className="slds-icon slds-icon_x-small slds-icon-text-default"
+                      >
+                        <use
+                          href="/assets/icons/utility-sprite/svg/symbols.svg#chevrondown"
+                        />
+                      </svg>
+                      
+                    </span>
+                  </span>
+                </button>
+              </div>
+            </li>
+          </ul>
+        </nav>
+        <div
+          className="slds-builder-header__item slds-has-flexi-truncate"
+        >
+          <h1
+            className="slds-builder-header__item-label"
+          >
+            <span
+              className="slds-truncate"
+              title="Page Type"
+            >
+              Page Type
+            </span>
+          </h1>
+        </div>
+        <div
+          className="slds-builder-header__item slds-builder-header__utilities"
+        >
+          <div
+            className="slds-builder-header__utilities-item"
+          >
+            <a
+              className="slds-builder-header__item-action slds-media slds-media_center"
+              href="javascript:void(0);"
+            >
+              <div
+                className="slds-media__figure"
+              >
+                <span
+                  className="slds-icon_container slds-icon-utility-settings slds-current-color"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="slds-icon slds-icon_x-small slds-icon-text-default"
+                  >
+                    <use
+                      href="/assets/icons/utility-sprite/svg/symbols.svg#back"
+                    />
+                  </svg>
+                  <span
+                    className="slds-assistive-text"
+                  >
+                    Back
+                  </span>
+                </span>
+              </div>
+              <div
+                className="slds-media__body"
+              >
+                Back
+              </div>
+            </a>
+          </div>
+          <div
+            className="slds-builder-header__utilities-item"
+          >
+            <a
+              className="slds-builder-header__item-action slds-media slds-media_center"
+              href="javascript:void(0);"
+            >
+              <div
+                className="slds-media__figure"
+              >
+                <span
+                  className="slds-icon_container slds-icon-utility-settings slds-current-color"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="slds-icon slds-icon_x-small slds-icon-text-default"
+                  >
+                    <use
+                      href="/assets/icons/utility-sprite/svg/symbols.svg#help"
+                    />
+                  </svg>
+                  <span
+                    className="slds-assistive-text"
+                  >
+                    Help
+                  </span>
+                </span>
+              </div>
+              <div
+                className="slds-media__body"
+              >
+                Help
+              </div>
+            </a>
+          </div>
+        </div>
+      </header>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`DOM snapshots SLDSBuilderHeader Failed Save 1`] = `
 <div
   className="slds-p-around_medium"

--- a/components/builder-header/__docs__/storybook-stories.jsx
+++ b/components/builder-header/__docs__/storybook-stories.jsx
@@ -3,6 +3,7 @@ import { storiesOf } from '@storybook/react';
 
 import BuilderHeaderBase from '../__examples__/base';
 import BuilderHeaderBaseWithToolbar from '../__examples__/base-with-toolbar';
+import BuilderHeaderCustomIcon from '../__examples__/custom-icon';
 import BuilderHeaderSuccessfulSave from '../__examples__/successful-save';
 import BuilderHeaderAfterSuccessfulSave from '../__examples__/after-successful-save';
 import BuilderHeaderFailedSave from '../__examples__/failed-save';
@@ -16,6 +17,7 @@ storiesOf(BUILDER_HEADER, module)
 	))
 	.add('Base', () => <BuilderHeaderBase />)
 	.add('Base with Toolbar', () => <BuilderHeaderBaseWithToolbar />)
+	.add('Custom Icon', () => <BuilderHeaderCustomIcon />)
 	.add('Successful Save', () => <BuilderHeaderSuccessfulSave />)
 	.add('After Successful Save', () => <BuilderHeaderAfterSuccessfulSave />)
 	.add('Failed Save', () => <BuilderHeaderFailedSave />)

--- a/components/builder-header/__examples__/custom-icon.jsx
+++ b/components/builder-header/__examples__/custom-icon.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import IconSettings from '../../icon-settings';
+import BuilderHeader from '..';
+import BuilderHeaderNav from '../nav';
+import BuilderHeaderNavDropdown from '../nav-dropdown';
+import BuilderHeaderNavLink from '../nav-link';
+
+const Example = (props) => (
+	<IconSettings iconPath="/assets/icons">
+		<BuilderHeader
+			assistiveText={{
+				icon: 'Builder',
+				backIcon: 'Back',
+				helpIcon: 'Help',
+			}}
+			iconName="world"
+			labels={{
+				back: 'Back',
+				help: 'Help',
+				pageType: 'Page Type',
+				title: 'App Name',
+			}}
+			style={{ position: 'relative' }}
+		>
+			<BuilderHeaderNav>
+				<BuilderHeaderNavLink
+					assistiveText={{ label: 'Link' }}
+					iconCategory="utility"
+					iconName="settings"
+					label="Link"
+				/>
+				<BuilderHeaderNavDropdown
+					assistiveText={{ icon: 'Dropdown' }}
+					iconCategory="utility"
+					iconName="page"
+					id="dropdown"
+					label="Dropdown"
+					options={[
+						{ label: 'Menu Item One', value: 'A0' },
+						{ label: 'Menu Item Two', value: 'B0' },
+					]}
+				/>
+			</BuilderHeaderNav>
+		</BuilderHeader>
+	</IconSettings>
+);
+
+Example.displayName = 'BuilderHeaderBase';
+export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/builder-header/index.jsx
+++ b/components/builder-header/index.jsx
@@ -55,6 +55,26 @@ const propTypes = {
 		onClickHelp: PropTypes.func,
 	}),
 	/**
+	 * Category of the title icon from [lightningdesignsystem.com/icons/](https://www.lightningdesignsystem.com/icons/)
+	 */
+	iconCategory: PropTypes.string,
+	/**
+	 * CSS classes that are applied to the title icon.
+	 */
+	iconClassName: PropTypes.oneOfType([
+		PropTypes.array,
+		PropTypes.object,
+		PropTypes.string,
+	]),
+	/**
+	 * Name of the title icon. Visit <a href='http://www.lightningdesignsystem.com/resources/icons'>Lightning Design System Icons</a> to reference icon names.
+	 */
+	iconName: PropTypes.string,
+	/**
+	 * Path to the title icon. This will override any global icon settings.
+	 */
+	iconPath: PropTypes.string,
+	/**
 	 * **Text labels for internationalization**
 	 * This object is merged with the default props object on every render.
 	 * * `back`: The label for the Back link.
@@ -81,6 +101,8 @@ const defaultProps = {
 		helpIcon: 'Help',
 		icon: 'Builder',
 	},
+	iconCategory: 'utility',
+	iconName: 'builder',
 	labels: {
 		back: 'Back',
 		help: 'Help',
@@ -127,6 +149,15 @@ const BuilderHeader = (props) => {
 		}
 	});
 
+	let iconCategory;
+	let iconName;
+	let iconPath;
+	if (props.iconPath) {
+		({ iconPath } = props);
+	} else {
+		({ iconCategory, iconName } = props);
+	}
+
 	return (
 		<div style={{ position: 'relative', height: '100px' }}>
 			<div
@@ -139,9 +170,15 @@ const BuilderHeader = (props) => {
 							<div className="slds-media__figure">
 								<Icon
 									assistiveText={{ label: assistiveText.icon }}
-									category="utility"
-									containerClassName="slds-icon_container slds-icon-utility-builder slds-current-color"
-									name="builder"
+									category={iconCategory}
+									containerClassName={classNames(
+										'slds-icon_container',
+										'slds-icon-utility-builder',
+										'slds-current-color',
+										props.iconClassName
+									)}
+									name={iconName}
+									path={iconPath}
 									size="x-small"
 								/>
 							</div>

--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -1422,6 +1422,53 @@
                 "required": false,
                 "description": "Event Callbacks\n* `onClickBack`: Called when the Back link is clicked.\n* `onClickHelp`: Called when the Help link is clicked.\n_Tested with Mocha testing._"
             },
+            "iconCategory": {
+                "type": {
+                    "name": "string"
+                },
+                "required": false,
+                "description": "Category of the title icon from [lightningdesignsystem.com/icons/](https://www.lightningdesignsystem.com/icons/)",
+                "defaultValue": {
+                    "value": "'utility'",
+                    "computed": false
+                }
+            },
+            "iconClassName": {
+                "type": {
+                    "name": "union",
+                    "value": [
+                        {
+                            "name": "array"
+                        },
+                        {
+                            "name": "object"
+                        },
+                        {
+                            "name": "string"
+                        }
+                    ]
+                },
+                "required": false,
+                "description": "CSS classes that are applied to the title icon."
+            },
+            "iconName": {
+                "type": {
+                    "name": "string"
+                },
+                "required": false,
+                "description": "Name of the title icon. Visit <a href='http://www.lightningdesignsystem.com/resources/icons'>Lightning Design System Icons</a> to reference icon names.",
+                "defaultValue": {
+                    "value": "'builder'",
+                    "computed": false
+                }
+            },
+            "iconPath": {
+                "type": {
+                    "name": "string"
+                },
+                "required": false,
+                "description": "Path to the title icon. This will override any global icon settings."
+            },
             "labels": {
                 "type": {
                     "name": "shape",


### PR DESCRIPTION
Add the ability to customize the Builder Header title icon:

<img width="488" alt="Screen Shot 2020-07-28 at 10 57 42 AM" src="https://user-images.githubusercontent.com/7608505/88703585-bad4df80-d0c1-11ea-9c80-6b893d0706fd.png">

Fixes https://github.com/salesforce/design-system-react/issues/2560
