### PR TITLE
Add note about info prop and record-home variant

### DIFF
--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -11487,6 +11487,13 @@
                 "returns": null
             },
             {
+                "name": "getAriaAttributes",
+                "docblock": null,
+                "modifiers": [],
+                "params": [],
+                "returns": null
+            },
+            {
                 "name": "getModal",
                 "docblock": null,
                 "modifiers": [],
@@ -11630,7 +11637,7 @@
                 "required": false,
                 "description": "**Assistive text for accessibility.**\nThis object is merged with the default props object on every render.\n* `dialogLabel`: This is a visually hidden label for the dialog. If not provided, `heading` is used.\n* `dialogLabelledBy`: This describes which node labels the dialog. If not provided and dialogLabel is unavailable, `id` is used.\n* `closeButton`: This is a visually hidden label for the close button.",
                 "defaultValue": {
-                    "value": "{\n\tdialogLabel: '',\n\tdialogLabelledBy: '',\n\tcloseButton: 'Close',\n}",
+                    "value": "{\n\tdialogLabelledBy: '',\n\tcloseButton: 'Close',\n}",
                     "computed": false
                 }
             },
@@ -11924,7 +11931,7 @@
                     "name": "array"
                 },
                 "required": false,
-                "description": "An array of detail blocks (used in \"recordHome\" variant)"
+                "description": "An array of detail blocks (used in `recordHome` variant)"
             },
             "label": {
                 "type": {
@@ -11961,7 +11968,7 @@
                     ]
                 },
                 "required": false,
-                "description": "The info property can be a string or a React element"
+                "description": "The info property can be a string or a React element. Can't be used with the `record-home` variant."
             },
             "joined": {
                 "type": {

--- a/components/page-header/index.jsx
+++ b/components/page-header/index.jsx
@@ -41,7 +41,7 @@ const propTypes = {
 		PropTypes.string,
 	]),
 	/**
-	 * An array of detail blocks (used in "recordHome" variant)
+	 * An array of detail blocks (used in `recordHome` variant)
 	 */
 	details: PropTypes.array,
 	/**
@@ -53,7 +53,7 @@ const propTypes = {
 	 */
 	icon: PropTypes.element,
 	/**
-	 * The info property can be a string or a React element
+	 * The info property can be a string or a React element. Can't be used with the `record-home` variant.
 	 */
 	info: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
 	/**


### PR DESCRIPTION
Adds a note about how the `info` prop can't be used with the `record-home` variant of `<PageHeader />`.

### Additional description

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [ ] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [ ] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
