### PR TITLE
Combobox: Padding and border issues

### DIFF
--- a/components/combobox/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/combobox/__docs__/__snapshots__/storybook-stories.storyshot
@@ -21,6 +21,7 @@ exports[`DOM snapshots SLDSCombobox Base 1`] = `
       >
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -228,6 +229,7 @@ exports[`DOM snapshots SLDSCombobox Base Custom Menu Item 1`] = `
       >
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -290,6 +292,7 @@ exports[`DOM snapshots SLDSCombobox Base Custom Menu Item Disabled 1`] = `
       >
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -372,6 +375,7 @@ exports[`DOM snapshots SLDSCombobox Base Inherit Menu Width - Right to Left (RTL
           <div
             aria-owns="combobox-base-inherit-menu-width-listbox"
             className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
+            role="combobox"
           >
             <div
               className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -799,6 +803,7 @@ exports[`DOM snapshots SLDSCombobox Base Inherit Menu Width 1`] = `
       >
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -904,6 +909,7 @@ exports[`DOM snapshots SLDSCombobox Base Inline Help 1`] = `
         >
           <div
             className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+            role="combobox"
           >
             <div
               className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -1112,6 +1118,7 @@ exports[`DOM snapshots SLDSCombobox Base Menu Item Disabled 1`] = `
       >
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -1321,6 +1328,7 @@ exports[`DOM snapshots SLDSCombobox Base Menu Item Disabled With Tooltip 1`] = `
       >
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -1531,6 +1539,7 @@ exports[`DOM snapshots SLDSCombobox Base Menu Item Disabled With Tooltip Open 1`
         <div
           aria-owns="combobox-base-listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -2152,6 +2161,7 @@ exports[`DOM snapshots SLDSCombobox Base Menu Separator 1`] = `
       >
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -2214,6 +2224,7 @@ exports[`DOM snapshots SLDSCombobox Base Menu Sub Headers 1`] = `
       >
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -2276,6 +2287,7 @@ exports[`DOM snapshots SLDSCombobox Base Pre-defined Options Only 1`] = `
       >
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -2484,6 +2496,7 @@ exports[`DOM snapshots SLDSCombobox Base With Input 1`] = `
         <div
           aria-owns="combobox-base-listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -2833,6 +2846,7 @@ exports[`DOM snapshots SLDSCombobox Base With Scroll 1`] = `
       >
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -3040,6 +3054,7 @@ exports[`DOM snapshots SLDSCombobox Dialog 1`] = `
       >
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+          role="combobox"
         >
           <div
             style={
@@ -3262,6 +3277,7 @@ exports[`DOM snapshots SLDSCombobox Inline Multiple Selection 1`] = `
         </div>
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -3324,6 +3340,7 @@ exports[`DOM snapshots SLDSCombobox Inline Multiple Selection Loading 1`] = `
       >
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -3404,6 +3421,7 @@ exports[`DOM snapshots SLDSCombobox Inline Single Entity Selection 1`] = `
               >
                 <div
                   className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+                  role="combobox"
                 >
                   <div
                     className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -3462,6 +3480,7 @@ exports[`DOM snapshots SLDSCombobox Inline Single Entity Selection 1`] = `
               >
                 <div
                   className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+                  role="combobox"
                 >
                   <div
                     className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -3528,6 +3547,7 @@ exports[`DOM snapshots SLDSCombobox Inline Single Search/Add Entities - Open 1`]
       >
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -3923,6 +3943,7 @@ exports[`DOM snapshots SLDSCombobox Inline Single Search/Add Entities 1`] = `
       >
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -3986,6 +4007,7 @@ exports[`DOM snapshots SLDSCombobox Inline Single Selection 1`] = `
       >
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -4049,6 +4071,7 @@ exports[`DOM snapshots SLDSCombobox Inline Single Selection Predefined Options O
       >
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -4112,6 +4135,7 @@ exports[`DOM snapshots SLDSCombobox Inline Single Selection With Custom Open Sta
       >
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -4175,6 +4199,7 @@ exports[`DOM snapshots SLDSCombobox Input Component as a Prop 1`] = `
       >
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -4382,6 +4407,7 @@ exports[`DOM snapshots SLDSCombobox Readonly Multiple Selection 1`] = `
       >
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -4448,6 +4474,7 @@ exports[`DOM snapshots SLDSCombobox Readonly Single Menu Item Disabled 1`] = `
       >
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -4539,6 +4566,7 @@ exports[`DOM snapshots SLDSCombobox Readonly Single Selection - Right to Left (R
         >
           <div
             className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+            role="combobox"
           >
             <div
               className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -4607,6 +4635,7 @@ exports[`DOM snapshots SLDSCombobox Readonly Single Selection 1`] = `
       >
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -4674,6 +4703,7 @@ exports[`DOM snapshots SLDSCombobox Readonly Single Selection Custom Menu Item 1
       >
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -4741,6 +4771,7 @@ exports[`DOM snapshots SLDSCombobox Readonly Single Selection Disabled 1`] = `
       >
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -4814,6 +4845,7 @@ exports[`DOM snapshots SLDSCombobox Required Input in Error State 1`] = `
       >
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-has-error"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -4888,6 +4920,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Custom Menu Item Open 1`] = `
         <div
           aria-owns="combobox-base-custom-menu-item-listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -5177,6 +5210,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Label Required 1`] = `
       >
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-has-error"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -5251,6 +5285,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Open 1`] = `
         <div
           aria-owns="combobox-unique-id-listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -5431,6 +5466,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Open Menu Sub Header Separator
         <div
           aria-owns="combobox-unique-id-listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -5553,6 +5589,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Open Menu inheritWidthOf prop 
         <div
           aria-owns="combobox-unique-id-listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -5674,6 +5711,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Selected 1`] = `
       >
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -5814,6 +5852,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Dialog Open 1`] = `
       >
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
+          role="combobox"
         >
           <div
             style={
@@ -5966,6 +6005,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Multiple Open Loading 1`] = 
       >
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -6322,6 +6362,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Multiple Selection 1`] = `
       >
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -6531,6 +6572,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Multiple Selection Selected 
         </div>
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -6611,6 +6653,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Single Entity Selection 1`] 
               >
                 <div
                   className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+                  role="combobox"
                 >
                   <div
                     className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -6665,6 +6708,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Single Entity Selection 1`] 
               >
                 <div
                   className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+                  role="combobox"
                 >
                   <div
                     className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -6731,6 +6775,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Single Search/Add Entities O
       >
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -7040,6 +7085,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Single Selection 1`] = `
       >
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -7103,6 +7149,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Single Selection Selected 1`
       >
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_left-right"
@@ -7195,6 +7242,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Multiple Selection 1`] = `
       >
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -7261,6 +7309,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Multiple Selection Multipl
       >
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -7430,6 +7479,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Multiple Selection Single 
       >
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -7496,6 +7546,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Single Selection 1`] = `
       >
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -7563,6 +7614,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Single Selection Custom Me
       >
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -8195,6 +8247,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Single Selection Disabled 
       >
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -8262,6 +8315,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Single Selection Selected 
       >
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -8329,6 +8383,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Single Selection Selected 
       >
         <div
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
+          role="combobox"
         >
           <div
             className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"

--- a/components/combobox/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/combobox/__docs__/__snapshots__/storybook-stories.storyshot
@@ -373,7 +373,6 @@ exports[`DOM snapshots SLDSCombobox Base Inherit Menu Width - Right to Left (RTL
           className="slds-combobox_container"
         >
           <div
-            aria-owns="combobox-base-inherit-menu-width-listbox"
             className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
             role="combobox"
           >
@@ -1537,7 +1536,6 @@ exports[`DOM snapshots SLDSCombobox Base Menu Item Disabled With Tooltip Open 1`
         className="slds-combobox_container"
       >
         <div
-          aria-owns="combobox-base-listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
           role="combobox"
         >
@@ -2494,7 +2492,6 @@ exports[`DOM snapshots SLDSCombobox Base With Input 1`] = `
         className="slds-combobox_container"
       >
         <div
-          aria-owns="combobox-base-listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
           role="combobox"
         >
@@ -4918,7 +4915,6 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Custom Menu Item Open 1`] = `
         className="slds-combobox_container"
       >
         <div
-          aria-owns="combobox-base-custom-menu-item-listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
           role="combobox"
         >
@@ -5283,7 +5279,6 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Open 1`] = `
         className="slds-combobox_container"
       >
         <div
-          aria-owns="combobox-unique-id-listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
           role="combobox"
         >
@@ -5464,7 +5459,6 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Open Menu Sub Header Separator
         className="slds-combobox_container"
       >
         <div
-          aria-owns="combobox-unique-id-listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
           role="combobox"
         >
@@ -5587,7 +5581,6 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Open Menu inheritWidthOf prop 
         className="slds-combobox_container"
       >
         <div
-          aria-owns="combobox-unique-id-listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
           role="combobox"
         >

--- a/components/combobox/__tests__/combobox.browser-test.jsx
+++ b/components/combobox/__tests__/combobox.browser-test.jsx
@@ -229,6 +229,7 @@ describe('SLDSCombobox', function describeFunction() {
 		it('has aria-haspopup, role is combobox, aria-expanded is false when closed, aria-expanded is true when open', function () {
 			wrapper = mount(<DemoComponent multiple />, { attachTo: mountNode });
 			const nodes = getNodes({ wrapper });
+			expect(nodes.combobox).attr('role', 'combobox');
 			expect(nodes.input).attr('aria-haspopup', 'listbox');
 			expect(nodes.input).attr('role', 'combobox');
 			// closed

--- a/components/combobox/combobox.jsx
+++ b/components/combobox/combobox.jsx
@@ -1074,6 +1074,7 @@ class Combobox extends React.Component {
 						},
 						props.className
 					)}
+					role="combobox"
 					// used on menu's listbox
 					aria-owns={this.getIsOpen() ? `${this.getId()}-listbox` : undefined} // eslint-disable-line jsx-a11y/aria-proptypes
 				>
@@ -1214,6 +1215,7 @@ class Combobox extends React.Component {
 						},
 						props.className
 					)}
+					role="combobox"
 				>
 					<InnerInput
 						aria-autocomplete="list"
@@ -1314,6 +1316,7 @@ class Combobox extends React.Component {
 							},
 							props.className
 						)}
+						role="combobox"
 					>
 						<InnerInput
 							defaultValue={props.defaultValue}
@@ -1478,6 +1481,7 @@ class Combobox extends React.Component {
 							},
 							props.className
 						)}
+						role="combobox"
 					>
 						<Popover {...popoverProps}>
 							<InnerInput
@@ -1563,6 +1567,7 @@ class Combobox extends React.Component {
 							},
 							props.className
 						)}
+						role="combobox"
 					>
 						<InnerInput
 							defaultValue={props.defaultValue}
@@ -1674,6 +1679,7 @@ class Combobox extends React.Component {
 							},
 							props.className
 						)}
+						role="combobox"
 					>
 						<InnerInput
 							defaultValue={props.defaultValue}

--- a/components/combobox/combobox.jsx
+++ b/components/combobox/combobox.jsx
@@ -2,7 +2,6 @@
 /* Copyright (c) 2015-present, salesforce.com, inc. All rights reserved */
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 
-/* eslint-disable jsx-a11y/role-has-required-aria-props */
 /* eslint-disable max-lines */
 
 import React from 'react';
@@ -1074,9 +1073,8 @@ class Combobox extends React.Component {
 						},
 						props.className
 					)}
-					role="combobox"
-					// used on menu's listbox
-					aria-owns={this.getIsOpen() ? `${this.getId()}-listbox` : undefined} // eslint-disable-line jsx-a11y/aria-proptypes
+					// Not in ARIA 1.2 spec, temporary for SLDS styles
+					role="combobox" // eslint-disable-line jsx-a11y/role-supports-aria-props, jsx-a11y/role-has-required-aria-props
 				>
 					<InnerInput
 						aria-autocomplete="list"
@@ -1090,7 +1088,7 @@ class Combobox extends React.Component {
 						}
 						aria-describedby={this.getErrorId()}
 						aria-expanded={this.getIsOpen()}
-						aria-haspopup="listbox" // eslint-disable-line jsx-a11y/aria-proptypes
+						aria-haspopup="listbox"
 						role="combobox"
 						autoComplete="off"
 						className="slds-combobox__input"
@@ -1215,7 +1213,8 @@ class Combobox extends React.Component {
 						},
 						props.className
 					)}
-					role="combobox"
+					// Not in ARIA 1.2 spec, temporary for SLDS styles
+					role="combobox" // eslint-disable-line jsx-a11y/role-supports-aria-props, jsx-a11y/role-has-required-aria-props
 				>
 					<InnerInput
 						aria-autocomplete="list"
@@ -1294,7 +1293,6 @@ class Combobox extends React.Component {
 				? props.selection[0].label
 				: props.value;
 
-		/* eslint-disable jsx-a11y/role-supports-aria-props */
 		return (
 			<div className="slds-form-element__control">
 				<div
@@ -1316,7 +1314,8 @@ class Combobox extends React.Component {
 							},
 							props.className
 						)}
-						role="combobox"
+						// Not in ARIA 1.2 spec, temporary for SLDS styles
+						role="combobox" // eslint-disable-line jsx-a11y/role-supports-aria-props, jsx-a11y/role-has-required-aria-props
 					>
 						<InnerInput
 							defaultValue={props.defaultValue}
@@ -1481,7 +1480,8 @@ class Combobox extends React.Component {
 							},
 							props.className
 						)}
-						role="combobox"
+						// Not in ARIA 1.2 spec, temporary for SLDS styles
+						role="combobox" // eslint-disable-line jsx-a11y/role-supports-aria-props, jsx-a11y/role-has-required-aria-props
 					>
 						<Popover {...popoverProps}>
 							<InnerInput
@@ -1549,7 +1549,6 @@ class Combobox extends React.Component {
 				  `${props.selection.length} options selected`
 				: (props.selection[0] && props.selection[0].label) || '';
 
-		/* eslint-disable jsx-a11y/role-supports-aria-props */
 		return (
 			<div className="slds-form-element__control">
 				<div className="slds-combobox_container">
@@ -1567,7 +1566,8 @@ class Combobox extends React.Component {
 							},
 							props.className
 						)}
-						role="combobox"
+						// Not in ARIA 1.2 spec, temporary for SLDS styles
+						role="combobox" // eslint-disable-line jsx-a11y/role-supports-aria-props, jsx-a11y/role-has-required-aria-props
 					>
 						<InnerInput
 							defaultValue={props.defaultValue}
@@ -1661,7 +1661,6 @@ class Combobox extends React.Component {
 	}) => {
 		const value = (props.selection[0] && props.selection[0].label) || '';
 
-		/* eslint-disable jsx-a11y/role-supports-aria-props */
 		return (
 			<div className="slds-form-element__control">
 				<div className="slds-combobox_container">
@@ -1679,7 +1678,8 @@ class Combobox extends React.Component {
 							},
 							props.className
 						)}
-						role="combobox"
+						// Not in ARIA 1.2 spec, temporary for SLDS styles
+						role="combobox" // eslint-disable-line jsx-a11y/role-supports-aria-props, jsx-a11y/role-has-required-aria-props
 					>
 						<InnerInput
 							defaultValue={props.defaultValue}
@@ -1838,7 +1838,6 @@ class Combobox extends React.Component {
 		);
 	}
 }
-/* eslint-enable jsx-a11y/role-supports-aria-props */
 
 Combobox.contextTypes = {
 	iconPath: PropTypes.string,

--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -215,7 +215,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility**\nThis object is merged with the default props object on every render.\n* `closeButton`: This is a visually hidden label for the close button.\n_Tested with snapshot testing._",
                 "defaultValue": {
-                    "value": "{\n\tcloseButton: 'Close',\n}",
+                    "value": "{\n    closeButton: 'Close',\n}",
                     "computed": false
                 }
             },
@@ -436,7 +436,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility.**\nThis object is merged with the default props object on every render.\n* `trigger`: This is a visually hidden label for the app launcher icon.",
                 "defaultValue": {
-                    "value": "{\n\ttrigger: 'Open App Launcher',\n}",
+                    "value": "{\n    trigger: 'Open App Launcher',\n}",
                     "computed": false
                 }
             },
@@ -746,7 +746,7 @@
                             "required": false,
                             "description": "**Assistive text for accessibility.**\n* `dragIconText`: Text that describes the purpose of the drag handle icon.",
                             "defaultValue": {
-                                "value": "{\n\tdragIconText: 'Reorder',\n}",
+                                "value": "{\n    dragIconText: 'Reorder',\n}",
                                 "computed": false
                             }
                         },
@@ -913,7 +913,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility.**\nThis object is merged with the default props object on every render.\n* `icon`: Assistive text for accessibility that labels the icon.",
                 "defaultValue": {
-                    "value": "{\n\ticon: 'User or Account Icon',\n}",
+                    "value": "{\n    icon: 'User or Account Icon',\n}",
                     "computed": false
                 }
             },
@@ -1325,7 +1325,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility.**\nThis object is merged with the default props object on every render.\n* `label`: The assistive text for the breadcrumb trail.",
                 "defaultValue": {
-                    "value": "{\n\tlabel: 'Breadcrumbs',\n}",
+                    "value": "{\n    label: 'Breadcrumbs',\n}",
                     "computed": false
                 }
             },
@@ -1388,7 +1388,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility**\nThis object is merged with the default props object on every render.\n* `backIcon`: Used for the back icon.\n* `helpIcon`: Used for the help icon.\n* `icon`: Used for the main icon next to the header title.\n* _Tested with snapshot testing._",
                 "defaultValue": {
-                    "value": "{\n\tbackIcon: 'Back',\n\thelpIcon: 'Help',\n\ticon: 'Builder',\n}",
+                    "value": "{\n    backIcon: 'Back',\n    helpIcon: 'Help',\n    icon: 'Builder',\n}",
                     "computed": false
                 }
             },
@@ -1506,7 +1506,7 @@
                 "required": false,
                 "description": "**Text labels for internationalization**\nThis object is merged with the default props object on every render.\n* `back`: The label for the Back link.\n* `help`: The label for the Help link.\n* `pageType`: The label that describes the page type.\n* `title`: The label for the page title.\n_Tested with snapshot testing._",
                 "defaultValue": {
-                    "value": "{\n\tback: 'Back',\n\thelp: 'Help',\n\tpageType: 'Page Type',\n\ttitle: 'App Name',\n}",
+                    "value": "{\n    back: 'Back',\n    help: 'Help',\n    pageType: 'Page Type',\n    title: 'App Name',\n}",
                     "computed": false
                 }
             },
@@ -1648,7 +1648,7 @@
                             "required": false,
                             "description": "**Assistive text for accessibility**\nThis object is merged with the default props object on every render.\n* `actions`: Used for the aria-label for the actions section of the toolbar.\n* _Tested with snapshot testing._",
                             "defaultValue": {
-                                "value": "{\n\tactions: 'Actions',\n}",
+                                "value": "{\n    actions: 'Actions',\n}",
                                 "computed": false
                             }
                         },
@@ -2156,7 +2156,7 @@
             "iconCategory": {
                 "type": {
                     "name": "custom",
-                    "raw": "requiredIf(\n\tPropTypes.oneOf(['action', 'custom', 'doctype', 'standard', 'utility']),\n\t(props) => !!props.iconName\n)"
+                    "raw": "requiredIf(\n    PropTypes.oneOf(['action', 'custom', 'doctype', 'standard', 'utility']),\n    (props) => !!props.iconName\n)"
                 },
                 "required": false,
                 "description": "Name of the icon category. Visit <a href=\"http://www.lightningdesignsystem.com/resources/icons\">Lightning Design System Icons</a> to reference icon categories."
@@ -2914,7 +2914,7 @@
                 "required": false,
                 "description": "Description of the carousel items for screen-readers.",
                 "defaultValue": {
-                    "value": "{\n\tautoplayButton: 'Start / Stop auto-play',\n\tnextPanel: 'Next Panel',\n\tpreviousPanel: 'Previous Panel',\n}",
+                    "value": "{\n    autoplayButton: 'Start / Stop auto-play',\n    nextPanel: 'Next Panel',\n    previousPanel: 'Previous Panel',\n}",
                     "computed": false
                 }
             },
@@ -3341,7 +3341,7 @@
                 "required": false,
                 "description": "**Text labels for internationalization**\nThis object is merged with the default props object on every render.\n* `heading`: Heading for the visual picker variant\n* `label`: Label for the _enabled_ state of the Toggle variant. Defaults to \"Enabled\".\n* `toggleDisabled`: Label for the _disabled_ state of the Toggle variant. Defaults to \"Disabled\". Note that this uses SLDS language, and meaning, of \"Enabled\" and \"Disabled\"; referring to the state of whatever the checkbox is _toggling_, not whether the checkbox itself is enabled or disabled.\n* `toggleEnabled`: Label for the _enabled_ state of the Toggle variant. Defaults to \"Enabled\".",
                 "defaultValue": {
-                    "value": "{\n\ttoggleDisabled: 'Disabled',\n\ttoggleEnabled: 'Enabled',\n}",
+                    "value": "{\n    toggleDisabled: 'Disabled',\n    toggleEnabled: 'Enabled',\n}",
                     "computed": false
                 }
             },
@@ -3742,7 +3742,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility**\n* `label`: Visually hidden label but read out loud by screen readers.\n* `hueSlider`: Instructions for hue selection input\n* `saturationValueGrid`: Instructions for using the grid for saturation\nand value selection",
                 "defaultValue": {
-                    "value": "{\n\tsaturationValueGrid:\n\t\t'Use arrow keys to select a saturation and brightness, on an x and y axis.',\n\thueSlider: 'Select Hue',\n}",
+                    "value": "{\n    saturationValueGrid:\n        'Use arrow keys to select a saturation and brightness, on an x and y axis.',\n    hueSlider: 'Select Hue',\n}",
                     "computed": false
                 }
             },
@@ -3941,7 +3941,7 @@
                 "required": false,
                 "description": "**Text labels for internationalization**\n* `blueAbbreviated`: One letter abbreviation of blue color component\n* `cancelButton`: Text for cancel button on popover\n* `customTab`: Text for custom tab of popover\n* `customTabActiveWorkingColorSwatch`: Label for custom tab active working color swatch\n* `customTabTransparentSwatch`: Label for custom tab active transparent swatch\n* `greenAbbreviated`: One letter abbreviation of green color component\n* `hexLabel`: Label for input of hexadecimal color\n* `invalidColor`: Error message when hex color input is invalid\n* `invalidComponent`: Error message when a component input is invalid\n* `label`: An `input` label as for a `form`\n* `redAbbreviated`: One letter abbreviation of red color component\n* `swatchTab`: Label for swatch tab of popover\n* `submitButton`: Text for submit/done button of popover",
                 "defaultValue": {
-                    "value": "{\n\tblueAbbreviated: 'B',\n\tcancelButton: 'Cancel',\n\tcustomTab: 'Custom',\n\tcustomTabActiveWorkingColorSwatch: 'Working Color',\n\tcustomTabTransparentSwatch: 'Transparent Swatch',\n\tgreenAbbreviated: 'G',\n\thexLabel: 'Hex',\n\tinvalidColor: 'The color entered is invalid',\n\tinvalidComponent: 'The value needs to be an integer from 0-255',\n\tredAbbreviated: 'R',\n\tsubmitButton: 'Done',\n\tswatchTab: 'Default',\n\tswatchTabTransparentSwatch: 'Transparent Swatch',\n}",
+                    "value": "{\n    blueAbbreviated: 'B',\n    cancelButton: 'Cancel',\n    customTab: 'Custom',\n    customTabActiveWorkingColorSwatch: 'Working Color',\n    customTabTransparentSwatch: 'Transparent Swatch',\n    greenAbbreviated: 'G',\n    hexLabel: 'Hex',\n    invalidColor: 'The color entered is invalid',\n    invalidComponent: 'The value needs to be an integer from 0-255',\n    redAbbreviated: 'R',\n    submitButton: 'Done',\n    swatchTab: 'Default',\n    swatchTabTransparentSwatch: 'Transparent Swatch',\n}",
                     "computed": false
                 }
             },
@@ -3980,7 +3980,7 @@
                 "required": false,
                 "description": "An array of hex color values which is used to set the options of the\nswatch tab of the colorpicker popover.\nTo specify transparent, use empty string as a value.",
                 "defaultValue": {
-                    "value": "[\n\t'#e3abec',\n\t'#c2dbf7',\n\t'#9fd6ff',\n\t'#9de7da',\n\t'#9df0c0',\n\t'#fff099',\n\t'#fed49a',\n\t'#d073e0',\n\t'#86baf3',\n\t'#5ebbff',\n\t'#44d8be',\n\t'#3be282',\n\t'#ffe654',\n\t'#ffb758',\n\t'#bd35bd',\n\t'#5779c1',\n\t'#5679c0',\n\t'#00aea9',\n\t'#3cba4c',\n\t'#f5bc25',\n\t'#f99221',\n\t'#580d8c',\n\t'#001970',\n\t'#0a2399',\n\t'#0b7477',\n\t'#0b6b50',\n\t'#b67e11',\n\t'#b85d0d',\n\t'',\n]",
+                    "value": "[\n    '#e3abec',\n    '#c2dbf7',\n    '#9fd6ff',\n    '#9de7da',\n    '#9df0c0',\n    '#fff099',\n    '#fed49a',\n    '#d073e0',\n    '#86baf3',\n    '#5ebbff',\n    '#44d8be',\n    '#3be282',\n    '#ffe654',\n    '#ffb758',\n    '#bd35bd',\n    '#5779c1',\n    '#5679c0',\n    '#00aea9',\n    '#3cba4c',\n    '#f5bc25',\n    '#f99221',\n    '#580d8c',\n    '#001970',\n    '#0a2399',\n    '#0b7477',\n    '#0b6b50',\n    '#b67e11',\n    '#b85d0d',\n    '',\n]",
                     "computed": false
                 }
             },
@@ -4474,7 +4474,7 @@
                 "modifiers": [],
                 "params": [
                     {
-                        "name": "{\n\tassistiveText,\n\tlabels,\n\tprops,\n\tuserDefinedProps,\n}",
+                        "name": "{\n    assistiveText,\n    labels,\n    props,\n    userDefinedProps,\n}",
                         "type": null
                     }
                 ],
@@ -4522,7 +4522,7 @@
                 "modifiers": [],
                 "params": [
                     {
-                        "name": "{\n\tassistiveText,\n\tlabels,\n\tprops,\n\tuserDefinedProps,\n}",
+                        "name": "{\n    assistiveText,\n    labels,\n    props,\n    userDefinedProps,\n}",
                         "type": null
                     }
                 ],
@@ -4534,7 +4534,7 @@
                 "modifiers": [],
                 "params": [
                     {
-                        "name": "{\n\tassistiveText,\n\tlabels,\n\tprops,\n\tuserDefinedProps,\n}",
+                        "name": "{\n    assistiveText,\n    labels,\n    props,\n    userDefinedProps,\n}",
                         "type": null
                     }
                 ],
@@ -4579,7 +4579,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility**\nThis object is merged with the default props object on every render.\n* `label`: This is used as a visually hidden label if, no `labels.label` is provided.\n* `loading`: Text added to loading spinner.\n* `optionSelectedInMenu`: Added before selected menu items in Read-only variants (Picklists). The default is `Current Selection:`.\n* `popoverLabel`: Used by popover variant, assistive text for the Popover aria-label.\n* `removeSingleSelectedOption`: Used by inline-listbox, single-select variant to remove the selected item (pill). This is a button with focus. The default is `Remove selected option`.\n* `removePill`: Used by multiple selection Comboboxes to remove a selected item (pill). Focus is on the pill. This is not a button. The default  is `, Press delete or backspace to remove`.\n* `selectedListboxLabel`: This is a label for the selected listbox. The grouping of pills for multiple selection Comboboxes. The default is `Selected Options:`.\n_Tested with snapshot testing._",
                 "defaultValue": {
-                    "value": "{\n\tloadingMenuItems: 'Loading',\n\toptionSelectedInMenu: 'Current Selection:',\n\tremoveSingleSelectedOption: 'Remove selected option',\n\tremovePill: ', Press delete or backspace to remove',\n\tselectedListboxLabel: 'Selected Options:',\n}",
+                    "value": "{\n    loadingMenuItems: 'Loading',\n    optionSelectedInMenu: 'Current Selection:',\n    removeSingleSelectedOption: 'Remove selected option',\n    removePill: ', Press delete or backspace to remove',\n    selectedListboxLabel: 'Selected Options:',\n}",
                     "computed": false
                 }
             },
@@ -4813,7 +4813,7 @@
                 "required": false,
                 "description": "**Text labels for internationalization**\nThis object is merged with the default props object on every render.\n* `label`: This label appears above the input.\n* `cancelButton`: This label is only used by the dialog variant for the cancel button in the footer of the dialog. The default is `Cancel`\n* `doneButton`: This label is only used by the dialog variant for the done button in the footer of the dialog. The default is `Done`\n* `multipleOptionsSelected`: This label is used by the readonly variant when multiple options are selected. The default is `${props.selection.length} options selected`. This will override the entire string.\n* `noOptionsFound`: Custom message that renders when no matches found. The default empty state is just text that says, 'No matches found.'.\n* `placeholder`: Input placeholder\n* `placeholderReadOnly`: Placeholder for Picklist-like Combobox\n* `removePillTitle`: Title on `X` icon\n_Tested with snapshot testing._",
                 "defaultValue": {
-                    "value": "{\n\tcancelButton: 'Cancel',\n\tdoneButton: `Done`,\n\tnoOptionsFound: 'No matches found.',\n\toptionDisabledTooltipLabel: 'This option is disabled.',\n\tplaceholderReadOnly: 'Select an Option',\n\tremovePillTitle: 'Remove',\n}",
+                    "value": "{\n    cancelButton: 'Cancel',\n    doneButton: `Done`,\n    noOptionsFound: 'No matches found.',\n    optionDisabledTooltipLabel: 'This option is disabled.',\n    placeholderReadOnly: 'Select an Option',\n    removePillTitle: 'Remove',\n}",
                     "computed": false
                 }
             },
@@ -5299,7 +5299,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility.**\nThis object is merged with the default props object on every render.\n* `actionsHeader`: Text for heading of actions column\n* `columnSort`: Text for sort action on table column header\n* `columnSortedAscending`: Text announced once a column is sorted in ascending order\n* `columnSortedDescending`: Text announced once a column is sorted in descending order\n* `selectAllRows`: Text for select all checkbox within the table header\n* `selectRow`: Text for select row. Default: \"Select row 1\"\n* `selectRowGroup`: This is an input group label and is attached to each checkbox or radio. Default is \"Choose a row to select\"",
                 "defaultValue": {
-                    "value": "{\n\tactionsHeader: 'Actions',\n\tcolumnSort: 'Sort by: ',\n\tcolumnSortedAscending: 'Sorted Ascending',\n\tcolumnSortedDescending: 'Sorted Descending',\n\tselectAllRows: 'Select all rows',\n\tselectRow: 'Select row',\n\tselectRowGroup: 'Choose a row to select',\n\tloadingMore: 'Loading more',\n}",
+                    "value": "{\n    actionsHeader: 'Actions',\n    columnSort: 'Sort by: ',\n    columnSortedAscending: 'Sorted Ascending',\n    columnSortedDescending: 'Sorted Descending',\n    selectAllRows: 'Select all rows',\n    selectRow: 'Select row',\n    selectRowGroup: 'Choose a row to select',\n    loadingMore: 'Loading more',\n}",
                     "computed": false
                 }
             },
@@ -6064,7 +6064,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility**\nThis object is merged with the default props object on every render.\n* `nextMonth`: Label for button to go to the next month _Tested with snapshot testing._\n* `openCalendar`: Call to action label for calendar dialog trigger _Tested with snapshot testing._\n* `previousMonth`: Label for button to go to the previous month _Tested with snapshot testing._",
                 "defaultValue": {
-                    "value": "{\n\tnextMonth: 'Next month',\n\topenCalendar: 'Open Calendar',\n\tpreviousMonth: 'Previous month',\n\tyear: 'Year',\n}",
+                    "value": "{\n    nextMonth: 'Next month',\n    openCalendar: 'Open Calendar',\n    previousMonth: 'Previous month',\n    year: 'Year',\n}",
                     "computed": false
                 }
             },
@@ -6132,7 +6132,7 @@
                 "required": false,
                 "description": "Date formatting function that formats the `value` prop (`value` is an ECMAScript `Date()` object) and returns a string to be rendered as the `input` value. Please use an external library such as [MomentJS](https://github.com/moment/moment/) for date formatting and internationalization. _Tested with snapshot testing._\nThe default `formatter` function is:\n```\nformatter(date) {\n  return date\n   ? `${date.getMonth() + 1}/${date.getDate()}/${date.getFullYear()}`\n   : '';\n}\n```",
                 "defaultValue": {
-                    "value": "(date) {\n\treturn date\n\t\t? `${date.getMonth() + 1}/${date.getDate()}/${date.getFullYear()}`\n\t\t: '';\n}",
+                    "value": "function(date) {\n    return date\n        ? `${date.getMonth() + 1}/${date.getDate()}/${date.getFullYear()}`\n        : '';\n}",
                     "computed": false
                 }
             },
@@ -6190,7 +6190,7 @@
                 "required": false,
                 "description": "**Text labels for internationalization**\nThis object is merged with the default props object on every render.\n* `abbreviatedWeekDays`: Three letter abbreviations of the days of the week, starting on Sunday. _Tested with snapshot testing._\n* `months`: Names of the months. _Tested with snapshot testing._\n* `label`: This label appears above the input.\n* `placeholder`: Placeholder text for input. _Tested with snapshot testing._\n* `today`: Label of shortcut to jump to today within the calendar. This is also used for assistive text on today's date. _Tested with snapshot testing._\n* `weekDays`: Full names of the seven days of the week, starting on Sunday. _Tested with snapshot testing._",
                 "defaultValue": {
-                    "value": "{\n\tabbreviatedWeekDays: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],\n\tmonths: [\n\t\t'January',\n\t\t'February',\n\t\t'March',\n\t\t'April',\n\t\t'May',\n\t\t'June',\n\t\t'July',\n\t\t'August',\n\t\t'September',\n\t\t'October',\n\t\t'November',\n\t\t'December',\n\t],\n\tplaceholder: 'Pick a Date',\n\ttoday: 'Today',\n\tweekDays: [\n\t\t'Sunday',\n\t\t'Monday',\n\t\t'Tuesday',\n\t\t'Wednesday',\n\t\t'Thursday',\n\t\t'Friday',\n\t\t'Saturday',\n\t],\n}",
+                    "value": "{\n    abbreviatedWeekDays: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],\n    months: [\n        'January',\n        'February',\n        'March',\n        'April',\n        'May',\n        'June',\n        'July',\n        'August',\n        'September',\n        'October',\n        'November',\n        'December',\n    ],\n    placeholder: 'Pick a Date',\n    today: 'Today',\n    weekDays: [\n        'Sunday',\n        'Monday',\n        'Tuesday',\n        'Wednesday',\n        'Thursday',\n        'Friday',\n        'Saturday',\n    ],\n}",
                     "computed": false
                 }
             },
@@ -6289,7 +6289,7 @@
                 "required": false,
                 "description": "Custom function to parse date string from the `input` value, which must return an ECMAScript `Date()` object.  Please use an external library such as [MomentJS](https://github.com/moment/moment/) for date parsing and internationalization. The default `parser` passes the input value to ECMAScript `Date()` and _prays_ for a miracle. **Do not use the default parsing function in production.** _Tested with snapshot testing._\nThe default `parser function is:\n```\nparser(str) {\n  return new Date(str);\n}\n```",
                 "defaultValue": {
-                    "value": "(str) {\n\tlowPriorityWarning(\n\t\tfalse,\n\t\t`Please use an external library for date parsing and internationalization like MomentJS (https://github.com/moment/moment/) instead of the default parser.`\n\t);\n\treturn new Date(str);\n}",
+                    "value": "function(str) {\n    lowPriorityWarning(\n        false,\n        `Please use an external library for date parsing and internationalization like MomentJS (https://github.com/moment/moment/) instead of the default parser.`\n    );\n    return new Date(str);\n}",
                     "computed": false
                 }
             },
