### PR TITLE
Get accessibility tests running again

### DIFF
--- a/components/combobox/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/combobox/__docs__/__snapshots__/storybook-stories.storyshot
@@ -2785,7 +2785,7 @@ exports[`DOM snapshots SLDSCombobox Inline Multiple Selection 1`] = `
         >
           <ul
             aria-label="Selected Options:"
-            aria-orientation=""
+            aria-orientation={null}
             className="slds-listbox slds-listbox_horizontal slds-p-top_xxx-small"
             role="group"
           >
@@ -6081,7 +6081,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Multiple Selection Selected 
         >
           <ul
             aria-label="Selected Options:"
-            aria-orientation=""
+            aria-orientation={null}
             className="slds-listbox slds-listbox_horizontal slds-p-top_xxx-small"
             role="group"
           >

--- a/components/combobox/combobox.jsx
+++ b/components/combobox/combobox.jsx
@@ -1176,7 +1176,7 @@ class Combobox extends React.Component {
 						containerRole="listbox"
 						containerAriaOrientation="horizontal"
 						listboxRole="group"
-						listboxAriaOrientation=""
+						listboxAriaOrientation={null}
 						events={{
 							onBlurPill: this.handleBlurPill,
 							onClickPill: this.handlePillClickSelectedListbox,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "design-system-react",
-	"version": "0.10.22",
+	"version": "0.10.23",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 		"test:image-snapshot": "cross-env NODE_ENV=test npx jest --runInBand --config=tests/story-based-tests.snapshot-test.config.json",
 		"test:dom-snapshot:update": "cross-env NODE_ENV=test npx jest --updateSnapshot --config=tests/story-based-tests.dom-snapshot-test.config.json",
 		"test:image-snapshot:update": "cross-env NODE_ENV=test npm run static:build && npx jest --updateSnapshot --config=tests/story-based-tests.snapshot-test.config.json",
-		"test:accessibility": "cross-env NODE_ENV=test PORT=8002 npm run static:build && npx jest --runInBand --config=tests/story-based-tests.accessibility-test.config.json",
+		"test:accessibility": "npm run static:build && cross-env NODE_ENV=test PORT=8002 npx jest --runInBand --config=tests/story-based-tests.accessibility-test.config.json",
 		"test:a11y": "npm run test:accessibility",
 		"travis-ci": "cross-env NODE_ENV=test scripts/travis-ci.sh",
 		"upload-diffs": "scripts/upload-diffs.sh",

--- a/tests/story-based-tests.accessibility-test.config.json
+++ b/tests/story-based-tests.accessibility-test.config.json
@@ -2,7 +2,7 @@
 	"rootDir": "../",
 	"testRegex": "/tests/story-based-tests.accessibility-test.js$",
 	"testEnvironment": "node",
-	"setupTestFrameworkScriptFile": "<rootDir>/tests/axe-puppeteer-matcher.js",
+	"setupFilesAfterEnv": ["<rootDir>/tests/axe-puppeteer-matcher.js"],
 	"moduleNameMapper": {
 		"\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":
 			"<rootDir>/tests/__mocks__/file-mock.js"


### PR DESCRIPTION
Get accessibility tests running again in Travis CI.  This was a simple fix to avoid setting `NODE_ENV=test` when doing the Storybook static build.

Also: Fix one accessibility test failure.