### PR TITLE
Add vertical tab variant

### DIFF
--- a/components/color-picker/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/color-picker/__docs__/__snapshots__/storybook-stories.storyshot
@@ -178,7 +178,7 @@ exports[`DOM snapshots SLDSColorPicker ColorPicker Menu Open 1`] = `
                 role="tablist"
               >
                 <li
-                  className="slds-active slds-tabs_default__item"
+                  className="slds-is-active slds-tabs_default__item"
                   id="color-picker-tabs-color-picker-slds-tabs_tab-0"
                   role="presentation"
                   tabIndex="0"
@@ -187,7 +187,7 @@ exports[`DOM snapshots SLDSColorPicker ColorPicker Menu Open 1`] = `
                   <a
                     aria-controls="color-picker-tabs-color-picker-slds-tabs_panel-0"
                     aria-selected="true"
-                    className="slds-active slds-tabs_default__link"
+                    className="slds-is-active slds-tabs_default__link"
                     href="javascript:void(0);"
                     role="tab"
                     tabIndex="-1"

--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -16171,11 +16171,15 @@
                         {
                             "value": "'scoped'",
                             "computed": false
+                        },
+                        {
+                            "value": "'vertical'",
+                            "computed": false
                         }
                     ]
                 },
                 "required": false,
-                "description": "If the Tabs should be scopped, defaults to false",
+                "description": "If the Tabs should be scoped, vertical, or default (default value)",
                 "defaultValue": {
                     "value": "'default'",
                     "computed": false

--- a/components/tabs/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/tabs/__docs__/__snapshots__/storybook-stories.storyshot
@@ -1577,6 +1577,7 @@ exports[`DOM snapshots SLDSTabs Vertical 1`] = `
       onKeyDown={[Function]}
     >
       <ul
+        aria-orientation="vertical"
         className="slds-vertical-tabs__nav"
         id="scoped-tabs-demo-slds-tabs__nav"
         role="tablist"

--- a/components/tabs/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/tabs/__docs__/__snapshots__/storybook-stories.storyshot
@@ -23,7 +23,7 @@ exports[`DOM snapshots SLDSTabs Base 1`] = `
         role="tablist"
       >
         <li
-          className="slds-active slds-tabs_default__item"
+          className="slds-is-active slds-tabs_default__item"
           id="main-tabs-demo-slds-tabs_tab-0"
           role="presentation"
           tabIndex="0"
@@ -32,7 +32,7 @@ exports[`DOM snapshots SLDSTabs Base 1`] = `
           <a
             aria-controls="main-tabs-demo-slds-tabs_panel-0"
             aria-selected="true"
-            className="slds-active slds-tabs_default__link"
+            className="slds-is-active slds-tabs_default__link"
             href="javascript:void(0);"
             role="tab"
             tabIndex="-1"
@@ -280,7 +280,7 @@ exports[`DOM snapshots SLDSTabs Conditional 1`] = `
         role="tablist"
       >
         <li
-          className="slds-active slds-tabs_default__item"
+          className="slds-is-active slds-tabs_default__item"
           id="tabs-checkbox-tabs-1-slds-tabs_tab-0"
           role="presentation"
           tabIndex="0"
@@ -290,7 +290,7 @@ exports[`DOM snapshots SLDSTabs Conditional 1`] = `
             aria-controls="tabs-checkbox-tabs-1-slds-tabs_panel-0"
             aria-disabled={false}
             aria-selected="true"
-            className="slds-active slds-tabs_default__link"
+            className="slds-is-active slds-tabs_default__link"
             href="javascript:void(0);"
             role="tab"
             tabIndex="-1"
@@ -471,7 +471,7 @@ exports[`DOM snapshots SLDSTabs Custom Tab Contents 1`] = `
         role="tablist"
       >
         <li
-          className="slds-active slds-tabs_default__item"
+          className="slds-is-active slds-tabs_default__item"
           id="getCustomContentTabs-slds-tabs_tab-0"
           role="presentation"
           tabIndex="0"
@@ -480,7 +480,7 @@ exports[`DOM snapshots SLDSTabs Custom Tab Contents 1`] = `
           <a
             aria-controls="getCustomContentTabs-slds-tabs_panel-0"
             aria-selected="true"
-            className="slds-active slds-tabs_default__link"
+            className="slds-is-active slds-tabs_default__link"
             href="javascript:void(0);"
             role="tab"
             tabIndex="-1"
@@ -589,7 +589,7 @@ exports[`DOM snapshots SLDSTabs Nested 1`] = `
         role="tablist"
       >
         <li
-          className="slds-active slds-tabs_default__item"
+          className="slds-is-active slds-tabs_default__item"
           id="nested-tabs-demo-slds-tabs_tab-0"
           role="presentation"
           tabIndex="0"
@@ -598,7 +598,7 @@ exports[`DOM snapshots SLDSTabs Nested 1`] = `
           <a
             aria-controls="nested-tabs-demo-slds-tabs_panel-0"
             aria-selected="true"
-            className="slds-active slds-tabs_default__link"
+            className="slds-is-active slds-tabs_default__link"
             href="javascript:void(0);"
             role="tab"
             tabIndex="-1"
@@ -725,7 +725,7 @@ exports[`DOM snapshots SLDSTabs Nested 1`] = `
               role="tablist"
             >
               <li
-                className="slds-active slds-tabs_default__item"
+                className="slds-is-active slds-tabs_default__item"
                 id="nested-second-layer-slds-tabs_tab-0"
                 role="presentation"
                 tabIndex="0"
@@ -734,7 +734,7 @@ exports[`DOM snapshots SLDSTabs Nested 1`] = `
                 <a
                   aria-controls="nested-second-layer-slds-tabs_panel-0"
                   aria-selected="true"
-                  className="slds-active slds-tabs_default__link"
+                  className="slds-is-active slds-tabs_default__link"
                   href="javascript:void(0);"
                   role="tab"
                   tabIndex="-1"
@@ -843,7 +843,7 @@ exports[`DOM snapshots SLDSTabs Nested 1`] = `
                     role="tablist"
                   >
                     <li
-                      className="slds-active slds-tabs_default__item"
+                      className="slds-is-active slds-tabs_default__item"
                       id="nested-third-layer-slds-tabs_tab-0"
                       role="presentation"
                       tabIndex="0"
@@ -852,7 +852,7 @@ exports[`DOM snapshots SLDSTabs Nested 1`] = `
                       <a
                         aria-controls="nested-third-layer-slds-tabs_panel-0"
                         aria-selected="true"
-                        className="slds-active slds-tabs_default__link"
+                        className="slds-is-active slds-tabs_default__link"
                         href="javascript:void(0);"
                         role="tab"
                         tabIndex="-1"
@@ -995,7 +995,7 @@ exports[`DOM snapshots SLDSTabs Outside Control 1`] = `
         role="tablist"
       >
         <li
-          className="slds-active slds-tabs_default__item"
+          className="slds-is-active slds-tabs_default__item"
           id="DemoTabsOutsideControlTabs-slds-tabs_tab-0"
           role="presentation"
           tabIndex="0"
@@ -1004,7 +1004,7 @@ exports[`DOM snapshots SLDSTabs Outside Control 1`] = `
           <a
             aria-controls="DemoTabsOutsideControlTabs-slds-tabs_panel-0"
             aria-selected="true"
-            className="slds-active slds-tabs_default__link"
+            className="slds-is-active slds-tabs_default__link"
             href="javascript:void(0);"
             role="tab"
             tabIndex="-1"
@@ -1172,7 +1172,7 @@ exports[`DOM snapshots SLDSTabs Scoped 1`] = `
         role="tablist"
       >
         <li
-          className="slds-active slds-tabs_scoped__item"
+          className="slds-is-active slds-tabs_scoped__item"
           id="scoped-tabs-demo-slds-tabs_tab-0"
           role="presentation"
           tabIndex="0"
@@ -1181,7 +1181,7 @@ exports[`DOM snapshots SLDSTabs Scoped 1`] = `
           <a
             aria-controls="scoped-tabs-demo-slds-tabs_panel-0"
             aria-selected="true"
-            className="slds-active slds-tabs_scoped__link"
+            className="slds-is-active slds-tabs_scoped__link"
             href="javascript:void(0);"
             role="tab"
             tabIndex="-1"
@@ -1313,7 +1313,7 @@ exports[`DOM snapshots SLDSTabs Tab Intercept Panel Select 1`] = `
         role="tablist"
       >
         <li
-          className="slds-active slds-tabs_default__item"
+          className="slds-is-active slds-tabs_default__item"
           id="DemoTabsInterceptSelect-slds-tabs_tab-0"
           role="presentation"
           tabIndex="0"
@@ -1322,7 +1322,7 @@ exports[`DOM snapshots SLDSTabs Tab Intercept Panel Select 1`] = `
           <a
             aria-controls="DemoTabsInterceptSelect-slds-tabs_panel-0"
             aria-selected="true"
-            className="slds-active slds-tabs_default__link"
+            className="slds-is-active slds-tabs_default__link"
             href="javascript:void(0);"
             role="tab"
             tabIndex="-1"
@@ -1390,7 +1390,7 @@ exports[`DOM snapshots SLDSTabs Tab Intercept Panel Select 1`] = `
         role="tablist"
       >
         <li
-          className="slds-active slds-tabs_default__item"
+          className="slds-is-active slds-tabs_default__item"
           id="DemoTabsInterceptSelect2-slds-tabs_tab-0"
           role="presentation"
           tabIndex="0"
@@ -1399,7 +1399,7 @@ exports[`DOM snapshots SLDSTabs Tab Intercept Panel Select 1`] = `
           <a
             aria-controls="DemoTabsInterceptSelect2-slds-tabs_panel-0"
             aria-selected="true"
-            className="slds-active slds-tabs_default__link"
+            className="slds-is-active slds-tabs_default__link"
             href="javascript:void(0);"
             role="tab"
             tabIndex="-1"
@@ -1474,7 +1474,7 @@ exports[`DOM snapshots SLDSTabs Unique Generated IDs 1`] = `
         role="tablist"
       >
         <li
-          className="slds-active slds-tabs_default__item"
+          className="slds-is-active slds-tabs_default__item"
           id="tabs-demo-id-1-slds-tabs_tab-0"
           role="presentation"
           tabIndex="0"
@@ -1483,7 +1483,7 @@ exports[`DOM snapshots SLDSTabs Unique Generated IDs 1`] = `
           <a
             aria-controls="tabs-demo-id-1-slds-tabs_panel-0"
             aria-selected="true"
-            className="slds-active slds-tabs_default__link"
+            className="slds-is-active slds-tabs_default__link"
             href="javascript:void(0);"
             role="tab"
             tabIndex="-1"
@@ -1521,7 +1521,7 @@ exports[`DOM snapshots SLDSTabs Unique Generated IDs 1`] = `
         role="tablist"
       >
         <li
-          className="slds-active slds-tabs_default__item"
+          className="slds-is-active slds-tabs_default__item"
           id="tabs-demo-id-2-slds-tabs_tab-0"
           role="presentation"
           tabIndex="0"
@@ -1530,7 +1530,7 @@ exports[`DOM snapshots SLDSTabs Unique Generated IDs 1`] = `
           <a
             aria-controls="tabs-demo-id-2-slds-tabs_panel-0"
             aria-selected="true"
-            className="slds-active slds-tabs_default__link"
+            className="slds-is-active slds-tabs_default__link"
             href="javascript:void(0);"
             role="tab"
             tabIndex="-1"
@@ -1552,6 +1552,179 @@ exports[`DOM snapshots SLDSTabs Unique Generated IDs 1`] = `
         </h2>
         <p>
           There should be two instances of Tabs in this story, and each should have a unique (generated) ID.
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DOM snapshots SLDSTabs Vertical 1`] = `
+<div
+  className="slds-p-around_medium"
+>
+  <div>
+    <h2
+      className="slds-text-heading_large"
+    >
+      Scoped Tabs Demo
+    </h2>
+    <div
+      className="slds-vertical-tabs"
+      data-tabs={true}
+      id="scoped-tabs-demo"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+    >
+      <ul
+        className="slds-vertical-tabs__nav"
+        id="scoped-tabs-demo-slds-tabs__nav"
+        role="tablist"
+      >
+        <li
+          className="slds-is-active slds-vertical-tabs__nav-item"
+          id="scoped-tabs-demo-slds-tabs_tab-0"
+          role="presentation"
+          tabIndex="0"
+          title="Tab 1"
+        >
+          <a
+            aria-controls="scoped-tabs-demo-slds-tabs_panel-0"
+            aria-selected="true"
+            className="slds-is-active slds-vertical-tabs__link"
+            href="javascript:void(0);"
+            role="tab"
+            tabIndex="-1"
+          >
+            Tab 1
+          </a>
+        </li>
+        <li
+          className="slds-vertical-tabs__nav-item"
+          id="scoped-tabs-demo-slds-tabs_tab-1"
+          role="presentation"
+          tabIndex={null}
+          title="Tab 2"
+        >
+          <a
+            aria-controls="scoped-tabs-demo-slds-tabs_panel-1"
+            aria-selected="false"
+            className="slds-vertical-tabs__link"
+            href="javascript:void(0);"
+            role="tab"
+            tabIndex="-1"
+          >
+            Tab 2
+          </a>
+        </li>
+        <li
+          className="slds-disabled slds-vertical-tabs__nav-item"
+          id="scoped-tabs-demo-slds-tabs_tab-2"
+          role="presentation"
+          tabIndex="-1"
+          title="Tab 3 (disabled)"
+        >
+          <a
+            aria-controls="scoped-tabs-demo-slds-tabs_panel-2"
+            aria-disabled={true}
+            aria-selected="false"
+            className="slds-disabled slds-vertical-tabs__link"
+            href="javascript:void(0);"
+            role="tab"
+            tabIndex="-1"
+          >
+            Tab 3 (disabled)
+          </a>
+        </li>
+        <li
+          className="slds-vertical-tabs__nav-item"
+          id="scoped-tabs-demo-slds-tabs_tab-3"
+          role="presentation"
+          tabIndex={null}
+          title="Tab 4"
+        >
+          <a
+            aria-controls="scoped-tabs-demo-slds-tabs_panel-3"
+            aria-selected="false"
+            className="slds-vertical-tabs__link"
+            href="javascript:void(0);"
+            role="tab"
+            tabIndex="-1"
+          >
+            Tab 4
+          </a>
+        </li>
+      </ul>
+      <div
+        aria-labelledby="scoped-tabs-demo-slds-tabs_tab-0"
+        className="slds-show slds-vertical-tabs__content"
+        id="scoped-tabs-demo-slds-tabs_panel-0"
+        role="tabpanel"
+      >
+        <h2
+          className="slds-text-heading_medium"
+        >
+          This is my tab 1 contents!
+        </h2>
+        <p>
+          And they’re amazing.
+        </p>
+        <p>
+          It"s awesome.
+        </p>
+        <p>
+          You can use your 
+          <var>
+            TAB
+          </var>
+           and 
+          <var>
+            ARROW
+          </var>
+           keys to navigate around. Try it!
+        </p>
+        <p
+          className="slds-box slds-theme_info slds-m-top_large"
+        >
+          (You might have to hit shift+tab to put the focus onto the tab bar ;)
+        </p>
+      </div>
+      <div
+        aria-labelledby="scoped-tabs-demo-slds-tabs_tab-1"
+        className="slds-hide slds-vertical-tabs__content"
+        id="scoped-tabs-demo-slds-tabs_panel-1"
+        role="tabpanel"
+      >
+        <h2
+          className="slds-text-heading_medium"
+        >
+          This is my tab 2 contents!
+        </h2>
+        <p>
+          And they’re also amazing.
+        </p>
+      </div>
+      <div
+        aria-labelledby="scoped-tabs-demo-slds-tabs_tab-2"
+        className="slds-hide slds-vertical-tabs__content"
+        id="scoped-tabs-demo-slds-tabs_panel-2"
+        role="tabpanel"
+      >
+        Disabled tab content.
+      </div>
+      <div
+        aria-labelledby="scoped-tabs-demo-slds-tabs_tab-3"
+        className="slds-hide slds-vertical-tabs__content"
+        id="scoped-tabs-demo-slds-tabs_panel-3"
+        role="tabpanel"
+      >
+        <h2
+          className="slds-text-heading_medium"
+        >
+          This is my tab 3 contents!
+        </h2>
+        <p>
+          And they’re quite spectacular.
         </p>
       </div>
     </div>
@@ -1582,7 +1755,7 @@ exports[`DOM snapshots SLDSTabs With disabled tab 1`] = `
         role="tablist"
       >
         <li
-          className="slds-active slds-tabs_default__item"
+          className="slds-is-active slds-tabs_default__item"
           id="disabled-tabs-demo-slds-tabs_tab-0"
           role="presentation"
           tabIndex="0"
@@ -1591,7 +1764,7 @@ exports[`DOM snapshots SLDSTabs With disabled tab 1`] = `
           <a
             aria-controls="disabled-tabs-demo-slds-tabs_panel-0"
             aria-selected="true"
-            className="slds-active slds-tabs_default__link"
+            className="slds-is-active slds-tabs_default__link"
             href="javascript:void(0);"
             role="tab"
             tabIndex="-1"
@@ -1766,7 +1939,7 @@ exports[`DOM snapshots SLDSTabs With error tab 1`] = `
         role="tablist"
       >
         <li
-          className="slds-active slds-tabs_default__item"
+          className="slds-is-active slds-tabs_default__item"
           id="disabled-tabs-demo-slds-tabs_tab-0"
           role="presentation"
           tabIndex="0"
@@ -1775,7 +1948,7 @@ exports[`DOM snapshots SLDSTabs With error tab 1`] = `
           <a
             aria-controls="disabled-tabs-demo-slds-tabs_panel-0"
             aria-selected="true"
-            className="slds-active slds-tabs_default__link"
+            className="slds-is-active slds-tabs_default__link"
             href="javascript:void(0);"
             role="tab"
             tabIndex="-1"

--- a/components/tabs/__docs__/storybook-stories.jsx
+++ b/components/tabs/__docs__/storybook-stories.jsx
@@ -174,6 +174,38 @@ const getTabsScoped = () => (
 	</div>
 );
 
+/* eslint-disable react/display-name */
+const getTabsVertical = () => (
+	<div>
+		<h2 className="slds-text-heading_large">Scoped Tabs Demo</h2>
+		<Tabs id="scoped-tabs-demo" variant="vertical">
+			<Panel label="Tab 1">
+				<h2 className="slds-text-heading_medium">This is my tab 1 contents!</h2>
+				<p>And they&rsquo;re amazing.</p>
+				<p>It&quot;s awesome.</p>
+				<p>
+					You can use your <var>TAB</var> and <var>ARROW</var> keys to navigate
+					around. Try it!
+				</p>
+				<p className="slds-box slds-theme_info slds-m-top_large">
+					(You might have to hit shift+tab to put the focus onto the tab bar ;)
+				</p>
+			</Panel>
+			<Panel label="Tab 2">
+				<h2 className="slds-text-heading_medium">This is my tab 2 contents!</h2>
+				<p>And they&rsquo;re also amazing.</p>
+			</Panel>
+			<Panel label="Tab 3 (disabled)" disabled>
+				Disabled tab content.
+			</Panel>
+			<Panel label="Tab 4">
+				<h2 className="slds-text-heading_medium">This is my tab 3 contents!</h2>
+				<p>And they&rsquo;re quite spectacular.</p>
+			</Panel>
+		</Tabs>
+	</div>
+);
+
 /* eslint-enable react/display-name */
 
 class DemoTabsConditional extends React.Component {
@@ -639,5 +671,6 @@ storiesOf(TABS, module)
 	.add('Conditional', () => <DemoTabsConditional className="conditional-yo" />)
 	.add('Unique Generated IDs', () => getTabsMoreThanOneAllowGeneratedID())
 	.add('Scoped', () => getTabsScoped())
+	.add('Vertical', () => getTabsVertical())
 	.add('Custom Tab Contents', () => getCustomContentTabs())
 	.add('Tab Intercept Panel Select', () => <DemoTabsInterceptSelect />);

--- a/components/tabs/__examples__/vertical.jsx
+++ b/components/tabs/__examples__/vertical.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import IconSettings from '~/components/icon-settings';
+import Tabs from '~/components/tabs'; // `~` is replaced with design-system-react at runtime
+import TabsPanel from '~/components/tabs/panel';
+
+class Example extends React.Component {
+	static displayName = 'TabsExample';
+
+	render() {
+		return (
+			<IconSettings iconPath="/assets/icons">
+				<Tabs variant="vertical" id="tabs-example-scoped">
+					<TabsPanel label="Item One">Item One Content</TabsPanel>
+					<TabsPanel label="Item Two">Item Two Content</TabsPanel>
+					<TabsPanel label="Item Three">Item Three Content</TabsPanel>
+					<TabsPanel disabled label="Disabled">
+						Disabled Content
+					</TabsPanel>
+				</Tabs>
+			</IconSettings>
+		);
+	}
+}
+
+export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/tabs/index.jsx
+++ b/components/tabs/index.jsx
@@ -39,7 +39,9 @@ function isTabNode(node) {
 	return (
 		(node.nodeName === 'A' && node.getAttribute('role') === 'tab') ||
 		(node.nodeName === 'LI' &&
-			node.classList.contains('slds-tabs_default__item'))
+			(node.classList.contains('slds-tabs_default__item') ||
+				node.classList.contains('slds-tabs_scoped__item') ||
+				node.classList.contains('slds-vertical-tabs__nav-item')))
 	);
 }
 

--- a/components/tabs/index.jsx
+++ b/components/tabs/index.jsx
@@ -114,9 +114,9 @@ const propTypes = {
 	onSelect: PropTypes.func,
 
 	/**
-	 * If the Tabs should be scopped, defaults to false
+	 * If the Tabs should be scoped, vertical, or default (default value)
 	 */
-	variant: PropTypes.oneOf(['default', 'scoped']),
+	variant: PropTypes.oneOf(['default', 'scoped', 'vertical']),
 
 	/**
 	 * The Tab (and corresponding TabPanel) that is currently selected.
@@ -219,7 +219,7 @@ class Tabs extends React.Component {
 	}
 
 	getVariant() {
-		return this.props.variant === 'scoped' ? 'scoped' : 'default';
+		return this.props.variant || 'default';
 	}
 
 	setSelected(index, focus) {
@@ -398,6 +398,7 @@ class Tabs extends React.Component {
 					{
 						'slds-tabs_default': variant === 'default',
 						'slds-tabs_scoped': variant === 'scoped',
+						'slds-vertical-tabs': variant === 'vertical',
 					},
 					className
 				)}

--- a/components/tabs/private/tab-panel.jsx
+++ b/components/tabs/private/tab-panel.jsx
@@ -34,6 +34,7 @@ const TabPanel = ({
 			'slds-hide': !selected,
 			'slds-tabs_default__content': variant === 'default',
 			'slds-tabs_scoped__content': variant === 'scoped',
+			'slds-vertical-tabs__content': variant === 'vertical',
 		})}
 		id={id}
 		role="tabpanel"
@@ -90,9 +91,9 @@ TabPanel.propTypes = {
 	selected: PropTypes.bool,
 
 	/**
-	 * If the Tabs should be scopped, defaults to false
+	 * If the Tabs should be scoped, vertical, or default (default value)
 	 */
-	variant: PropTypes.oneOf(['default', 'scoped']),
+	variant: PropTypes.oneOf(['default', 'scoped', 'vertical']),
 
 	/**
 	 * The HTML ID of the `<Tab />` that controls this panel.

--- a/components/tabs/private/tab.jsx
+++ b/components/tabs/private/tab.jsx
@@ -75,9 +75,9 @@ class Tab extends React.Component {
 		children: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
 
 		/**
-		 * If the Tabs should be scopped, defaults to false
+		 * If the Tabs should be scoped, vertical, or default (default value)
 		 */
-		variant: PropTypes.oneOf(['default', 'scoped']),
+		variant: PropTypes.oneOf(['default', 'scoped', 'vertical']),
 
 		/**
 		 * Show an icon that can be used to communicate when a tab contains a validation error that needs attention
@@ -97,7 +97,7 @@ class Tab extends React.Component {
 	static defaultProps = {
 		focus: false,
 		selected: false,
-		activeTabClassName: 'slds-active',
+		activeTabClassName: 'slds-is-active',
 		disabledTabClassName: 'slds-disabled',
 		variant: 'default',
 		hasError: false,
@@ -150,6 +150,7 @@ class Tab extends React.Component {
 					[disabledTabClassName]: disabled,
 					'slds-tabs_default__item': variant === 'default',
 					'slds-tabs_scoped__item': variant === 'scoped',
+					'slds-vertical-tabs__nav-item': variant === 'vertical',
 				})}
 				role="presentation"
 				ref={(node) => {
@@ -165,6 +166,7 @@ class Tab extends React.Component {
 						[disabledTabClassName]: disabled,
 						'slds-tabs_default__link': variant === 'default',
 						'slds-tabs_scoped__link': variant === 'scoped',
+						'slds-vertical-tabs__link': variant === 'vertical',
 					})}
 					href="javascript:void(0);" // eslint-disable-line no-script-url
 					role="tab"
@@ -175,7 +177,12 @@ class Tab extends React.Component {
 				>
 					{children}
 					{hasError && (
-						<span className="slds-tabs__right-icon">
+						<span
+							className={classNames({
+								'slds-tabs__right-icon': variant !== 'vertical',
+								'slds-vertical-tabs__right-icon': variant === 'vertical',
+							})}
+						>
 							<Icon
 								assistiveText={{
 									label: this.props.assistiveText.withErrorIcon,

--- a/components/tabs/private/tab.jsx
+++ b/components/tabs/private/tab.jsx
@@ -45,7 +45,7 @@ class Tab extends React.Component {
 		focus: PropTypes.bool,
 
 		/**
-		 * When `true`, the class `.slds-active` is applied.
+		 * When `true`, the class `.slds-is-active` is applied.
 		 */
 		selected: PropTypes.bool,
 
@@ -55,7 +55,7 @@ class Tab extends React.Component {
 		disabled: PropTypes.bool,
 
 		/**
-		 * The CSS class to be applied when this tab is selected. Defaults to `.slds-active`. If another class is desired, it should be passed in _along with_ `.slds-active`, not _instead_ of it.
+		 * The CSS class to be applied when this tab is selected. Defaults to `.slds-is-active`. If another class is desired, it should be passed in _along with_ `.slds-is-active`, not _instead_ of it.
 		 */
 		activeTabClassName: PropTypes.string,
 

--- a/components/tabs/private/tabs-list.jsx
+++ b/components/tabs/private/tabs-list.jsx
@@ -21,6 +21,7 @@ const TabsList = ({ id, className, children, variant }) => (
 		className={classNames(className, {
 			'slds-tabs_default__nav': variant === 'default',
 			'slds-tabs_scoped__nav': variant === 'scoped',
+			'slds-vertical-tabs__nav': variant === 'vertical',
 		})}
 		role="tablist"
 	>
@@ -51,9 +52,9 @@ TabsList.propTypes = {
 	children: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
 
 	/**
-	 * If the Tabs should be scopped, defaults to false
+	 * If the Tabs should be scoped, vertical, or default (default value)
 	 */
-	variant: PropTypes.oneOf(['default', 'scoped']),
+	variant: PropTypes.oneOf(['default', 'scoped', 'vertical']),
 };
 
 export default TabsList;

--- a/components/tabs/private/tabs-list.jsx
+++ b/components/tabs/private/tabs-list.jsx
@@ -24,6 +24,7 @@ const TabsList = ({ id, className, children, variant }) => (
 			'slds-vertical-tabs__nav': variant === 'vertical',
 		})}
 		role="tablist"
+		aria-orientation={variant === 'vertical' ? 'vertical' : undefined}
 	>
 		{children}
 	</ul>


### PR DESCRIPTION
Fixes #
Fixed bug with keydown event with scoped variant not working after the first keydown event.

### Additional description
Added vertical variant with accompanying example and story.
---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [x] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [x] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [x] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