@@ -6602,7 +6602,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility.**\n* `toggleSection`: Label for the icon that expands / collapses the section",
                 "defaultValue": {
-                    "value": "{\n\ttoggleSection: 'Toggle visibility of section',\n}",
+                    "value": "{\n    toggleSection: 'Toggle visibility of section',\n}",
                     "computed": false
                 }
             },
@@ -6777,7 +6777,7 @@
                 "required": false,
                 "description": "**Text labels for internationalization**\nThis object is merged with the default props object on every render.\n* `addCondition`: Label for the Add Condition Button. Defaults to \"Add Condition\"\n* `addGroup`: Label for the Add Group Button. Defaults to \"Add Group\"\n* `customLogic`: Label for the text box for inputting `customLogicValue`, if the `triggerType` is `custom`. Defaults to \"Custom Logic\"\n* `takeAction`: Label for the `triggerType` selector. Defaults to \"Take Action When\"\n* `title` : Title for the Expression. Defaults to \"Conditions\"\n* `triggerAll`: Label for the `all` value within the trigger selector\n* `triggerAlways`: Label for the `always` value within the trigger selector\n* `triggerAny`: Label for the `any` value within the trigger selector\n* `triggerCustom`: Label for the `custom` value within the trigger selector\n* `triggerFormula`: Label for the `formula` value within the trigger selector",
                 "defaultValue": {
-                    "value": "{\n\ttitle: 'Conditions',\n}",
+                    "value": "{\n    title: 'Conditions',\n}",
                     "computed": false
                 }
             },
