### PR TITLE
Combobox: Set role='combobox' on input element

### DIFF
--- a/components/combobox/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/combobox/__docs__/__snapshots__/storybook-stories.storyshot
@@ -23,7 +23,6 @@ exports[`DOM snapshots SLDSCombobox Base 1`] = `
           aria-expanded={false}
           aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -43,7 +42,7 @@ exports[`DOM snapshots SLDSCombobox Base 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value=""
             />
@@ -231,7 +230,6 @@ exports[`DOM snapshots SLDSCombobox Base Custom Menu Item 1`] = `
           aria-expanded={false}
           aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -251,7 +249,7 @@ exports[`DOM snapshots SLDSCombobox Base Custom Menu Item 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value=""
             />
@@ -294,7 +292,6 @@ exports[`DOM snapshots SLDSCombobox Base Custom Menu Item Disabled 1`] = `
           aria-expanded={false}
           aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -314,7 +311,7 @@ exports[`DOM snapshots SLDSCombobox Base Custom Menu Item Disabled 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value=""
             />
@@ -377,7 +374,6 @@ exports[`DOM snapshots SLDSCombobox Base Inherit Menu Width - Right to Left (RTL
             aria-haspopup="listbox"
             aria-owns="combobox-base-inherit-menu-width-listbox"
             className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
-            role="combobox"
           >
             <div
               className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -398,7 +394,7 @@ exports[`DOM snapshots SLDSCombobox Base Inherit Menu Width - Right to Left (RTL
                 placeholder="Search Salesforce"
                 readOnly={false}
                 required={false}
-                role="textbox"
+                role="combobox"
                 type="text"
                 value=""
               />
@@ -805,7 +801,6 @@ exports[`DOM snapshots SLDSCombobox Base Inherit Menu Width 1`] = `
           aria-expanded={false}
           aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -825,7 +820,7 @@ exports[`DOM snapshots SLDSCombobox Base Inherit Menu Width 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value=""
             />
@@ -911,7 +906,6 @@ exports[`DOM snapshots SLDSCombobox Base Inline Help 1`] = `
             aria-expanded={false}
             aria-haspopup="listbox"
             className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-            role="combobox"
           >
             <div
               className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -931,7 +925,7 @@ exports[`DOM snapshots SLDSCombobox Base Inline Help 1`] = `
                 placeholder="Search Salesforce"
                 readOnly={false}
                 required={false}
-                role="textbox"
+                role="combobox"
                 type="text"
                 value=""
               />
@@ -1120,7 +1114,6 @@ exports[`DOM snapshots SLDSCombobox Base Menu Item Disabled 1`] = `
           aria-expanded={false}
           aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -1140,7 +1133,7 @@ exports[`DOM snapshots SLDSCombobox Base Menu Item Disabled 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value=""
             />
@@ -1330,7 +1323,6 @@ exports[`DOM snapshots SLDSCombobox Base Menu Item Disabled With Tooltip 1`] = `
           aria-expanded={false}
           aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -1350,7 +1342,7 @@ exports[`DOM snapshots SLDSCombobox Base Menu Item Disabled With Tooltip 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value=""
             />
@@ -1541,7 +1533,6 @@ exports[`DOM snapshots SLDSCombobox Base Menu Item Disabled With Tooltip Open 1`
           aria-haspopup="listbox"
           aria-owns="combobox-base-listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -1562,7 +1553,7 @@ exports[`DOM snapshots SLDSCombobox Base Menu Item Disabled With Tooltip Open 1`
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value=""
             />
@@ -2163,7 +2154,6 @@ exports[`DOM snapshots SLDSCombobox Base Menu Separator 1`] = `
           aria-expanded={false}
           aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -2183,7 +2173,7 @@ exports[`DOM snapshots SLDSCombobox Base Menu Separator 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value=""
             />
@@ -2226,7 +2216,6 @@ exports[`DOM snapshots SLDSCombobox Base Menu Sub Headers 1`] = `
           aria-expanded={false}
           aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -2246,7 +2235,7 @@ exports[`DOM snapshots SLDSCombobox Base Menu Sub Headers 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value=""
             />
@@ -2289,7 +2278,6 @@ exports[`DOM snapshots SLDSCombobox Base Pre-defined Options Only 1`] = `
           aria-expanded={false}
           aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -2309,7 +2297,7 @@ exports[`DOM snapshots SLDSCombobox Base Pre-defined Options Only 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value=""
             />
@@ -2498,7 +2486,6 @@ exports[`DOM snapshots SLDSCombobox Base With Input 1`] = `
           aria-haspopup="listbox"
           aria-owns="combobox-base-listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -2519,7 +2506,7 @@ exports[`DOM snapshots SLDSCombobox Base With Input 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value="b"
             />
@@ -2848,7 +2835,6 @@ exports[`DOM snapshots SLDSCombobox Base With Scroll 1`] = `
           aria-expanded={false}
           aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -2868,7 +2854,7 @@ exports[`DOM snapshots SLDSCombobox Base With Scroll 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value=""
             />
@@ -4202,7 +4188,6 @@ exports[`DOM snapshots SLDSCombobox Input Component as a Prop 1`] = `
           aria-expanded={false}
           aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -4222,7 +4207,7 @@ exports[`DOM snapshots SLDSCombobox Input Component as a Prop 1`] = `
               placeholder="My overridden placeholder"
               readOnly={false}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value=""
             />
@@ -4848,7 +4833,6 @@ exports[`DOM snapshots SLDSCombobox Required Input in Error State 1`] = `
           aria-expanded={false}
           aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-has-error"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -4869,7 +4853,7 @@ exports[`DOM snapshots SLDSCombobox Required Input in Error State 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={true}
-              role="textbox"
+              role="combobox"
               type="text"
               value=""
             />
@@ -4923,7 +4907,6 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Custom Menu Item Open 1`] = `
           aria-haspopup="listbox"
           aria-owns="combobox-base-custom-menu-item-listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -4944,7 +4927,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Custom Menu Item Open 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value=""
             />
@@ -5213,7 +5196,6 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Label Required 1`] = `
           aria-expanded={false}
           aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-has-error"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -5234,7 +5216,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Label Required 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={true}
-              role="textbox"
+              role="combobox"
               type="text"
               value=""
             />
@@ -5288,7 +5270,6 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Open 1`] = `
           aria-haspopup="listbox"
           aria-owns="combobox-unique-id-listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -5309,7 +5290,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Open 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value=""
             />
@@ -5469,7 +5450,6 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Open Menu Sub Header Separator
           aria-haspopup="listbox"
           aria-owns="combobox-unique-id-listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -5490,7 +5470,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Open Menu Sub Header Separator
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value=""
             />
@@ -5592,7 +5572,6 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Open Menu inheritWidthOf prop 
           aria-haspopup="listbox"
           aria-owns="combobox-unique-id-listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -5613,7 +5592,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Open Menu inheritWidthOf prop 
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value=""
             />
@@ -5714,7 +5693,6 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Selected 1`] = `
           aria-expanded={false}
           aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -5734,7 +5712,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Selected 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value=""
             />

--- a/components/combobox/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/combobox/__docs__/__snapshots__/storybook-stories.storyshot
@@ -20,8 +20,6 @@ exports[`DOM snapshots SLDSCombobox Base 1`] = `
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={false}
-          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
         >
           <div
@@ -31,6 +29,8 @@ exports[`DOM snapshots SLDSCombobox Base 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
+              aria-expanded={false}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-base"
@@ -227,8 +227,6 @@ exports[`DOM snapshots SLDSCombobox Base Custom Menu Item 1`] = `
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={false}
-          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
         >
           <div
@@ -238,6 +236,8 @@ exports[`DOM snapshots SLDSCombobox Base Custom Menu Item 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
+              aria-expanded={false}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-base-custom-menu-item"
@@ -289,8 +289,6 @@ exports[`DOM snapshots SLDSCombobox Base Custom Menu Item Disabled 1`] = `
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={false}
-          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
         >
           <div
@@ -300,6 +298,8 @@ exports[`DOM snapshots SLDSCombobox Base Custom Menu Item Disabled 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
+              aria-expanded={false}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-unique-id"
@@ -370,8 +370,6 @@ exports[`DOM snapshots SLDSCombobox Base Inherit Menu Width - Right to Left (RTL
           className="slds-combobox_container"
         >
           <div
-            aria-expanded={true}
-            aria-haspopup="listbox"
             aria-owns="combobox-base-inherit-menu-width-listbox"
             className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
           >
@@ -383,6 +381,8 @@ exports[`DOM snapshots SLDSCombobox Base Inherit Menu Width - Right to Left (RTL
                 aria-activedescendant={null}
                 aria-autocomplete="list"
                 aria-controls="combobox-base-inherit-menu-width-listbox"
+                aria-expanded={true}
+                aria-haspopup="listbox"
                 autoComplete="off"
                 className="slds-input slds-combobox__input"
                 id="combobox-base-inherit-menu-width"
@@ -798,8 +798,6 @@ exports[`DOM snapshots SLDSCombobox Base Inherit Menu Width 1`] = `
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={false}
-          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
         >
           <div
@@ -809,6 +807,8 @@ exports[`DOM snapshots SLDSCombobox Base Inherit Menu Width 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
+              aria-expanded={false}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-base-inherit-menu-width"
@@ -903,8 +903,6 @@ exports[`DOM snapshots SLDSCombobox Base Inline Help 1`] = `
           className="slds-combobox_container"
         >
           <div
-            aria-expanded={false}
-            aria-haspopup="listbox"
             className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
           >
             <div
@@ -914,6 +912,8 @@ exports[`DOM snapshots SLDSCombobox Base Inline Help 1`] = `
               <input
                 aria-activedescendant={null}
                 aria-autocomplete="list"
+                aria-expanded={false}
+                aria-haspopup="listbox"
                 autoComplete="off"
                 className="slds-input slds-combobox__input"
                 id="combobox-base-inline-help"
@@ -1111,8 +1111,6 @@ exports[`DOM snapshots SLDSCombobox Base Menu Item Disabled 1`] = `
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={false}
-          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
         >
           <div
@@ -1122,6 +1120,8 @@ exports[`DOM snapshots SLDSCombobox Base Menu Item Disabled 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
+              aria-expanded={false}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-base"
@@ -1320,8 +1320,6 @@ exports[`DOM snapshots SLDSCombobox Base Menu Item Disabled With Tooltip 1`] = `
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={false}
-          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
         >
           <div
@@ -1331,6 +1329,8 @@ exports[`DOM snapshots SLDSCombobox Base Menu Item Disabled With Tooltip 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
+              aria-expanded={false}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-base"
@@ -1529,8 +1529,6 @@ exports[`DOM snapshots SLDSCombobox Base Menu Item Disabled With Tooltip Open 1`
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={true}
-          aria-haspopup="listbox"
           aria-owns="combobox-base-listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
         >
@@ -1542,6 +1540,8 @@ exports[`DOM snapshots SLDSCombobox Base Menu Item Disabled With Tooltip Open 1`
               aria-activedescendant={null}
               aria-autocomplete="list"
               aria-controls="combobox-base-listbox"
+              aria-expanded={true}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-base"
@@ -2151,8 +2151,6 @@ exports[`DOM snapshots SLDSCombobox Base Menu Separator 1`] = `
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={false}
-          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
         >
           <div
@@ -2162,6 +2160,8 @@ exports[`DOM snapshots SLDSCombobox Base Menu Separator 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
+              aria-expanded={false}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-base-menu-separator"
@@ -2213,8 +2213,6 @@ exports[`DOM snapshots SLDSCombobox Base Menu Sub Headers 1`] = `
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={false}
-          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
         >
           <div
@@ -2224,6 +2222,8 @@ exports[`DOM snapshots SLDSCombobox Base Menu Sub Headers 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
+              aria-expanded={false}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-base-menu-subheader"
@@ -2275,8 +2275,6 @@ exports[`DOM snapshots SLDSCombobox Base Pre-defined Options Only 1`] = `
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={false}
-          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
         >
           <div
@@ -2286,6 +2284,8 @@ exports[`DOM snapshots SLDSCombobox Base Pre-defined Options Only 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
+              aria-expanded={false}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-base-predefined-options"
@@ -2482,8 +2482,6 @@ exports[`DOM snapshots SLDSCombobox Base With Input 1`] = `
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={true}
-          aria-haspopup="listbox"
           aria-owns="combobox-base-listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
         >
@@ -2495,6 +2493,8 @@ exports[`DOM snapshots SLDSCombobox Base With Input 1`] = `
               aria-activedescendant={null}
               aria-autocomplete="list"
               aria-controls="combobox-base-listbox"
+              aria-expanded={true}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-base"
@@ -2832,8 +2832,6 @@ exports[`DOM snapshots SLDSCombobox Base With Scroll 1`] = `
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={false}
-          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
         >
           <div
@@ -2843,6 +2841,8 @@ exports[`DOM snapshots SLDSCombobox Base With Scroll 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
+              aria-expanded={false}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-base"
@@ -3039,10 +3039,7 @@ exports[`DOM snapshots SLDSCombobox Dialog 1`] = `
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={false}
-          aria-haspopup="dialog"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-          role="combobox"
         >
           <div
             style={
@@ -3058,6 +3055,7 @@ exports[`DOM snapshots SLDSCombobox Dialog 1`] = `
               <input
                 aria-autocomplete="none"
                 aria-describedby={null}
+                aria-expanded={false}
                 aria-haspopup="dialog"
                 autoComplete="off"
                 className="slds-input slds-combobox__input"
@@ -3070,7 +3068,7 @@ exports[`DOM snapshots SLDSCombobox Dialog 1`] = `
                 placeholder="Select an option"
                 readOnly={true}
                 required={false}
-                role="textbox"
+                role="combobox"
                 tabIndex="0"
                 type="text"
                 value="Select an option"
@@ -3263,10 +3261,7 @@ exports[`DOM snapshots SLDSCombobox Inline Multiple Selection 1`] = `
           </ul>
         </div>
         <div
-          aria-expanded={false}
-          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -3275,6 +3270,8 @@ exports[`DOM snapshots SLDSCombobox Inline Multiple Selection 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
+              aria-expanded={false}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-inline-multiple"
@@ -3286,7 +3283,7 @@ exports[`DOM snapshots SLDSCombobox Inline Multiple Selection 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value=""
             />
@@ -3326,10 +3323,7 @@ exports[`DOM snapshots SLDSCombobox Inline Multiple Selection Loading 1`] = `
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={false}
-          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -3338,6 +3332,8 @@ exports[`DOM snapshots SLDSCombobox Inline Multiple Selection Loading 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
+              aria-expanded={false}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-unique-id"
@@ -3349,7 +3345,7 @@ exports[`DOM snapshots SLDSCombobox Inline Multiple Selection Loading 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value=""
             />
@@ -3407,10 +3403,7 @@ exports[`DOM snapshots SLDSCombobox Inline Single Entity Selection 1`] = `
                 className="slds-combobox_container"
               >
                 <div
-                  aria-expanded={false}
-                  aria-haspopup="listbox"
                   className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-                  role="combobox"
                 >
                   <div
                     className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -3419,6 +3412,8 @@ exports[`DOM snapshots SLDSCombobox Inline Single Entity Selection 1`] = `
                     <input
                       aria-activedescendant={null}
                       aria-autocomplete="list"
+                      aria-expanded={false}
+                      aria-haspopup="listbox"
                       autoComplete="off"
                       className="slds-input slds-combobox__input"
                       disabled={false}
@@ -3431,7 +3426,7 @@ exports[`DOM snapshots SLDSCombobox Inline Single Entity Selection 1`] = `
                       placeholder="Select an Option"
                       readOnly={true}
                       required={false}
-                      role="textbox"
+                      role="combobox"
                       type="text"
                       value="All"
                     />
@@ -3466,10 +3461,7 @@ exports[`DOM snapshots SLDSCombobox Inline Single Entity Selection 1`] = `
                 className="slds-combobox_container"
               >
                 <div
-                  aria-expanded={false}
-                  aria-haspopup="listbox"
                   className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-                  role="combobox"
                 >
                   <div
                     className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -3478,6 +3470,8 @@ exports[`DOM snapshots SLDSCombobox Inline Single Entity Selection 1`] = `
                     <input
                       aria-activedescendant={null}
                       aria-autocomplete="list"
+                      aria-expanded={false}
+                      aria-haspopup="listbox"
                       autoComplete="off"
                       className="slds-input slds-combobox__input"
                       id="combobox-unique-id"
@@ -3489,7 +3483,7 @@ exports[`DOM snapshots SLDSCombobox Inline Single Entity Selection 1`] = `
                       placeholder="Search Salesforce"
                       readOnly={false}
                       required={false}
-                      role="textbox"
+                      role="combobox"
                       type="text"
                       value=""
                     />
@@ -3533,10 +3527,7 @@ exports[`DOM snapshots SLDSCombobox Inline Single Search/Add Entities - Open 1`]
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={true}
-          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -3546,6 +3537,8 @@ exports[`DOM snapshots SLDSCombobox Inline Single Search/Add Entities - Open 1`]
               aria-activedescendant={null}
               aria-autocomplete="list"
               aria-controls="combobox-unique-id-listbox"
+              aria-expanded={true}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               disabled={false}
@@ -3558,7 +3551,7 @@ exports[`DOM snapshots SLDSCombobox Inline Single Search/Add Entities - Open 1`]
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value=""
             />
@@ -3929,10 +3922,7 @@ exports[`DOM snapshots SLDSCombobox Inline Single Search/Add Entities 1`] = `
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={false}
-          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -3941,6 +3931,8 @@ exports[`DOM snapshots SLDSCombobox Inline Single Search/Add Entities 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
+              aria-expanded={false}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               disabled={false}
@@ -3953,7 +3945,7 @@ exports[`DOM snapshots SLDSCombobox Inline Single Search/Add Entities 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value=""
             />
@@ -3993,10 +3985,7 @@ exports[`DOM snapshots SLDSCombobox Inline Single Selection 1`] = `
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={false}
-          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -4005,6 +3994,8 @@ exports[`DOM snapshots SLDSCombobox Inline Single Selection 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
+              aria-expanded={false}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               disabled={false}
@@ -4017,7 +4008,7 @@ exports[`DOM snapshots SLDSCombobox Inline Single Selection 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value=""
             />
@@ -4057,10 +4048,7 @@ exports[`DOM snapshots SLDSCombobox Inline Single Selection Predefined Options O
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={false}
-          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -4069,6 +4057,8 @@ exports[`DOM snapshots SLDSCombobox Inline Single Selection Predefined Options O
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
+              aria-expanded={false}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               disabled={false}
@@ -4081,7 +4071,7 @@ exports[`DOM snapshots SLDSCombobox Inline Single Selection Predefined Options O
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value=""
             />
@@ -4121,10 +4111,7 @@ exports[`DOM snapshots SLDSCombobox Inline Single Selection With Custom Open Sta
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={false}
-          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -4133,6 +4120,8 @@ exports[`DOM snapshots SLDSCombobox Inline Single Selection With Custom Open Sta
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
+              aria-expanded={false}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               disabled={false}
@@ -4145,7 +4134,7 @@ exports[`DOM snapshots SLDSCombobox Inline Single Selection With Custom Open Sta
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value=""
             />
@@ -4185,8 +4174,6 @@ exports[`DOM snapshots SLDSCombobox Input Component as a Prop 1`] = `
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={false}
-          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
         >
           <div
@@ -4196,6 +4183,8 @@ exports[`DOM snapshots SLDSCombobox Input Component as a Prop 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
+              aria-expanded={false}
+              aria-haspopup="listbox"
               autoComplete="test"
               className="slds-input slds-combobox__input"
               id="combobox-input-prop-example"
@@ -4392,10 +4381,7 @@ exports[`DOM snapshots SLDSCombobox Readonly Multiple Selection 1`] = `
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={false}
-          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -4404,6 +4390,8 @@ exports[`DOM snapshots SLDSCombobox Readonly Multiple Selection 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
+              aria-expanded={false}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-readonly-multiple"
@@ -4415,7 +4403,7 @@ exports[`DOM snapshots SLDSCombobox Readonly Multiple Selection 1`] = `
               placeholder="Select an Option"
               readOnly={true}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value=""
             />
@@ -4459,10 +4447,7 @@ exports[`DOM snapshots SLDSCombobox Readonly Single Menu Item Disabled 1`] = `
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={false}
-          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -4471,6 +4456,8 @@ exports[`DOM snapshots SLDSCombobox Readonly Single Menu Item Disabled 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
+              aria-expanded={false}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               disabled={false}
@@ -4483,7 +4470,7 @@ exports[`DOM snapshots SLDSCombobox Readonly Single Menu Item Disabled 1`] = `
               placeholder="Select an Option"
               readOnly={true}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value=""
             />
@@ -4551,10 +4538,7 @@ exports[`DOM snapshots SLDSCombobox Readonly Single Selection - Right to Left (R
           className="slds-combobox_container"
         >
           <div
-            aria-expanded={false}
-            aria-haspopup="listbox"
             className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-            role="combobox"
           >
             <div
               className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -4563,6 +4547,8 @@ exports[`DOM snapshots SLDSCombobox Readonly Single Selection - Right to Left (R
               <input
                 aria-activedescendant={null}
                 aria-autocomplete="list"
+                aria-expanded={false}
+                aria-haspopup="listbox"
                 autoComplete="off"
                 className="slds-input slds-combobox__input"
                 disabled={false}
@@ -4575,7 +4561,7 @@ exports[`DOM snapshots SLDSCombobox Readonly Single Selection - Right to Left (R
                 placeholder="Select an Option"
                 readOnly={true}
                 required={false}
-                role="textbox"
+                role="combobox"
                 type="text"
                 value=""
               />
@@ -4620,10 +4606,7 @@ exports[`DOM snapshots SLDSCombobox Readonly Single Selection 1`] = `
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={false}
-          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -4632,6 +4615,8 @@ exports[`DOM snapshots SLDSCombobox Readonly Single Selection 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
+              aria-expanded={false}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               disabled={false}
@@ -4644,7 +4629,7 @@ exports[`DOM snapshots SLDSCombobox Readonly Single Selection 1`] = `
               placeholder="Select an Option"
               readOnly={true}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value=""
             />
@@ -4688,10 +4673,7 @@ exports[`DOM snapshots SLDSCombobox Readonly Single Selection Custom Menu Item 1
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={false}
-          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -4700,6 +4682,8 @@ exports[`DOM snapshots SLDSCombobox Readonly Single Selection Custom Menu Item 1
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
+              aria-expanded={false}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               disabled={false}
@@ -4712,7 +4696,7 @@ exports[`DOM snapshots SLDSCombobox Readonly Single Selection Custom Menu Item 1
               placeholder="Select company"
               readOnly={true}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value=""
             />
@@ -4756,10 +4740,7 @@ exports[`DOM snapshots SLDSCombobox Readonly Single Selection Disabled 1`] = `
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={false}
-          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -4768,6 +4749,8 @@ exports[`DOM snapshots SLDSCombobox Readonly Single Selection Disabled 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
+              aria-expanded={false}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               disabled={true}
@@ -4780,7 +4763,7 @@ exports[`DOM snapshots SLDSCombobox Readonly Single Selection Disabled 1`] = `
               placeholder="Select an Option"
               readOnly={true}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value=""
             />
@@ -4830,8 +4813,6 @@ exports[`DOM snapshots SLDSCombobox Required Input in Error State 1`] = `
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={false}
-          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-has-error"
         >
           <div
@@ -4842,6 +4823,8 @@ exports[`DOM snapshots SLDSCombobox Required Input in Error State 1`] = `
               aria-activedescendant={null}
               aria-autocomplete="list"
               aria-describedby="description-unique-id"
+              aria-expanded={false}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-required-error-state"
@@ -4903,8 +4886,6 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Custom Menu Item Open 1`] = `
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={true}
-          aria-haspopup="listbox"
           aria-owns="combobox-base-custom-menu-item-listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
         >
@@ -4916,6 +4897,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Custom Menu Item Open 1`] = `
               aria-activedescendant={null}
               aria-autocomplete="list"
               aria-controls="combobox-base-custom-menu-item-listbox"
+              aria-expanded={true}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-base-custom-menu-item"
@@ -5193,8 +5176,6 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Label Required 1`] = `
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={false}
-          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-has-error"
         >
           <div
@@ -5205,6 +5186,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Label Required 1`] = `
               aria-activedescendant={null}
               aria-autocomplete="list"
               aria-describedby="description-unique-id"
+              aria-expanded={false}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-required-error-state"
@@ -5266,8 +5249,6 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Open 1`] = `
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={true}
-          aria-haspopup="listbox"
           aria-owns="combobox-unique-id-listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
         >
@@ -5279,6 +5260,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Open 1`] = `
               aria-activedescendant={null}
               aria-autocomplete="list"
               aria-controls="combobox-unique-id-listbox"
+              aria-expanded={true}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-unique-id"
@@ -5446,8 +5429,6 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Open Menu Sub Header Separator
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={true}
-          aria-haspopup="listbox"
           aria-owns="combobox-unique-id-listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
         >
@@ -5459,6 +5440,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Open Menu Sub Header Separator
               aria-activedescendant={null}
               aria-autocomplete="list"
               aria-controls="combobox-unique-id-listbox"
+              aria-expanded={true}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-unique-id"
@@ -5568,8 +5551,6 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Open Menu inheritWidthOf prop 
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={true}
-          aria-haspopup="listbox"
           aria-owns="combobox-unique-id-listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
         >
@@ -5581,6 +5562,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Open Menu inheritWidthOf prop 
               aria-activedescendant={null}
               aria-autocomplete="list"
               aria-controls="combobox-unique-id-listbox"
+              aria-expanded={true}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-unique-id"
@@ -5690,8 +5673,6 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Selected 1`] = `
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={false}
-          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
         >
           <div
@@ -5701,6 +5682,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Selected 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
+              aria-expanded={false}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-unique-id"
@@ -5830,10 +5813,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Dialog Open 1`] = `
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={true}
-          aria-haspopup="dialog"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
-          role="combobox"
         >
           <div
             style={
@@ -5849,6 +5829,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Dialog Open 1`] = `
               <input
                 aria-autocomplete="none"
                 aria-controls="combobox-unique-id-popover"
+                aria-expanded={true}
                 aria-haspopup="dialog"
                 autoComplete="off"
                 className="slds-input slds-combobox__input"
@@ -5861,7 +5842,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Dialog Open 1`] = `
                 placeholder="Select an option"
                 readOnly={true}
                 required={false}
-                role="textbox"
+                role="combobox"
                 tabIndex="0"
                 type="text"
                 value="Select an option"
@@ -5984,10 +5965,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Multiple Open Loading 1`] = 
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={true}
-          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -5997,6 +5975,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Multiple Open Loading 1`] = 
               aria-activedescendant={null}
               aria-autocomplete="list"
               aria-controls="combobox-unique-id-listbox"
+              aria-expanded={true}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-unique-id"
@@ -6008,7 +5988,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Multiple Open Loading 1`] = 
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value=""
             />
@@ -6341,10 +6321,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Multiple Selection 1`] = `
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={false}
-          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -6353,6 +6330,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Multiple Selection 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
+              aria-expanded={false}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-unique-id"
@@ -6364,7 +6343,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Multiple Selection 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value=""
             />
@@ -6551,10 +6530,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Multiple Selection Selected 
           </ul>
         </div>
         <div
-          aria-expanded={false}
-          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -6563,6 +6539,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Multiple Selection Selected 
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
+              aria-expanded={false}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-unique-id"
@@ -6574,7 +6552,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Multiple Selection Selected 
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value=""
             />
@@ -6632,10 +6610,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Single Entity Selection 1`] 
                 className="slds-combobox_container"
               >
                 <div
-                  aria-expanded={false}
-                  aria-haspopup="listbox"
                   className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-                  role="combobox"
                 >
                   <div
                     className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -6644,6 +6619,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Single Entity Selection 1`] 
                     <input
                       aria-activedescendant={null}
                       aria-autocomplete="list"
+                      aria-expanded={false}
+                      aria-haspopup="listbox"
                       autoComplete="off"
                       className="slds-input slds-combobox__input"
                       disabled={false}
@@ -6656,7 +6633,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Single Entity Selection 1`] 
                       placeholder="entity"
                       readOnly={false}
                       required={false}
-                      role="textbox"
+                      role="combobox"
                       type="text"
                       value=""
                     />
@@ -6687,10 +6664,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Single Entity Selection 1`] 
                 className="slds-combobox_container"
               >
                 <div
-                  aria-expanded={false}
-                  aria-haspopup="listbox"
                   className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-                  role="combobox"
                 >
                   <div
                     className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -6699,6 +6673,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Single Entity Selection 1`] 
                     <input
                       aria-activedescendant={null}
                       aria-autocomplete="list"
+                      aria-expanded={false}
+                      aria-haspopup="listbox"
                       autoComplete="off"
                       className="slds-input slds-combobox__input"
                       id="combobox-unique-id"
@@ -6710,7 +6686,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Single Entity Selection 1`] 
                       placeholder="Search Salesforce"
                       readOnly={false}
                       required={false}
-                      role="textbox"
+                      role="combobox"
                       type="text"
                       value=""
                     />
@@ -6754,10 +6730,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Single Search/Add Entities O
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={true}
-          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -6767,6 +6740,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Single Search/Add Entities O
               aria-activedescendant={null}
               aria-autocomplete="list"
               aria-controls="combobox-unique-id-listbox"
+              aria-expanded={true}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               disabled={false}
@@ -6779,7 +6754,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Single Search/Add Entities O
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value=""
             />
@@ -7064,10 +7039,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Single Selection 1`] = `
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={false}
-          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -7076,6 +7048,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Single Selection 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
+              aria-expanded={false}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               disabled={false}
@@ -7088,7 +7062,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Single Selection 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value=""
             />
@@ -7128,10 +7102,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Single Selection Selected 1`
         className="slds-combobox_container slds-has-inline-listbox"
       >
         <div
-          aria-expanded={false}
-          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_left-right"
@@ -7157,6 +7128,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Single Selection Selected 1`
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
+              aria-expanded={false}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               disabled={false}
@@ -7169,7 +7142,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Single Selection Selected 1`
               placeholder="Search Salesforce"
               readOnly={true}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value="Acme"
             />
@@ -7221,10 +7194,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Multiple Selection 1`] = `
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={false}
-          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -7233,6 +7203,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Multiple Selection 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
+              aria-expanded={false}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-unique-id"
@@ -7244,7 +7216,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Multiple Selection 1`] = `
               placeholder="Select an Option"
               readOnly={true}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value=""
             />
@@ -7288,10 +7260,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Multiple Selection Multipl
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={false}
-          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -7300,6 +7269,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Multiple Selection Multipl
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
+              aria-expanded={false}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-unique-id"
@@ -7311,7 +7282,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Multiple Selection Multipl
               placeholder="Select an Option"
               readOnly={true}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value="2 options selected"
             />
@@ -7458,10 +7429,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Multiple Selection Single 
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={false}
-          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -7470,6 +7438,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Multiple Selection Single 
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
+              aria-expanded={false}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-unique-id"
@@ -7481,7 +7451,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Multiple Selection Single 
               placeholder="Select an Option"
               readOnly={true}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value="Acme"
             />
@@ -7525,10 +7495,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Single Selection 1`] = `
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={false}
-          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -7537,6 +7504,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Single Selection 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
+              aria-expanded={false}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               disabled={false}
@@ -7549,7 +7518,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Single Selection 1`] = `
               placeholder="Select an Option"
               readOnly={true}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value=""
             />
@@ -7593,10 +7562,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Single Selection Custom Me
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={true}
-          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -7606,6 +7572,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Single Selection Custom Me
               aria-activedescendant={null}
               aria-autocomplete="list"
               aria-controls="combobox-readonly-single-custom-item-listbox"
+              aria-expanded={true}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               disabled={false}
@@ -7618,7 +7586,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Single Selection Custom Me
               placeholder="Select company"
               readOnly={true}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value=""
             />
@@ -8226,10 +8194,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Single Selection Disabled 
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={false}
-          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -8238,6 +8203,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Single Selection Disabled 
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
+              aria-expanded={false}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               disabled={true}
@@ -8250,7 +8217,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Single Selection Disabled 
               placeholder="Select an Option"
               readOnly={true}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value=""
             />
@@ -8294,10 +8261,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Single Selection Selected 
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={false}
-          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -8306,6 +8270,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Single Selection Selected 
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
+              aria-expanded={false}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               disabled={false}
@@ -8318,7 +8284,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Single Selection Selected 
               placeholder="Select an Option"
               readOnly={true}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value="Acme"
             />
@@ -8362,10 +8328,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Single Selection Selected 
         className="slds-combobox_container"
       >
         <div
-          aria-expanded={true}
-          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
-          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -8375,6 +8338,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Single Selection Selected 
               aria-activedescendant={null}
               aria-autocomplete="list"
               aria-controls="combobox-unique-id-listbox"
+              aria-expanded={true}
+              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               disabled={false}
@@ -8387,7 +8352,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Single Selection Selected 
               placeholder="Select an Option"
               readOnly={true}
               required={false}
-              role="textbox"
+              role="combobox"
               type="text"
               value="Acme"
             />

--- a/components/combobox/__tests__/combobox.browser-test.jsx
+++ b/components/combobox/__tests__/combobox.browser-test.jsx
@@ -229,13 +229,13 @@ describe('SLDSCombobox', function describeFunction() {
 		it('has aria-haspopup, role is combobox, aria-expanded is false when closed, aria-expanded is true when open', function () {
 			wrapper = mount(<DemoComponent multiple />, { attachTo: mountNode });
 			const nodes = getNodes({ wrapper });
-			expect(nodes.combobox).attr('aria-haspopup', 'listbox');
+			expect(nodes.input).attr('aria-haspopup', 'listbox');
 			expect(nodes.input).attr('role', 'combobox');
 			// closed
-			expect(nodes.combobox).attr('aria-expanded', 'false');
+			expect(nodes.input).attr('aria-expanded', 'false');
 			// open
 			nodes.input.simulate('click', {});
-			expect(nodes.combobox).attr('aria-expanded', 'true');
+			expect(nodes.input).attr('aria-expanded', 'true');
 		});
 
 		it('menu filters to second item, menu listbox menu item 2 aria-selected is true, input activedescendent has item 2 id, after pressing down arrow, enter selects item 2', function () {

--- a/components/combobox/__tests__/combobox.browser-test.jsx
+++ b/components/combobox/__tests__/combobox.browser-test.jsx
@@ -226,10 +226,11 @@ describe('SLDSCombobox', function describeFunction() {
 			destroyMountNode({ wrapper, mountNode });
 		});
 
-		it('has aria-haspopup, aria-expanded is false when closed, aria-expanded is true when open', function () {
+		it('has aria-haspopup, role is combobox, aria-expanded is false when closed, aria-expanded is true when open', function () {
 			wrapper = mount(<DemoComponent multiple />, { attachTo: mountNode });
 			const nodes = getNodes({ wrapper });
 			expect(nodes.combobox).attr('aria-haspopup', 'listbox');
+			expect(nodes.input).attr('role', 'combobox');
 			// closed
 			expect(nodes.combobox).attr('aria-expanded', 'false');
 			// open

--- a/components/combobox/combobox.jsx
+++ b/components/combobox/combobox.jsx
@@ -1074,8 +1074,6 @@ class Combobox extends React.Component {
 						},
 						props.className
 					)}
-					aria-expanded={this.getIsOpen()}
-					aria-haspopup="listbox" // eslint-disable-line jsx-a11y/aria-proptypes
 					// used on menu's listbox
 					aria-owns={this.getIsOpen() ? `${this.getId()}-listbox` : undefined} // eslint-disable-line jsx-a11y/aria-proptypes
 				>
@@ -1090,6 +1088,9 @@ class Combobox extends React.Component {
 								: null
 						}
 						aria-describedby={this.getErrorId()}
+						aria-expanded={this.getIsOpen()}
+						aria-haspopup="listbox" // eslint-disable-line jsx-a11y/aria-proptypes
+						role="combobox"
 						autoComplete="off"
 						className="slds-combobox__input"
 						containerProps={{
@@ -1119,7 +1120,6 @@ class Combobox extends React.Component {
 							!!(props.predefinedOptionsOnly && this.state.activeOption)
 						}
 						required={props.required}
-						role="combobox"
 						value={
 							props.predefinedOptionsOnly
 								? (this.state.activeOption && this.state.activeOption.label) ||
@@ -1214,9 +1214,6 @@ class Combobox extends React.Component {
 						},
 						props.className
 					)}
-					aria-expanded={this.getIsOpen()}
-					aria-haspopup="listbox" // eslint-disable-line jsx-a11y/aria-proptypes
-					role="combobox"
 				>
 					<InnerInput
 						aria-autocomplete="list"
@@ -1229,6 +1226,9 @@ class Combobox extends React.Component {
 								: null
 						}
 						aria-describedby={this.getErrorId()}
+						aria-expanded={this.getIsOpen()}
+						aria-haspopup="listbox" // eslint-disable-line jsx-a11y/aria-proptypes
+						role="combobox"
 						defaultValue={props.defaultValue}
 						autoComplete="off"
 						className="slds-combobox__input"
@@ -1258,7 +1258,6 @@ class Combobox extends React.Component {
 							!!(props.predefinedOptionsOnly && this.state.activeOption)
 						}
 						required={props.required}
-						role="textbox"
 						value={
 							props.predefinedOptionsOnly
 								? (this.state.activeOption && this.state.activeOption.label) ||
@@ -1315,9 +1314,6 @@ class Combobox extends React.Component {
 							},
 							props.className
 						)}
-						aria-expanded={this.getIsOpen()}
-						aria-haspopup="listbox" // eslint-disable-line jsx-a11y/aria-proptypes
-						role="combobox"
 					>
 						<InnerInput
 							defaultValue={props.defaultValue}
@@ -1333,6 +1329,9 @@ class Combobox extends React.Component {
 									: null
 							}
 							aria-describedby={this.getErrorId()}
+							aria-expanded={this.getIsOpen()}
+							aria-haspopup="listbox" // eslint-disable-line jsx-a11y/aria-proptypes
+							role="combobox"
 							autoComplete="off"
 							className="slds-combobox__input"
 							containerProps={{
@@ -1383,7 +1382,6 @@ class Combobox extends React.Component {
 								!!props.selection.length
 							}
 							required={props.required}
-							role="textbox"
 							value={
 								props.predefinedOptionsOnly
 									? (this.state.activeOption &&
@@ -1480,9 +1478,6 @@ class Combobox extends React.Component {
 							},
 							props.className
 						)}
-						aria-expanded={this.getIsOpen()}
-						aria-haspopup="dialog" // eslint-disable-line jsx-a11y/aria-proptypes
-						role="combobox"
 					>
 						<Popover {...popoverProps}>
 							<InnerInput
@@ -1491,6 +1486,9 @@ class Combobox extends React.Component {
 									this.getIsOpen() ? `${this.getId()}-popover` : undefined
 								}
 								aria-describedby={this.getErrorId()}
+								aria-expanded={this.getIsOpen()}
+								aria-haspopup="dialog" // eslint-disable-line jsx-a11y/aria-proptypes
+								role="combobox"
 								autoComplete="off"
 								className="slds-combobox__input"
 								containerProps={{
@@ -1516,7 +1514,6 @@ class Combobox extends React.Component {
 								placeholder={labels.placeholder}
 								readOnly
 								required={props.required}
-								role="textbox"
 								value={props.value}
 							/>
 						</Popover>
@@ -1566,9 +1563,6 @@ class Combobox extends React.Component {
 							},
 							props.className
 						)}
-						aria-expanded={this.getIsOpen()}
-						aria-haspopup="listbox" // eslint-disable-line jsx-a11y/aria-proptypes
-						role="combobox"
 					>
 						<InnerInput
 							defaultValue={props.defaultValue}
@@ -1584,6 +1578,9 @@ class Combobox extends React.Component {
 									: null
 							}
 							aria-describedby={this.getErrorId()}
+							aria-expanded={this.getIsOpen()}
+							aria-haspopup="listbox" // eslint-disable-line jsx-a11y/aria-proptypes
+							role="combobox"
 							autoComplete="off"
 							className="slds-combobox__input"
 							containerProps={{
@@ -1609,7 +1606,6 @@ class Combobox extends React.Component {
 							placeholder={labels.placeholderReadOnly}
 							readOnly
 							required={props.required}
-							role="textbox"
 							value={value}
 							{...userDefinedProps.input}
 						/>
@@ -1678,9 +1674,6 @@ class Combobox extends React.Component {
 							},
 							props.className
 						)}
-						aria-expanded={this.getIsOpen()}
-						aria-haspopup="listbox" // eslint-disable-line jsx-a11y/aria-proptypes
-						role="combobox"
 					>
 						<InnerInput
 							defaultValue={props.defaultValue}
@@ -1696,6 +1689,9 @@ class Combobox extends React.Component {
 									: null
 							}
 							aria-describedby={this.getErrorId()}
+							aria-expanded={this.getIsOpen()}
+							aria-haspopup="listbox" // eslint-disable-line jsx-a11y/aria-proptypes
+							role="combobox"
 							autoComplete="off"
 							className="slds-combobox__input"
 							containerProps={{
@@ -1722,7 +1718,6 @@ class Combobox extends React.Component {
 							placeholder={labels.placeholderReadOnly}
 							readOnly
 							required={props.required}
-							role="textbox"
 							value={
 								(this.state.activeOption && this.state.activeOption.label) ||
 								value

--- a/components/combobox/combobox.jsx
+++ b/components/combobox/combobox.jsx
@@ -1078,7 +1078,6 @@ class Combobox extends React.Component {
 					aria-haspopup="listbox" // eslint-disable-line jsx-a11y/aria-proptypes
 					// used on menu's listbox
 					aria-owns={this.getIsOpen() ? `${this.getId()}-listbox` : undefined} // eslint-disable-line jsx-a11y/aria-proptypes
-					role="combobox"
 				>
 					<InnerInput
 						aria-autocomplete="list"
@@ -1120,7 +1119,7 @@ class Combobox extends React.Component {
 							!!(props.predefinedOptionsOnly && this.state.activeOption)
 						}
 						required={props.required}
-						role="textbox"
+						role="combobox"
 						value={
 							props.predefinedOptionsOnly
 								? (this.state.activeOption && this.state.activeOption.label) ||

--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -215,7 +215,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility**\nThis object is merged with the default props object on every render.\n* `closeButton`: This is a visually hidden label for the close button.\n_Tested with snapshot testing._",
                 "defaultValue": {
-                    "value": "{\n\tcloseButton: 'Close',\n}",
+                    "value": "{\n    closeButton: 'Close',\n}",
                     "computed": false
                 }
             },
@@ -436,7 +436,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility.**\nThis object is merged with the default props object on every render.\n* `trigger`: This is a visually hidden label for the app launcher icon.",
                 "defaultValue": {
-                    "value": "{\n\ttrigger: 'Open App Launcher',\n}",
+                    "value": "{\n    trigger: 'Open App Launcher',\n}",
                     "computed": false
                 }
             },
@@ -746,7 +746,7 @@
                             "required": false,
                             "description": "**Assistive text for accessibility.**\n* `dragIconText`: Text that describes the purpose of the drag handle icon.",
                             "defaultValue": {
-                                "value": "{\n\tdragIconText: 'Reorder',\n}",
+                                "value": "{\n    dragIconText: 'Reorder',\n}",
                                 "computed": false
                             }
                         },
@@ -913,7 +913,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility.**\nThis object is merged with the default props object on every render.\n* `icon`: Assistive text for accessibility that labels the icon.",
                 "defaultValue": {
-                    "value": "{\n\ticon: 'User or Account Icon',\n}",
+                    "value": "{\n    icon: 'User or Account Icon',\n}",
                     "computed": false
                 }
             },
@@ -1325,7 +1325,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility.**\nThis object is merged with the default props object on every render.\n* `label`: The assistive text for the breadcrumb trail.",
                 "defaultValue": {
-                    "value": "{\n\tlabel: 'Breadcrumbs',\n}",
+                    "value": "{\n    label: 'Breadcrumbs',\n}",
                     "computed": false
                 }
             },
@@ -1388,7 +1388,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility**\nThis object is merged with the default props object on every render.\n* `backIcon`: Used for the back icon.\n* `helpIcon`: Used for the help icon.\n* `icon`: Used for the main icon next to the header title.\n* _Tested with snapshot testing._",
                 "defaultValue": {
-                    "value": "{\n\tbackIcon: 'Back',\n\thelpIcon: 'Help',\n\ticon: 'Builder',\n}",
+                    "value": "{\n    backIcon: 'Back',\n    helpIcon: 'Help',\n    icon: 'Builder',\n}",
                     "computed": false
                 }
             },
@@ -1506,7 +1506,7 @@
                 "required": false,
                 "description": "**Text labels for internationalization**\nThis object is merged with the default props object on every render.\n* `back`: The label for the Back link.\n* `help`: The label for the Help link.\n* `pageType`: The label that describes the page type.\n* `title`: The label for the page title.\n_Tested with snapshot testing._",
                 "defaultValue": {
-                    "value": "{\n\tback: 'Back',\n\thelp: 'Help',\n\tpageType: 'Page Type',\n\ttitle: 'App Name',\n}",
+                    "value": "{\n    back: 'Back',\n    help: 'Help',\n    pageType: 'Page Type',\n    title: 'App Name',\n}",
                     "computed": false
                 }
             },
@@ -1648,7 +1648,7 @@
                             "required": false,
                             "description": "**Assistive text for accessibility**\nThis object is merged with the default props object on every render.\n* `actions`: Used for the aria-label for the actions section of the toolbar.\n* _Tested with snapshot testing._",
                             "defaultValue": {
-                                "value": "{\n\tactions: 'Actions',\n}",
+                                "value": "{\n    actions: 'Actions',\n}",
                                 "computed": false
                             }
                         },
@@ -2156,7 +2156,7 @@
             "iconCategory": {
                 "type": {
                     "name": "custom",
-                    "raw": "requiredIf(\n\tPropTypes.oneOf(['action', 'custom', 'doctype', 'standard', 'utility']),\n\t(props) => !!props.iconName\n)"
+                    "raw": "requiredIf(\n    PropTypes.oneOf(['action', 'custom', 'doctype', 'standard', 'utility']),\n    (props) => !!props.iconName\n)"
                 },
                 "required": false,
                 "description": "Name of the icon category. Visit <a href=\"http://www.lightningdesignsystem.com/resources/icons\">Lightning Design System Icons</a> to reference icon categories."
@@ -2914,7 +2914,7 @@
                 "required": false,
                 "description": "Description of the carousel items for screen-readers.",
                 "defaultValue": {
-                    "value": "{\n\tautoplayButton: 'Start / Stop auto-play',\n\tnextPanel: 'Next Panel',\n\tpreviousPanel: 'Previous Panel',\n}",
+                    "value": "{\n    autoplayButton: 'Start / Stop auto-play',\n    nextPanel: 'Next Panel',\n    previousPanel: 'Previous Panel',\n}",
                     "computed": false
                 }
             },
@@ -3341,7 +3341,7 @@
                 "required": false,
                 "description": "**Text labels for internationalization**\nThis object is merged with the default props object on every render.\n* `heading`: Heading for the visual picker variant\n* `label`: Label for the _enabled_ state of the Toggle variant. Defaults to \"Enabled\".\n* `toggleDisabled`: Label for the _disabled_ state of the Toggle variant. Defaults to \"Disabled\". Note that this uses SLDS language, and meaning, of \"Enabled\" and \"Disabled\"; referring to the state of whatever the checkbox is _toggling_, not whether the checkbox itself is enabled or disabled.\n* `toggleEnabled`: Label for the _enabled_ state of the Toggle variant. Defaults to \"Enabled\".",
                 "defaultValue": {
-                    "value": "{\n\ttoggleDisabled: 'Disabled',\n\ttoggleEnabled: 'Enabled',\n}",
+                    "value": "{\n    toggleDisabled: 'Disabled',\n    toggleEnabled: 'Enabled',\n}",
                     "computed": false
                 }
             },
@@ -3742,7 +3742,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility**\n* `label`: Visually hidden label but read out loud by screen readers.\n* `hueSlider`: Instructions for hue selection input\n* `saturationValueGrid`: Instructions for using the grid for saturation\nand value selection",
                 "defaultValue": {
-                    "value": "{\n\tsaturationValueGrid:\n\t\t'Use arrow keys to select a saturation and brightness, on an x and y axis.',\n\thueSlider: 'Select Hue',\n}",
+                    "value": "{\n    saturationValueGrid:\n        'Use arrow keys to select a saturation and brightness, on an x and y axis.',\n    hueSlider: 'Select Hue',\n}",
                     "computed": false
                 }
             },
@@ -3941,7 +3941,7 @@
                 "required": false,
                 "description": "**Text labels for internationalization**\n* `blueAbbreviated`: One letter abbreviation of blue color component\n* `cancelButton`: Text for cancel button on popover\n* `customTab`: Text for custom tab of popover\n* `customTabActiveWorkingColorSwatch`: Label for custom tab active working color swatch\n* `customTabTransparentSwatch`: Label for custom tab active transparent swatch\n* `greenAbbreviated`: One letter abbreviation of green color component\n* `hexLabel`: Label for input of hexadecimal color\n* `invalidColor`: Error message when hex color input is invalid\n* `invalidComponent`: Error message when a component input is invalid\n* `label`: An `input` label as for a `form`\n* `redAbbreviated`: One letter abbreviation of red color component\n* `swatchTab`: Label for swatch tab of popover\n* `submitButton`: Text for submit/done button of popover",
                 "defaultValue": {
-                    "value": "{\n\tblueAbbreviated: 'B',\n\tcancelButton: 'Cancel',\n\tcustomTab: 'Custom',\n\tcustomTabActiveWorkingColorSwatch: 'Working Color',\n\tcustomTabTransparentSwatch: 'Transparent Swatch',\n\tgreenAbbreviated: 'G',\n\thexLabel: 'Hex',\n\tinvalidColor: 'The color entered is invalid',\n\tinvalidComponent: 'The value needs to be an integer from 0-255',\n\tredAbbreviated: 'R',\n\tsubmitButton: 'Done',\n\tswatchTab: 'Default',\n\tswatchTabTransparentSwatch: 'Transparent Swatch',\n}",
+                    "value": "{\n    blueAbbreviated: 'B',\n    cancelButton: 'Cancel',\n    customTab: 'Custom',\n    customTabActiveWorkingColorSwatch: 'Working Color',\n    customTabTransparentSwatch: 'Transparent Swatch',\n    greenAbbreviated: 'G',\n    hexLabel: 'Hex',\n    invalidColor: 'The color entered is invalid',\n    invalidComponent: 'The value needs to be an integer from 0-255',\n    redAbbreviated: 'R',\n    submitButton: 'Done',\n    swatchTab: 'Default',\n    swatchTabTransparentSwatch: 'Transparent Swatch',\n}",
                     "computed": false
                 }
             },
@@ -3980,7 +3980,7 @@
                 "required": false,
                 "description": "An array of hex color values which is used to set the options of the\nswatch tab of the colorpicker popover.\nTo specify transparent, use empty string as a value.",
                 "defaultValue": {
-                    "value": "[\n\t'#e3abec',\n\t'#c2dbf7',\n\t'#9fd6ff',\n\t'#9de7da',\n\t'#9df0c0',\n\t'#fff099',\n\t'#fed49a',\n\t'#d073e0',\n\t'#86baf3',\n\t'#5ebbff',\n\t'#44d8be',\n\t'#3be282',\n\t'#ffe654',\n\t'#ffb758',\n\t'#bd35bd',\n\t'#5779c1',\n\t'#5679c0',\n\t'#00aea9',\n\t'#3cba4c',\n\t'#f5bc25',\n\t'#f99221',\n\t'#580d8c',\n\t'#001970',\n\t'#0a2399',\n\t'#0b7477',\n\t'#0b6b50',\n\t'#b67e11',\n\t'#b85d0d',\n\t'',\n]",
+                    "value": "[\n    '#e3abec',\n    '#c2dbf7',\n    '#9fd6ff',\n    '#9de7da',\n    '#9df0c0',\n    '#fff099',\n    '#fed49a',\n    '#d073e0',\n    '#86baf3',\n    '#5ebbff',\n    '#44d8be',\n    '#3be282',\n    '#ffe654',\n    '#ffb758',\n    '#bd35bd',\n    '#5779c1',\n    '#5679c0',\n    '#00aea9',\n    '#3cba4c',\n    '#f5bc25',\n    '#f99221',\n    '#580d8c',\n    '#001970',\n    '#0a2399',\n    '#0b7477',\n    '#0b6b50',\n    '#b67e11',\n    '#b85d0d',\n    '',\n]",
                     "computed": false
                 }
             },
@@ -4474,7 +4474,7 @@
                 "modifiers": [],
                 "params": [
                     {
-                        "name": "{\n\tassistiveText,\n\tlabels,\n\tprops,\n\tuserDefinedProps,\n}",
+                        "name": "{\n    assistiveText,\n    labels,\n    props,\n    userDefinedProps,\n}",
                         "type": null
                     }
                 ],
@@ -4522,7 +4522,7 @@
                 "modifiers": [],
                 "params": [
                     {
-                        "name": "{\n\tassistiveText,\n\tlabels,\n\tprops,\n\tuserDefinedProps,\n}",
+                        "name": "{\n    assistiveText,\n    labels,\n    props,\n    userDefinedProps,\n}",
                         "type": null
                     }
                 ],
@@ -4534,7 +4534,7 @@
                 "modifiers": [],
                 "params": [
                     {
-                        "name": "{\n\tassistiveText,\n\tlabels,\n\tprops,\n\tuserDefinedProps,\n}",
+                        "name": "{\n    assistiveText,\n    labels,\n    props,\n    userDefinedProps,\n}",
                         "type": null
                     }
                 ],
@@ -4579,7 +4579,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility**\nThis object is merged with the default props object on every render.\n* `label`: This is used as a visually hidden label if, no `labels.label` is provided.\n* `loading`: Text added to loading spinner.\n* `optionSelectedInMenu`: Added before selected menu items in Read-only variants (Picklists). The default is `Current Selection:`.\n* `popoverLabel`: Used by popover variant, assistive text for the Popover aria-label.\n* `removeSingleSelectedOption`: Used by inline-listbox, single-select variant to remove the selected item (pill). This is a button with focus. The default is `Remove selected option`.\n* `removePill`: Used by multiple selection Comboboxes to remove a selected item (pill). Focus is on the pill. This is not a button. The default  is `, Press delete or backspace to remove`.\n* `selectedListboxLabel`: This is a label for the selected listbox. The grouping of pills for multiple selection Comboboxes. The default is `Selected Options:`.\n_Tested with snapshot testing._",
                 "defaultValue": {
-                    "value": "{\n\tloadingMenuItems: 'Loading',\n\toptionSelectedInMenu: 'Current Selection:',\n\tremoveSingleSelectedOption: 'Remove selected option',\n\tremovePill: ', Press delete or backspace to remove',\n\tselectedListboxLabel: 'Selected Options:',\n}",
+                    "value": "{\n    loadingMenuItems: 'Loading',\n    optionSelectedInMenu: 'Current Selection:',\n    removeSingleSelectedOption: 'Remove selected option',\n    removePill: ', Press delete or backspace to remove',\n    selectedListboxLabel: 'Selected Options:',\n}",
                     "computed": false
                 }
             },
@@ -4813,7 +4813,7 @@
                 "required": false,
                 "description": "**Text labels for internationalization**\nThis object is merged with the default props object on every render.\n* `label`: This label appears above the input.\n* `cancelButton`: This label is only used by the dialog variant for the cancel button in the footer of the dialog. The default is `Cancel`\n* `doneButton`: This label is only used by the dialog variant for the done button in the footer of the dialog. The default is `Done`\n* `multipleOptionsSelected`: This label is used by the readonly variant when multiple options are selected. The default is `${props.selection.length} options selected`. This will override the entire string.\n* `noOptionsFound`: Custom message that renders when no matches found. The default empty state is just text that says, 'No matches found.'.\n* `placeholder`: Input placeholder\n* `placeholderReadOnly`: Placeholder for Picklist-like Combobox\n* `removePillTitle`: Title on `X` icon\n_Tested with snapshot testing._",
                 "defaultValue": {
-                    "value": "{\n\tcancelButton: 'Cancel',\n\tdoneButton: `Done`,\n\tnoOptionsFound: 'No matches found.',\n\toptionDisabledTooltipLabel: 'This option is disabled.',\n\tplaceholderReadOnly: 'Select an Option',\n\tremovePillTitle: 'Remove',\n}",
+                    "value": "{\n    cancelButton: 'Cancel',\n    doneButton: `Done`,\n    noOptionsFound: 'No matches found.',\n    optionDisabledTooltipLabel: 'This option is disabled.',\n    placeholderReadOnly: 'Select an Option',\n    removePillTitle: 'Remove',\n}",
                     "computed": false
                 }
             },
@@ -5299,7 +5299,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility.**\nThis object is merged with the default props object on every render.\n* `actionsHeader`: Text for heading of actions column\n* `columnSort`: Text for sort action on table column header\n* `columnSortedAscending`: Text announced once a column is sorted in ascending order\n* `columnSortedDescending`: Text announced once a column is sorted in descending order\n* `selectAllRows`: Text for select all checkbox within the table header\n* `selectRow`: Text for select row. Default: \"Select row 1\"\n* `selectRowGroup`: This is an input group label and is attached to each checkbox or radio. Default is \"Choose a row to select\"",
                 "defaultValue": {
-                    "value": "{\n\tactionsHeader: 'Actions',\n\tcolumnSort: 'Sort by: ',\n\tcolumnSortedAscending: 'Sorted Ascending',\n\tcolumnSortedDescending: 'Sorted Descending',\n\tselectAllRows: 'Select all rows',\n\tselectRow: 'Select row',\n\tselectRowGroup: 'Choose a row to select',\n\tloadingMore: 'Loading more',\n}",
+                    "value": "{\n    actionsHeader: 'Actions',\n    columnSort: 'Sort by: ',\n    columnSortedAscending: 'Sorted Ascending',\n    columnSortedDescending: 'Sorted Descending',\n    selectAllRows: 'Select all rows',\n    selectRow: 'Select row',\n    selectRowGroup: 'Choose a row to select',\n    loadingMore: 'Loading more',\n}",
                     "computed": false
                 }
             },
@@ -6064,7 +6064,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility**\nThis object is merged with the default props object on every render.\n* `nextMonth`: Label for button to go to the next month _Tested with snapshot testing._\n* `openCalendar`: Call to action label for calendar dialog trigger _Tested with snapshot testing._\n* `previousMonth`: Label for button to go to the previous month _Tested with snapshot testing._",
                 "defaultValue": {
-                    "value": "{\n\tnextMonth: 'Next month',\n\topenCalendar: 'Open Calendar',\n\tpreviousMonth: 'Previous month',\n\tyear: 'Year',\n}",
+                    "value": "{\n    nextMonth: 'Next month',\n    openCalendar: 'Open Calendar',\n    previousMonth: 'Previous month',\n    year: 'Year',\n}",
                     "computed": false
                 }
             },
@@ -6132,7 +6132,7 @@
                 "required": false,
                 "description": "Date formatting function that formats the `value` prop (`value` is an ECMAScript `Date()` object) and returns a string to be rendered as the `input` value. Please use an external library such as [MomentJS](https://github.com/moment/moment/) for date formatting and internationalization. _Tested with snapshot testing._\nThe default `formatter` function is:\n```\nformatter(date) {\n  return date\n   ? `${date.getMonth() + 1}/${date.getDate()}/${date.getFullYear()}`\n   : '';\n}\n```",
                 "defaultValue": {
-                    "value": "(date) {\n\treturn date\n\t\t? `${date.getMonth() + 1}/${date.getDate()}/${date.getFullYear()}`\n\t\t: '';\n}",
+                    "value": "function(date) {\n    return date\n        ? `${date.getMonth() + 1}/${date.getDate()}/${date.getFullYear()}`\n        : '';\n}",
                     "computed": false
                 }
             },
@@ -6190,7 +6190,7 @@
                 "required": false,
                 "description": "**Text labels for internationalization**\nThis object is merged with the default props object on every render.\n* `abbreviatedWeekDays`: Three letter abbreviations of the days of the week, starting on Sunday. _Tested with snapshot testing._\n* `months`: Names of the months. _Tested with snapshot testing._\n* `label`: This label appears above the input.\n* `placeholder`: Placeholder text for input. _Tested with snapshot testing._\n* `today`: Label of shortcut to jump to today within the calendar. This is also used for assistive text on today's date. _Tested with snapshot testing._\n* `weekDays`: Full names of the seven days of the week, starting on Sunday. _Tested with snapshot testing._",
                 "defaultValue": {
-                    "value": "{\n\tabbreviatedWeekDays: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],\n\tmonths: [\n\t\t'January',\n\t\t'February',\n\t\t'March',\n\t\t'April',\n\t\t'May',\n\t\t'June',\n\t\t'July',\n\t\t'August',\n\t\t'September',\n\t\t'October',\n\t\t'November',\n\t\t'December',\n\t],\n\tplaceholder: 'Pick a Date',\n\ttoday: 'Today',\n\tweekDays: [\n\t\t'Sunday',\n\t\t'Monday',\n\t\t'Tuesday',\n\t\t'Wednesday',\n\t\t'Thursday',\n\t\t'Friday',\n\t\t'Saturday',\n\t],\n}",
+                    "value": "{\n    abbreviatedWeekDays: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],\n    months: [\n        'January',\n        'February',\n        'March',\n        'April',\n        'May',\n        'June',\n        'July',\n        'August',\n        'September',\n        'October',\n        'November',\n        'December',\n    ],\n    placeholder: 'Pick a Date',\n    today: 'Today',\n    weekDays: [\n        'Sunday',\n        'Monday',\n        'Tuesday',\n        'Wednesday',\n        'Thursday',\n        'Friday',\n        'Saturday',\n    ],\n}",
                     "computed": false
                 }
             },
@@ -6289,7 +6289,7 @@
                 "required": false,
                 "description": "Custom function to parse date string from the `input` value, which must return an ECMAScript `Date()` object.  Please use an external library such as [MomentJS](https://github.com/moment/moment/) for date parsing and internationalization. The default `parser` passes the input value to ECMAScript `Date()` and _prays_ for a miracle. **Do not use the default parsing function in production.** _Tested with snapshot testing._\nThe default `parser function is:\n```\nparser(str) {\n  return new Date(str);\n}\n```",
                 "defaultValue": {
-                    "value": "(str) {\n\tlowPriorityWarning(\n\t\tfalse,\n\t\t`Please use an external library for date parsing and internationalization like MomentJS (https://github.com/moment/moment/) instead of the default parser.`\n\t);\n\treturn new Date(str);\n}",
+                    "value": "function(str) {\n    lowPriorityWarning(\n        false,\n        `Please use an external library for date parsing and internationalization like MomentJS (https://github.com/moment/moment/) instead of the default parser.`\n    );\n    return new Date(str);\n}",
                     "computed": false
                 }
             },
