### PR TITLE
Tab with error

### DIFF
--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -16233,6 +16233,26 @@
                             },
                             "required": true,
                             "description": "The `children` are the actual tab panels to be rendered. They get created by [tabs/index.jsx](./index.jsx) in the `renderTabPanels` function.\n\nNote that the `<TabsPanel />` component inserts a `div` element around the children, because React requires exactly one \"parent\" element returned. The `<TabPanel />` component simply dips down into `children` to get the children of this wrapping `div` so that it does not get rendered in the DOM."
+                        },
+                        "hasError": {
+                            "type": {
+                                "name": "bool"
+                            },
+                            "required": false,
+                            "description": "Show an icon on the `<Tab />` next to the title that can be used to communicate when a tab contains a validation error that needs attention"
+                        },
+                        "assistiveText": {
+                            "type": {
+                                "name": "shape",
+                                "value": {
+                                    "withErrorIcon": {
+                                        "name": "string",
+                                        "required": false
+                                    }
+                                }
+                            },
+                            "required": false,
+                            "description": "**Assistive text for accessibility**\nThis object is merged with the default props object on every render.\n* `withErrorIcon`: This text is for the error icon that will be placed next to the `<Tab />` title"
                         }
                     },
                     "name": "panel",

--- a/components/tabs/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/tabs/__docs__/__snapshots__/storybook-stories.storyshot
@@ -1742,3 +1742,207 @@ exports[`DOM snapshots SLDSTabs With disabled tab 1`] = `
   </div>
 </div>
 `;