@@ -6871,7 +6871,7 @@
                             "required": false,
                             "description": "**Assistive text for accessibility.**\n* `title`: For users of assistive technology, title for the condition fieldset. Defaults to 'Condition'\n* `deleteIcon`: For users of assistive technology, assistive text for the Delete Condition button's icon. Defaults to 'Delete Condition'",
                             "defaultValue": {
-                                "value": "{\n\ttitle: 'Condition',\n\tdeleteIcon: 'Delete Condition',\n}",
+                                "value": "{\n    title: 'Condition',\n    deleteIcon: 'Delete Condition',\n}",
                                 "computed": false
                             }
                         },
@@ -6961,7 +6961,7 @@
                             "required": false,
                             "description": "**Text labels for internationalization**\nThis object is merged with the default props object on every\n* `deleteCondition`: Title for the delete condition button. Defaults to \"Delete Condition\".\n* `label`: Label for the condition, shown left-most in the row. Left empty on default.\n* `operator`: Label for the operator selection dropdown. Defaults to \"Operator\"\n* `resource`: Label for the resource selection dropdown. Defaults to \"Resource\"\n* `value`: Label for the value input box. Defaults to \"Value\"",
                             "defaultValue": {
-                                "value": "{\n\tlabel: '',\n\toperator: 'Operator',\n\tresource: 'Resource',\n\tvalue: 'Value',\n\tdeleteCondition: 'Delete Condition',\n}",
+                                "value": "{\n    label: '',\n    operator: 'Operator',\n    resource: 'Resource',\n    value: 'Value',\n    deleteCondition: 'Delete Condition',\n}",
                                 "computed": false
                             }
                         },