@@ -6602,7 +6602,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility.**\n* `toggleSection`: Label for the icon that expands / collapses the section",
                 "defaultValue": {
-                    "value": "{\n\ttoggleSection: 'Toggle visibility of section',\n}",
+                    "value": "{\n    toggleSection: 'Toggle visibility of section',\n}",
                     "computed": false
                 }
             },
@@ -6777,7 +6777,7 @@
                 "required": false,
                 "description": "**Text labels for internationalization**\nThis object is merged with the default props object on every render.\n* `addCondition`: Label for the Add Condition Button. Defaults to \"Add Condition\"\n* `addGroup`: Label for the Add Group Button. Defaults to \"Add Group\"\n* `customLogic`: Label for the text box for inputting `customLogicValue`, if the `triggerType` is `custom`. Defaults to \"Custom Logic\"\n* `takeAction`: Label for the `triggerType` selector. Defaults to \"Take Action When\"\n* `title` : Title for the Expression. Defaults to \"Conditions\"\n* `triggerAll`: Label for the `all` value within the trigger selector\n* `triggerAlways`: Label for the `always` value within the trigger selector\n* `triggerAny`: Label for the `any` value within the trigger selector\n* `triggerCustom`: Label for the `custom` value within the trigger selector\n* `triggerFormula`: Label for the `formula` value within the trigger selector",
                 "defaultValue": {
-                    "value": "{\n\ttitle: 'Conditions',\n}",
+                    "value": "{\n    title: 'Conditions',\n}",
                     "computed": false
                 }
             },
