### PR TITLE
Fix auto-align of selected item when combo-box is opened

### DIFF
--- a/components/combobox/combobox.jsx
+++ b/components/combobox/combobox.jsx
@@ -913,7 +913,7 @@ class Combobox extends React.Component {
 				this.props.events.onOpen(event, data);
 			}
 
-			if (this.props.variant === 'readonly') {
+			if (this.props.variant === 'readonly' && this.menuRef !== null) {
 				const activeOptionIndex = findIndex(this.getOptions(), (item) =>
 					isEqual(item, this.props.selection[0])
 				);

--- a/components/combobox/combobox.jsx
+++ b/components/combobox/combobox.jsx
@@ -912,6 +912,17 @@ class Combobox extends React.Component {
 			if (this.props.events.onOpen) {
 				this.props.events.onOpen(event, data);
 			}
+
+			if (this.props.variant === 'readonly') {
+				const activeOptionIndex = findIndex(this.getOptions(), (item) =>
+					isEqual(item, this.props.selection[0])
+				);
+
+				menuItemSelectScroll({
+					container: this.menuRef,
+					focusedIndex: activeOptionIndex,
+				});
+			}
 		}
 	};
 

--- a/components/combobox/combobox.jsx
+++ b/components/combobox/combobox.jsx
@@ -918,6 +918,10 @@ class Combobox extends React.Component {
 					isEqual(item, this.props.selection[0])
 				);
 
+				this.setState({
+					activeOptionIndex,
+				});
+
 				menuItemSelectScroll({
 					container: this.menuRef,
 					focusedIndex: activeOptionIndex,

--- a/components/expression/__tests__/expression.browser-test.jsx
+++ b/components/expression/__tests__/expression.browser-test.jsx
@@ -111,7 +111,7 @@ describe('SLDSExpression', function describeFunction() {
 			expect(resourceChange !== undefined).to.eql(true);
 			expect(typeof resourceChange.event).to.eql('object');
 			expect(typeof resourceChange.data).to.eql('object');
-			expect(resourceChange.data.selection[0]).to.equal(ResourcesList[1]);
+			expect(resourceChange.data.selection[0]).to.equal(ResourcesList[0]);
 		});
 
 		it('Operator selector works', function () {
@@ -124,7 +124,7 @@ describe('SLDSExpression', function describeFunction() {
 			expect(operatorChange !== undefined).to.eql(true);
 			expect(typeof operatorChange.event).to.eql('object');
 			expect(typeof operatorChange.data).to.eql('object');
-			expect(operatorChange.data.selection[0]).to.equal(OperatorsList[1]);
+			expect(operatorChange.data.selection[0]).to.equal(OperatorsList[0]);
 		});
 
 		it('Value input works', function () {


### PR DESCRIPTION
Fixes #2745

### Additional description

This PR should fix the auto-align issue which affects sub-components like the `date-picker`. The item which is already selected should appear on the bottom of the combo-box view when it's opened.

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [x] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [x] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
