### PR TITLE
Fix Input styling with inline help text and icons

### DIFF
--- a/components/input/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/input/__docs__/__snapshots__/storybook-stories.storyshot
@@ -1928,16 +1928,24 @@ exports[`DOM snapshots SLDSInput Inline Help 1`] = `
             className="slds-form-element__label"
             htmlFor="inline-help-with-error"
           >
+            <abbr
+              className="slds-required"
+              title="required"
+            >
+              *
+            </abbr>
             My Label
           </label>
           <div
             className="slds-form-element__control"
           >
             <input
-              aria-describedby="ozFSBXHiHwJ"
+              aria-describedby="inline-with-error-1"
               className="slds-input"
               id="inline-help-with-error"
+              name="inline-help-with-error"
               onChange={[Function]}
+              required={true}
               type="text"
             />
           </div>
@@ -1948,7 +1956,7 @@ exports[`DOM snapshots SLDSInput Inline Help 1`] = `
           </div>
           <div
             className="slds-form-element__help"
-            id="ozFSBXHiHwJ"
+            id="inline-with-error-1"
           >
             This field is required.
           </div>
@@ -1969,6 +1977,12 @@ exports[`DOM snapshots SLDSInput Inline Help 1`] = `
             className="slds-form-element__label"
             htmlFor="inline-help-with-error-and-icon"
           >
+            <abbr
+              className="slds-required"
+              title="required"
+            >
+              *
+            </abbr>
             My Label
           </label>
           <div
@@ -1983,10 +1997,12 @@ exports[`DOM snapshots SLDSInput Inline Help 1`] = `
               />
             </svg>
             <input
-              aria-describedby="lOp-giCXFdj"
+              aria-describedby="inline-with-error-2"
               className="slds-input"
               id="inline-help-with-error-and-icon"
+              name="inline-help-with-error-and-icon"
               onChange={[Function]}
+              required={true}
               type="text"
             />
           </div>
@@ -1997,7 +2013,7 @@ exports[`DOM snapshots SLDSInput Inline Help 1`] = `
           </div>
           <div
             className="slds-form-element__help"
-            id="lOp-giCXFdj"
+            id="inline-with-error-2"
           >
             This field is required.
           </div>

--- a/components/input/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/input/__docs__/__snapshots__/storybook-stories.storyshot
@@ -1793,38 +1793,218 @@ exports[`DOM snapshots SLDSInput Inline Help 1`] = `
 <div
   className="slds-p-around_medium"
 >
-  <div>
-    <h1
-      className="slds-text-title_caps slds-p-vertical_medium"
-    >
-      Inline Help
-    </h1>
-    <div
-      className="slds-form-element"
-    >
-      <label
-        className="slds-form-element__label"
-        htmlFor="inline-help"
+  <section>
+    <ol>
+      <li
+        className="slds-p-bottom_large"
       >
-        My Label
-      </label>
-      <div
-        className="slds-form-element__control"
-      >
-        <input
-          className="slds-input"
-          id="inline-help"
-          onChange={[Function]}
-          type="text"
-        />
-        <div
-          className="slds-form-element__help"
+        <h1
+          className="slds-text-title_caps slds-p-vertical_medium"
         >
-          ex: (415) 111-2222
+          1. Inline Help
+        </h1>
+        <div
+          className="slds-form-element"
+        >
+          <label
+            className="slds-form-element__label"
+            htmlFor="inline-help"
+          >
+            My Label
+          </label>
+          <div
+            className="slds-form-element__control"
+          >
+            <input
+              className="slds-input"
+              id="inline-help"
+              onChange={[Function]}
+              type="text"
+            />
+          </div>
+          <div
+            className="slds-form-element__help"
+          >
+            ex: (415) 111-2222
+          </div>
         </div>