@@ -6871,7 +6871,7 @@
                             "required": false,
                             "description": "**Assistive text for accessibility.**\n* `title`: For users of assistive technology, title for the condition fieldset. Defaults to 'Condition'\n* `deleteIcon`: For users of assistive technology, assistive text for the Delete Condition button's icon. Defaults to 'Delete Condition'",
                             "defaultValue": {
-                                "value": "{\n\ttitle: 'Condition',\n\tdeleteIcon: 'Delete Condition',\n}",
+                                "value": "{\n    title: 'Condition',\n    deleteIcon: 'Delete Condition',\n}",
                                 "computed": false
                             }
                         },
@@ -6961,7 +6961,7 @@
                             "required": false,
                             "description": "**Text labels for internationalization**\nThis object is merged with the default props object on every\n* `deleteCondition`: Title for the delete condition button. Defaults to \"Delete Condition\".\n* `label`: Label for the condition, shown left-most in the row. Left empty on default.\n* `operator`: Label for the operator selection dropdown. Defaults to \"Operator\"\n* `resource`: Label for the resource selection dropdown. Defaults to \"Resource\"\n* `value`: Label for the value input box. Defaults to \"Value\"",
                             "defaultValue": {
-                                "value": "{\n\tlabel: '',\n\toperator: 'Operator',\n\tresource: 'Resource',\n\tvalue: 'Value',\n\tdeleteCondition: 'Delete Condition',\n}",
+                                "value": "{\n    label: '',\n    operator: 'Operator',\n    resource: 'Resource',\n    value: 'Value',\n    deleteCondition: 'Delete Condition',\n}",
                                 "computed": false
                             }
                         },