@@ -7061,7 +7061,7 @@
                             "required": false,
                             "description": "**Assistive text for accessibility.**\n* `help`: Assistive text for help icon",
                             "defaultValue": {
-                                "value": "{\n\thelp: 'Help',\n}",
+                                "value": "{\n    help: 'Help',\n}",
                                 "computed": false
                             }
                         },
@@ -7132,7 +7132,7 @@
                             "required": false,
                             "description": "**Text labels for internationalization**\nThis object is merged with the default props object on every render.\n* `label`: Label for the Expression Formula group.Defaults to \"Formula\"\n* `checkSyntax`: Label for the Check Syntax Button. Defaults to \"Check Syntax\"\n* `textArea`: Label for the `triggerType` selector. Defaults to \"Take Action When\"",
                             "defaultValue": {
-                                "value": "{\n\tlabel: 'Formula',\n\tcheckSyntax: 'Check Syntax',\n\ttextArea: 'Text Area',\n}",
+                                "value": "{\n    label: 'Formula',\n    checkSyntax: 'Check Syntax',\n    textArea: 'Text Area',\n}",
                                 "computed": false
                             }
                         },
@@ -7350,7 +7350,7 @@
                             "required": false,
                             "description": "**Text labels for internationalization**\nThis object is merged with the default props object on every render.\n* `addCondition`: Label for the Add Condition Button. Defaults to \"Add Condition\"\n* `addGroup`: Label for the Add Group Button. Defaults to \"Add Group\"\n* `customLogic`: Label for the text box for inputting `customLogicValue`, if the `triggerType` is `custom`. Defaults to \"Custom Logic\"\n* `label`: Label for the expression group, to indicate condition connectors based on the parent's trigger-type chosen. Defaults to \"\"\n* `takeAction`: Label for the `triggerType` selector. Defaults to \"Take Action When\"\n* `triggerAll`: Label for the `all` value within the trigger selector\n* `triggerAlways`: Label for the `always` value within the trigger selector\n* `triggerAny`: Label for the `any` value within the trigger selector\n* `triggerCustom`: Label for the `custom` value within the trigger selector\n* `triggerFormula`: Label for the `formula` value within the trigger selector",
                             "defaultValue": {
-                                "value": "{\n\tlabel: '',\n\ttakeAction: 'Take Action When',\n\tcustomLogic: 'Custom Logic',\n\taddCondition: 'Add Condition',\n\taddGroup: 'Add Group',\n\ttriggerAll: 'All Conditions Are Met',\n\ttriggerAny: 'Any Condition Is Met',\n\ttriggerCustom: 'Custom Logic Is Met',\n\ttriggerAlways: 'Always (No Criteria)',\n\ttriggerFormula: 'Formula Evaluates To True',\n}",
+                                "value": "{\n    label: '',\n    takeAction: 'Take Action When',\n    customLogic: 'Custom Logic',\n    addCondition: 'Add Condition',\n    addGroup: 'Add Group',\n    triggerAll: 'All Conditions Are Met',\n    triggerAny: 'Any Condition Is Met',\n    triggerCustom: 'Custom Logic Is Met',\n    triggerAlways: 'Always (No Criteria)',\n    triggerFormula: 'Formula Evaluates To True',\n}",
                                 "computed": false
                             }
                         },
