### PR TITLE
No mandatory requirement for Canvas

### DIFF
--- a/components/utilities/truncate/index.jsx
+++ b/components/utilities/truncate/index.jsx
@@ -12,17 +12,19 @@ const documentDefined = typeof document !== 'undefined';
 let canvas;
 let docFragment;
 let canvasContext;
-let measureWidth = () => {};
+let measureWidth = () => 0;
 
 if (documentDefined) {
 	canvas = document.createElement('canvas');
-	docFragment = document.createDocumentFragment();
-	docFragment.appendChild(canvas);
-	canvasContext = canvas.getContext('2d');
-	measureWidth = memoize((text, font) => {
-		canvasContext.font = font;
-		return canvasContext.measureText(text).width;
-	});
+	if (canvas.getContext) {
+		docFragment = document.createDocumentFragment();
+		docFragment.appendChild(canvas);
+		canvasContext = canvas.getContext('2d');
+		measureWidth = memoize((text, font) => {
+			canvasContext.font = font;
+			return canvasContext.measureText(text).width;
+		});
+	}
 }
 
 class TextTruncate extends React.Component {


### PR DESCRIPTION
Fixes #1717 

### Additional description

While most modern browsers support Canvas, JSDom does not out-of-the-box. Attempting to run jest jsdom-based tests on code that uses these components results in error messages logged to the console (see #1717).

While it is made clear in the jsdom readme that to support canvas, you need to [add canvas as a peer dependency](https://github.com/jsdom/jsdom#canvas-support), or alternatively [jest-canvas-mock](https://github.com/hustcc/jest-canvas-mock), it seems unnecessary to need to add a dependency just to remove a spurious error message from tests, which doesn't actually affect the running of those tests.

This simple code change in the truncate utility checks that canvas is supported by the environment, with fallback behaviour of not truncating text at all.

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [x] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [x] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [x] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