@@ -7061,7 +7061,7 @@
                             "required": false,
                             "description": "**Assistive text for accessibility.**\n* `help`: Assistive text for help icon",
                             "defaultValue": {
-                                "value": "{\n\thelp: 'Help',\n}",
+                                "value": "{\n    help: 'Help',\n}",
                                 "computed": false
                             }
                         },
@@ -7132,7 +7132,7 @@
                             "required": false,
                             "description": "**Text labels for internationalization**\nThis object is merged with the default props object on every render.\n* `label`: Label for the Expression Formula group.Defaults to \"Formula\"\n* `checkSyntax`: Label for the Check Syntax Button. Defaults to \"Check Syntax\"\n* `textArea`: Label for the `triggerType` selector. Defaults to \"Take Action When\"",
                             "defaultValue": {
-                                "value": "{\n\tlabel: 'Formula',\n\tcheckSyntax: 'Check Syntax',\n\ttextArea: 'Text Area',\n}",
+                                "value": "{\n    label: 'Formula',\n    checkSyntax: 'Check Syntax',\n    textArea: 'Text Area',\n}",
                                 "computed": false
                             }
                         },
@@ -7350,7 +7350,7 @@
                             "required": false,
                             "description": "**Text labels for internationalization**\nThis object is merged with the default props object on every render.\n* `addCondition`: Label for the Add Condition Button. Defaults to \"Add Condition\"\n* `addGroup`: Label for the Add Group Button. Defaults to \"Add Group\"\n* `customLogic`: Label for the text box for inputting `customLogicValue`, if the `triggerType` is `custom`. Defaults to \"Custom Logic\"\n* `label`: Label for the expression group, to indicate condition connectors based on the parent's trigger-type chosen. Defaults to \"\"\n* `takeAction`: Label for the `triggerType` selector. Defaults to \"Take Action When\"\n* `triggerAll`: Label for the `all` value within the trigger selector\n* `triggerAlways`: Label for the `always` value within the trigger selector\n* `triggerAny`: Label for the `any` value within the trigger selector\n* `triggerCustom`: Label for the `custom` value within the trigger selector\n* `triggerFormula`: Label for the `formula` value within the trigger selector",
                             "defaultValue": {
-                                "value": "{\n\tlabel: '',\n\ttakeAction: 'Take Action When',\n\tcustomLogic: 'Custom Logic',\n\taddCondition: 'Add Condition',\n\taddGroup: 'Add Group',\n\ttriggerAll: 'All Conditions Are Met',\n\ttriggerAny: 'Any Condition Is Met',\n\ttriggerCustom: 'Custom Logic Is Met',\n\ttriggerAlways: 'Always (No Criteria)',\n\ttriggerFormula: 'Formula Evaluates To True',\n}",
+                                "value": "{\n    label: '',\n    takeAction: 'Take Action When',\n    customLogic: 'Custom Logic',\n    addCondition: 'Add Condition',\n    addGroup: 'Add Group',\n    triggerAll: 'All Conditions Are Met',\n    triggerAny: 'Any Condition Is Met',\n    triggerCustom: 'Custom Logic Is Met',\n    triggerAlways: 'Always (No Criteria)',\n    triggerFormula: 'Formula Evaluates To True',\n}",
                                 "computed": false
                             }
                         },