@@ -7539,7 +7539,7 @@
                             "required": false,
                             "description": "**Assistive text for accessibility**\n * download - description for the download button if present\n * image - description for the file image\n * link - description for the file link\n * loading - description for the loading spinner if present\n * moreActions - description for the more actions dropdown if present",
                             "defaultValue": {
-                                "value": "{\n\tdownload: 'download',\n\tlink: 'Preview:',\n\tloading: 'loading',\n\tmoreActions: 'more actions',\n}",
+                                "value": "{\n    download: 'download',\n    link: 'Preview:',\n    loading: 'loading',\n    moreActions: 'more actions',\n}",
                                 "computed": false
                             }
                         },
@@ -7720,7 +7720,7 @@
                             "required": false,
                             "description": "**Assistive text for accessibility**\n * count - description for the more files count\n * image - description for the image\n * link - description for the more files link",
                             "defaultValue": {
-                                "value": "{\n\tcount: 'more files',\n\timage: 'Show more files',\n\tlink: 'Preview:',\n}",
+                                "value": "{\n    count: 'more files',\n    image: 'Show more files',\n    link: 'Preview:',\n}",
                                 "computed": false
                             }
                         },
@@ -7910,7 +7910,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility**\n* `removeFilter`: Assistive text for removing a filter. The default is `Remove Filter: this.props.property this.props.predicate`.\n* `editFilter`: Assistive text for changing a filter.\n* `editFilterHeading`: Assistive text for Popover heading.",
                 "defaultValue": {
-                    "value": "{\n\teditFilter: 'Edit filter:',\n\teditFilterHeading: 'Choose filter criteria',\n}",
+                    "value": "{\n    editFilter: 'Edit filter:',\n    editFilterHeading: 'Choose filter criteria',\n}",
                     "computed": false
                 }
             },