-      </div>
-    </div>
-  </div>
+      </li>
+      <li
+        className="slds-p-bottom_large"
+      >
+        <h1
+          className="slds-text-title_caps slds-p-vertical_medium"
+        >
+          2. Inline Help With Left Icon
+        </h1>
+        <div
+          className="slds-form-element"
+        >
+          <label
+            className="slds-form-element__label"
+            htmlFor="inline-help-with-left-icon"
+          >
+            My Label
+          </label>
+          <div
+            className="slds-form-element__control slds-input-has-icon slds-input-has-icon_left"
+          >
+            <svg
+              aria-hidden={true}
+              className="slds-input__icon slds-icon-text-default slds-input__icon_left"
+            >
+              <use
+                href="/assets/icons/utility-sprite/svg/symbols.svg#search"
+              />
+            </svg>
+            <input
+              className="slds-input"
+              id="inline-help-with-left-icon"
+              onChange={[Function]}
+              type="text"
+            />
+          </div>
+          <div
+            className="slds-form-element__help"
+          >
+            ex: (415) 111-2222
+          </div>
+        </div>
+      </li>
+      <li
+        className="slds-p-bottom_large"
+      >
+        <h1
+          className="slds-text-title_caps slds-p-vertical_medium"
+        >
+          3. Inline Help With Right Icon
+        </h1>
+        <div
+          className="slds-form-element"
+        >
+          <label
+            className="slds-form-element__label"
+            htmlFor="inline-help-with-right-icon"
+          >
+            My Label
+          </label>
+          <div
+            className="slds-form-element__control slds-input-has-icon slds-input-has-icon_right"
+          >
+            <input
+              className="slds-input"
+              id="inline-help-with-right-icon"
+              onChange={[Function]}
+              type="text"
+            />
+            <svg
+              aria-hidden={true}
+              className="slds-input__icon slds-icon-text-default slds-input__icon_right"
+            >
+              <use
+                href="/assets/icons/utility-sprite/svg/symbols.svg#search"
+              />
+            </svg>
+          </div>
+          <div
+            className="slds-form-element__help"
+          >
+            ex: (415) 111-2222
+          </div>
+        </div>
+      </li>
+      <li
+        className="slds-p-bottom_large"
+      >
+        <h1
+          className="slds-text-title_caps slds-p-vertical_medium"
+        >
+          4. Inline Help With Error Text
+        </h1>
+        <div
+          className="slds-form-element slds-has-error"
+        >
+          <label
+            className="slds-form-element__label"
+            htmlFor="inline-help-with-error"
+          >
+            My Label
+          </label>
+          <div
+            className="slds-form-element__control"
+          >
+            <input
+              aria-describedby="ozFSBXHiHwJ"
+              className="slds-input"
+              id="inline-help-with-error"
+              onChange={[Function]}
+              type="text"
+            />
+          </div>
+          <div
+            className="slds-form-element__help"
+          >
+            ex: (415) 111-2222
+          </div>
+          <div
+            className="slds-form-element__help"
+            id="ozFSBXHiHwJ"
+          >
+            This field is required.
+          </div>
+        </div>
+      </li>
+      <li
+        className="slds-p-bottom_large"
+      >
+        <h1
+          className="slds-text-title_caps slds-p-vertical_medium"
+        >
+          4. Inline Help With Error Text and Icon
+        </h1>
+        <div
+          className="slds-form-element slds-has-error"
+        >
+          <label
+            className="slds-form-element__label"
+            htmlFor="inline-help-with-error-and-icon"
+          >
+            My Label
+          </label>
+          <div
+            className="slds-form-element__control slds-input-has-icon slds-input-has-icon_left"
+          >
+            <svg
+              aria-hidden={true}
+              className="slds-input__icon slds-icon-text-default slds-input__icon_left"
+            >
+              <use
+                href="/assets/icons/utility-sprite/svg/symbols.svg#error"
+              />
+            </svg>
+            <input
+              aria-describedby="lOp-giCXFdj"
+              className="slds-input"
+              id="inline-help-with-error-and-icon"
+              onChange={[Function]}
+              type="text"
+            />
+          </div>
+          <div
+            className="slds-form-element__help"
+          >
+            ex: (415) 111-2222
+          </div>
+          <div
+            className="slds-form-element__help"
+            id="lOp-giCXFdj"
+          >
+            This field is required.
+          </div>
+        </div>
+      </li>
+    </ol>
+  </section>
 </div>
 `;
 
@@ -1870,60 +2050,106 @@ exports[`DOM snapshots SLDSInput Required Input in Error State 1`] = `
   className="slds-p-around_medium"
 >
   <section>