@@ -7539,7 +7539,7 @@
                             "required": false,
                             "description": "**Assistive text for accessibility**\n * download - description for the download button if present\n * image - description for the file image\n * link - description for the file link\n * loading - description for the loading spinner if present\n * moreActions - description for the more actions dropdown if present",
                             "defaultValue": {
-                                "value": "{\n\tdownload: 'download',\n\tlink: 'Preview:',\n\tloading: 'loading',\n\tmoreActions: 'more actions',\n}",
+                                "value": "{\n    download: 'download',\n    link: 'Preview:',\n    loading: 'loading',\n    moreActions: 'more actions',\n}",
                                 "computed": false
                             }
                         },
@@ -7720,7 +7720,7 @@
                             "required": false,
                             "description": "**Assistive text for accessibility**\n * count - description for the more files count\n * image - description for the image\n * link - description for the more files link",
                             "defaultValue": {
-                                "value": "{\n\tcount: 'more files',\n\timage: 'Show more files',\n\tlink: 'Preview:',\n}",
+                                "value": "{\n    count: 'more files',\n    image: 'Show more files',\n    link: 'Preview:',\n}",
                                 "computed": false
                             }
                         },
@@ -7910,7 +7910,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility**\n* `removeFilter`: Assistive text for removing a filter. The default is `Remove Filter: this.props.property this.props.predicate`.\n* `editFilter`: Assistive text for changing a filter.\n* `editFilterHeading`: Assistive text for Popover heading.",
                 "defaultValue": {
-                    "value": "{\n\teditFilter: 'Edit filter:',\n\teditFilterHeading: 'Choose filter criteria',\n}",
+                    "value": "{\n    editFilter: 'Edit filter:',\n    editFilterHeading: 'Choose filter criteria',\n}",
                     "computed": false
                 }
             },
@@ -8072,7 +8072,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility.**\nThis object is merged with the default props object on every render.\n* `skipToNav`: The localized text that will be read back for the \"Skip to Navigation\" accessibility link.\n* `skipToContent`: The localized text that will be read back for the \"Skip to Main Content\" accessibility link.",
                 "defaultValue": {
-                    "value": "{\n\tskipToNav: 'Skip to Navigation',\n\tskipToContent: 'Skip to Main Content',\n}",
+                    "value": "{\n    skipToNav: 'Skip to Navigation',\n    skipToContent: 'Skip to Main Content',\n}",
                     "computed": false
                 }
             },
@@ -8155,7 +8155,7 @@
                             "required": false,
                             "description": "**Assistive text for accessibility**\n* `action`: Description of star button. Default is \"Toggle Favorite.\"\n* `more`: Description of dropdown menu. Default is \"View Favorites.\"",
                             "defaultValue": {
-                                "value": "{\n\taction: 'Toggle Favorite',\n\tmore: 'View Favorites',\n}",
+                                "value": "{\n    action: 'Toggle Favorite',\n    more: 'View Favorites',\n}",
                                 "computed": false
                             }
                         },
@@ -8210,7 +8210,7 @@
                             "required": false,
                             "description": "**Assistive text for accessibility**\n* `triggerButton`: Assistive text for the GlobalHeaderHelp trigger button. The default is `Help and Training`.",
                             "defaultValue": {
-                                "value": "{\n\ttriggerButton: 'Help and Training',\n}",
+                                "value": "{\n    triggerButton: 'Help and Training',\n}",
                                 "computed": false
                             }
                         },
@@ -8252,7 +8252,7 @@
                             "required": false,
                             "description": "**Assistive text for accessibility**\n* `newNotificationsAfter`: Assistive text for when there are new notifications, after the notificationCount. The default is ' new notifications'.\n* `newNotificationsBefore`: Assistive text for when there are new notifications, before the notificationCount. The default is ''.\n* `noNotifications`: Assistive text for when there are no new notifications.",
                             "defaultValue": {
-                                "value": "{\n\tnewNotificationsAfter: ' new notifications',\n\tnewNotificationsBefore: '',\n\tnoNotifications: 'No new notifications',\n}",
+                                "value": "{\n    newNotificationsAfter: ' new notifications',\n    newNotificationsBefore: '',\n    noNotifications: 'No new notifications',\n}",
                                 "computed": false
                             }
                         },
@@ -8389,7 +8389,7 @@
                             "required": false,
                             "description": "**Assistive text for accessibility**\n* `triggerButton`: Assistive text for the GlobalHeaderSetup trigger button. The default is `Setup`.",
                             "defaultValue": {
-                                "value": "{\n\ttriggerButton: 'Setup',\n}",
+                                "value": "{\n    triggerButton: 'Setup',\n}",
                                 "computed": false
                             }
                         },
@@ -8423,7 +8423,7 @@
                             "required": false,
                             "description": "**Assistive text for accessibility**\n* `triggerButton`: Assistive text for the GlobalHeaderTask trigger button. The default is `Global Actions`.",
                             "defaultValue": {
-                                "value": "{\n\ttriggerButton: 'Global Actions',\n}",
+                                "value": "{\n    triggerButton: 'Global Actions',\n}",
                                 "computed": false
                             }
                         },
@@ -8802,7 +8802,7 @@
                             "required": false,
                             "description": "**Assistive text for accessibility.**\n* `activeDescriptor`: The text that appears alongside a link that is currently active.",
                             "defaultValue": {
-                                "value": "{\n\tactiveDescriptor: 'Current page:',\n}",
+                                "value": "{\n    activeDescriptor: 'Current page:',\n}",
                                 "computed": false
                             }
                         },
@@ -9551,7 +9551,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility**\n* `label`: Visually hidden label but read out loud by screen readers.\n* `spinner`: Text for loading spinner icon.",
                 "defaultValue": {
-                    "value": "{\n\tdecrement: `${DECREMENT} ${COUNTER}`,\n\tincrement: `${INCREMENT} ${COUNTER}`,\n}",
+                    "value": "{\n    decrement: `${DECREMENT} ${COUNTER}`,\n    increment: `${INCREMENT} ${COUNTER}`,\n}",
                     "computed": false
                 }
             },
@@ -10556,7 +10556,7 @@
                 "modifiers": [],
                 "params": [
                     {
-                        "name": "{\n\tevent,\n\tisOpen = true,\n\tkeyCode,\n\tonFocus = this.handleKeyboardFocus,\n\tonSelect,\n\ttarget,\n\ttoggleOpen = noop,\n}",
+                        "name": "{\n    event,\n    isOpen = true,\n    keyCode,\n    onFocus = this.handleKeyboardFocus,\n    onSelect,\n    target,\n    toggleOpen = noop,\n}",
                         "type": null
                     }
                 ],
@@ -10838,7 +10838,7 @@
             "iconCategory": {
                 "type": {
                     "name": "custom",
-                    "raw": "requiredIf(\n\tPropTypes.oneOf(['action', 'custom', 'doctype', 'standard', 'utility']),\n\t(props) => !!props.iconName\n)"
+                    "raw": "requiredIf(\n    PropTypes.oneOf(['action', 'custom', 'doctype', 'standard', 'utility']),\n    (props) => !!props.iconName\n)"
                 },
                 "required": false,
                 "description": "Name of the icon category. Visit <a href=\"http://www.lightningdesignsystem.com/resources/icons\">Lightning Design System Icons</a> to reference icon categories."
@@ -11630,7 +11630,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility.**\nThis object is merged with the default props object on every render.\n* `dialogLabel`: This is a visually hidden label for the dialog. If not provided, `heading` is used.\n* `dialogLabelledBy`: This describes which node labels the dialog. If not provided and dialogLabel is unavailable, `id` is used.\n* `closeButton`: This is a visually hidden label for the close button.",
                 "defaultValue": {
-                    "value": "{\n\tdialogLabel: '',\n\tdialogLabelledBy: '',\n\tcloseButton: 'Close',\n}",
+                    "value": "{\n    dialogLabel: '',\n    dialogLabelledBy: '',\n    closeButton: 'Close',\n}",
                     "computed": false
                 }
             },