@@ -8072,7 +8072,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility.**\nThis object is merged with the default props object on every render.\n* `skipToNav`: The localized text that will be read back for the \"Skip to Navigation\" accessibility link.\n* `skipToContent`: The localized text that will be read back for the \"Skip to Main Content\" accessibility link.",
                 "defaultValue": {
-                    "value": "{\n\tskipToNav: 'Skip to Navigation',\n\tskipToContent: 'Skip to Main Content',\n}",
+                    "value": "{\n    skipToNav: 'Skip to Navigation',\n    skipToContent: 'Skip to Main Content',\n}",
                     "computed": false
                 }
             },
@@ -8155,7 +8155,7 @@
                             "required": false,
                             "description": "**Assistive text for accessibility**\n* `action`: Description of star button. Default is \"Toggle Favorite.\"\n* `more`: Description of dropdown menu. Default is \"View Favorites.\"",
                             "defaultValue": {
-                                "value": "{\n\taction: 'Toggle Favorite',\n\tmore: 'View Favorites',\n}",
+                                "value": "{\n    action: 'Toggle Favorite',\n    more: 'View Favorites',\n}",
                                 "computed": false
                             }
                         },
@@ -8210,7 +8210,7 @@
                             "required": false,
                             "description": "**Assistive text for accessibility**\n* `triggerButton`: Assistive text for the GlobalHeaderHelp trigger button. The default is `Help and Training`.",
                             "defaultValue": {
-                                "value": "{\n\ttriggerButton: 'Help and Training',\n}",
+                                "value": "{\n    triggerButton: 'Help and Training',\n}",
                                 "computed": false
                             }
                         },
@@ -8252,7 +8252,7 @@
                             "required": false,
                             "description": "**Assistive text for accessibility**\n* `newNotificationsAfter`: Assistive text for when there are new notifications, after the notificationCount. The default is ' new notifications'.\n* `newNotificationsBefore`: Assistive text for when there are new notifications, before the notificationCount. The default is ''.\n* `noNotifications`: Assistive text for when there are no new notifications.",
                             "defaultValue": {
-                                "value": "{\n\tnewNotificationsAfter: ' new notifications',\n\tnewNotificationsBefore: '',\n\tnoNotifications: 'No new notifications',\n}",
+                                "value": "{\n    newNotificationsAfter: ' new notifications',\n    newNotificationsBefore: '',\n    noNotifications: 'No new notifications',\n}",
                                 "computed": false
                             }
                         },
@@ -8389,7 +8389,7 @@
                             "required": false,
                             "description": "**Assistive text for accessibility**\n* `triggerButton`: Assistive text for the GlobalHeaderSetup trigger button. The default is `Setup`.",
                             "defaultValue": {
-                                "value": "{\n\ttriggerButton: 'Setup',\n}",
+                                "value": "{\n    triggerButton: 'Setup',\n}",
                                 "computed": false
                             }
                         },
@@ -8423,7 +8423,7 @@
                             "required": false,
                             "description": "**Assistive text for accessibility**\n* `triggerButton`: Assistive text for the GlobalHeaderTask trigger button. The default is `Global Actions`.",
                             "defaultValue": {
-                                "value": "{\n\ttriggerButton: 'Global Actions',\n}",
+                                "value": "{\n    triggerButton: 'Global Actions',\n}",
                                 "computed": false
                             }
                         },
@@ -8802,7 +8802,7 @@
                             "required": false,
                             "description": "**Assistive text for accessibility.**\n* `activeDescriptor`: The text that appears alongside a link that is currently active.",
                             "defaultValue": {
-                                "value": "{\n\tactiveDescriptor: 'Current page:',\n}",
+                                "value": "{\n    activeDescriptor: 'Current page:',\n}",
                                 "computed": false
                             }
                         },
@@ -9551,7 +9551,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility**\n* `label`: Visually hidden label but read out loud by screen readers.\n* `spinner`: Text for loading spinner icon.",
                 "defaultValue": {
-                    "value": "{\n\tdecrement: `${DECREMENT} ${COUNTER}`,\n\tincrement: `${INCREMENT} ${COUNTER}`,\n}",
+                    "value": "{\n    decrement: `${DECREMENT} ${COUNTER}`,\n    increment: `${INCREMENT} ${COUNTER}`,\n}",
                     "computed": false
                 }
             },
@@ -10556,7 +10556,7 @@
                 "modifiers": [],
                 "params": [
                     {
-                        "name": "{\n\tevent,\n\tisOpen = true,\n\tkeyCode,\n\tonFocus = this.handleKeyboardFocus,\n\tonSelect,\n\ttarget,\n\ttoggleOpen = noop,\n}",
+                        "name": "{\n    event,\n    isOpen = true,\n    keyCode,\n    onFocus = this.handleKeyboardFocus,\n    onSelect,\n    target,\n    toggleOpen = noop,\n}",
                         "type": null
                     }
                 ],
@@ -10838,7 +10838,7 @@
             "iconCategory": {
                 "type": {
                     "name": "custom",
-                    "raw": "requiredIf(\n\tPropTypes.oneOf(['action', 'custom', 'doctype', 'standard', 'utility']),\n\t(props) => !!props.iconName\n)"
+                    "raw": "requiredIf(\n    PropTypes.oneOf(['action', 'custom', 'doctype', 'standard', 'utility']),\n    (props) => !!props.iconName\n)"
                 },
                 "required": false,
                 "description": "Name of the icon category. Visit <a href=\"http://www.lightningdesignsystem.com/resources/icons\">Lightning Design System Icons</a> to reference icon categories."
@@ -11630,7 +11630,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility.**\nThis object is merged with the default props object on every render.\n* `dialogLabel`: This is a visually hidden label for the dialog. If not provided, `heading` is used.\n* `dialogLabelledBy`: This describes which node labels the dialog. If not provided and dialogLabel is unavailable, `id` is used.\n* `closeButton`: This is a visually hidden label for the close button.",
                 "defaultValue": {
-                    "value": "{\n\tdialogLabel: '',\n\tdialogLabelledBy: '',\n\tcloseButton: 'Close',\n}",
+                    "value": "{\n    dialogLabel: '',\n    dialogLabelledBy: '',\n    closeButton: 'Close',\n}",
                     "computed": false
                 }
             },
@@ -12142,7 +12142,7 @@
                             "required": false,
                             "description": "**Assistive text for accessibility.**\nThis object is merged with the default props object on every render.\n* `closeButton`: Localized description of the close button for the panel for screen readers",
                             "defaultValue": {
-                                "value": "{\n\tcloseButton: 'Close Filter Panel',\n}",
+                                "value": "{\n    closeButton: 'Close Filter Panel',\n}",
                                 "computed": false
                             }
                         },
@@ -12508,7 +12508,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility**\n* `listboxLabel`: This is a label for the listbox. The default is `Selected Options:`.\n* `removePill`: Used to remove a selected item (pill). Focus is on the pill. This is not a button. The default is `Press delete or backspace to remove`.",
                 "defaultValue": {
-                    "value": "{\n\tlistboxLabel: 'Selected Options:',\n\tremovePill: 'Press delete or backspace to remove',\n}",
+                    "value": "{\n    listboxLabel: 'Selected Options:',\n    removePill: 'Press delete or backspace to remove',\n}",
                     "computed": false
                 }
             },
@@ -12550,7 +12550,7 @@
                 "required": false,
                 "description": "**Text labels for internationalization**\n* `removePillTitle`: Title on `X` icon",
                 "defaultValue": {
-                    "value": "{\n\tremovePillTitle: 'Remove',\n}",
+                    "value": "{\n    removePillTitle: 'Remove',\n}",
                     "computed": false
                 }
             },
@@ -13233,7 +13233,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility.**\nThis object is merged with the default props object on every render.\n* `closeButton`: This is a visually hidden label for the close button.",
                 "defaultValue": {
-                    "value": "{\n\tcloseButton: 'Close dialog',\n}",
+                    "value": "{\n    closeButton: 'Close dialog',\n}",
                     "computed": false
                 }
             },
@@ -13647,7 +13647,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility**\nThis object is merged with the default props object on every render.\n* `progress`: This is a visually hidden label for the percent of progress.\n_Tested with snapshot testing._",
                 "defaultValue": {
-                    "value": "{\n\tprogress: 'Progress',\n}",
+                    "value": "{\n    progress: 'Progress',\n}",
                     "computed": false
                 }
             },