+
+exports[`DOM snapshots SLDSTabs With error tab 1`] = `
+<div
+  className="slds-p-around_medium"
+>
+  <div>
+    <h2
+      className="slds-text-heading_large"
+    >
+      Error Tabs Demo
+    </h2>
+    <div
+      className="slds-tabs_default"
+      data-tabs={true}
+      id="disabled-tabs-demo"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+    >
+      <ul
+        className="slds-tabs_default__nav"
+        id="disabled-tabs-demo-slds-tabs__nav"
+        role="tablist"
+      >
+        <li
+          className="slds-active slds-tabs_default__item"
+          id="disabled-tabs-demo-slds-tabs_tab-0"
+          role="presentation"
+          tabIndex="0"
+          title="Tab 1"
+        >
+          <a
+            aria-controls="disabled-tabs-demo-slds-tabs_panel-0"
+            aria-selected="true"
+            className="slds-active slds-tabs_default__link"
+            href="javascript:void(0);"
+            role="tab"
+            tabIndex="-1"
+          >
+            Tab 1
+          </a>
+        </li>
+        <li
+          className="slds-tabs_default__item"
+          id="disabled-tabs-demo-slds-tabs_tab-1"
+          role="presentation"
+          tabIndex={null}
+          title="Tab 2"
+        >
+          <a
+            aria-controls="disabled-tabs-demo-slds-tabs_panel-1"
+            aria-selected="false"
+            className="slds-tabs_default__link"
+            href="javascript:void(0);"
+            role="tab"
+            tabIndex="-1"
+          >
+            Tab 2
+            <span
+              className="slds-tabs__right-icon"
+            >
+              <span
+                className="slds-icon_container slds-icon-utility-error"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="slds-icon slds-icon_x-small slds-icon-text-error"
+                >
+                  <use
+                    href="/assets/icons/utility-sprite/svg/symbols.svg#error"
+                  />
+                </svg>
+                <span
+                  className="slds-assistive-text"
+                >
+                  This item has an error
+                </span>
+              </span>
+            </span>
+          </a>
+        </li>
+        <li
+          className="slds-tabs_default__item"
+          id="disabled-tabs-demo-slds-tabs_tab-2"
+          role="presentation"
+          tabIndex={null}
+          title="Tab 3"
+        >
+          <a
+            aria-controls="disabled-tabs-demo-slds-tabs_panel-2"
+            aria-selected="false"
+            className="slds-tabs_default__link"
+            href="javascript:void(0);"
+            role="tab"
+            tabIndex="-1"
+          >
+            Tab 3
+          </a>
+        </li>
+        <li
+          className="slds-tabs_default__item"
+          id="disabled-tabs-demo-slds-tabs_tab-3"
+          role="presentation"
+          tabIndex={null}
+          title="Tab 4"
+        >
+          <a
+            aria-controls="disabled-tabs-demo-slds-tabs_panel-3"
+            aria-selected="false"
+            className="slds-tabs_default__link"
+            href="javascript:void(0);"
+            role="tab"
+            tabIndex="-1"
+          >
+            Tab 4
+          </a>
+        </li>
+      </ul>
+      <div
+        aria-labelledby="disabled-tabs-demo-slds-tabs_tab-0"
+        className="slds-show slds-tabs_default__content"
+        id="disabled-tabs-demo-slds-tabs_panel-0"
+        role="tabpanel"
+      >
+        <h2
+          className="slds-text-heading_medium"
+        >
+          This is my tab 1 contents!
+        </h2>
+        <p>
+          And they’re amazing.
+        </p>
+        <p>
+          It’s awesome.
+        </p>
+        <p>
+          You can use your 
+          <var>
+            TAB
+          </var>
+           and 
+          <var>
+            ARROW
+          </var>
+           keys to navigate around. Try it!
+        </p>
+        <p
+          className="slds-box slds-theme_info slds-m-top_large"
+        >
+          (You might have to hit shift+tab to put the focus onto the tab bar ;)
+        </p>
+      </div>
+      <div
+        aria-labelledby="disabled-tabs-demo-slds-tabs_tab-1"
+        className="slds-hide slds-tabs_default__content"
+        id="disabled-tabs-demo-slds-tabs_panel-1"
+        role="tabpanel"
+      >
+        <h2
+          className="slds-text-heading_medium"
+        >
+          This is my tab 2 contents!
+        </h2>
+        <p>
+          Tab should have an error icon. Uh oh!
+        </p>
+      </div>
+      <div
+        aria-labelledby="disabled-tabs-demo-slds-tabs_tab-2"
+        className="slds-hide slds-tabs_default__content"
+        id="disabled-tabs-demo-slds-tabs_panel-2"
+        role="tabpanel"
+      >
+        <h2
+          className="slds-text-heading_medium"
+        >
+          This is my tab 3 contents!
+        </h2>
+        <p>
+          And they’re quite spectacular.
+        </p>
+      </div>
+      <div
+        aria-labelledby="disabled-tabs-demo-slds-tabs_tab-3"
+        className="slds-hide slds-tabs_default__content"
+        id="disabled-tabs-demo-slds-tabs_panel-3"
+        role="tabpanel"
+      >
+        <h2
+          className="slds-text-heading_medium"
+        >
+          This is my tab 3 contents!
+        </h2>
+        <p>
+          Note that using your arrow keys you can loop 
+          <em>
+            around the tabs
+          </em>
+          ! 🎉
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/components/tabs/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/tabs/__docs__/__snapshots__/storybook-stories.storyshot
@@ -1804,6 +1804,7 @@ exports[`DOM snapshots SLDSTabs With error tab 1`] = `
             >
               <span
                 className="slds-icon_container slds-icon-utility-error"
+                title="An error on this Panel needs to be addressed"
               >
                 <svg
                   aria-hidden="true"