@@ -12142,7 +12142,7 @@
                             "required": false,
                             "description": "**Assistive text for accessibility.**\nThis object is merged with the default props object on every render.\n* `closeButton`: Localized description of the close button for the panel for screen readers",
                             "defaultValue": {
-                                "value": "{\n\tcloseButton: 'Close Filter Panel',\n}",
+                                "value": "{\n    closeButton: 'Close Filter Panel',\n}",
                                 "computed": false
                             }
                         },
@@ -12508,7 +12508,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility**\n* `listboxLabel`: This is a label for the listbox. The default is `Selected Options:`.\n* `removePill`: Used to remove a selected item (pill). Focus is on the pill. This is not a button. The default is `Press delete or backspace to remove`.",
                 "defaultValue": {
-                    "value": "{\n\tlistboxLabel: 'Selected Options:',\n\tremovePill: 'Press delete or backspace to remove',\n}",
+                    "value": "{\n    listboxLabel: 'Selected Options:',\n    removePill: 'Press delete or backspace to remove',\n}",
                     "computed": false
                 }
             },
@@ -12550,7 +12550,7 @@
                 "required": false,
                 "description": "**Text labels for internationalization**\n* `removePillTitle`: Title on `X` icon",
                 "defaultValue": {
-                    "value": "{\n\tremovePillTitle: 'Remove',\n}",
+                    "value": "{\n    removePillTitle: 'Remove',\n}",
                     "computed": false
                 }
             },
@@ -13233,7 +13233,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility.**\nThis object is merged with the default props object on every render.\n* `closeButton`: This is a visually hidden label for the close button.",
                 "defaultValue": {
-                    "value": "{\n\tcloseButton: 'Close dialog',\n}",
+                    "value": "{\n    closeButton: 'Close dialog',\n}",
                     "computed": false
                 }
             },
@@ -13647,7 +13647,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility**\nThis object is merged with the default props object on every render.\n* `progress`: This is a visually hidden label for the percent of progress.\n_Tested with snapshot testing._",
                 "defaultValue": {
-                    "value": "{\n\tprogress: 'Progress',\n}",
+                    "value": "{\n    progress: 'Progress',\n}",
                     "computed": false
                 }
             },
@@ -13709,7 +13709,7 @@
                 "required": false,
                 "description": "Label for the progress bar",
                 "defaultValue": {
-                    "value": "{\n\tcomplete: 'Complete',\n}",
+                    "value": "{\n    complete: 'Complete',\n}",
                     "computed": false
                 }
             },
@@ -13799,7 +13799,7 @@
                 "required": false,
                 "description": "Custom styles to be passed to the component",
                 "defaultValue": {
-                    "value": "{\n\theight: '100%',\n}",
+                    "value": "{\n    height: '100%',\n}",
                     "computed": false
                 }
             }
@@ -13854,7 +13854,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility**\nThis object is merged with the default props object on every render.\n* `completedStep`: Label for a completed step. The default is `Completed Step`\n* `disabledStep`: Label for disabled step. The default is `Disabled Step`\n* `errorStep`: Label for a step with an error. The default is `Error Step`\n* `percentage`: Label for Progress Bar. The default is `Progress: [this.props.value]%`. You will need to calculate the percentage yourself if changing this string.\n* `step`: Label for a step. It will be typically followed by the number of the step such as \"Step 1\".",
                 "defaultValue": {
-                    "value": "{\n\tcompletedStep: 'Completed',\n\tdisabledStep: 'Disabled',\n\terrorStep: 'Error',\n\tstep: 'Step',\n}",
+                    "value": "{\n    completedStep: 'Completed',\n    disabledStep: 'Disabled',\n    errorStep: 'Error',\n    step: 'Step',\n}",
                     "computed": false
                 }
             },
@@ -15492,7 +15492,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility**\n* `toggleButtonOpen`: The button used to open the split view.\n* `toggleButtonClose`: The button used to close the split view.",
                 "defaultValue": {
-                    "value": "{\n\ttoggleButtonOpen: 'Close split view',\n\ttoggleButtonClose: 'Open split view',\n}",
+                    "value": "{\n    toggleButtonOpen: 'Close split view',\n    toggleButtonClose: 'Open split view',\n}",
                     "computed": false
                 }
             },
@@ -15866,7 +15866,7 @@
                             "required": false,
                             "description": "**Assistive text for accessibility**\n* `list`: aria label for the list\n* `sort`\n   * `sortedBy`: Clickable sort header for the list.\n   * `descending`: Descending sorting.\n   * `ascending`: Ascending sorting.",
                             "defaultValue": {
-                                "value": "{\n\tlist: 'Select an item to open it in a new workspace tab.',\n\tsort: {\n\t\tsortedBy: 'Sorted by',\n\t\tdescending: 'Descending',\n\t\tascending: 'Ascending',\n\t},\n}",
+                                "value": "{\n    list: 'Select an item to open it in a new workspace tab.',\n    sort: {\n        sortedBy: 'Sorted by',\n        descending: 'Descending',\n        ascending: 'Ascending',\n    },\n}",
                                 "computed": false
                             }
                         },
@@ -16726,7 +16726,7 @@
                 "required": false,
                 "description": "Time formatting function",
                 "defaultValue": {
-                    "value": "(date) {\n\tif (date) {\n\t\treturn date.toLocaleTimeString(navigator.language, {\n\t\t\thour: '2-digit',\n\t\t\tminute: '2-digit',\n\t\t});\n\t}\n\n\treturn null;\n}",
+                    "value": "function(date) {\n    if (date) {\n        return date.toLocaleTimeString(navigator.language, {\n            hour: '2-digit',\n            minute: '2-digit',\n        });\n    }\n\n    return null;\n}",
                     "computed": false
                 }
             },
@@ -16790,7 +16790,7 @@
                 "required": false,
                 "description": "Parsing date string into Date",
                 "defaultValue": {
-                    "value": "(timeStr) {\n\tconst date = new Date();\n\tconst dateStr = date.toLocaleString(navigator.language, {\n\t\tyear: 'numeric',\n\t\tmonth: 'numeric',\n\t\tday: 'numeric',\n\t});\n\treturn new Date(`${dateStr} ${timeStr}`);\n}",
+                    "value": "function(timeStr) {\n    const date = new Date();\n    const dateStr = date.toLocaleString(navigator.language, {\n        year: 'numeric',\n        month: 'numeric',\n        day: 'numeric',\n    });\n    return new Date(`${dateStr} ${timeStr}`);\n}",
                     "computed": false
                 }
             },
@@ -16896,7 +16896,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility**\nThis object is merged with the default props object on every render.\n* `closeButton`: This is a visually hidden label for the close button.\n* `error`: This is a visually hidden label to mark the toast as an error variant\n* `info`: This is a visually hidden label to mark the toast as an info variant\n* `success`: This is a visually hidden label to mark the toast as an success variant\n* `warning`: This is a visually hidden label to mark the toast as an warning variant\n_Tested with snapshot testing._",
                 "defaultValue": {
-                    "value": "{\n\tcloseButton: 'Close',\n\terror: 'error',\n\tinfo: 'info',\n\tsuccess: 'success',\n\twarning: 'warning',\n}",
+                    "value": "{\n    closeButton: 'Close',\n    error: 'error',\n    info: 'info',\n    success: 'success',\n    warning: 'warning',\n}",
                     "computed": false
                 }
             },
@@ -17234,7 +17234,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility**\nThis object is merged with the default props object on every render.\n* `tooltipTipLearnMoreIcon`: This text is inside the info icon within the tooltip content and exists to \"complete the sentence\" for assistive tech users.\n* `triggerLearnMoreIcon`: This text is inside the info icon that triggers the tooltip in order to have text within the link.",
                 "defaultValue": {
-                    "value": "{\n\ttooltipTipLearnMoreIcon: 'this link',\n\ttriggerLearnMoreIcon: 'Help',\n}",
+                    "value": "{\n    tooltipTipLearnMoreIcon: 'this link',\n    triggerLearnMoreIcon: 'Help',\n}",
                     "computed": false
                 }
             },
@@ -17334,7 +17334,7 @@
                 "required": false,
                 "description": "**Text labels for internationalization**\nThis object is merged with the default props object on every render.\n* `learnMoreAfter`: This label appears in the tooltip after the info icon.\n* `learnMoreBefore`: This label appears in the tooltip before the info icon.",
                 "defaultValue": {
-                    "value": "{\n\tlearnMoreAfter: 'to learn more.',\n\tlearnMoreBefore: 'Click',\n}",
+                    "value": "{\n    learnMoreAfter: 'to learn more.',\n    learnMoreBefore: 'Click',\n}",
                     "computed": false
                 }
             },
@@ -17726,7 +17726,7 @@
                 "required": false,
                 "description": "**Text labels for internationalization**\nThis object is merged with the default props object on every render.\n* `learnMoreAfter`: Amount of time left in trial, e.g. `30`\n* `learnMoreBefore`: Unit of the amount of time left, e.g. `days`\n* `timeLeftUnitAfter`: String after `timeLeftUnit`",
                 "defaultValue": {
-                    "value": "{\n\ttimeLeftUnitAfter: 'left in trial',\n}",
+                    "value": "{\n    timeLeftUnitAfter: 'left in trial',\n}",
                     "computed": false
                 }
             },
@@ -18084,7 +18084,7 @@
                 "required": false,
                 "description": "**Weclome Mat labels for internationalization**\nThis object is merged with the default props object on every render.\n* `title`: Title for the Welcome Mat\n* `description`: Label for the radio input\n* `unitsCompletedAfter`: Label for the radio input",
                 "defaultValue": {
-                    "value": "{\n\tunitsCompletedAfter: 'units completed',\n}",
+                    "value": "{\n    unitsCompletedAfter: 'units completed',\n}",
                     "computed": false
                 }
             },
@@ -18273,7 +18273,7 @@
                             "required": false,
                             "description": "**Assistive text for accessibility.**\nThis object is merged with the default props object on every render.\n* `completeIcon`: Text that is visually hidden but read aloud by screenreaders to tell the user what the complete icon means.",
                             "defaultValue": {
-                                "value": "{\n\tcompletedIcon: 'Completed',\n}",
+                                "value": "{\n    completedIcon: 'Completed',\n}",
                                 "computed": false
                             }
                         },