-    <h1
-      className="slds-text-title_caps slds-p-vertical_medium"
-    >
-      Example Button
-    </h1>
-    <button
-      className="slds-button slds-button_neutral"
-      disabled={false}
-      onClick={[Function]}
-      type="button"
-    >
-      Test
-    </button>
-    <h1
-      className="slds-text-title_caps slds-p-vertical_medium"
-    >
-      Required Input with Error
-    </h1>
-    <div
-      className="slds-form-element slds-has-error"
-    >
-      <label
-        className="slds-form-element__label"
-        htmlFor="required-input-error"
+    <ol>
+      <li
+        className="slds-p-bottom_large"
       >
-        <abbr
-          className="slds-required"
-          title="required"
+        <h1
+          className="slds-text-title_caps slds-p-vertical_medium"
         >
-          *
-        </abbr>
-        My Label
-      </label>
-      <div
-        className="slds-form-element__control"
+          Required Input with Error Text
+        </h1>
+        <div
+          className="slds-form-element slds-has-error"
+        >
+          <label
+            className="slds-form-element__label"
+            htmlFor="required-input-error"
+          >
+            <abbr
+              className="slds-required"
+              title="required"
+            >
+              *
+            </abbr>
+            My Label
+          </label>
+          <div
+            className="slds-form-element__control"
+          >
+            <input
+              aria-describedby="error-1"
+              className="slds-input"
+              id="required-input-error"
+              name="required-input-error"
+              onChange={[Function]}
+              placeholder="My placeholder"
+              required={true}
+              type="text"
+            />
+          </div>
+          <div
+            className="slds-form-element__help"
+            id="error-1"
+          >
+            This field is required.
+          </div>
+        </div>
+      </li>
+      <li
+        className="slds-p-bottom_large"
       >