@@ -13709,7 +13709,7 @@
                 "required": false,
                 "description": "Label for the progress bar",
                 "defaultValue": {
-                    "value": "{\n\tcomplete: 'Complete',\n}",
+                    "value": "{\n    complete: 'Complete',\n}",
                     "computed": false
                 }
             },
@@ -13799,7 +13799,7 @@
                 "required": false,
                 "description": "Custom styles to be passed to the component",
                 "defaultValue": {
-                    "value": "{\n\theight: '100%',\n}",
+                    "value": "{\n    height: '100%',\n}",
                     "computed": false
                 }
             }
@@ -13854,7 +13854,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility**\nThis object is merged with the default props object on every render.\n* `completedStep`: Label for a completed step. The default is `Completed Step`\n* `disabledStep`: Label for disabled step. The default is `Disabled Step`\n* `errorStep`: Label for a step with an error. The default is `Error Step`\n* `percentage`: Label for Progress Bar. The default is `Progress: [this.props.value]%`. You will need to calculate the percentage yourself if changing this string.\n* `step`: Label for a step. It will be typically followed by the number of the step such as \"Step 1\".",
                 "defaultValue": {
-                    "value": "{\n\tcompletedStep: 'Completed',\n\tdisabledStep: 'Disabled',\n\terrorStep: 'Error',\n\tstep: 'Step',\n}",
+                    "value": "{\n    completedStep: 'Completed',\n    disabledStep: 'Disabled',\n    errorStep: 'Error',\n    step: 'Step',\n}",
                     "computed": false
                 }
             },
@@ -15492,7 +15492,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility**\n* `toggleButtonOpen`: The button used to open the split view.\n* `toggleButtonClose`: The button used to close the split view.",
                 "defaultValue": {
-                    "value": "{\n\ttoggleButtonOpen: 'Close split view',\n\ttoggleButtonClose: 'Open split view',\n}",
+                    "value": "{\n    toggleButtonOpen: 'Close split view',\n    toggleButtonClose: 'Open split view',\n}",
                     "computed": false
                 }
             },
@@ -15866,7 +15866,7 @@
                             "required": false,
                             "description": "**Assistive text for accessibility**\n* `list`: aria label for the list\n* `sort`\n   * `sortedBy`: Clickable sort header for the list.\n   * `descending`: Descending sorting.\n   * `ascending`: Ascending sorting.",
                             "defaultValue": {
-                                "value": "{\n\tlist: 'Select an item to open it in a new workspace tab.',\n\tsort: {\n\t\tsortedBy: 'Sorted by',\n\t\tdescending: 'Descending',\n\t\tascending: 'Ascending',\n\t},\n}",
+                                "value": "{\n    list: 'Select an item to open it in a new workspace tab.',\n    sort: {\n        sortedBy: 'Sorted by',\n        descending: 'Descending',\n        ascending: 'Ascending',\n    },\n}",
                                 "computed": false
                             }
                         },
@@ -16726,7 +16726,7 @@
                 "required": false,
                 "description": "Time formatting function",
                 "defaultValue": {
-                    "value": "(date) {\n\tif (date) {\n\t\treturn date.toLocaleTimeString(navigator.language, {\n\t\t\thour: '2-digit',\n\t\t\tminute: '2-digit',\n\t\t});\n\t}\n\n\treturn null;\n}",
+                    "value": "function(date) {\n    if (date) {\n        return date.toLocaleTimeString(navigator.language, {\n            hour: '2-digit',\n            minute: '2-digit',\n        });\n    }\n\n    return null;\n}",
                     "computed": false
                 }
             },
@@ -16790,7 +16790,7 @@
                 "required": false,
                 "description": "Parsing date string into Date",
                 "defaultValue": {
-                    "value": "(timeStr) {\n\tconst date = new Date();\n\tconst dateStr = date.toLocaleString(navigator.language, {\n\t\tyear: 'numeric',\n\t\tmonth: 'numeric',\n\t\tday: 'numeric',\n\t});\n\treturn new Date(`${dateStr} ${timeStr}`);\n}",
+                    "value": "function(timeStr) {\n    const date = new Date();\n    const dateStr = date.toLocaleString(navigator.language, {\n        year: 'numeric',\n        month: 'numeric',\n        day: 'numeric',\n    });\n    return new Date(`${dateStr} ${timeStr}`);\n}",
                     "computed": false
                 }
             },
@@ -16896,7 +16896,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility**\nThis object is merged with the default props object on every render.\n* `closeButton`: This is a visually hidden label for the close button.\n* `error`: This is a visually hidden label to mark the toast as an error variant\n* `info`: This is a visually hidden label to mark the toast as an info variant\n* `success`: This is a visually hidden label to mark the toast as an success variant\n* `warning`: This is a visually hidden label to mark the toast as an warning variant\n_Tested with snapshot testing._",
                 "defaultValue": {
-                    "value": "{\n\tcloseButton: 'Close',\n\terror: 'error',\n\tinfo: 'info',\n\tsuccess: 'success',\n\twarning: 'warning',\n}",
+                    "value": "{\n    closeButton: 'Close',\n    error: 'error',\n    info: 'info',\n    success: 'success',\n    warning: 'warning',\n}",
                     "computed": false
                 }
             },
@@ -17234,7 +17234,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility**\nThis object is merged with the default props object on every render.\n* `tooltipTipLearnMoreIcon`: This text is inside the info icon within the tooltip content and exists to \"complete the sentence\" for assistive tech users.\n* `triggerLearnMoreIcon`: This text is inside the info icon that triggers the tooltip in order to have text within the link.",
                 "defaultValue": {
-                    "value": "{\n\ttooltipTipLearnMoreIcon: 'this link',\n\ttriggerLearnMoreIcon: 'Help',\n}",
+                    "value": "{\n    tooltipTipLearnMoreIcon: 'this link',\n    triggerLearnMoreIcon: 'Help',\n}",
                     "computed": false
                 }
             },
@@ -17334,7 +17334,7 @@
                 "required": false,
                 "description": "**Text labels for internationalization**\nThis object is merged with the default props object on every render.\n* `learnMoreAfter`: This label appears in the tooltip after the info icon.\n* `learnMoreBefore`: This label appears in the tooltip before the info icon.",
                 "defaultValue": {
-                    "value": "{\n\tlearnMoreAfter: 'to learn more.',\n\tlearnMoreBefore: 'Click',\n}",
+                    "value": "{\n    learnMoreAfter: 'to learn more.',\n    learnMoreBefore: 'Click',\n}",
                     "computed": false
                 }
             },
@@ -17726,7 +17726,7 @@
                 "required": false,
                 "description": "**Text labels for internationalization**\nThis object is merged with the default props object on every render.\n* `learnMoreAfter`: Amount of time left in trial, e.g. `30`\n* `learnMoreBefore`: Unit of the amount of time left, e.g. `days`\n* `timeLeftUnitAfter`: String after `timeLeftUnit`",
                 "defaultValue": {
-                    "value": "{\n\ttimeLeftUnitAfter: 'left in trial',\n}",
+                    "value": "{\n    timeLeftUnitAfter: 'left in trial',\n}",
                     "computed": false
                 }
             },
@@ -18084,7 +18084,7 @@
                 "required": false,
                 "description": "**Weclome Mat labels for internationalization**\nThis object is merged with the default props object on every render.\n* `title`: Title for the Welcome Mat\n* `description`: Label for the radio input\n* `unitsCompletedAfter`: Label for the radio input",
                 "defaultValue": {
-                    "value": "{\n\tunitsCompletedAfter: 'units completed',\n}",
+                    "value": "{\n    unitsCompletedAfter: 'units completed',\n}",
                     "computed": false
                 }
             },
@@ -18273,7 +18273,7 @@
                             "required": false,
                             "description": "**Assistive text for accessibility.**\nThis object is merged with the default props object on every render.\n* `completeIcon`: Text that is visually hidden but read aloud by screenreaders to tell the user what the complete icon means.",
                             "defaultValue": {
-                                "value": "{\n\tcompletedIcon: 'Completed',\n}",
+                                "value": "{\n    completedIcon: 'Completed',\n}",
                                 "computed": false
                             }
                         },