@@ -1816,7 +1817,7 @@ exports[`DOM snapshots SLDSTabs With error tab 1`] = `
                 <span
                   className="slds-assistive-text"
                 >
-                  This item has an error
+                  An error on this Panel needs to be addressed
                 </span>
               </span>
             </span>

--- a/components/tabs/__docs__/storybook-stories.jsx
+++ b/components/tabs/__docs__/storybook-stories.jsx
@@ -502,6 +502,43 @@ const getTabsDisabled = () => (
 /* eslint-enable react/display-name */
 
 /* eslint-disable react/display-name */
+const getTabsError = () => (
+	<div>
+		<h2 className="slds-text-heading_large">Error Tabs Demo</h2>
+		<Tabs id="disabled-tabs-demo">
+			<Panel label="Tab 1">
+				<h2 className="slds-text-heading_medium">This is my tab 1 contents!</h2>
+				<p>And they&rsquo;re amazing.</p>
+				<p>It&rsquo;s awesome.</p>
+				<p>
+					You can use your <var>TAB</var> and <var>ARROW</var> keys to navigate
+					around. Try it!
+				</p>
+				<p className="slds-box slds-theme_info slds-m-top_large">
+					(You might have to hit shift+tab to put the focus onto the tab bar ;)
+				</p>
+			</Panel>
+			<Panel label="Tab 2" hasError>
+				<h2 className="slds-text-heading_medium">This is my tab 2 contents!</h2>
+				<p>Tab should have an error icon. Uh oh!</p>
+			</Panel>
+			<Panel label="Tab 3">
+				<h2 className="slds-text-heading_medium">This is my tab 3 contents!</h2>
+				<p>And they&rsquo;re quite spectacular.</p>
+			</Panel>
+			<Panel label="Tab 4">
+				<h2 className="slds-text-heading_medium">This is my tab 3 contents!</h2>
+				<p>
+					Note that using your arrow keys you can loop <em>around the tabs</em>!
+					🎉
+				</p>
+			</Panel>
+		</Tabs>
+	</div>
+);
+/* eslint-enable react/display-name */
+
+/* eslint-disable react/display-name */
 const getCustomContentTabs = () => {
 	const tab1Label = (
 		<div aria-label="test accessibility!">
@@ -588,6 +625,7 @@ storiesOf(TABS, module)
 	))
 	.add('Base', () => getTabs())
 	.add('With disabled tab', () => getTabsDisabled())
+	.add('With error tab', () => getTabsError())
 	.add('Nested', () => getTabsNested())
 	.add('Outside Control', () => (
 		<DemoTabsOutsideControl className="controlled-yo" />

--- a/components/tabs/__docs__/storybook-stories.jsx
+++ b/components/tabs/__docs__/storybook-stories.jsx
@@ -518,7 +518,13 @@ const getTabsError = () => (
 					(You might have to hit shift+tab to put the focus onto the tab bar ;)
 				</p>
 			</Panel>
-			<Panel label="Tab 2" hasError assistiveText={{ withErrorIcon: 'An error on this Panel needs to be addressed' }}>
+			<Panel
+				label="Tab 2"
+				hasError
+				assistiveText={{
+					withErrorIcon: 'An error on this Panel needs to be addressed',
+				}}
+			>
 				<h2 className="slds-text-heading_medium">This is my tab 2 contents!</h2>
 				<p>Tab should have an error icon. Uh oh!</p>
 			</Panel>

--- a/components/tabs/__docs__/storybook-stories.jsx
+++ b/components/tabs/__docs__/storybook-stories.jsx
@@ -518,7 +518,7 @@ const getTabsError = () => (
 					(You might have to hit shift+tab to put the focus onto the tab bar ;)
 				</p>
 			</Panel>
-			<Panel label="Tab 2" hasError>
+			<Panel label="Tab 2" hasError assistiveText={{ withErrorIcon: 'An error on this Panel needs to be addressed' }}>
 				<h2 className="slds-text-heading_medium">This is my tab 2 contents!</h2>
 				<p>Tab should have an error icon. Uh oh!</p>
 			</Panel>

--- a/components/tabs/__tests__/tabs.browser-test.jsx
+++ b/components/tabs/__tests__/tabs.browser-test.jsx
@@ -213,10 +213,10 @@ describe('Tabs', () => {
 			expect(myTabsPanels).to.have.length(4);
 		});
 
-		it('Tab 2 should have an error icon', function() {
+		it('Tab 2 should have an error icon', function () {
 			this.wrapper
 				.find(`.${COMPONENT_CSS_CLASSES.link}`)
-				.forEach(function(node, index) {
+				.forEach(function (node, index) {
 					if (index === 2) {
 						expect(node).to.have.descendants('.slds-icon-utility-error');
 					} else {

--- a/components/tabs/__tests__/tabs.browser-test.jsx
+++ b/components/tabs/__tests__/tabs.browser-test.jsx
@@ -217,7 +217,7 @@ describe('Tabs', () => {
 			this.wrapper
 				.find(`.${COMPONENT_CSS_CLASSES.link}`)
 				.forEach(function(node, index) {
-					if (index === 1) {
+					if (index === 2) {
 						expect(node).to.have.descendants('.slds-icon-utility-error');
 					} else {
 						expect(node).to.not.have.descendants('.slds-icon-utility-error');

--- a/components/tabs/__tests__/tabs.browser-test.jsx
+++ b/components/tabs/__tests__/tabs.browser-test.jsx
@@ -86,8 +86,9 @@ class TabsDemoComponent extends React.Component {
 						<p>This is tab B.</p>
 						<p>It is disabled.</p>
 					</Panel>
-					<Panel label="Tab C">
+					<Panel label="Tab C" hasError>
 						<p>This is tab C</p>
+						<p>It has an error icon next to the tab label.</p>
 					</Panel>
 					<Panel label="Always No">
 						<p>
@@ -210,6 +211,18 @@ describe('Tabs', () => {
 			);
 			expect(myTabsListItems).to.have.length(4);
 			expect(myTabsPanels).to.have.length(4);
+		});
+
+		it('Tab 2 should have an error icon', function() {
+			this.wrapper
+				.find(`.${COMPONENT_CSS_CLASSES.link}`)
+				.forEach(function(node, index) {
+					if (index === 1) {
+						expect(node).to.have.descendants('.slds-icon-utility-error');
+					} else {
+						expect(node).to.not.have.descendants('.slds-icon-utility-error');
+					}
+				});
 		});
 	});
 

--- a/components/tabs/index.jsx
+++ b/components/tabs/index.jsx
@@ -372,6 +372,7 @@ class Tabs extends React.Component {
 							panelId={panelId}
 							disabled={child.props.disabled}
 							variant={variant}
+							hasError={child.props.hasError}
 						>
 							{child.props.label}
 						</Tab>

--- a/components/tabs/index.jsx
+++ b/components/tabs/index.jsx
@@ -373,6 +373,7 @@ class Tabs extends React.Component {
 							disabled={child.props.disabled}
 							variant={variant}
 							hasError={child.props.hasError}
+							assistiveText={child.props.assistiveText}
 						>
 							{child.props.label}
 						</Tab>

--- a/components/tabs/panel.jsx
+++ b/components/tabs/panel.jsx
@@ -53,7 +53,8 @@ Panel.propTypes = {
 	 * This object is merged with the default props object on every render.
 	 * * `withErrorIcon`: This text is for the error icon that will be placed next to the `<Tab />` title
 	 */
-	assistiveText: PropTypes.shape({ // deepscan-disable-line REACT_USELESS_PROP_TYPES
+	assistiveText: PropTypes.shape({
+		// deepscan-disable-line REACT_USELESS_PROP_TYPES
 		withErrorIcon: PropTypes.string,
 	}),
 };

--- a/components/tabs/panel.jsx
+++ b/components/tabs/panel.jsx
@@ -53,10 +53,11 @@ Panel.propTypes = {
 	 * This object is merged with the default props object on every render.
 	 * * `withErrorIcon`: This text is for the error icon that will be placed next to the `<Tab />` title
 	 */
+	/* deepscan-disable REACT_USELESS_PROP_TYPES */
 	assistiveText: PropTypes.shape({
-		// deepscan-disable-line REACT_USELESS_PROP_TYPES
 		withErrorIcon: PropTypes.string,
 	}),
+	/* deepscan-enable REACT_USELESS_PROP_TYPES */
 };
 
 export default Panel;

--- a/components/tabs/panel.jsx
+++ b/components/tabs/panel.jsx
@@ -46,14 +46,14 @@ Panel.propTypes = {
 	/**
 	 * Show an icon on the `<Tab />` next to the title that can be used to communicate when a tab contains a validation error that needs attention
 	 */
-	hasError: PropTypes.bool,
+	hasError: PropTypes.bool, // deepscan-disable-line REACT_USELESS_PROP_TYPES
 
 	/**
 	 * **Assistive text for accessibility**
 	 * This object is merged with the default props object on every render.
 	 * * `withErrorIcon`: This text is for the error icon that will be placed next to the `<Tab />` title
 	 */
-	assistiveText: PropTypes.shape({
+	assistiveText: PropTypes.shape({ // deepscan-disable-line REACT_USELESS_PROP_TYPES
 		withErrorIcon: PropTypes.string,
 	}),
 };

--- a/components/tabs/panel.jsx
+++ b/components/tabs/panel.jsx
@@ -42,6 +42,20 @@ Panel.propTypes = {
 		PropTypes.node,
 		PropTypes.element,
 	]).isRequired,
+
+	/**
+	 * Show an icon on the `<Tab />` next to the title that can be used to communicate when a tab contains a validation error that needs attention
+	 */
+	hasError: PropTypes.bool,
+
+	/**
+	 * **Assistive text for accessibility**
+	 * This object is merged with the default props object on every render.
+	 * * `withErrorIcon`: This text is for the error icon that will be placed next to the `<Tab />` title
+	 */
+	assistiveText: PropTypes.shape({
+		withErrorIcon: PropTypes.string,
+	}),
 };
 
 export default Panel;

--- a/components/tabs/private/tab.jsx
+++ b/components/tabs/private/tab.jsx
@@ -87,7 +87,7 @@ class Tab extends React.Component {
 		/**
 		 * **Assistive text for accessibility**
 		 * This object is merged with the default props object on every render.
-		 * * `withErrorIcon`: This text is inside the info icon within the tooltip content and exists to "complete the sentence" for assistive tech users.
+		 * * `withErrorIcon`: This text is for the error icon that will be placed next to the `<Tab />` title
 		 */
 		assistiveText: PropTypes.shape({
 			withErrorIcon: PropTypes.string,
@@ -185,6 +185,7 @@ class Tab extends React.Component {
 								size="x-small"
 								name="error"
 								colorVariant="error"
+								title={this.props.assistiveText.withErrorIcon}
 							/>
 						</span>
 					)}

--- a/components/tabs/private/tab.jsx
+++ b/components/tabs/private/tab.jsx
@@ -18,6 +18,8 @@ import classNames from 'classnames';
 // ## Constants
 import { TAB } from '../../../utilities/constants';
 
+import Icon from '../../icon';
+
 /*
  * Disabled Tab CSS has been removed. If you'd like to use the styling, please import it in your module bundler.
  */
@@ -76,6 +78,20 @@ class Tab extends React.Component {
 		 * If the Tabs should be scopped, defaults to false
 		 */
 		variant: PropTypes.oneOf(['default', 'scoped']),
+
+		/**
+		 * Show an icon that can be used to communicate when a tab contains a validation error that needs attention
+		 */
+		hasError: PropTypes.bool,
+
+		/**
+		 * **Assistive text for accessibility**
+		 * This object is merged with the default props object on every render.
+		 * * `withErrorIcon`: This text is inside the info icon within the tooltip content and exists to "complete the sentence" for assistive tech users.
+		 */
+		assistiveText: PropTypes.shape({
+			withErrorIcon: PropTypes.string,
+		}),
 	};
 
 	static defaultProps = {
@@ -84,6 +100,10 @@ class Tab extends React.Component {
 		activeTabClassName: 'slds-active',
 		disabledTabClassName: 'slds-disabled',
 		variant: 'default',
+		hasError: false,
+		assistiveText: {
+			withErrorIcon: 'This item has an error',
+		},
 	};
 
 	componentDidMount() {
@@ -111,6 +131,7 @@ class Tab extends React.Component {
 			children,
 			id,
 			variant,
+			hasError,
 		} = this.props;
 		let tabIndex;
 
@@ -153,6 +174,20 @@ class Tab extends React.Component {
 					aria-selected={selected ? 'true' : 'false'}
 				>
 					{children}
+					{hasError && (
+						<span className="slds-tabs__right-icon">
+							<Icon
+								assistiveText={{
+									label: this.props.assistiveText.withErrorIcon,
+								}}
+								category="utility"
+								containerClassName="slds-icon_container slds-icon-utility-error"
+								size="x-small"
+								name="error"
+								colorVariant="error"
+							/>
+						</span>
+					)}
 				</a>
 			</li>
 		);


### PR DESCRIPTION
Add error icon to tab - https://www.lightningdesignsystem.com/components/tabs/#With-Error

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