-        <input
-          aria-describedby="error-1"
-          className="slds-input"
-          id="required-input-error"
-          name="required-input-error"
-          onChange={[Function]}
-          placeholder="My placeholder"
-          required={true}
-          type="text"
-        />
-      </div>
-      <div
-        className="slds-form-element__help"
-        id="error-1"
-      >
-        This field is required.
-      </div>
-    </div>
+        <h1
+          className="slds-text-title_caps slds-p-vertical_medium"
+        >
+          Required Input with Error Text and Icon
+        </h1>
+        <div
+          className="slds-form-element slds-has-error"
+        >
+          <label
+            className="slds-form-element__label"
+            htmlFor="required-input-error-with-icon"
+          >
+            <abbr
+              className="slds-required"
+              title="required"
+            >
+              *
+            </abbr>
+            My Label
+          </label>
+          <div
+            className="slds-form-element__control slds-input-has-icon slds-input-has-icon_left"
+          >
+            <svg
+              aria-hidden={true}
+              className="slds-input__icon slds-icon-text-default slds-input__icon_left"
+            >
+              <use
+                href="/assets/icons/utility-sprite/svg/symbols.svg#error"
+              />
+            </svg>
+            <input
+              aria-describedby="error-2"
+              className="slds-input"
+              id="required-input-error-with-icon"
+              name="required-input-error-with-icon"
+              onChange={[Function]}
+              placeholder="My placeholder"
+              required={true}
+              type="text"
+            />
+          </div>
+          <div
+            className="slds-form-element__help"
+            id="error-2"
+          >
+            This field is required.
+          </div>
+        </div>
+      </li>
+    </ol>
   </section>
 </div>
 `;

--- a/components/input/__docs__/storybook-stories.jsx
+++ b/components/input/__docs__/storybook-stories.jsx
@@ -46,6 +46,8 @@ const searchIconClickable = (
 		onClick={iconClicked('Search icon clicked')}
 	/>
 );
+const errorIcon = <InputIcon name="error" category="utility" />;
+
 storiesOf(INPUT, module)
 	.addDecorator((getStory) => (
 		<div className="slds-p-around_medium">{getStory()}</div>
@@ -275,23 +277,37 @@ storiesOf(INPUT, module)
 	.add('Required Input in Error State', () => (
 		<IconSettings iconPath="/assets/icons">
 			<section>
-				<h1 className="slds-text-title_caps slds-p-vertical_medium">
-					Example Button
-				</h1>
-				<Button label="Test" />
-
-				<h1 className="slds-text-title_caps slds-p-vertical_medium">
-					Required Input with Error
-				</h1>
-				<Input
-					id="required-input-error"
-					aria-describedby="error-1"
-					name="required-input-error"
-					label="My Label"
-					required
-					errorText="This field is required."
-					placeholder="My placeholder"
-				/>
+				<ol>
+					<li className="slds-p-bottom_large">
+						<h1 className="slds-text-title_caps slds-p-vertical_medium">
+							Required Input with Error Text
+						</h1>
+						<Input
+							id="required-input-error"
+							aria-describedby="error-1"
+							name="required-input-error"
+							label="My Label"
+							required
+							errorText="This field is required."
+							placeholder="My placeholder"
+						/>
+					</li>
+					<li className="slds-p-bottom_large">
+						<h1 className="slds-text-title_caps slds-p-vertical_medium">
+							Required Input with Error Text and Icon
+						</h1>
+						<Input
+							id="required-input-error-with-icon"
+							aria-describedby="error-2"
+							name="required-input-error-with-icon"
+							label="My Label"
+							required
+							errorText="This field is required."
+							placeholder="My placeholder"
+							iconLeft={errorIcon}
+						/>
+					</li>
+				</ol>
 			</section>
 		</IconSettings>
 	))

--- a/components/input/__docs__/storybook-stories.jsx
+++ b/components/input/__docs__/storybook-stories.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { INPUT } from '../../../utilities/constants';
-import Button from '../../button';
 import IconSettings from '../../icon-settings';
 import Input from '../';
 import InputIcon from '../../icon/input-icon';

--- a/components/input/__examples__/inline-help.jsx
+++ b/components/input/__examples__/inline-help.jsx
@@ -1,19 +1,72 @@
 import React from 'react';
 import Input from '~/components/input'; // `~` is replaced with design-system-react at runtime
+import IconSettings from '~/components/icon-settings';
+import InputIcon from '~/components/icon/input-icon';
 
 class Example extends React.Component {
 	render() {
 		return (
-			<div>
-				<h1 className="slds-text-title_caps slds-p-vertical_medium">
-					Inline Help
-				</h1>
-				<Input
-					id="inline-help"
-					label="My Label"
-					inlineHelpText="ex: (415) 111-2222"
-				/>
-			</div>
+			<IconSettings iconPath="/assets/icons">
+				<section>
+					<ol>
+						<li className="slds-p-bottom_large">
+							<h1 className="slds-text-title_caps slds-p-vertical_medium">
+								1. Inline Help
+							</h1>
+							<Input
+								id="inline-help"
+								label="My Label"
+								inlineHelpText="ex: (415) 111-2222"
+							/>
+						</li>
+						<li className="slds-p-bottom_large">
+							<h1 className="slds-text-title_caps slds-p-vertical_medium">
+								2. Inline Help With Left Icon
+							</h1>
+							<Input
+								id="inline-help-with-left-icon"
+								label="My Label"
+								inlineHelpText="ex: (415) 111-2222"
+								iconLeft={<InputIcon name="search" category="utility" />}
+							/>
+						</li>
+						<li className="slds-p-bottom_large">
+							<h1 className="slds-text-title_caps slds-p-vertical_medium">
+								3. Inline Help With Right Icon
+							</h1>
+							<Input
+								id="inline-help-with-right-icon"
+								label="My Label"
+								inlineHelpText="ex: (415) 111-2222"
+								iconRight={<InputIcon name="search" category="utility" />}
+							/>
+						</li>
+						<li className="slds-p-bottom_large">
+							<h1 className="slds-text-title_caps slds-p-vertical_medium">
+								4. Inline Help With Error Text
+							</h1>
+							<Input
+								id="inline-help-with-error"
+								label="My Label"
+								inlineHelpText="ex: (415) 111-2222"
+								errorText="This field is required."
+							/>
+						</li>
+						<li className="slds-p-bottom_large">
+							<h1 className="slds-text-title_caps slds-p-vertical_medium">
+								4. Inline Help With Error Text and Icon
+							</h1>
+							<Input
+								id="inline-help-with-error-and-icon"
+								label="My Label"
+								inlineHelpText="ex: (415) 111-2222"
+								errorText="This field is required."
+								iconLeft={<InputIcon name="error" category="utility" />}
+							/>
+						</li>
+					</ol>
+				</section>
+			</IconSettings>
 		);
 	}
 }

--- a/components/input/__examples__/inline-help.jsx
+++ b/components/input/__examples__/inline-help.jsx
@@ -47,7 +47,10 @@ class Example extends React.Component {
 							</h1>
 							<Input
 								id="inline-help-with-error"
+								aria-describedby="inline-with-error-1"
+								name="inline-help-with-error"
 								label="My Label"
+								required
 								inlineHelpText="ex: (415) 111-2222"
 								errorText="This field is required."
 							/>
@@ -58,7 +61,10 @@ class Example extends React.Component {
 							</h1>
 							<Input
 								id="inline-help-with-error-and-icon"
+								aria-describedby="inline-with-error-2"
+								name="inline-help-with-error-and-icon"
 								label="My Label"
+								required
 								inlineHelpText="ex: (415) 111-2222"
 								errorText="This field is required."
 								iconLeft={<InputIcon name="error" category="utility" />}

--- a/components/input/index.jsx
+++ b/components/input/index.jsx
@@ -631,7 +631,6 @@ class Input extends React.Component {
 					iconLeft={iconLeft}
 					iconRight={iconRight}
 					inlineEditTrigger={this.props.inlineEditTrigger}
-					inlineHelpText={this.props.inlineHelpText}
 					isStatic={this.props.isStatic}
 					minLength={this.props.minLength}
 					minValue={this.props.minValue}
@@ -661,6 +660,11 @@ class Input extends React.Component {
 					step={this.props.step}
 					style={this.props.styleInput}
 				/>
+				{this.props.inlineHelpText && (
+					<div className="slds-form-element__help">
+						{this.props.inlineHelpText}
+					</div>
+				)}
 				{this.props.errorText && (
 					<div id={this.getErrorId()} className="slds-form-element__help">
 						{this.props.errorText}

--- a/components/input/private/inner-input.jsx
+++ b/components/input/private/inner-input.jsx
@@ -97,10 +97,6 @@ const propTypes = {
 	 */
 	id: PropTypes.string.isRequired,
 	/**
-	 * Displays help text under the input.
-	 */
-	inlineHelpText: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
-	/**
 	 * This callback exposes the input reference / DOM node to parent components. `<Parent inputRef={(inputComponent) => this.input = inputComponent} />
 	 */
 	inputRef: PropTypes.func,
@@ -332,10 +328,6 @@ const InnerInput = (props) => {
 				</span>
 			)}
 			{/* eslint-enable jsx-a11y/no-static-element-interactions */}
-
-			{props.inlineHelpText && (
-				<div className="slds-form-element__help">{props.inlineHelpText}</div>
-			)}
 		</div>
 	);
 };


### PR DESCRIPTION
Fixes #2718

### Additional description

- Moves the div for `inlineHelpText` outside of the `InnerInput` div. This makes sure icons are vertically centered (`top: 50%`), because the inline help text no longer affects the input div's height.
- Follows the same pattern as `errorText`, which is rendered outside of `InnerInput` as well
- Added new stories to test these cases

![image](https://user-images.githubusercontent.com/16738211/103670510-a7b71d00-4f47-11eb-824e-17d9c27cce44.png)

Please take a look, thanks!
---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [x] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