--- a/components/date-picker/__tests__/__snapshots__/datepicker.dom-snapshot-test.jsx.snap
+++ b/components/date-picker/__tests__/__snapshots__/datepicker.dom-snapshot-test.jsx.snap
@@ -171,6 +171,7 @@ exports[`Datepicker
               >
                 <div
                   className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-shrink-none"
+                  role="combobox"
                 >
                   <div
                     className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -1034,6 +1035,7 @@ exports[`Datepicker
                 >
                   <div
                     className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-shrink-none"
+                    role="combobox"
                   >
                     <div
                       className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -1896,6 +1898,7 @@ exports[`Datepicker
               >
                 <div
                   className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-shrink-none"
+                  role="combobox"
                 >
                   <div
                     className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -2755,6 +2758,7 @@ exports[`Datepicker Default DOM Snapshot 1`] = `
               >
                 <div
                   className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-shrink-none"
+                  role="combobox"
                 >
                   <div
                     className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -3481,7 +3485,7 @@ exports[`Datepicker Default HTML Snapshot 1`] = `
           <div class=\\"slds-form-element\\"><label class=\\"slds-form-element__label slds-assistive-text\\" for=\\"sample-datepicker-year-picklist\\">Year</label>
             <div class=\\"slds-form-element__control\\">
               <div class=\\"slds-combobox_container\\">
-                <div class=\\"slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-shrink-none\\">
+                <div class=\\"slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-shrink-none\\" role=\\"combobox\\">
                   <div class=\\"slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right\\" role=\\"none\\"><input type=\\"text\\" autoComplete=\\"off\\" class=\\"slds-input slds-combobox__input\\" id=\\"sample-datepicker-year-picklist\\" placeholder=\\"Select an Option\\" readonly=\\"\\" role=\\"combobox\\" aria-autocomplete=\\"list\\" aria-expanded=\\"false\\" aria-haspopup=\\"listbox\\" value=\\"2014\\" /><span class=\\"slds-icon_container slds-input__icon slds-input__icon_right\\"><svg aria-hidden=\\"true\\" class=\\"slds-icon slds-icon_x-small slds-icon-text-default\\">
                         <use href=\\"/assets/icons/utility-sprite/svg/symbols.svg#down\\"></use>
                       </svg></span></div>

--- a/components/expression/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/expression/__docs__/__snapshots__/storybook-stories.storyshot
@@ -37,6 +37,7 @@ exports[`DOM snapshots SLDSExpression Initial State 1`] = `
             >
               <div
                 className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+                role="combobox"
               >
                 <div
                   className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -122,6 +123,7 @@ exports[`DOM snapshots SLDSExpression Initial State 1`] = `
                     >
                       <div
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+                        role="combobox"
                       >
                         <div
                           className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -186,6 +188,7 @@ exports[`DOM snapshots SLDSExpression Initial State 1`] = `
                     >
                       <div
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+                        role="combobox"
                       >
                         <div
                           className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -379,6 +382,7 @@ exports[`DOM snapshots SLDSExpression w/ Custom Logic 1`] = `
             >
               <div
                 className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+                role="combobox"
               >
                 <div
                   className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -485,6 +489,7 @@ exports[`DOM snapshots SLDSExpression w/ Custom Logic 1`] = `
                     >
                       <div
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+                        role="combobox"
                       >
                         <div
                           className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -549,6 +554,7 @@ exports[`DOM snapshots SLDSExpression w/ Custom Logic 1`] = `
                     >
                       <div
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+                        role="combobox"
                       >
                         <div
                           className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -701,6 +707,7 @@ exports[`DOM snapshots SLDSExpression w/ Custom Logic 1`] = `
                     >
                       <div
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+                        role="combobox"
                       >
                         <div
                           className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -765,6 +772,7 @@ exports[`DOM snapshots SLDSExpression w/ Custom Logic 1`] = `
                     >
                       <div
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+                        role="combobox"
                       >
                         <div
                           className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -954,6 +962,7 @@ exports[`DOM snapshots SLDSExpression w/ Formula Logic 1`] = `
           >
             <div
               className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+              role="combobox"
             >
               <div
                 className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -1040,6 +1049,7 @@ exports[`DOM snapshots SLDSExpression w/ Formula Logic 1`] = `
                     >
                       <div
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+                        role="combobox"
                       >
                         <div
                           className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -1099,6 +1109,7 @@ exports[`DOM snapshots SLDSExpression w/ Formula Logic 1`] = `
                     >
                       <div
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+                        role="combobox"
                       >
                         <div
                           className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -1269,6 +1280,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
             >
               <div
                 className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+                role="combobox"
               >
                 <div
                   className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -1354,6 +1366,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                     >
                       <div
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+                        role="combobox"
                       >
                         <div
                           className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -1418,6 +1431,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                     >
                       <div
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+                        role="combobox"
                       >
                         <div
                           className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -1565,6 +1579,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                   >
                     <div
                       className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+                      role="combobox"
                     >
                       <div
                         className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -1650,6 +1665,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                           >
                             <div
                               className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+                              role="combobox"
                             >
                               <div
                                 className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -1714,6 +1730,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                           >
                             <div
                               className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+                              role="combobox"
                             >
                               <div
                                 className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -1866,6 +1883,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                           >
                             <div
                               className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+                              role="combobox"
                             >
                               <div
                                 className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -1930,6 +1948,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                           >
                             <div
                               className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+                              role="combobox"
                             >
                               <div
                                 className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -2101,6 +2120,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                   >
                     <div
                       className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+                      role="combobox"
                     >
                       <div
                         className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -2207,6 +2227,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                           >
                             <div
                               className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+                              role="combobox"
                             >
                               <div
                                 className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -2271,6 +2292,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                           >
                             <div
                               className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+                              role="combobox"
                             >
                               <div
                                 className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -2488,6 +2510,7 @@ exports[`DOM snapshots SLDSExpression w/ Multiple Conditions 1`] = `
             >
               <div
                 className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+                role="combobox"
               >
                 <div
                   className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -2573,6 +2596,7 @@ exports[`DOM snapshots SLDSExpression w/ Multiple Conditions 1`] = `
                     >
                       <div
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+                        role="combobox"
                       >
                         <div
                           className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -2637,6 +2661,7 @@ exports[`DOM snapshots SLDSExpression w/ Multiple Conditions 1`] = `
                     >
                       <div
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+                        role="combobox"
                       >
                         <div
                           className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -2789,6 +2814,7 @@ exports[`DOM snapshots SLDSExpression w/ Multiple Conditions 1`] = `
                     >
                       <div
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+                        role="combobox"
                       >
                         <div
                           className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -2853,6 +2879,7 @@ exports[`DOM snapshots SLDSExpression w/ Multiple Conditions 1`] = `
                     >
                       <div
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+                        role="combobox"
                       >
                         <div
                           className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -3046,6 +3073,7 @@ exports[`DOM snapshots SLDSExpression w/ Resource Selected 1`] = `
             >
               <div
                 className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+                role="combobox"
               >
                 <div
                   className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -3131,6 +3159,7 @@ exports[`DOM snapshots SLDSExpression w/ Resource Selected 1`] = `
                     >
                       <div
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+                        role="combobox"
                       >
                         <div
                           className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -3195,6 +3224,7 @@ exports[`DOM snapshots SLDSExpression w/ Resource Selected 1`] = `
                     >
                       <div
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+                        role="combobox"
                       >
                         <div
                           className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"

--- a/components/global-header/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/global-header/__docs__/__snapshots__/storybook-stories.storyshot
@@ -56,6 +56,7 @@ exports[`DOM snapshots SLDSGlobalHeader Doc site Default 1`] = `
             >
               <div
                 className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+                role="combobox"
               >
                 <div
                   className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -547,6 +548,7 @@ exports[`DOM snapshots SLDSGlobalHeader Search + Navigation 1`] = `
             >
               <div
                 className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+                role="combobox"
               >
                 <div
                   className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
@@ -929,6 +931,7 @@ exports[`DOM snapshots SLDSGlobalHeader With custom <Avatar/> 1`] = `
             >
               <div
                 className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
+                role="combobox"
               >
                 <div
                   className="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"

--- a/tests/axe-config.js
+++ b/tests/axe-config.js
@@ -14,12 +14,17 @@ const axeConfig = {
 			id: 'autocomplete-valid',
 			enabled: false,
 		},
-		// .slds-combobox[aria-haspopup="dialog" is not currently supported by aXe-core
-		// See issue https://github.com/dequelabs/axe-core/issues/1009
+		// Not in ARIA 1.2 spec, temporary for SLDS styles
+		{
+			id: 'aria-required-attr',
+			enabled: false,
+			selector: '.slds-combobox',
+		},
+    // Not in ARIA 1.2 spec, temporary for SLDS styles
 		{
 			id: 'aria-required-children',
 			enabled: false,
-			selector: '.slds-combobox[aria-haspopup="dialog"]',
+			selector: '.slds-combobox',
 		},
 		{
 			id: 'color-contrast',

--- a/tests/axe-config.js
+++ b/tests/axe-config.js
@@ -20,7 +20,7 @@ const axeConfig = {
 			enabled: false,
 			selector: '.slds-combobox',
 		},
-    // Not in ARIA 1.2 spec, temporary for SLDS styles
+		// Not in ARIA 1.2 spec, temporary for SLDS styles
 		{
 			id: 'aria-required-children',
 			enabled: false,


### PR DESCRIPTION
Fixes #2759 

Temporary fix: Added `role="combobox"` to the outer div of the `input` to allow the input to be picked up by the SLDS attribute selectors. See issue description.

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [x] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [x] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [x] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
