### PR TITLE
Adds support for data-* attributes to Button.

### DIFF
--- a/components/button/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/button/__docs__/__snapshots__/storybook-stories.storyshot
@@ -1,11 +1,43 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`DOM snapshots SLDSButton Aria attribute 1`] = `
+<div
+  className="slds-p-around_medium"
+>
+  <button
+    aria-label="Base"
+    className="slds-button"
+    disabled={false}
+    onClick={[Function]}
+    type="button"
+  >
+    Base
+  </button>
+</div>
+`;
+
 exports[`DOM snapshots SLDSButton Base 1`] = `
 <div
   className="slds-p-around_medium"
 >
   <button
     className="slds-button"
+    disabled={false}
+    onClick={[Function]}
+    type="button"
+  >
+    Base
+  </button>
+</div>
+`;
+
+exports[`DOM snapshots SLDSButton Data attribute 1`] = `
+<div
+  className="slds-p-around_medium"
+>
+  <button
+    className="slds-button"
+    data-some-property="Some value"
     disabled={false}
     onClick={[Function]}
     type="button"

--- a/components/button/__docs__/storybook-stories.jsx
+++ b/components/button/__docs__/storybook-stories.jsx
@@ -29,6 +29,16 @@ storiesOf(BUTTON, module)
 		</div>
 	))
 	.add('Base', () => getButton({ label: 'Base', variant: 'base' }))
+	.add('Aria attribute', () =>
+		getButton({ label: 'Base', 'aria-label': 'Base', variant: 'base' })
+	)
+	.add('Data attribute', () =>
+		getButton({
+			label: 'Base',
+			'data-some-property': 'Some value',
+			variant: 'base',
+		})
+	)
 	.add('Neutral', () => getButton({ label: 'Neutral' }))
 	.add('Neutral with id', () =>
 		getButton({ label: 'Neutral', id: 'custom-id' })

--- a/components/button/__tests__/button.browser-test.jsx
+++ b/components/button/__tests__/button.browser-test.jsx
@@ -102,6 +102,27 @@ describe('SLDSButton: ', () => {
 		});
 	});
 
+	describe('Data Props Render ', () => {
+		let cmp;
+		let btn;
+
+		beforeEach(() => {
+			cmp = getButton({
+				id: 'custom-id',
+				'data-some-attribute': 'some value',
+			});
+			btn = findRenderedDOMComponentWithClass(cmp, 'slds-button');
+		});
+
+		afterEach(() => {
+			removeButton();
+		});
+
+		it('renders data-some-attribute prop', () => {
+			expect(btn.getAttribute('data-some-attribute')).to.equal('some value');
+		});
+	});
+
 	describe('Icon with Label Button Props Render', () => {
 		let cmp;
 		let btn;

--- a/components/button/index.jsx
+++ b/components/button/index.jsx
@@ -15,6 +15,7 @@ import componentDoc from './component.json';
 import Tooltip from '../tooltip';
 
 import getAriaProps from '../../utilities/get-aria-props';
+import getDataProps from '../../utilities/get-data-props';
 import getFormProps from '../../utilities/get-form-props';
 
 import { BUTTON } from '../../utilities/constants';
@@ -32,7 +33,7 @@ const defaultProps = {
 /**
  * The Button component is the Lightning Design System Button component. The Button should be used for label buttons, icon buttons, or buttons that have both labels and icons.
  * Either a <code>label</code> or <code>assistiveText.icon</code> is required; see the Prop Details table below. For buttons that maintain selected/unselected states, use the <a href="#/button-stateful">ButtonStateful</a> component.
- * Although not listed in the prop table, all `aria-*` and `form*` props will be added to the `button` element if passed in.
+ * Although not listed in the prop table, all `aria-*`, `data-*` and `form*` props will be added to the `button` element if passed in.
  */
 class Button extends React.Component {
 	static displayName = BUTTON;
@@ -305,6 +306,7 @@ class Button extends React.Component {
 
 	renderButton = () => {
 		const ariaProps = getAriaProps(this.props);
+		const dataProps = getDataProps(this.props);
 		const formProps = getFormProps(this.props);
 
 		return (
@@ -334,6 +336,7 @@ class Button extends React.Component {
 				type={this.props.type || 'button'}
 				style={this.props.style}
 				{...ariaProps}
+				{...dataProps}
 				{...formProps}
 			>
 				{this.props.iconPosition === 'right' ? this.renderLabel() : null}

--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -2033,7 +2033,7 @@
         "dependencies": []
     },
     "button": {
-        "description": "The Button component is the Lightning Design System Button component. The Button should be used for label buttons, icon buttons, or buttons that have both labels and icons.\nEither a <code>label</code> or <code>assistiveText.icon</code> is required; see the Prop Details table below. For buttons that maintain selected/unselected states, use the <a href=\"#/button-stateful\">ButtonStateful</a> component.\nAlthough not listed in the prop table, all `aria-*` and `form*` props will be added to the `button` element if passed in.",
+        "description": "The Button component is the Lightning Design System Button component. The Button should be used for label buttons, icon buttons, or buttons that have both labels and icons.\nEither a <code>label</code> or <code>assistiveText.icon</code> is required; see the Prop Details table below. For buttons that maintain selected/unselected states, use the <a href=\"#/button-stateful\">ButtonStateful</a> component.\nAlthough not listed in the prop table, all `aria-*`, `data-*` and `form*` props will be added to the `button` element if passed in.",
         "methods": [
             {
                 "name": "getClassName",


### PR DESCRIPTION
### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [x] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [x] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [x] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