--- a/components/date-picker/__tests__/__snapshots__/datepicker.dom-snapshot-test.jsx.snap
+++ b/components/date-picker/__tests__/__snapshots__/datepicker.dom-snapshot-test.jsx.snap
@@ -170,10 +170,7 @@ exports[`Datepicker
                 className="slds-combobox_container"
               >
                 <div
-                  aria-expanded={false}
-                  aria-haspopup="listbox"
                   className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-shrink-none"
-                  role="combobox"
                 >
                   <div
                     className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -182,6 +179,8 @@ exports[`Datepicker
                     <input
                       aria-activedescendant={null}
                       aria-autocomplete="list"
+                      aria-expanded={false}
+                      aria-haspopup="listbox"
                       autoComplete="off"
                       className="slds-input slds-combobox__input"
                       disabled={false}
@@ -194,7 +193,7 @@ exports[`Datepicker
                       placeholder="Select an Option"
                       readOnly={true}
                       required={false}
-                      role="textbox"
+                      role="combobox"
                       type="text"
                       value="2007"
                     />
@@ -1034,10 +1033,7 @@ exports[`Datepicker
                   className="slds-combobox_container"
                 >
                   <div
-                    aria-expanded={false}
-                    aria-haspopup="listbox"
                     className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-shrink-none"
-                    role="combobox"
                   >
                     <div
                       className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -1046,6 +1042,8 @@ exports[`Datepicker
                       <input
                         aria-activedescendant={null}
                         aria-autocomplete="list"
+                        aria-expanded={false}
+                        aria-haspopup="listbox"
                         autoComplete="off"
                         className="slds-input slds-combobox__input"
                         disabled={false}
@@ -1058,7 +1056,7 @@ exports[`Datepicker
                         placeholder="Select an Option"
                         readOnly={true}
                         required={false}
-                        role="textbox"
+                        role="combobox"
                         type="text"
                         value="2007"
                       />
@@ -1897,10 +1895,7 @@ exports[`Datepicker
                 className="slds-combobox_container"
               >
                 <div
-                  aria-expanded={false}
-                  aria-haspopup="listbox"
                   className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-shrink-none"
-                  role="combobox"
                 >
                   <div
                     className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -1909,6 +1904,8 @@ exports[`Datepicker
                     <input
                       aria-activedescendant={null}
                       aria-autocomplete="list"
+                      aria-expanded={false}
+                      aria-haspopup="listbox"
                       autoComplete="off"
                       className="slds-input slds-combobox__input"
                       disabled={false}
@@ -1921,7 +1918,7 @@ exports[`Datepicker
                       placeholder="Select an Option"
                       readOnly={true}
                       required={false}
-                      role="textbox"
+                      role="combobox"
                       type="text"
                       value="2014"
                     />
@@ -2757,10 +2754,7 @@ exports[`Datepicker Default DOM Snapshot 1`] = `
                 className="slds-combobox_container"
               >
                 <div
-                  aria-expanded={false}
-                  aria-haspopup="listbox"
                   className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-shrink-none"
-                  role="combobox"
                 >
                   <div
                     className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -2769,6 +2763,8 @@ exports[`Datepicker Default DOM Snapshot 1`] = `
                     <input
                       aria-activedescendant={null}
                       aria-autocomplete="list"
+                      aria-expanded={false}
+                      aria-haspopup="listbox"
                       autoComplete="off"
                       className="slds-input slds-combobox__input"
                       disabled={false}
@@ -2781,7 +2777,7 @@ exports[`Datepicker Default DOM Snapshot 1`] = `
                       placeholder="Select an Option"
                       readOnly={true}
                       required={false}
-                      role="textbox"
+                      role="combobox"
                       type="text"
                       value="2014"
                     />
@@ -3485,8 +3481,8 @@ exports[`Datepicker Default HTML Snapshot 1`] = `
           <div class=\\"slds-form-element\\"><label class=\\"slds-form-element__label slds-assistive-text\\" for=\\"sample-datepicker-year-picklist\\">Year</label>
             <div class=\\"slds-form-element__control\\">
               <div class=\\"slds-combobox_container\\">
-                <div class=\\"slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-shrink-none\\" aria-expanded=\\"false\\" aria-haspopup=\\"listbox\\" role=\\"combobox\\">
-                  <div class=\\"slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right\\" role=\\"none\\"><input type=\\"text\\" autoComplete=\\"off\\" class=\\"slds-input slds-combobox__input\\" id=\\"sample-datepicker-year-picklist\\" placeholder=\\"Select an Option\\" readonly=\\"\\" role=\\"textbox\\" aria-autocomplete=\\"list\\" value=\\"2014\\" /><span class=\\"slds-icon_container slds-input__icon slds-input__icon_right\\"><svg aria-hidden=\\"true\\" class=\\"slds-icon slds-icon_x-small slds-icon-text-default\\">
+                <div class=\\"slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-shrink-none\\">
+                  <div class=\\"slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right\\" role=\\"none\\"><input type=\\"text\\" autoComplete=\\"off\\" class=\\"slds-input slds-combobox__input\\" id=\\"sample-datepicker-year-picklist\\" placeholder=\\"Select an Option\\" readonly=\\"\\" role=\\"combobox\\" aria-autocomplete=\\"list\\" aria-expanded=\\"false\\" aria-haspopup=\\"listbox\\" value=\\"2014\\" /><span class=\\"slds-icon_container slds-input__icon slds-input__icon_right\\"><svg aria-hidden=\\"true\\" class=\\"slds-icon slds-icon_x-small slds-icon-text-default\\">
                         <use href=\\"/assets/icons/utility-sprite/svg/symbols.svg#down\\"></use>
                       </svg></span></div>
                 </div>

--- a/components/expression/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/expression/__docs__/__snapshots__/storybook-stories.storyshot
@@ -36,10 +36,7 @@ exports[`DOM snapshots SLDSExpression Initial State 1`] = `
               className="slds-combobox_container"
             >
               <div
-                aria-expanded={false}
-                aria-haspopup="listbox"
                 className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-                role="combobox"
               >
                 <div
                   className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -48,6 +45,8 @@ exports[`DOM snapshots SLDSExpression Initial State 1`] = `
                   <input
                     aria-activedescendant={null}
                     aria-autocomplete="list"
+                    aria-expanded={false}
+                    aria-haspopup="listbox"
                     autoComplete="off"
                     className="slds-input slds-combobox__input"
                     disabled={false}
@@ -60,7 +59,7 @@ exports[`DOM snapshots SLDSExpression Initial State 1`] = `
                     placeholder="Select an Option"
                     readOnly={true}
                     required={false}
-                    role="textbox"
+                    role="combobox"
                     type="text"
                     value="All Conditions Are Met"
                   />
@@ -122,10 +121,7 @@ exports[`DOM snapshots SLDSExpression Initial State 1`] = `
                       className="slds-combobox_container"
                     >
                       <div
-                        aria-expanded={false}
-                        aria-haspopup="listbox"
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-                        role="combobox"
                       >
                         <div
                           className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -134,6 +130,8 @@ exports[`DOM snapshots SLDSExpression Initial State 1`] = `
                           <input
                             aria-activedescendant={null}
                             aria-autocomplete="list"
+                            aria-expanded={false}
+                            aria-haspopup="listbox"
                             autoComplete="off"
                             className="slds-input slds-combobox__input"
                             disabled={false}
@@ -146,7 +144,7 @@ exports[`DOM snapshots SLDSExpression Initial State 1`] = `
                             placeholder="Select an Option"
                             readOnly={true}
                             required={false}
-                            role="textbox"
+                            role="combobox"
                             type="text"
                             value=""
                           />
@@ -187,10 +185,7 @@ exports[`DOM snapshots SLDSExpression Initial State 1`] = `
                       className="slds-combobox_container"
                     >
                       <div
-                        aria-expanded={false}
-                        aria-haspopup="listbox"
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-                        role="combobox"
                       >
                         <div
                           className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -199,6 +194,8 @@ exports[`DOM snapshots SLDSExpression Initial State 1`] = `
                           <input
                             aria-activedescendant={null}
                             aria-autocomplete="list"
+                            aria-expanded={false}
+                            aria-haspopup="listbox"
                             autoComplete="off"
                             className="slds-input slds-combobox__input"
                             disabled={true}
@@ -211,7 +208,7 @@ exports[`DOM snapshots SLDSExpression Initial State 1`] = `
                             placeholder="Select an Option"
                             readOnly={true}
                             required={false}
-                            role="textbox"
+                            role="combobox"
                             type="text"
                             value=""
                           />
@@ -381,10 +378,7 @@ exports[`DOM snapshots SLDSExpression w/ Custom Logic 1`] = `
               className="slds-combobox_container"
             >
               <div
-                aria-expanded={false}
-                aria-haspopup="listbox"
                 className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-                role="combobox"
               >
                 <div
                   className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -393,6 +387,8 @@ exports[`DOM snapshots SLDSExpression w/ Custom Logic 1`] = `
                   <input
                     aria-activedescendant={null}
                     aria-autocomplete="list"
+                    aria-expanded={false}
+                    aria-haspopup="listbox"
                     autoComplete="off"
                     className="slds-input slds-combobox__input"
                     disabled={false}
@@ -405,7 +401,7 @@ exports[`DOM snapshots SLDSExpression w/ Custom Logic 1`] = `
                     placeholder="Select an Option"
                     readOnly={true}
                     required={false}
-                    role="textbox"
+                    role="combobox"
                     type="text"
                     value="Custom Logic Is Met"
                   />
@@ -488,10 +484,7 @@ exports[`DOM snapshots SLDSExpression w/ Custom Logic 1`] = `
                       className="slds-combobox_container"
                     >
                       <div
-                        aria-expanded={false}
-                        aria-haspopup="listbox"
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-                        role="combobox"
                       >
                         <div
                           className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -500,6 +493,8 @@ exports[`DOM snapshots SLDSExpression w/ Custom Logic 1`] = `
                           <input
                             aria-activedescendant={null}
                             aria-autocomplete="list"
+                            aria-expanded={false}
+                            aria-haspopup="listbox"
                             autoComplete="off"
                             className="slds-input slds-combobox__input"
                             disabled={false}
@@ -512,7 +507,7 @@ exports[`DOM snapshots SLDSExpression w/ Custom Logic 1`] = `
                             placeholder="Select an Option"
                             readOnly={true}
                             required={false}
-                            role="textbox"
+                            role="combobox"
                             type="text"
                             value="Resource 1"
                           />
@@ -553,10 +548,7 @@ exports[`DOM snapshots SLDSExpression w/ Custom Logic 1`] = `
                       className="slds-combobox_container"
                     >
                       <div
-                        aria-expanded={false}
-                        aria-haspopup="listbox"
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-                        role="combobox"
                       >
                         <div
                           className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -565,6 +557,8 @@ exports[`DOM snapshots SLDSExpression w/ Custom Logic 1`] = `
                           <input
                             aria-activedescendant={null}
                             aria-autocomplete="list"
+                            aria-expanded={false}
+                            aria-haspopup="listbox"
                             autoComplete="off"
                             className="slds-input slds-combobox__input"
                             disabled={false}
@@ -577,7 +571,7 @@ exports[`DOM snapshots SLDSExpression w/ Custom Logic 1`] = `
                             placeholder="Select an Option"
                             readOnly={true}
                             required={false}
-                            role="textbox"
+                            role="combobox"
                             type="text"
                             value=""
                           />
@@ -706,10 +700,7 @@ exports[`DOM snapshots SLDSExpression w/ Custom Logic 1`] = `
                       className="slds-combobox_container"
                     >
                       <div
-                        aria-expanded={false}
-                        aria-haspopup="listbox"
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-                        role="combobox"
                       >
                         <div
                           className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -718,6 +709,8 @@ exports[`DOM snapshots SLDSExpression w/ Custom Logic 1`] = `
                           <input
                             aria-activedescendant={null}
                             aria-autocomplete="list"
+                            aria-expanded={false}
+                            aria-haspopup="listbox"
                             autoComplete="off"
                             className="slds-input slds-combobox__input"
                             disabled={false}
@@ -730,7 +723,7 @@ exports[`DOM snapshots SLDSExpression w/ Custom Logic 1`] = `
                             placeholder="Select an Option"
                             readOnly={true}
                             required={false}
-                            role="textbox"
+                            role="combobox"
                             type="text"
                             value=""
                           />
@@ -771,10 +764,7 @@ exports[`DOM snapshots SLDSExpression w/ Custom Logic 1`] = `
                       className="slds-combobox_container"
                     >
                       <div
-                        aria-expanded={false}
-                        aria-haspopup="listbox"
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-                        role="combobox"
                       >
                         <div
                           className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -783,6 +773,8 @@ exports[`DOM snapshots SLDSExpression w/ Custom Logic 1`] = `
                           <input
                             aria-activedescendant={null}
                             aria-autocomplete="list"
+                            aria-expanded={false}
+                            aria-haspopup="listbox"
                             autoComplete="off"
                             className="slds-input slds-combobox__input"
                             disabled={true}
@@ -795,7 +787,7 @@ exports[`DOM snapshots SLDSExpression w/ Custom Logic 1`] = `
                             placeholder="Select an Option"
                             readOnly={true}
                             required={false}
-                            role="textbox"
+                            role="combobox"
                             type="text"
                             value=""
                           />
@@ -961,10 +953,7 @@ exports[`DOM snapshots SLDSExpression w/ Formula Logic 1`] = `
             className="slds-combobox_container"
           >
             <div
-              aria-expanded={false}
-              aria-haspopup="listbox"
               className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-              role="combobox"
             >
               <div
                 className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -973,6 +962,8 @@ exports[`DOM snapshots SLDSExpression w/ Formula Logic 1`] = `
                 <input
                   aria-activedescendant={null}
                   aria-autocomplete="list"
+                  aria-expanded={false}
+                  aria-haspopup="listbox"
                   autoComplete="off"
                   className="slds-input slds-combobox__input"
                   disabled={false}
@@ -985,7 +976,7 @@ exports[`DOM snapshots SLDSExpression w/ Formula Logic 1`] = `
                   placeholder="Select an Option"
                   readOnly={true}
                   required={false}
-                  role="textbox"
+                  role="combobox"
                   type="text"
                   value="Formula Evaluates To True"
                 />
@@ -1048,10 +1039,7 @@ exports[`DOM snapshots SLDSExpression w/ Formula Logic 1`] = `
                       className="slds-combobox_container"
                     >
                       <div
-                        aria-expanded={false}
-                        aria-haspopup="listbox"
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-                        role="combobox"
                       >
                         <div
                           className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -1060,6 +1048,8 @@ exports[`DOM snapshots SLDSExpression w/ Formula Logic 1`] = `
                           <input
                             aria-activedescendant={null}
                             aria-autocomplete="list"
+                            aria-expanded={false}
+                            aria-haspopup="listbox"
                             autoComplete="off"
                             className="slds-input slds-combobox__input"
                             disabled={false}
@@ -1072,7 +1062,7 @@ exports[`DOM snapshots SLDSExpression w/ Formula Logic 1`] = `
                             placeholder="Insert a Resource"
                             readOnly={false}
                             required={false}
-                            role="textbox"
+                            role="combobox"
                             type="text"
                           />
                           <svg
@@ -1108,10 +1098,7 @@ exports[`DOM snapshots SLDSExpression w/ Formula Logic 1`] = `
                       className="slds-combobox_container"
                     >
                       <div
-                        aria-expanded={false}
-                        aria-haspopup="listbox"
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-                        role="combobox"
                       >
                         <div
                           className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -1120,6 +1107,8 @@ exports[`DOM snapshots SLDSExpression w/ Formula Logic 1`] = `
                           <input
                             aria-activedescendant={null}
                             aria-autocomplete="list"
+                            aria-expanded={false}
+                            aria-haspopup="listbox"
                             autoComplete="off"
                             className="slds-input slds-combobox__input"
                             disabled={false}
@@ -1132,7 +1121,7 @@ exports[`DOM snapshots SLDSExpression w/ Formula Logic 1`] = `
                             placeholder="Insert a Function"
                             readOnly={false}
                             required={false}
-                            role="textbox"
+                            role="combobox"
                             type="text"
                           />
                           <svg
@@ -1279,10 +1268,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
               className="slds-combobox_container"
             >
               <div
-                aria-expanded={false}
-                aria-haspopup="listbox"
                 className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-                role="combobox"
               >
                 <div
                   className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -1291,6 +1277,8 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                   <input
                     aria-activedescendant={null}
                     aria-autocomplete="list"
+                    aria-expanded={false}
+                    aria-haspopup="listbox"
                     autoComplete="off"
                     className="slds-input slds-combobox__input"
                     disabled={false}
@@ -1303,7 +1291,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                     placeholder="Select an Option"
                     readOnly={true}
                     required={false}
-                    role="textbox"
+                    role="combobox"
                     type="text"
                     value="All Conditions Are Met"
                   />
@@ -1365,10 +1353,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                       className="slds-combobox_container"
                     >
                       <div
-                        aria-expanded={false}
-                        aria-haspopup="listbox"
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-                        role="combobox"
                       >
                         <div
                           className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -1377,6 +1362,8 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                           <input
                             aria-activedescendant={null}
                             aria-autocomplete="list"
+                            aria-expanded={false}
+                            aria-haspopup="listbox"
                             autoComplete="off"
                             className="slds-input slds-combobox__input"
                             disabled={false}
@@ -1389,7 +1376,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                             placeholder="Select an Option"
                             readOnly={true}
                             required={false}
-                            role="textbox"
+                            role="combobox"
                             type="text"
                             value="Resource 1"
                           />
@@ -1430,10 +1417,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                       className="slds-combobox_container"
                     >
                       <div
-                        aria-expanded={false}
-                        aria-haspopup="listbox"
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-                        role="combobox"
                       >
                         <div
                           className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -1442,6 +1426,8 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                           <input
                             aria-activedescendant={null}
                             aria-autocomplete="list"
+                            aria-expanded={false}
+                            aria-haspopup="listbox"
                             autoComplete="off"
                             className="slds-input slds-combobox__input"
                             disabled={false}
@@ -1454,7 +1440,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                             placeholder="Select an Option"
                             readOnly={true}
                             required={false}
-                            role="textbox"
+                            role="combobox"
                             type="text"
                             value=""
                           />
@@ -1578,10 +1564,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                     className="slds-combobox_container"
                   >
                     <div
-                      aria-expanded={false}
-                      aria-haspopup="listbox"
                       className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-                      role="combobox"
                     >
                       <div
                         className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -1590,6 +1573,8 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                         <input
                           aria-activedescendant={null}
                           aria-autocomplete="list"
+                          aria-expanded={false}
+                          aria-haspopup="listbox"
                           autoComplete="off"
                           className="slds-input slds-combobox__input"
                           disabled={false}
@@ -1602,7 +1587,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                           placeholder="Select an Option"
                           readOnly={true}
                           required={false}
-                          role="textbox"
+                          role="combobox"
                           type="text"
                           value="Any Condition Is Met"
                         />
@@ -1664,10 +1649,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                             className="slds-combobox_container"
                           >
                             <div
-                              aria-expanded={false}
-                              aria-haspopup="listbox"
                               className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-                              role="combobox"
                             >
                               <div
                                 className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -1676,6 +1658,8 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                                 <input
                                   aria-activedescendant={null}
                                   aria-autocomplete="list"
+                                  aria-expanded={false}
+                                  aria-haspopup="listbox"
                                   autoComplete="off"
                                   className="slds-input slds-combobox__input"
                                   disabled={false}
@@ -1688,7 +1672,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                                   placeholder="Select an Option"
                                   readOnly={true}
                                   required={false}
-                                  role="textbox"
+                                  role="combobox"
                                   type="text"
                                   value="Resource 1"
                                 />
@@ -1729,10 +1713,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                             className="slds-combobox_container"
                           >
                             <div
-                              aria-expanded={false}
-                              aria-haspopup="listbox"
                               className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-                              role="combobox"
                             >
                               <div
                                 className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -1741,6 +1722,8 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                                 <input
                                   aria-activedescendant={null}
                                   aria-autocomplete="list"
+                                  aria-expanded={false}
+                                  aria-haspopup="listbox"
                                   autoComplete="off"
                                   className="slds-input slds-combobox__input"
                                   disabled={false}
@@ -1753,7 +1736,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                                   placeholder="Select an Option"
                                   readOnly={true}
                                   required={false}
-                                  role="textbox"
+                                  role="combobox"
                                   type="text"
                                   value=""
                                 />
@@ -1882,10 +1865,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                             className="slds-combobox_container"
                           >
                             <div
-                              aria-expanded={false}
-                              aria-haspopup="listbox"
                               className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-                              role="combobox"
                             >
                               <div
                                 className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -1894,6 +1874,8 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                                 <input
                                   aria-activedescendant={null}
                                   aria-autocomplete="list"
+                                  aria-expanded={false}
+                                  aria-haspopup="listbox"
                                   autoComplete="off"
                                   className="slds-input slds-combobox__input"
                                   disabled={false}
@@ -1906,7 +1888,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                                   placeholder="Select an Option"
                                   readOnly={true}
                                   required={false}
-                                  role="textbox"
+                                  role="combobox"
                                   type="text"
                                   value=""
                                 />
@@ -1947,10 +1929,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                             className="slds-combobox_container"
                           >
                             <div
-                              aria-expanded={false}
-                              aria-haspopup="listbox"
                               className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-                              role="combobox"
                             >
                               <div
                                 className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -1959,6 +1938,8 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                                 <input
                                   aria-activedescendant={null}
                                   aria-autocomplete="list"
+                                  aria-expanded={false}
+                                  aria-haspopup="listbox"
                                   autoComplete="off"
                                   className="slds-input slds-combobox__input"
                                   disabled={true}
@@ -1971,7 +1952,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                                   placeholder="Select an Option"
                                   readOnly={true}
                                   required={false}
-                                  role="textbox"
+                                  role="combobox"
                                   type="text"
                                   value=""
                                 />
@@ -2119,10 +2100,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                     className="slds-combobox_container"
                   >
                     <div
-                      aria-expanded={false}
-                      aria-haspopup="listbox"
                       className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-                      role="combobox"
                     >
                       <div
                         className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -2131,6 +2109,8 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                         <input
                           aria-activedescendant={null}
                           aria-autocomplete="list"
+                          aria-expanded={false}
+                          aria-haspopup="listbox"
                           autoComplete="off"
                           className="slds-input slds-combobox__input"
                           disabled={false}
@@ -2143,7 +2123,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                           placeholder="Select an Option"
                           readOnly={true}
                           required={false}
-                          role="textbox"
+                          role="combobox"
                           type="text"
                           value="Custom Logic Is Met"
                         />
@@ -2226,10 +2206,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                             className="slds-combobox_container"
                           >
                             <div
-                              aria-expanded={false}
-                              aria-haspopup="listbox"
                               className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-                              role="combobox"
                             >
                               <div
                                 className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -2238,6 +2215,8 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                                 <input
                                   aria-activedescendant={null}
                                   aria-autocomplete="list"
+                                  aria-expanded={false}
+                                  aria-haspopup="listbox"
                                   autoComplete="off"
                                   className="slds-input slds-combobox__input"
                                   disabled={false}
@@ -2250,7 +2229,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                                   placeholder="Select an Option"
                                   readOnly={true}
                                   required={false}
-                                  role="textbox"
+                                  role="combobox"
                                   type="text"
                                   value="Resource 1"
                                 />
@@ -2291,10 +2270,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                             className="slds-combobox_container"
                           >
                             <div
-                              aria-expanded={false}
-                              aria-haspopup="listbox"
                               className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-                              role="combobox"
                             >
                               <div
                                 className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -2303,6 +2279,8 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                                 <input
                                   aria-activedescendant={null}
                                   aria-autocomplete="list"
+                                  aria-expanded={false}
+                                  aria-haspopup="listbox"
                                   autoComplete="off"
                                   className="slds-input slds-combobox__input"
                                   disabled={false}
@@ -2315,7 +2293,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                                   placeholder="Select an Option"
                                   readOnly={true}
                                   required={false}
-                                  role="textbox"
+                                  role="combobox"
                                   type="text"
                                   value=""
                                 />
@@ -2509,10 +2487,7 @@ exports[`DOM snapshots SLDSExpression w/ Multiple Conditions 1`] = `
               className="slds-combobox_container"
             >
               <div
-                aria-expanded={false}
-                aria-haspopup="listbox"
                 className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-                role="combobox"
               >
                 <div
                   className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -2521,6 +2496,8 @@ exports[`DOM snapshots SLDSExpression w/ Multiple Conditions 1`] = `
                   <input
                     aria-activedescendant={null}
                     aria-autocomplete="list"
+                    aria-expanded={false}
+                    aria-haspopup="listbox"
                     autoComplete="off"
                     className="slds-input slds-combobox__input"
                     disabled={false}
@@ -2533,7 +2510,7 @@ exports[`DOM snapshots SLDSExpression w/ Multiple Conditions 1`] = `
                     placeholder="Select an Option"
                     readOnly={true}
                     required={false}
-                    role="textbox"
+                    role="combobox"
                     type="text"
                     value="Any Condition Is Met"
                   />
@@ -2595,10 +2572,7 @@ exports[`DOM snapshots SLDSExpression w/ Multiple Conditions 1`] = `
                       className="slds-combobox_container"
                     >
                       <div
-                        aria-expanded={false}
-                        aria-haspopup="listbox"
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-                        role="combobox"
                       >
                         <div
                           className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -2607,6 +2581,8 @@ exports[`DOM snapshots SLDSExpression w/ Multiple Conditions 1`] = `
                           <input
                             aria-activedescendant={null}
                             aria-autocomplete="list"
+                            aria-expanded={false}
+                            aria-haspopup="listbox"
                             autoComplete="off"
                             className="slds-input slds-combobox__input"
                             disabled={false}
@@ -2619,7 +2595,7 @@ exports[`DOM snapshots SLDSExpression w/ Multiple Conditions 1`] = `
                             placeholder="Select an Option"
                             readOnly={true}
                             required={false}
-                            role="textbox"
+                            role="combobox"
                             type="text"
                             value="Resource 1"
                           />
@@ -2660,10 +2636,7 @@ exports[`DOM snapshots SLDSExpression w/ Multiple Conditions 1`] = `
                       className="slds-combobox_container"
                     >
                       <div
-                        aria-expanded={false}
-                        aria-haspopup="listbox"
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-                        role="combobox"
                       >
                         <div
                           className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -2672,6 +2645,8 @@ exports[`DOM snapshots SLDSExpression w/ Multiple Conditions 1`] = `
                           <input
                             aria-activedescendant={null}
                             aria-autocomplete="list"
+                            aria-expanded={false}
+                            aria-haspopup="listbox"
                             autoComplete="off"
                             className="slds-input slds-combobox__input"
                             disabled={false}
@@ -2684,7 +2659,7 @@ exports[`DOM snapshots SLDSExpression w/ Multiple Conditions 1`] = `
                             placeholder="Select an Option"
                             readOnly={true}
                             required={false}
-                            role="textbox"
+                            role="combobox"
                             type="text"
                             value=""
                           />
@@ -2813,10 +2788,7 @@ exports[`DOM snapshots SLDSExpression w/ Multiple Conditions 1`] = `
                       className="slds-combobox_container"
                     >
                       <div
-                        aria-expanded={false}
-                        aria-haspopup="listbox"
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-                        role="combobox"
                       >
                         <div
                           className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -2825,6 +2797,8 @@ exports[`DOM snapshots SLDSExpression w/ Multiple Conditions 1`] = `
                           <input
                             aria-activedescendant={null}
                             aria-autocomplete="list"
+                            aria-expanded={false}
+                            aria-haspopup="listbox"
                             autoComplete="off"
                             className="slds-input slds-combobox__input"
                             disabled={false}
@@ -2837,7 +2811,7 @@ exports[`DOM snapshots SLDSExpression w/ Multiple Conditions 1`] = `
                             placeholder="Select an Option"
                             readOnly={true}
                             required={false}
-                            role="textbox"
+                            role="combobox"
                             type="text"
                             value="Resource 2"
                           />
@@ -2878,10 +2852,7 @@ exports[`DOM snapshots SLDSExpression w/ Multiple Conditions 1`] = `
                       className="slds-combobox_container"
                     >
                       <div
-                        aria-expanded={false}
-                        aria-haspopup="listbox"
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-                        role="combobox"
                       >
                         <div
                           className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -2890,6 +2861,8 @@ exports[`DOM snapshots SLDSExpression w/ Multiple Conditions 1`] = `
                           <input
                             aria-activedescendant={null}
                             aria-autocomplete="list"
+                            aria-expanded={false}
+                            aria-haspopup="listbox"
                             autoComplete="off"
                             className="slds-input slds-combobox__input"
                             disabled={false}
@@ -2902,7 +2875,7 @@ exports[`DOM snapshots SLDSExpression w/ Multiple Conditions 1`] = `
                             placeholder="Select an Option"
                             readOnly={true}
                             required={false}
-                            role="textbox"
+                            role="combobox"
                             type="text"
                             value=""
                           />
@@ -3072,10 +3045,7 @@ exports[`DOM snapshots SLDSExpression w/ Resource Selected 1`] = `
               className="slds-combobox_container"
             >
               <div
-                aria-expanded={false}
-                aria-haspopup="listbox"
                 className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-                role="combobox"
               >
                 <div
                   className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -3084,6 +3054,8 @@ exports[`DOM snapshots SLDSExpression w/ Resource Selected 1`] = `
                   <input
                     aria-activedescendant={null}
                     aria-autocomplete="list"
+                    aria-expanded={false}
+                    aria-haspopup="listbox"
                     autoComplete="off"
                     className="slds-input slds-combobox__input"
                     disabled={false}
@@ -3096,7 +3068,7 @@ exports[`DOM snapshots SLDSExpression w/ Resource Selected 1`] = `
                     placeholder="Select an Option"
                     readOnly={true}
                     required={false}
-                    role="textbox"
+                    role="combobox"
                     type="text"
                     value="All Conditions Are Met"
                   />
@@ -3158,10 +3130,7 @@ exports[`DOM snapshots SLDSExpression w/ Resource Selected 1`] = `
                       className="slds-combobox_container"
                     >
                       <div
-                        aria-expanded={false}
-                        aria-haspopup="listbox"
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-                        role="combobox"
                       >
                         <div
                           className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -3170,6 +3139,8 @@ exports[`DOM snapshots SLDSExpression w/ Resource Selected 1`] = `
                           <input
                             aria-activedescendant={null}
                             aria-autocomplete="list"
+                            aria-expanded={false}
+                            aria-haspopup="listbox"
                             autoComplete="off"
                             className="slds-input slds-combobox__input"
                             disabled={false}
@@ -3182,7 +3153,7 @@ exports[`DOM snapshots SLDSExpression w/ Resource Selected 1`] = `
                             placeholder="Select an Option"
                             readOnly={true}
                             required={false}
-                            role="textbox"
+                            role="combobox"
                             type="text"
                             value="Resource 1"
                           />
@@ -3223,10 +3194,7 @@ exports[`DOM snapshots SLDSExpression w/ Resource Selected 1`] = `
                       className="slds-combobox_container"
                     >
                       <div
-                        aria-expanded={false}
-                        aria-haspopup="listbox"
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-                        role="combobox"
                       >
                         <div
                           className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -3235,6 +3203,8 @@ exports[`DOM snapshots SLDSExpression w/ Resource Selected 1`] = `
                           <input
                             aria-activedescendant={null}
                             aria-autocomplete="list"
+                            aria-expanded={false}
+                            aria-haspopup="listbox"
                             autoComplete="off"
                             className="slds-input slds-combobox__input"
                             disabled={false}
@@ -3247,7 +3217,7 @@ exports[`DOM snapshots SLDSExpression w/ Resource Selected 1`] = `
                             placeholder="Select an Option"
                             readOnly={true}
                             required={false}
-                            role="textbox"
+                            role="combobox"
                             type="text"
                             value=""
                           />

--- a/components/global-header/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/global-header/__docs__/__snapshots__/storybook-stories.storyshot
@@ -55,8 +55,6 @@ exports[`DOM snapshots SLDSGlobalHeader Doc site Default 1`] = `
               className="slds-combobox_container"
             >
               <div
-                aria-expanded={false}
-                aria-haspopup="listbox"
                 className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
               >
                 <div
@@ -66,6 +64,8 @@ exports[`DOM snapshots SLDSGlobalHeader Doc site Default 1`] = `
                   <input
                     aria-activedescendant={null}
                     aria-autocomplete="list"
+                    aria-expanded={false}
+                    aria-haspopup="listbox"
                     autoComplete="off"
                     className="slds-input slds-combobox__input"
                     id="header-search-custom-id"
@@ -546,8 +546,6 @@ exports[`DOM snapshots SLDSGlobalHeader Search + Navigation 1`] = `
               className="slds-combobox_container"
             >
               <div
-                aria-expanded={false}
-                aria-haspopup="listbox"
                 className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
               >
                 <div
@@ -557,6 +555,8 @@ exports[`DOM snapshots SLDSGlobalHeader Search + Navigation 1`] = `
                   <input
                     aria-activedescendant={null}
                     aria-autocomplete="list"
+                    aria-expanded={false}
+                    aria-haspopup="listbox"
                     autoComplete="off"
                     className="slds-input slds-combobox__input"
                     id="header-search-custom-id"
@@ -928,8 +928,6 @@ exports[`DOM snapshots SLDSGlobalHeader With custom <Avatar/> 1`] = `
               className="slds-combobox_container"
             >
               <div
-                aria-expanded={false}
-                aria-haspopup="listbox"
                 className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
               >
                 <div
@@ -939,6 +937,8 @@ exports[`DOM snapshots SLDSGlobalHeader With custom <Avatar/> 1`] = `
                   <input
                     aria-activedescendant={null}
                     aria-autocomplete="list"
+                    aria-expanded={false}
+                    aria-haspopup="listbox"
                     autoComplete="off"
                     className="slds-input slds-combobox__input"
                     id="header-search-custom-id"

--- a/components/global-header/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/global-header/__docs__/__snapshots__/storybook-stories.storyshot
@@ -58,7 +58,6 @@ exports[`DOM snapshots SLDSGlobalHeader Doc site Default 1`] = `
                 aria-expanded={false}
                 aria-haspopup="listbox"
                 className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-                role="combobox"
               >
                 <div
                   className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -78,7 +77,7 @@ exports[`DOM snapshots SLDSGlobalHeader Doc site Default 1`] = `
                     placeholder="Search Salesforce"
                     readOnly={false}
                     required={false}
-                    role="textbox"
+                    role="combobox"
                     type="text"
                   />
                   <svg
@@ -550,7 +549,6 @@ exports[`DOM snapshots SLDSGlobalHeader Search + Navigation 1`] = `
                 aria-expanded={false}
                 aria-haspopup="listbox"
                 className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-                role="combobox"
               >
                 <div
                   className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -570,7 +568,7 @@ exports[`DOM snapshots SLDSGlobalHeader Search + Navigation 1`] = `
                     placeholder="Search Salesforce"
                     readOnly={false}
                     required={false}
-                    role="textbox"
+                    role="combobox"
                     type="text"
                   />
                   <svg
@@ -933,7 +931,6 @@ exports[`DOM snapshots SLDSGlobalHeader With custom <Avatar/> 1`] = `
                 aria-expanded={false}
                 aria-haspopup="listbox"
                 className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
-                role="combobox"
               >
                 <div
                   className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -953,7 +950,7 @@ exports[`DOM snapshots SLDSGlobalHeader With custom <Avatar/> 1`] = `
                     placeholder="Search Salesforce"
                     readOnly={false}
                     required={false}
-                    role="textbox"
+                    role="combobox"
                     type="text"
                   />
                   <svg


### PR DESCRIPTION
Fixes #2753 

According to the Aria 1.2 spec for combobox https://www.w3.org/TR/wai-aria-practices-1.2/examples/combobox/combobox-autocomplete-list.html, the `role="combobox"` attribute should be set on the inner `input` element, not the containing `div`.

### Additional description

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [x] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [x] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [x] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
