### PR TITLE
Remove `javascript:` URLs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -158,8 +158,6 @@ module.exports = {
 				},
 			},
 		],
-		// javascript:void(0) is present in SLDS markup
-		'no-script-url': 'off',
 		// _ is not really private.
 		'no-underscore-dangle': ['error', { allowAfterThis: true }],
 		//
@@ -247,7 +245,7 @@ module.exports = {
 		// TODO: Should be removed
 		'react/no-deprecated': 'off',
 
-		// javascript:void(0) is present in SLDS markup
+		// <a href="#"> is present in SLDS markup
 		'jsx-a11y/anchor-is-valid': 'off',
 		'jsx-a11y/aria-activedescendant-has-tabindex': 2,
 		'jsx-a11y/interactive-supports-focus': 2,

--- a/components/alert/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/alert/__docs__/__snapshots__/storybook-stories.storyshot
@@ -53,7 +53,7 @@ exports[`DOM snapshots SLDSAlert Custom Class Names 1`] = `
         Logged in as John Smith (johnsmith@acme.com).
          
         <a
-          href="javascript:void(0);"
+          href="#"
           onClick={[Function]}
         >
           Log out
@@ -102,7 +102,7 @@ exports[`DOM snapshots SLDSAlert Custom Styles 1`] = `
         Logged in as John Smith (johnsmith@acme.com).
          
         <a
-          href="javascript:void(0);"
+          href="#"
           onClick={[Function]}
         >
           Log out
@@ -146,7 +146,7 @@ exports[`DOM snapshots SLDSAlert Dismissable 1`] = `
         Logged in as John Smith (johnsmith@acme.com).
          
         <a
-          href="javascript:void(0);"
+          href="#"
           onClick={[Function]}
         >
           Log out
@@ -211,7 +211,7 @@ exports[`DOM snapshots SLDSAlert Error 1`] = `
         Your browser is currently not supported. Your Salesforce may be degraded.
          
         <a
-          href="javascript:void(0);"
+          href="#"
           onClick={[Function]}
         >
           More Information
@@ -255,7 +255,7 @@ exports[`DOM snapshots SLDSAlert Info 1`] = `
         Logged in as John Smith (johnsmith@acme.com).
          
         <a
-          href="javascript:void(0);"
+          href="#"
           onClick={[Function]}
         >
           Log out
@@ -299,7 +299,7 @@ exports[`DOM snapshots SLDSAlert Offline 1`] = `
         You are in offline mode.
          
         <a
-          href="javascript:void(0);"
+          href="#"
           onClick={[Function]}
         >
           More information
@@ -343,7 +343,7 @@ exports[`DOM snapshots SLDSAlert Warning 1`] = `
         Your browser is outdated. Your Salesforce experience may be degraded.
          
         <a
-          href="javascript:void(0);"
+          href="#"
           onClick={[Function]}
         >
           More Information

--- a/components/alert/__examples__/close-alert.jsx
+++ b/components/alert/__examples__/close-alert.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { action } from '@storybook/addon-actions';
+
 import Alert from '~/components/alert'; // `~` is replaced with design-system-react at runtime
 import AlertContainer from '~/components/alert/container'; // `~` is replaced with design-system-react at runtime
 import Icon from '~/components/icon'; // `~` is replaced with design-system-react at runtime
@@ -33,10 +35,9 @@ class Example extends React.Component {
 									heading: 'Logged in as John Smith (johnsmith@acme.com).',
 									headingLink: 'Log out',
 								}}
-								onClickHeadingLink={() => {
-									console.log('Link clicked.');
-								}}
+								onClickHeadingLink={action('onClickHeadingLink')}
 								onRequestClose={() => {
+									action('onRequestClose')();
 									this.setState({ isOpen: false });
 								}}
 							/>

--- a/components/alert/__examples__/custom-class-name.jsx
+++ b/components/alert/__examples__/custom-class-name.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { action } from '@storybook/addon-actions';
+
 import Alert from '~/components/alert'; // `~` is replaced with design-system-react at runtime
 import AlertContainer from '~/components/alert/container'; // `~` is replaced with design-system-react at runtime
 import Icon from '~/components/icon'; // `~` is replaced with design-system-react at runtime
@@ -16,9 +18,7 @@ class Example extends React.Component {
 							heading: 'Logged in as John Smith (johnsmith@acme.com).',
 							headingLink: 'Log out',
 						}}
-						onClickHeadingLink={() => {
-							console.log('Link clicked.');
-						}}
+						onClickHeadingLink={action('onClickHeadingLink')}
 					/>
 				</AlertContainer>
 			</IconSettings>

--- a/components/alert/__examples__/custom-style.jsx
+++ b/components/alert/__examples__/custom-style.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { action } from '@storybook/addon-actions';
+
 import Alert from '~/components/alert'; // `~` is replaced with design-system-react at runtime
 import AlertContainer from '~/components/alert/container'; // `~` is replaced with design-system-react at runtime
 import Icon from '~/components/icon'; // `~` is replaced with design-system-react at runtime
@@ -16,9 +18,7 @@ class Example extends React.Component {
 							heading: 'Logged in as John Smith (johnsmith@acme.com).',
 							headingLink: 'Log out',
 						}}
-						onClickHeadingLink={() => {
-							console.log('Link clicked.');
-						}}
+						onClickHeadingLink={action('onClickHeadingLink')}
 					/>
 				</AlertContainer>
 			</IconSettings>

--- a/components/alert/__examples__/dismissable.jsx
+++ b/components/alert/__examples__/dismissable.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { action } from '@storybook/addon-actions';
+
 import Alert from '~/components/alert'; // `~` is replaced with design-system-react at runtime
 import AlertContainer from '~/components/alert/container'; // `~` is replaced with design-system-react at runtime
 import Icon from '~/components/icon'; // `~` is replaced with design-system-react at runtime
@@ -25,10 +27,9 @@ class Example extends React.Component {
 								heading: 'Logged in as John Smith (johnsmith@acme.com).',
 								headingLink: 'Log out',
 							}}
-							onClickHeadingLink={() => {
-								console.log('Link clicked.');
-							}}
+							onClickHeadingLink={action('onClickHeadingLink')}
 							onRequestClose={() => {
+								action('onRequestClose')();
 								this.setState({ isOpen: false });
 							}}
 						/>

--- a/components/alert/__examples__/error.jsx
+++ b/components/alert/__examples__/error.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { action } from '@storybook/addon-actions';
+
 import Alert from '~/components/alert'; // `~` is replaced with design-system-react at runtime
 import AlertContainer from '~/components/alert/container'; // `~` is replaced with design-system-react at runtime
 import Icon from '~/components/icon'; // `~` is replaced with design-system-react at runtime
@@ -16,9 +18,7 @@ class Example extends React.Component {
 								'Your browser is currently not supported. Your Salesforce may be degraded.',
 							headingLink: 'More Information',
 						}}
-						onClickHeadingLink={() => {
-							console.log('Link clicked.');
-						}}
+						onClickHeadingLink={action('onClickHeadingLink')}
 						variant="error"
 					/>
 				</AlertContainer>

--- a/components/alert/__examples__/info.jsx
+++ b/components/alert/__examples__/info.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { action } from '@storybook/addon-actions';
+
 import Alert from '~/components/alert'; // `~` is replaced with design-system-react at runtime
 import AlertContainer from '~/components/alert/container'; // `~` is replaced with design-system-react at runtime
 import Icon from '~/components/icon'; // `~` is replaced with design-system-react at runtime
@@ -15,9 +17,7 @@ class Example extends React.Component {
 							heading: 'Logged in as John Smith (johnsmith@acme.com).',
 							headingLink: 'Log out',
 						}}
-						onClickHeadingLink={() => {
-							console.log('Link clicked.');
-						}}
+						onClickHeadingLink={action('onClickHeadingLink')}
 					/>
 				</AlertContainer>
 			</IconSettings>

--- a/components/alert/__examples__/offline.jsx
+++ b/components/alert/__examples__/offline.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { action } from '@storybook/addon-actions';
+
 import Alert from '~/components/alert'; // `~` is replaced with design-system-react at runtime
 import AlertContainer from '~/components/alert/container'; // `~` is replaced with design-system-react at runtime
 
@@ -14,9 +16,7 @@ class Example extends React.Component {
 							heading: 'You are in offline mode.',
 							headingLink: 'More information',
 						}}
-						onClickHeadingLink={() => {
-							console.log('Link clicked.');
-						}}
+						onClickHeadingLink={action('onClickHeadingLink')}
 						variant="offline"
 					/>
 				</AlertContainer>

--- a/components/alert/__examples__/warning.jsx
+++ b/components/alert/__examples__/warning.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { action } from '@storybook/addon-actions';
+
 import Alert from '~/components/alert'; // `~` is replaced with design-system-react at runtime
 import AlertContainer from '~/components/alert/container'; // `~` is replaced
 import IconSettings from '~/components/icon-settings';
@@ -14,9 +16,7 @@ class Example extends React.Component {
 								'Your browser is outdated. Your Salesforce experience may be degraded.',
 							headingLink: 'More Information',
 						}}
-						onClickHeadingLink={() => {
-							console.log('Link clicked.');
-						}}
+						onClickHeadingLink={action('onClickHeadingLink')}
 						variant="warning"
 					/>
 				</AlertContainer>

--- a/components/alert/index.jsx
+++ b/components/alert/index.jsx
@@ -15,6 +15,7 @@ import checkProps from './check-props';
 import componentDoc from './component.json';
 import { ALERT } from '../../utilities/constants';
 import DOMElementFocus from '../../utilities/dom-element-focus';
+import EventUtil from '../../utilities/event';
 
 const propTypes = {
 	/**
@@ -163,7 +164,6 @@ class Alert extends React.Component {
 			size: 'x-small',
 		});
 
-		/* eslint-disable no-script-url */
 		return (
 			<div
 				className={classNames(
@@ -187,8 +187,8 @@ class Alert extends React.Component {
 					{heading}{' '}
 					{labels.headingLink ? (
 						<a
-							onClick={this.props.onClickHeadingLink}
-							href="javascript:void(0);"
+							onClick={EventUtil.trappedHandler(this.props.onClickHeadingLink)}
+							href="#"
 						>
 							{labels.headingLink}
 						</a>

--- a/components/app-launcher/link.jsx
+++ b/components/app-launcher/link.jsx
@@ -62,7 +62,7 @@ class AppLauncherLink extends React.Component {
 
 	// ### Default Props
 	static defaultProps = {
-		href: 'javascript:void(0);', // eslint-disable-line no-script-url
+		href: '#',
 	};
 
 	render() {
@@ -74,9 +74,12 @@ class AppLauncherLink extends React.Component {
 
 		return (
 			<a
-				href={this.props.href} // eslint-disable-line no-script-url
+				href={this.props.href}
 				className={classNames('slds-truncate', this.props.className)}
 				onClick={(event) => {
+					if (this.props.href === '#') {
+						event.preventDefault();
+					}
 					if (this.props.onClick) {
 						event.preventDefault();
 						this.props.onClick(event, { href: this.props.href });

--- a/components/app-launcher/tile.jsx
+++ b/components/app-launcher/tile.jsx
@@ -91,7 +91,7 @@ const defaultProps = {
 	assistiveText: {
 		dragIconText: 'Reorder',
 	},
-	href: 'javascript:void(0);', // eslint-disable-line no-script-url
+	href: '#',
 	moreLabel: ' More',
 };
 
@@ -158,7 +158,10 @@ class AppLauncherTile extends React.Component {
 				</div>
 				<div className="slds-app-launcher__tile-body">
 					<a
-						href={this.props.href} // eslint-disable-line no-script-url
+						href={this.props.href}
+						onClick={(event) =>
+							this.props.href === '#' && event.preventDefault()
+						}
 					>
 						<Highlighter search={this.props.search}>
 							{this.props.title}

--- a/components/breadcrumb/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/breadcrumb/__docs__/__snapshots__/storybook-stories.storyshot
@@ -15,7 +15,7 @@ exports[`DOM snapshots SLDSBreadcrumb 1 Item 1`] = `
         className="slds-breadcrumb__item"
       >
         <a
-          href="javascript:void(0);"
+          href="#entity"
         >
           Parent Entity
         </a>
@@ -40,7 +40,7 @@ exports[`DOM snapshots SLDSBreadcrumb 2 Items 1`] = `
         className="slds-breadcrumb__item"
       >
         <a
-          href="javascript:void(0);"
+          href="#entity"
           id="parent-entity"
         >
           Parent Entity
@@ -50,7 +50,7 @@ exports[`DOM snapshots SLDSBreadcrumb 2 Items 1`] = `
         className="slds-breadcrumb__item"
       >
         <a
-          href="javascript:void(0);"
+          href="#record"
         >
           Parent Record Name
         </a>
@@ -112,7 +112,7 @@ exports[`DOM snapshots SLDSBreadcrumb Base with overflow menu 1`] = `
         className="slds-breadcrumb__item"
       >
         <a
-          href="javascript:void(0);"
+          href="#entity"
         >
           Parent Entity
         </a>
@@ -121,7 +121,7 @@ exports[`DOM snapshots SLDSBreadcrumb Base with overflow menu 1`] = `
         className="slds-breadcrumb__item"
       >
         <a
-          href="javascript:void(0);"
+          href="#record"
         >
           Parent Record Name
         </a>

--- a/components/breadcrumb/__examples__/base-with-overflow-menu.jsx
+++ b/components/breadcrumb/__examples__/base-with-overflow-menu.jsx
@@ -9,8 +9,8 @@ class Example extends React.Component {
 
 	render() {
 		const trail = [
-			<a href="javascript:void(0);">Parent Entity</a>,
-			<a href="javascript:void(0);">Parent Record Name</a>,
+			<a href="#entity">Parent Entity</a>,
+			<a href="#record">Parent Record Name</a>,
 		];
 
 		return (

--- a/components/breadcrumb/__examples__/base.jsx
+++ b/components/breadcrumb/__examples__/base.jsx
@@ -8,10 +8,10 @@ class Example extends React.Component {
 
 	render() {
 		const trail = [
-			<a id="parent-entity" href="javascript:void(0);">
+			<a id="parent-entity" href="#entity">
 				Parent Entity
 			</a>,
-			<a href="javascript:void(0);">Parent Record Name</a>,
+			<a href="#record">Parent Record Name</a>,
 		];
 
 		return (

--- a/components/breadcrumb/__examples__/one-item.jsx
+++ b/components/breadcrumb/__examples__/one-item.jsx
@@ -7,7 +7,7 @@ class Example extends React.Component {
 	static displayName = 'BreadCrumbExample';
 
 	render() {
-		const trail = [<a href="javascript:void(0);">Parent Entity</a>];
+		const trail = [<a href="#entity">Parent Entity</a>];
 
 		return (
 			<IconSettings iconPath="/assets/icons">

--- a/components/builder-header/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/builder-header/__docs__/__snapshots__/storybook-stories.storyshot
@@ -68,7 +68,8 @@ exports[`DOM snapshots SLDSBuilderHeader After Successful Save 1`] = `
             >
               <a
                 className="slds-builder-header__item-action slds-media slds-media_center"
-                href="javascript:void(0)"
+                href="#"
+                onClick={[Function]}
               >
                 <span
                   className="slds-media__figure"
@@ -191,7 +192,8 @@ exports[`DOM snapshots SLDSBuilderHeader After Successful Save 1`] = `
           >
             <a
               className="slds-builder-header__item-action slds-media slds-media_center"
-              href="javascript:void(0);"
+              href="#"
+              onClick={[Function]}
             >
               <div
                 className="slds-media__figure"
@@ -226,7 +228,8 @@ exports[`DOM snapshots SLDSBuilderHeader After Successful Save 1`] = `
           >
             <a
               className="slds-builder-header__item-action slds-media slds-media_center"
-              href="javascript:void(0);"
+              href="#"
+              onClick={[Function]}
             >
               <div
                 className="slds-media__figure"
@@ -518,7 +521,8 @@ exports[`DOM snapshots SLDSBuilderHeader Base 1`] = `
             >
               <a
                 className="slds-builder-header__item-action slds-media slds-media_center"
-                href="javascript:void(0)"
+                href="#"
+                onClick={[Function]}
               >
                 <span
                   className="slds-media__figure"
@@ -641,7 +645,8 @@ exports[`DOM snapshots SLDSBuilderHeader Base 1`] = `
           >
             <a
               className="slds-builder-header__item-action slds-media slds-media_center"
-              href="javascript:void(0);"
+              href="#"
+              onClick={[Function]}
             >
               <div
                 className="slds-media__figure"
@@ -676,7 +681,8 @@ exports[`DOM snapshots SLDSBuilderHeader Base 1`] = `
           >
             <a
               className="slds-builder-header__item-action slds-media slds-media_center"
-              href="javascript:void(0);"
+              href="#"
+              onClick={[Function]}
             >
               <div
                 className="slds-media__figure"
@@ -781,7 +787,8 @@ exports[`DOM snapshots SLDSBuilderHeader Base with Page Type Editable 1`] = `
             >
               <a
                 className="slds-builder-header__item-action slds-media slds-media_center"
-                href="javascript:void(0)"
+                href="#"
+                onClick={[Function]}
               >
                 <span
                   className="slds-media__figure"
@@ -1052,7 +1059,8 @@ exports[`DOM snapshots SLDSBuilderHeader Base with Page Type Editable 1`] = `
           >
             <a
               className="slds-builder-header__item-action slds-media slds-media_center"
-              href="javascript:void(0);"
+              href="#"
+              onClick={[Function]}
             >
               <div
                 className="slds-media__figure"
@@ -1087,7 +1095,8 @@ exports[`DOM snapshots SLDSBuilderHeader Base with Page Type Editable 1`] = `
           >
             <a
               className="slds-builder-header__item-action slds-media slds-media_center"
-              href="javascript:void(0);"
+              href="#"
+              onClick={[Function]}
             >
               <div
                 className="slds-media__figure"
@@ -1192,7 +1201,8 @@ exports[`DOM snapshots SLDSBuilderHeader Base with Toolbar 1`] = `
             >
               <a
                 className="slds-builder-header__item-action slds-media slds-media_center"
-                href="javascript:void(0)"
+                href="#"
+                onClick={[Function]}
               >
                 <span
                   className="slds-media__figure"
@@ -1315,7 +1325,8 @@ exports[`DOM snapshots SLDSBuilderHeader Base with Toolbar 1`] = `
           >
             <a
               className="slds-builder-header__item-action slds-media slds-media_center"
-              href="javascript:void(0);"
+              href="#"
+              onClick={[Function]}
             >
               <div
                 className="slds-media__figure"
@@ -1350,7 +1361,8 @@ exports[`DOM snapshots SLDSBuilderHeader Base with Toolbar 1`] = `
           >
             <a
               className="slds-builder-header__item-action slds-media slds-media_center"
-              href="javascript:void(0);"
+              href="#"
+              onClick={[Function]}
             >
               <div
                 className="slds-media__figure"
@@ -1621,7 +1633,8 @@ exports[`DOM snapshots SLDSBuilderHeader Custom Icon 1`] = `
             >
               <a
                 className="slds-builder-header__item-action slds-media slds-media_center"
-                href="javascript:void(0)"
+                href="#"
+                onClick={[Function]}
               >
                 <span
                   className="slds-media__figure"
@@ -1744,7 +1757,8 @@ exports[`DOM snapshots SLDSBuilderHeader Custom Icon 1`] = `
           >
             <a
               className="slds-builder-header__item-action slds-media slds-media_center"
-              href="javascript:void(0);"
+              href="#"
+              onClick={[Function]}
             >
               <div
                 className="slds-media__figure"
@@ -1779,7 +1793,8 @@ exports[`DOM snapshots SLDSBuilderHeader Custom Icon 1`] = `
           >
             <a
               className="slds-builder-header__item-action slds-media slds-media_center"
-              href="javascript:void(0);"
+              href="#"
+              onClick={[Function]}
             >
               <div
                 className="slds-media__figure"
@@ -1884,7 +1899,8 @@ exports[`DOM snapshots SLDSBuilderHeader Failed Save 1`] = `
             >
               <a
                 className="slds-builder-header__item-action slds-media slds-media_center"
-                href="javascript:void(0)"
+                href="#"
+                onClick={[Function]}
               >
                 <span
                   className="slds-media__figure"
@@ -2007,7 +2023,8 @@ exports[`DOM snapshots SLDSBuilderHeader Failed Save 1`] = `
           >
             <a
               className="slds-builder-header__item-action slds-media slds-media_center"
-              href="javascript:void(0);"
+              href="#"
+              onClick={[Function]}
             >
               <div
                 className="slds-media__figure"
@@ -2042,7 +2059,8 @@ exports[`DOM snapshots SLDSBuilderHeader Failed Save 1`] = `
           >
             <a
               className="slds-builder-header__item-action slds-media slds-media_center"
-              href="javascript:void(0);"
+              href="#"
+              onClick={[Function]}
             >
               <div
                 className="slds-media__figure"
@@ -2368,7 +2386,8 @@ exports[`DOM snapshots SLDSBuilderHeader Successful Save 1`] = `
             >
               <a
                 className="slds-builder-header__item-action slds-media slds-media_center"
-                href="javascript:void(0)"
+                href="#"
+                onClick={[Function]}
               >
                 <span
                   className="slds-media__figure"
@@ -2491,7 +2510,8 @@ exports[`DOM snapshots SLDSBuilderHeader Successful Save 1`] = `
           >
             <a
               className="slds-builder-header__item-action slds-media slds-media_center"
-              href="javascript:void(0);"
+              href="#"
+              onClick={[Function]}
             >
               <div
                 className="slds-media__figure"
@@ -2526,7 +2546,8 @@ exports[`DOM snapshots SLDSBuilderHeader Successful Save 1`] = `
           >
             <a
               className="slds-builder-header__item-action slds-media slds-media_center"
-              href="javascript:void(0);"
+              href="#"
+              onClick={[Function]}
             >
               <div
                 className="slds-media__figure"

--- a/components/builder-header/__examples__/base-with-page-type-editable.jsx
+++ b/components/builder-header/__examples__/base-with-page-type-editable.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { actions } from '@storybook/addon-actions';
 
 import IconSettings from '~/components/icon-settings';
 import EditDialog from '~/components/popover/edit-dialog'; // `~` is replaced with design-system-react at runtime
@@ -111,6 +112,7 @@ class Example extends React.Component {
 						backIcon: 'Back',
 						helpIcon: 'Help',
 					}}
+					events={actions('onClickBack', 'onClickHelp')}
 					labels={{
 						back: 'Back',
 						help: 'Help',

--- a/components/builder-header/__examples__/base-with-toolbar.jsx
+++ b/components/builder-header/__examples__/base-with-toolbar.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { actions } from '@storybook/addon-actions';
+
 import IconSettings from '../../icon-settings';
 import Button from '../../button';
 import ButtonGroup from '../../button-group';
@@ -16,6 +18,7 @@ const Example = (props) => (
 				helpIcon: 'Help',
 				icon: 'Builder',
 			}}
+			events={actions('onClickBack', 'onClickHelp')}
 			labels={{
 				back: 'Back',
 				help: 'Help',

--- a/components/builder-header/__examples__/base.jsx
+++ b/components/builder-header/__examples__/base.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { actions, action } from '@storybook/addon-actions';
+
 import IconSettings from '../../icon-settings';
 import BuilderHeader from '../../builder-header';
 import BuilderHeaderNav from '../../builder-header/nav';
@@ -13,6 +15,7 @@ const Example = (props) => (
 				backIcon: 'Back',
 				helpIcon: 'Help',
 			}}
+			events={actions('onClickBack', 'onClickHelp')}
 			labels={{
 				back: 'Back',
 				help: 'Help',
@@ -27,6 +30,7 @@ const Example = (props) => (
 					iconCategory="utility"
 					iconName="settings"
 					label="Link"
+					onClick={action('link/onClick')}
 				/>
 				<BuilderHeaderNavDropdown
 					assistiveText={{ icon: 'Dropdown' }}
@@ -38,6 +42,7 @@ const Example = (props) => (
 						{ label: 'Menu Item One', value: 'A0' },
 						{ label: 'Menu Item Two', value: 'B0' },
 					]}
+					onSelect={action('dropdown/onSelect')}
 				/>
 			</BuilderHeaderNav>
 		</BuilderHeader>

--- a/components/builder-header/__examples__/failed-save.jsx
+++ b/components/builder-header/__examples__/failed-save.jsx
@@ -70,7 +70,7 @@ const Example = (props) => (
 									<p className="slds-p-bottom_x-small">
 										Pellentesque magna tellus, dapibus vitae placerat nec,
 										viverra vel mi.{' '}
-										<a href="javascript:void(0);" title="Learn More">
+										<a href="#" title="Learn More">
 											Learn More
 										</a>
 									</p>

--- a/components/builder-header/index.jsx
+++ b/components/builder-header/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import EventUtil from '../../utilities/event';
 
 import Icon from '../icon';
 
@@ -202,9 +203,9 @@ const BuilderHeader = (props) => {
 					<div className="slds-builder-header__item slds-builder-header__utilities">
 						<div className="slds-builder-header__utilities-item">
 							<a
-								href="javascript:void(0);"
+								href="#"
 								className="slds-builder-header__item-action slds-media slds-media_center"
-								onClick={events.onClickBack}
+								onClick={EventUtil.trappedHandler(events.onClickBack)}
 							>
 								<div className="slds-media__figure">
 									<Icon
@@ -220,9 +221,9 @@ const BuilderHeader = (props) => {
 						</div>
 						<div className="slds-builder-header__utilities-item">
 							<a
-								href="javascript:void(0);"
+								href="#"
 								className="slds-builder-header__item-action slds-media slds-media_center"
-								onClick={events.onClickHelp}
+								onClick={EventUtil.trappedHandler(events.onClickHelp)}
 							>
 								<div className="slds-media__figure">
 									<Icon

--- a/components/builder-header/nav-link.jsx
+++ b/components/builder-header/nav-link.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import EventUtil from '../../utilities/event';
 
 import Icon from '../icon';
 
@@ -58,12 +59,13 @@ const BuilderHeaderNavLink = (props) => {
 		...defaultProps.assistiveText,
 		...props.assistiveText,
 	};
+
 	return (
 		<li className="slds-builder-header__nav-item">
 			<a
 				className="slds-builder-header__item-action slds-media slds-media_center"
-				href="javascript:void(0)"
-				onClick={props.onClick}
+				href="#"
+				onClick={EventUtil.trappedHandler(props.onClick)}
 			>
 				<span className="slds-media__figure">
 					<Icon

--- a/components/card/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/card/__docs__/__snapshots__/storybook-stories.storyshot
@@ -812,7 +812,8 @@ exports[`DOM snapshots SLDSCard Set height card 1`] = `
       className="slds-card__footer"
     >
       <a
-        href="javascript:void(0);"
+        href="#"
+        onClick={[Function]}
       >
         Footer text
       </a>
@@ -1133,7 +1134,8 @@ exports[`DOM snapshots SLDSCard w/o Header 1`] = `
       className="slds-card__footer"
     >
       <a
-        href="javascript:void(0);"
+        href="#"
+        onClick={[Function]}
       >
         Footer text
       </a>

--- a/components/card/__docs__/storybook-stories.jsx
+++ b/components/card/__docs__/storybook-stories.jsx
@@ -130,7 +130,11 @@ const SetHeightCard = () => (
 	<Card
 		bodyClassName="slds-grow slds-scrollable_y"
 		className="slds-grid slds-grid_vertical"
-		footer={<a href="javascript:void(0);">Footer text</a>} // eslint-disable-line no-script-url
+		footer={
+			<a href="#" onClick={(event) => event.preventDefault()}>
+				Footer text
+			</a>
+		}
 		heading="Card with set height"
 		icon={<Icon category="standard" name="document" size="small" />}
 		style={{ height: '300px' }}
@@ -159,7 +163,11 @@ const DemoCardWithoutHeader = () => (
 	<Card
 		bodyClassName="slds-grow slds-scrollable_y"
 		className="slds-grid slds-grid_vertical"
-		footer={<a href="javascript:void(0);">Footer text</a>} // eslint-disable-line no-script-url
+		footer={
+			<a href="#" onClick={(event) => event.preventDefault()}>
+				Footer text
+			</a>
+		}
 		hasNoHeader
 		icon={<Icon category="standard" name="document" size="small" />}
 		style={{ height: '300px' }}

--- a/components/carousel/index.jsx
+++ b/components/carousel/index.jsx
@@ -105,7 +105,7 @@ class Carousel extends React.Component {
 		 * * `description`: Secondary string that is used to describe the item
 		 * * `buttonLabel`: If assigned a call to button action will be rendered with this text, if unassigned no button is rendered
 		 * * `imageAssistiveText`: Image alt text, if not present heading will be used instead
-		 * * `href`: Used for item link, if not provided 'javascript:void(0);' is used instead
+		 * * `href`: Used for item link, if not provided '#' is used instead
 		 * * `src`: Item image src value
 		 */
 		items: PropTypes.array.isRequired,

--- a/components/carousel/private/carousel-item.jsx
+++ b/components/carousel/private/carousel-item.jsx
@@ -15,59 +15,71 @@ import { CAROUSEL_ITEM } from '../../../utilities/constants';
 /**
  * A carousel allows multiple pieces of featured content to occupy an allocated amount of space.
  */
-const CarouselItem = (props) => (
-	<div
-		id={props.getPanelId({ carouselId: props.carouselId, itemId: props.id })}
-		className="slds-carousel__panel slds-m-horizontal_xx-small slds-list_horizontal"
-		role="tabpanel"
-		aria-hidden="false"
-		aria-labelledby={`indicator-id-${props.carouselId}-${props.panelIndex}`}
-		style={{
-			margin: 0,
-			maxWidth: `${props.itemWidth}px`,
-			padding: '0 6px',
-		}}
-	>
-		{props.onRenderItem ? (
-			props.onRenderItem({ item: props })
-		) : (
-			<a
-				className="slds-carousel__panel-action slds-text-link_reset"
-				href={props.href}
-				onClick={props.onClick}
-				onFocus={props.onFocus}
-				style={{
-					backgroundColor: 'white',
-					width: '100%',
-				}}
-				tabIndex={props.isInCurrentPanel ? '0' : '-1'}
-			>
-				<div className="slds-carousel__image">
-					<img
-						src={props.src}
-						alt={props.imageAssistiveText || props.heading}
-					/>
-				</div>
-				<div className="slds-carousel__content" style={{ height: 'auto' }}>
-					<h2 className="slds-carousel__content-title">{props.heading}</h2>
-					<div
-						className="slds-p-bottom_x-small slds-text-body_small"
-						style={{ minHeight: '40px' }}
-					>
-						{props.description}
-					</div>
-					{props.buttonLabel && (
-						<Button
-							label={props.buttonLabel}
-							tabIndex={props.isInCurrentPanel ? '0' : '-1'}
-							variant="neutral"
+const CarouselItem = (props) => {
+	function handleOnClick(event) {
+		if (props.href === '#') {
+			event.preventDefault();
+		}
+
+		if (props.onClick) {
+			props.onClick(event);
+		}
+	}
+
+	return (
+		<div
+			id={props.getPanelId({ carouselId: props.carouselId, itemId: props.id })}
+			className="slds-carousel__panel slds-m-horizontal_xx-small slds-list_horizontal"
+			role="tabpanel"
+			aria-hidden="false"
+			aria-labelledby={`indicator-id-${props.carouselId}-${props.panelIndex}`}
+			style={{
+				margin: 0,
+				maxWidth: `${props.itemWidth}px`,
+				padding: '0 6px',
+			}}
+		>
+			{props.onRenderItem ? (
+				props.onRenderItem({ item: props })
+			) : (
+				<a
+					className="slds-carousel__panel-action slds-text-link_reset"
+					href={props.href}
+					onClick={handleOnClick}
+					onFocus={props.onFocus}
+					style={{
+						backgroundColor: 'white',
+						width: '100%',
+					}}
+					tabIndex={props.isInCurrentPanel ? '0' : '-1'}
+				>
+					<div className="slds-carousel__image">
+						<img
+							src={props.src}
+							alt={props.imageAssistiveText || props.heading}
 						/>
-					)}
-				</div>
-			</a>
-		)}
-	</div>
-);
+					</div>
+					<div className="slds-carousel__content" style={{ height: 'auto' }}>
+						<h2 className="slds-carousel__content-title">{props.heading}</h2>
+						<div
+							className="slds-p-bottom_x-small slds-text-body_small"
+							style={{ minHeight: '40px' }}
+						>
+							{props.description}
+						</div>
+						{props.buttonLabel && (
+							<Button
+								label={props.buttonLabel}
+								tabIndex={props.isInCurrentPanel ? '0' : '-1'}
+								variant="neutral"
+							/>
+						)}
+					</div>
+				</a>
+			)}
+		</div>
+	);
+};
 
 CarouselItem.displayName = CAROUSEL_ITEM;
 
@@ -132,7 +144,7 @@ CarouselItem.propTypes = {
 };
 
 CarouselItem.defaultProps = {
-	href: 'javascript:void(0);',
+	href: '#',
 };
 
 export default CarouselItem;

--- a/components/color-picker/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/color-picker/__docs__/__snapshots__/storybook-stories.storyshot
@@ -187,7 +187,8 @@ exports[`DOM snapshots SLDSColorPicker ColorPicker Menu Open 1`] = `
                     aria-controls="color-picker-tabs-color-picker-slds-tabs_panel-0"
                     aria-selected="true"
                     className="slds-is-active slds-tabs_default__link"
-                    href="javascript:void(0);"
+                    href="#"
+                    onClick={[Function]}
                     role="tab"
                     tabIndex="0"
                   >
@@ -204,7 +205,8 @@ exports[`DOM snapshots SLDSColorPicker ColorPicker Menu Open 1`] = `
                     aria-controls="color-picker-tabs-color-picker-slds-tabs_panel-1"
                     aria-selected="false"
                     className="slds-tabs_default__link"
-                    href="javascript:void(0);"
+                    href="#"
+                    onClick={[Function]}
                     role="tab"
                     tabIndex="-1"
                   >

--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -685,7 +685,7 @@
                             "required": false,
                             "description": "The `href` attribute of the link. If the `onClick` callback is specified this URL will be prevented from changing the browser's location.",
                             "defaultValue": {
-                                "value": "'javascript:void(0);'",
+                                "value": "'#'",
                                 "computed": false
                             }
                         },
@@ -789,7 +789,7 @@
                             "required": false,
                             "description": "The `href` attribute of the tile. Please pass in bookmarkable URLs from your routing library. If the `onClick` callback is specified this URL will be prevented from changing the browser's location.",
                             "defaultValue": {
-                                "value": "'javascript:void(0);'",
+                                "value": "'#'",
                                 "computed": false
                             }
                         },
@@ -3006,7 +3006,7 @@
                     "name": "array"
                 },
                 "required": true,
-                "description": "* **Array of item objects used by the default carousel item renderer.**\nEach object can contain:\n* `id`: The id of the carousel item. [REQUIRED]\n* `heading`: Primary string that will be used as the heading\n* `description`: Secondary string that is used to describe the item\n* `buttonLabel`: If assigned a call to button action will be rendered with this text, if unassigned no button is rendered\n* `imageAssistiveText`: Image alt text, if not present heading will be used instead\n* `href`: Used for item link, if not provided 'javascript:void(0);' is used instead\n* `src`: Item image src value"
+                "description": "* **Array of item objects used by the default carousel item renderer.**\nEach object can contain:\n* `id`: The id of the carousel item. [REQUIRED]\n* `heading`: Primary string that will be used as the heading\n* `description`: Secondary string that is used to describe the item\n* `buttonLabel`: If assigned a call to button action will be rendered with this text, if unassigned no button is rendered\n* `imageAssistiveText`: Image alt text, if not present heading will be used instead\n* `href`: Used for item link, if not provided '#' is used instead\n* `src`: Item image src value"
             },
             "itemsPerPanel": {
                 "type": {
@@ -5308,7 +5308,7 @@
                     "name": "node"
                 },
                 "required": false,
-                "description": "Provide children of the type `<DataTableColumn />` to define the structure of the data being represented and children of the type `<DataTableRowActions />` to define a menu which will be rendered for each item in the grid. Use a _higher-order component_ to customize a data table cell that will override the default cell rendering. `CustomDataTableCell` must have the same `displayName` as `DataTableCell` or it will be ignored. If you want complete control of the HTML, including the wrapping `td`, you don't have to use `DataTableCell`.\n```\nimport DataTableCell from 'design-system-react/data-table/cell';\nconst CustomDataTableCell = ({ children, ...props }) => (\n  <DataTableCell {...props} >\n  <a href=\"javascript:void(0);\">{children}</a>\n  </DataTableCell>\n);\nCustomDataTableCell.displayName = DataTableCell.displayName;\n\n<DataTable>\n  <DataTableColumn />\n  <DataTableColumn>\n  <DataTableCustomCell />\n  </DataTableColumn>\n  <DataTableRowActions />\n</DataTable>\n```"
+                "description": "Provide children of the type `<DataTableColumn />` to define the structure of the data being represented and children of the type `<DataTableRowActions />` to define a menu which will be rendered for each item in the grid. Use a _higher-order component_ to customize a data table cell that will override the default cell rendering. `CustomDataTableCell` must have the same `displayName` as `DataTableCell` or it will be ignored. If you want complete control of the HTML, including the wrapping `td`, you don't have to use `DataTableCell`.\n```\nimport DataTableCell from 'design-system-react/data-table/cell';\nconst CustomDataTableCell = ({ children, ...props }) => (\n  <DataTableCell {...props} >\n    <a href=\"#\">{children}</a>\n  </DataTableCell>\n);\nCustomDataTableCell.displayName = DataTableCell.displayName;\n\n<DataTable>\n  <DataTableColumn />\n  <DataTableColumn>\n  <DataTableCustomCell />\n  </DataTableColumn>\n  <DataTableRowActions />\n</DataTable>\n```"
             },
             "className": {
                 "type": {
@@ -5632,7 +5632,7 @@
                                 "name": "element"
                             },
                             "required": false,
-                            "description": "Use a _higher-order component_ to customize a data table cell that will override the default cell rendering. `CustomDataTableCell` must have the same `displayName` as `DataTableCell` or it will be ignored. If you want complete control of the HTML, including the wrapping `td`, you don't have to use `DataTableCell`.\n```\nimport DataTableCell from 'design-system-react/data-table/cell';\nconst CustomDataTableCell = ({ children, ...props }) => (\n  <DataTableCell {...props} >\n    <a href=\"javascript:void(0);\">{children}</a>\n  </DataTableCell>\n);\nCustomDataTableCell.displayName = DataTableCell.displayName;\n\n<DataTable>\n  <DataTableColumn />\n  <DataTableColumn>\n    <DataTableCustomCell />\n  </DataTableColumn>\n  <DataTableRowActions />\n</DataTable>\n```"
+                            "description": "Use a _higher-order component_ to customize a data table cell that will override the default cell rendering. `CustomDataTableCell` must have the same `displayName` as `DataTableCell` or it will be ignored. If you want complete control of the HTML, including the wrapping `td`, you don't have to use `DataTableCell`.\n```\nimport DataTableCell from 'design-system-react/data-table/cell';\nconst CustomDataTableCell = ({ children, ...props }) => (\n  <DataTableCell {...props} >\n    <a href=\"#\">{children}</a>\n  </DataTableCell>\n);\nCustomDataTableCell.displayName = DataTableCell.displayName;\n\n<DataTable>\n  <DataTableColumn />\n  <DataTableColumn>\n    <DataTableCustomCell />\n  </DataTableColumn>\n  <DataTableRowActions />\n</DataTable>\n```"
                         },
                         "isDefaultSortDescending": {
                             "type": {
@@ -7507,6 +7507,18 @@
                             "params": [],
                             "returns": null,
                             "description": "Get the File's HTML id. Generate a new one if no ID present."
+                        },
+                        {
+                            "name": "handleOnClickImage",
+                            "docblock": null,
+                            "modifiers": [],
+                            "params": [
+                                {
+                                    "name": "event",
+                                    "type": null
+                                }
+                            ],
+                            "returns": null
                         }
                     ],
                     "props": {
@@ -7653,7 +7665,7 @@
                             "required": false,
                             "description": "Href attribute for image",
                             "defaultValue": {
-                                "value": "'javascript:void(0);'",
+                                "value": "'#'",
                                 "computed": false
                             }
                         },
@@ -7795,7 +7807,7 @@
                             "required": false,
                             "description": "Href attribute for image",
                             "defaultValue": {
-                                "value": "'javascript:void(0);'",
+                                "value": "'#'",
                                 "computed": false
                             }
                         }
@@ -8848,7 +8860,7 @@
                             "required": false,
                             "description": "The `href` attribute of the link. Please pass in bookmarkable URLs from your routing library. Use `GlobalNavigationBarButton` if a \"real URL\" is not desired. If the `onClick` callback is specified this URL will still be prevented from changing the browser's location.",
                             "defaultValue": {
-                                "value": "'javascript:void(0);'",
+                                "value": "'#'",
                                 "computed": false
                             }
                         },
@@ -12742,6 +12754,18 @@
                 "params": [
                     {
                         "name": "root",
+                        "type": null
+                    }
+                ],
+                "returns": null
+            },
+            {
+                "name": "handleOnClick",
+                "docblock": null,
+                "modifiers": [],
+                "params": [
+                    {
+                        "name": "event",
                         "type": null
                     }
                 ],

--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -5431,7 +5431,7 @@
                     "name": "func"
                 },
                 "required": false,
-                "description": "This function fires when infinite loading loads more data.\n\nThis will be called multiple times while the table is being scrolled within the `loadMoreOffset`.  Please track whether or not loading is in progress and check it at the start of this function to avoid executing your callback too many times."
+                "description": "This function fires when infinite loading loads more data.\n\nThis will be called multiple times while the table is being scrolled within the `loadMoreOffset`. It'll also continue to be called while `hasMore` is `true` and the table has not yet loaded enough rows to allow a user to scroll.  Please track whether or not loading is in progress and check it at the start of this function to avoid executing your callback too many times."
             },
             "onRowChange": {
                 "type": {

--- a/components/data-table/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/data-table/__docs__/__snapshots__/storybook-stories.storyshot
@@ -85,7 +85,7 @@ exports[`DOM snapshots SLDSDataTable Advanced (Fixed Layout) 1`] = `
           >
             <a
               className="slds-th__action slds-text-link_reset"
-              href="javascript:void(0)"
+              href="#"
               onClick={[Function]}
               role="button"
               tabIndex="0"
@@ -159,7 +159,7 @@ exports[`DOM snapshots SLDSDataTable Advanced (Fixed Layout) 1`] = `
           >
             <a
               className="slds-th__action slds-text-link_reset"
-              href="javascript:void(0)"
+              href="#"
               onClick={[Function]}
               role="button"
               tabIndex="0"
@@ -227,7 +227,7 @@ exports[`DOM snapshots SLDSDataTable Advanced (Fixed Layout) 1`] = `
           >
             <a
               className="slds-th__action slds-text-link_reset"
-              href="javascript:void(0)"
+              href="#"
               onClick={[Function]}
               role="button"
               tabIndex="0"
@@ -390,7 +390,7 @@ exports[`DOM snapshots SLDSDataTable Advanced (Fixed Layout) 1`] = `
               title="Acme - 1,200 Widgets"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 Acme - 1,200 Widgets
@@ -477,7 +477,7 @@ exports[`DOM snapshots SLDSDataTable Advanced (Fixed Layout) 1`] = `
               title="jrogers@acme.com"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 jrogers@acme.com
@@ -592,7 +592,7 @@ exports[`DOM snapshots SLDSDataTable Advanced (Fixed Layout) 1`] = `
               title="Acme - 200 Widgets"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 Acme - 200 Widgets
@@ -679,7 +679,7 @@ exports[`DOM snapshots SLDSDataTable Advanced (Fixed Layout) 1`] = `
               title="bob@acme.com"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 bob@acme.com
@@ -794,7 +794,7 @@ exports[`DOM snapshots SLDSDataTable Advanced (Fixed Layout) 1`] = `
               title="salesforce.com - 1,000 Widgets"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 salesforce.com - 1,000 Widgets
@@ -881,7 +881,7 @@ exports[`DOM snapshots SLDSDataTable Advanced (Fixed Layout) 1`] = `
               title="nathan@salesforce.com"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 nathan@salesforce.com
@@ -987,7 +987,7 @@ exports[`DOM snapshots SLDSDataTable Advanced Single Select (Fixed Header) 1`] =
           >
             <a
               className="slds-th__action slds-text-link_reset"
-              href="javascript:void(0)"
+              href="#"
               onClick={[Function]}
               role="button"
               tabIndex="0"
@@ -1107,7 +1107,7 @@ exports[`DOM snapshots SLDSDataTable Advanced Single Select (Fixed Header) 1`] =
           >
             <a
               className="slds-th__action slds-text-link_reset"
-              href="javascript:void(0)"
+              href="#"
               onClick={[Function]}
               role="button"
               tabIndex="0"
@@ -1267,7 +1267,7 @@ exports[`DOM snapshots SLDSDataTable Advanced Single Select (Fixed Header) 1`] =
               title="Acme - 1,200 Widgets"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 Acme - 1,200 Widgets
@@ -1354,7 +1354,7 @@ exports[`DOM snapshots SLDSDataTable Advanced Single Select (Fixed Header) 1`] =
               title="jrogers@acme.com"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 jrogers@acme.com
@@ -1466,7 +1466,7 @@ exports[`DOM snapshots SLDSDataTable Advanced Single Select (Fixed Header) 1`] =
               title="Acme - 200 Widgets"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 Acme - 200 Widgets
@@ -1553,7 +1553,7 @@ exports[`DOM snapshots SLDSDataTable Advanced Single Select (Fixed Header) 1`] =
               title="bob@acme.com"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 bob@acme.com
@@ -1665,7 +1665,7 @@ exports[`DOM snapshots SLDSDataTable Advanced Single Select (Fixed Header) 1`] =
               title="salesforce.com - 1,000 Widgets"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 salesforce.com - 1,000 Widgets
@@ -1752,7 +1752,7 @@ exports[`DOM snapshots SLDSDataTable Advanced Single Select (Fixed Header) 1`] =
               title="nathan@salesforce.com"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 nathan@salesforce.com
@@ -1858,7 +1858,7 @@ exports[`DOM snapshots SLDSDataTable Advanced Single Select (Fixed Layout) 1`] =
           >
             <a
               className="slds-th__action slds-text-link_reset"
-              href="javascript:void(0)"
+              href="#"
               onClick={[Function]}
               role="button"
               tabIndex="0"
@@ -1978,7 +1978,7 @@ exports[`DOM snapshots SLDSDataTable Advanced Single Select (Fixed Layout) 1`] =
           >
             <a
               className="slds-th__action slds-text-link_reset"
-              href="javascript:void(0)"
+              href="#"
               onClick={[Function]}
               role="button"
               tabIndex="0"
@@ -2138,7 +2138,7 @@ exports[`DOM snapshots SLDSDataTable Advanced Single Select (Fixed Layout) 1`] =
               title="Acme - 1,200 Widgets"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 Acme - 1,200 Widgets
@@ -2225,7 +2225,7 @@ exports[`DOM snapshots SLDSDataTable Advanced Single Select (Fixed Layout) 1`] =
               title="jrogers@acme.com"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 jrogers@acme.com
@@ -2337,7 +2337,7 @@ exports[`DOM snapshots SLDSDataTable Advanced Single Select (Fixed Layout) 1`] =
               title="Acme - 200 Widgets"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 Acme - 200 Widgets
@@ -2424,7 +2424,7 @@ exports[`DOM snapshots SLDSDataTable Advanced Single Select (Fixed Layout) 1`] =
               title="bob@acme.com"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 bob@acme.com
@@ -2536,7 +2536,7 @@ exports[`DOM snapshots SLDSDataTable Advanced Single Select (Fixed Layout) 1`] =
               title="salesforce.com - 1,000 Widgets"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 salesforce.com - 1,000 Widgets
@@ -2623,7 +2623,7 @@ exports[`DOM snapshots SLDSDataTable Advanced Single Select (Fixed Layout) 1`] =
               title="nathan@salesforce.com"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 nathan@salesforce.com
@@ -4514,7 +4514,7 @@ exports[`DOM snapshots SLDSDataTable Basic Fluid Layout (Default) 1`] = `
               title="Cloudhub"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 Cloudhub
@@ -4597,7 +4597,7 @@ exports[`DOM snapshots SLDSDataTable Basic Fluid Layout (Default) 1`] = `
               title="jrogers@cloudhub.com"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 jrogers@cloudhub.com
@@ -4619,7 +4619,7 @@ exports[`DOM snapshots SLDSDataTable Basic Fluid Layout (Default) 1`] = `
               title="Cloudhub + Anypoint Connectors"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 Cloudhub + Anypoint Connectors
@@ -4702,7 +4702,7 @@ exports[`DOM snapshots SLDSDataTable Basic Fluid Layout (Default) 1`] = `
               title="jrogers@cloudhub.com"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 jrogers@cloudhub.com
@@ -4724,7 +4724,7 @@ exports[`DOM snapshots SLDSDataTable Basic Fluid Layout (Default) 1`] = `
               title="Cloudhub"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 Cloudhub
@@ -4807,7 +4807,7 @@ exports[`DOM snapshots SLDSDataTable Basic Fluid Layout (Default) 1`] = `
               title="jrogers@cloudhub.com"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 jrogers@cloudhub.com
@@ -4956,7 +4956,7 @@ exports[`DOM snapshots SLDSDataTable Basic Fluid Layout - Column Bordered 1`] = 
               title="Cloudhub"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 Cloudhub
@@ -5039,7 +5039,7 @@ exports[`DOM snapshots SLDSDataTable Basic Fluid Layout - Column Bordered 1`] = 
               title="jrogers@cloudhub.com"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 jrogers@cloudhub.com
@@ -5061,7 +5061,7 @@ exports[`DOM snapshots SLDSDataTable Basic Fluid Layout - Column Bordered 1`] = 
               title="Cloudhub + Anypoint Connectors"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 Cloudhub + Anypoint Connectors
@@ -5144,7 +5144,7 @@ exports[`DOM snapshots SLDSDataTable Basic Fluid Layout - Column Bordered 1`] = 
               title="jrogers@cloudhub.com"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 jrogers@cloudhub.com
@@ -5166,7 +5166,7 @@ exports[`DOM snapshots SLDSDataTable Basic Fluid Layout - Column Bordered 1`] = 
               title="Cloudhub"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 Cloudhub
@@ -5249,7 +5249,7 @@ exports[`DOM snapshots SLDSDataTable Basic Fluid Layout - Column Bordered 1`] = 
               title="jrogers@cloudhub.com"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 jrogers@cloudhub.com
@@ -5398,7 +5398,7 @@ exports[`DOM snapshots SLDSDataTable Basic Fluid Layout - No Row Hover 1`] = `
               title="Cloudhub"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 Cloudhub
@@ -5481,7 +5481,7 @@ exports[`DOM snapshots SLDSDataTable Basic Fluid Layout - No Row Hover 1`] = `
               title="jrogers@cloudhub.com"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 jrogers@cloudhub.com
@@ -5503,7 +5503,7 @@ exports[`DOM snapshots SLDSDataTable Basic Fluid Layout - No Row Hover 1`] = `
               title="Cloudhub + Anypoint Connectors"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 Cloudhub + Anypoint Connectors
@@ -5586,7 +5586,7 @@ exports[`DOM snapshots SLDSDataTable Basic Fluid Layout - No Row Hover 1`] = `
               title="jrogers@cloudhub.com"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 jrogers@cloudhub.com
@@ -5608,7 +5608,7 @@ exports[`DOM snapshots SLDSDataTable Basic Fluid Layout - No Row Hover 1`] = `
               title="Cloudhub"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 Cloudhub
@@ -5691,7 +5691,7 @@ exports[`DOM snapshots SLDSDataTable Basic Fluid Layout - No Row Hover 1`] = `
               title="jrogers@cloudhub.com"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 jrogers@cloudhub.com
@@ -5840,7 +5840,7 @@ exports[`DOM snapshots SLDSDataTable Basic Fluid Layout - Striped 1`] = `
               title="Cloudhub"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 Cloudhub
@@ -5923,7 +5923,7 @@ exports[`DOM snapshots SLDSDataTable Basic Fluid Layout - Striped 1`] = `
               title="jrogers@cloudhub.com"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 jrogers@cloudhub.com
@@ -5945,7 +5945,7 @@ exports[`DOM snapshots SLDSDataTable Basic Fluid Layout - Striped 1`] = `
               title="Cloudhub + Anypoint Connectors"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 Cloudhub + Anypoint Connectors
@@ -6028,7 +6028,7 @@ exports[`DOM snapshots SLDSDataTable Basic Fluid Layout - Striped 1`] = `
               title="jrogers@cloudhub.com"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 jrogers@cloudhub.com
@@ -6050,7 +6050,7 @@ exports[`DOM snapshots SLDSDataTable Basic Fluid Layout - Striped 1`] = `
               title="Cloudhub"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 Cloudhub
@@ -6133,7 +6133,7 @@ exports[`DOM snapshots SLDSDataTable Basic Fluid Layout - Striped 1`] = `
               title="jrogers@cloudhub.com"
             >
               <a
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
               >
                 jrogers@cloudhub.com
@@ -6733,7 +6733,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
               >
                 <a
                   className="slds-th__action slds-text-link_reset"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   role="button"
                   style={
@@ -6790,7 +6790,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                 >
                   <a
                     className="slds-th__action slds-text-link_reset"
-                    href="javascript:void(0)"
+                    href="#"
                     onClick={[Function]}
                     role="button"
                     style={
@@ -7046,7 +7046,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
               >
                 <a
                   className="slds-th__action slds-text-link_reset"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   role="button"
                   style={
@@ -7097,7 +7097,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                 >
                   <a
                     className="slds-th__action slds-text-link_reset"
-                    href="javascript:void(0)"
+                    href="#"
                     onClick={[Function]}
                     role="button"
                     style={
@@ -7384,7 +7384,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                   title="Acme - 1,200 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     Acme - 1,200 Widgets
@@ -7467,7 +7467,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                   title="jrogers@acme.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     jrogers@acme.com
@@ -7578,7 +7578,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                   title="Acme - 200 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     Acme - 200 Widgets
@@ -7661,7 +7661,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                   title="bob@acme.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     bob@acme.com
@@ -7772,7 +7772,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                   title="salesforce.com - 1,000 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     salesforce.com - 1,000 Widgets
@@ -7855,7 +7855,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                   title="nathan@salesforce.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     nathan@salesforce.com
@@ -7966,7 +7966,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                   title="Acme - 800 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     Acme - 800 Widgets
@@ -8049,7 +8049,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                   title="jrogers@acme.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     jrogers@acme.com
@@ -8160,7 +8160,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                   title="Acme - 744 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     Acme - 744 Widgets
@@ -8243,7 +8243,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                   title="bob@acme.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     bob@acme.com
@@ -8354,7 +8354,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                   title="salesforce.com - 847 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     salesforce.com - 847 Widgets
@@ -8437,7 +8437,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                   title="nathan@salesforce.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     nathan@salesforce.com
@@ -8548,7 +8548,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                   title="Acme - 1,621 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     Acme - 1,621 Widgets
@@ -8631,7 +8631,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                   title="jrogers@acme.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     jrogers@acme.com
@@ -8742,7 +8742,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                   title="Acme - 430 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     Acme - 430 Widgets
@@ -8825,7 +8825,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                   title="bob@acme.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     bob@acme.com
@@ -8936,7 +8936,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                   title="salesforce.com - 677 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     salesforce.com - 677 Widgets
@@ -9019,7 +9019,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                   title="nathan@salesforce.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     nathan@salesforce.com
@@ -9130,7 +9130,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                   title="Acme - 1,444 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     Acme - 1,444 Widgets
@@ -9213,7 +9213,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                   title="jrogers@acme.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     jrogers@acme.com
@@ -9324,7 +9324,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                   title="Acme - 320 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     Acme - 320 Widgets
@@ -9407,7 +9407,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                   title="bob@acme.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     bob@acme.com
@@ -9518,7 +9518,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                   title="salesforce.com - 4,000 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     salesforce.com - 4,000 Widgets
@@ -9601,7 +9601,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
                   title="nathan@salesforce.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     nathan@salesforce.com
@@ -9841,7 +9841,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header Horizontal Scrolling 1`] = `
               >
                 <a
                   className="slds-th__action slds-text-link_reset"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   role="button"
                   style={
@@ -9898,7 +9898,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header Horizontal Scrolling 1`] = `
                 >
                   <a
                     className="slds-th__action slds-text-link_reset"
-                    href="javascript:void(0)"
+                    href="#"
                     onClick={[Function]}
                     role="button"
                     style={
@@ -10154,7 +10154,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header Horizontal Scrolling 1`] = `
               >
                 <a
                   className="slds-th__action slds-text-link_reset"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   role="button"
                   style={
@@ -10205,7 +10205,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header Horizontal Scrolling 1`] = `
                 >
                   <a
                     className="slds-th__action slds-text-link_reset"
-                    href="javascript:void(0)"
+                    href="#"
                     onClick={[Function]}
                     role="button"
                     style={
@@ -10492,7 +10492,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header Horizontal Scrolling 1`] = `
                   title="Acme - 1,200 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     Acme - 1,200 Widgets
@@ -10575,7 +10575,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header Horizontal Scrolling 1`] = `
                   title="jrogers@acme.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     jrogers@acme.com
@@ -10686,7 +10686,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header Horizontal Scrolling 1`] = `
                   title="Acme - 200 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     Acme - 200 Widgets
@@ -10769,7 +10769,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header Horizontal Scrolling 1`] = `
                   title="bob@acme.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     bob@acme.com
@@ -10880,7 +10880,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header Horizontal Scrolling 1`] = `
                   title="salesforce.com - 1,000 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     salesforce.com - 1,000 Widgets
@@ -10963,7 +10963,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header Horizontal Scrolling 1`] = `
                   title="nathan@salesforce.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     nathan@salesforce.com
@@ -11074,7 +11074,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header Horizontal Scrolling 1`] = `
                   title="Acme - 800 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     Acme - 800 Widgets
@@ -11157,7 +11157,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header Horizontal Scrolling 1`] = `
                   title="jrogers@acme.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     jrogers@acme.com
@@ -11268,7 +11268,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header Horizontal Scrolling 1`] = `
                   title="Acme - 744 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     Acme - 744 Widgets
@@ -11351,7 +11351,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header Horizontal Scrolling 1`] = `
                   title="bob@acme.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     bob@acme.com
@@ -11462,7 +11462,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header Horizontal Scrolling 1`] = `
                   title="salesforce.com - 847 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     salesforce.com - 847 Widgets
@@ -11545,7 +11545,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header Horizontal Scrolling 1`] = `
                   title="nathan@salesforce.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     nathan@salesforce.com
@@ -11656,7 +11656,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header Horizontal Scrolling 1`] = `
                   title="Acme - 1,621 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     Acme - 1,621 Widgets
@@ -11739,7 +11739,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header Horizontal Scrolling 1`] = `
                   title="jrogers@acme.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     jrogers@acme.com
@@ -11850,7 +11850,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header Horizontal Scrolling 1`] = `
                   title="Acme - 430 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     Acme - 430 Widgets
@@ -11933,7 +11933,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header Horizontal Scrolling 1`] = `
                   title="bob@acme.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     bob@acme.com
@@ -12044,7 +12044,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header Horizontal Scrolling 1`] = `
                   title="salesforce.com - 677 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     salesforce.com - 677 Widgets
@@ -12127,7 +12127,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header Horizontal Scrolling 1`] = `
                   title="nathan@salesforce.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     nathan@salesforce.com
@@ -12238,7 +12238,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header Horizontal Scrolling 1`] = `
                   title="Acme - 1,444 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     Acme - 1,444 Widgets
@@ -12321,7 +12321,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header Horizontal Scrolling 1`] = `
                   title="jrogers@acme.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     jrogers@acme.com
@@ -12432,7 +12432,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header Horizontal Scrolling 1`] = `
                   title="Acme - 320 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     Acme - 320 Widgets
@@ -12515,7 +12515,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header Horizontal Scrolling 1`] = `
                   title="bob@acme.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     bob@acme.com
@@ -12626,7 +12626,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header Horizontal Scrolling 1`] = `
                   title="salesforce.com - 4,000 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     salesforce.com - 4,000 Widgets
@@ -12709,7 +12709,7 @@ exports[`DOM snapshots SLDSDataTable Fixed Header Horizontal Scrolling 1`] = `
                   title="nathan@salesforce.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     nathan@salesforce.com
@@ -12943,7 +12943,7 @@ exports[`DOM snapshots SLDSDataTable Infinite Scrolling 1`] = `
               >
                 <a
                   className="slds-th__action slds-text-link_reset"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   role="button"
                   style={
@@ -13000,7 +13000,7 @@ exports[`DOM snapshots SLDSDataTable Infinite Scrolling 1`] = `
                 >
                   <a
                     className="slds-th__action slds-text-link_reset"
-                    href="javascript:void(0)"
+                    href="#"
                     onClick={[Function]}
                     role="button"
                     style={
@@ -13256,7 +13256,7 @@ exports[`DOM snapshots SLDSDataTable Infinite Scrolling 1`] = `
               >
                 <a
                   className="slds-th__action slds-text-link_reset"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   role="button"
                   style={
@@ -13307,7 +13307,7 @@ exports[`DOM snapshots SLDSDataTable Infinite Scrolling 1`] = `
                 >
                   <a
                     className="slds-th__action slds-text-link_reset"
-                    href="javascript:void(0)"
+                    href="#"
                     onClick={[Function]}
                     role="button"
                     style={
@@ -13594,7 +13594,7 @@ exports[`DOM snapshots SLDSDataTable Infinite Scrolling 1`] = `
                   title="Acme - 1,200 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     Acme - 1,200 Widgets
@@ -13677,7 +13677,7 @@ exports[`DOM snapshots SLDSDataTable Infinite Scrolling 1`] = `
                   title="jrogers@acme.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     jrogers@acme.com
@@ -13788,7 +13788,7 @@ exports[`DOM snapshots SLDSDataTable Infinite Scrolling 1`] = `
                   title="Acme - 200 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     Acme - 200 Widgets
@@ -13871,7 +13871,7 @@ exports[`DOM snapshots SLDSDataTable Infinite Scrolling 1`] = `
                   title="bob@acme.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     bob@acme.com
@@ -13982,7 +13982,7 @@ exports[`DOM snapshots SLDSDataTable Infinite Scrolling 1`] = `
                   title="salesforce.com - 1,000 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     salesforce.com - 1,000 Widgets
@@ -14065,7 +14065,7 @@ exports[`DOM snapshots SLDSDataTable Infinite Scrolling 1`] = `
                   title="nathan@salesforce.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     nathan@salesforce.com
@@ -14176,7 +14176,7 @@ exports[`DOM snapshots SLDSDataTable Infinite Scrolling 1`] = `
                   title="Acme - 800 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     Acme - 800 Widgets
@@ -14259,7 +14259,7 @@ exports[`DOM snapshots SLDSDataTable Infinite Scrolling 1`] = `
                   title="jrogers@acme.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     jrogers@acme.com
@@ -14370,7 +14370,7 @@ exports[`DOM snapshots SLDSDataTable Infinite Scrolling 1`] = `
                   title="Acme - 744 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     Acme - 744 Widgets
@@ -14453,7 +14453,7 @@ exports[`DOM snapshots SLDSDataTable Infinite Scrolling 1`] = `
                   title="bob@acme.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     bob@acme.com
@@ -14564,7 +14564,7 @@ exports[`DOM snapshots SLDSDataTable Infinite Scrolling 1`] = `
                   title="salesforce.com - 847 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     salesforce.com - 847 Widgets
@@ -14647,7 +14647,7 @@ exports[`DOM snapshots SLDSDataTable Infinite Scrolling 1`] = `
                   title="nathan@salesforce.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     nathan@salesforce.com
@@ -14758,7 +14758,7 @@ exports[`DOM snapshots SLDSDataTable Infinite Scrolling 1`] = `
                   title="Acme - 1,621 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     Acme - 1,621 Widgets
@@ -14841,7 +14841,7 @@ exports[`DOM snapshots SLDSDataTable Infinite Scrolling 1`] = `
                   title="jrogers@acme.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     jrogers@acme.com
@@ -14952,7 +14952,7 @@ exports[`DOM snapshots SLDSDataTable Infinite Scrolling 1`] = `
                   title="Acme - 430 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     Acme - 430 Widgets
@@ -15035,7 +15035,7 @@ exports[`DOM snapshots SLDSDataTable Infinite Scrolling 1`] = `
                   title="bob@acme.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     bob@acme.com
@@ -15146,7 +15146,7 @@ exports[`DOM snapshots SLDSDataTable Infinite Scrolling 1`] = `
                   title="salesforce.com - 677 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     salesforce.com - 677 Widgets
@@ -15229,7 +15229,7 @@ exports[`DOM snapshots SLDSDataTable Infinite Scrolling 1`] = `
                   title="nathan@salesforce.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     nathan@salesforce.com
@@ -15340,7 +15340,7 @@ exports[`DOM snapshots SLDSDataTable Infinite Scrolling 1`] = `
                   title="Acme - 1,444 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     Acme - 1,444 Widgets
@@ -15423,7 +15423,7 @@ exports[`DOM snapshots SLDSDataTable Infinite Scrolling 1`] = `
                   title="jrogers@acme.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     jrogers@acme.com
@@ -15534,7 +15534,7 @@ exports[`DOM snapshots SLDSDataTable Infinite Scrolling 1`] = `
                   title="Acme - 320 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     Acme - 320 Widgets
@@ -15617,7 +15617,7 @@ exports[`DOM snapshots SLDSDataTable Infinite Scrolling 1`] = `
                   title="bob@acme.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     bob@acme.com
@@ -15728,7 +15728,7 @@ exports[`DOM snapshots SLDSDataTable Infinite Scrolling 1`] = `
                   title="salesforce.com - 4,000 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     salesforce.com - 4,000 Widgets
@@ -15811,7 +15811,7 @@ exports[`DOM snapshots SLDSDataTable Infinite Scrolling 1`] = `
                   title="nathan@salesforce.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     nathan@salesforce.com
@@ -16435,7 +16435,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
               >
                 <a
                   className="slds-th__action slds-text-link_reset"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   role="button"
                   style={
@@ -16492,7 +16492,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                 >
                   <a
                     className="slds-th__action slds-text-link_reset"
-                    href="javascript:void(0)"
+                    href="#"
                     onClick={[Function]}
                     role="button"
                     style={
@@ -16748,7 +16748,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
               >
                 <a
                   className="slds-th__action slds-text-link_reset"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   role="button"
                   style={
@@ -16799,7 +16799,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                 >
                   <a
                     className="slds-th__action slds-text-link_reset"
-                    href="javascript:void(0)"
+                    href="#"
                     onClick={[Function]}
                     role="button"
                     style={
@@ -17086,7 +17086,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                   title="Acme - 1,200 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     Acme - 1,200 Widgets
@@ -17169,7 +17169,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                   title="jrogers@acme.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     jrogers@acme.com
@@ -17280,7 +17280,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                   title="Acme - 200 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     Acme - 200 Widgets
@@ -17363,7 +17363,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                   title="bob@acme.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     bob@acme.com
@@ -17474,7 +17474,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                   title="salesforce.com - 1,000 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     salesforce.com - 1,000 Widgets
@@ -17557,7 +17557,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                   title="nathan@salesforce.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     nathan@salesforce.com
@@ -17668,7 +17668,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                   title="Acme - 800 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     Acme - 800 Widgets
@@ -17751,7 +17751,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                   title="jrogers@acme.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     jrogers@acme.com
@@ -17862,7 +17862,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                   title="Acme - 744 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     Acme - 744 Widgets
@@ -17945,7 +17945,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                   title="bob@acme.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     bob@acme.com
@@ -18056,7 +18056,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                   title="salesforce.com - 847 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     salesforce.com - 847 Widgets
@@ -18139,7 +18139,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                   title="nathan@salesforce.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     nathan@salesforce.com
@@ -18250,7 +18250,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                   title="Acme - 1,621 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     Acme - 1,621 Widgets
@@ -18333,7 +18333,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                   title="jrogers@acme.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     jrogers@acme.com
@@ -18444,7 +18444,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                   title="Acme - 430 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     Acme - 430 Widgets
@@ -18527,7 +18527,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                   title="bob@acme.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     bob@acme.com
@@ -18638,7 +18638,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                   title="salesforce.com - 677 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     salesforce.com - 677 Widgets
@@ -18721,7 +18721,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                   title="nathan@salesforce.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     nathan@salesforce.com
@@ -18832,7 +18832,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                   title="Acme - 1,444 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     Acme - 1,444 Widgets
@@ -18915,7 +18915,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                   title="jrogers@acme.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     jrogers@acme.com
@@ -19026,7 +19026,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                   title="Acme - 320 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     Acme - 320 Widgets
@@ -19109,7 +19109,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                   title="bob@acme.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     bob@acme.com
@@ -19220,7 +19220,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                   title="salesforce.com - 4,000 Widgets"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     salesforce.com - 4,000 Widgets
@@ -19303,7 +19303,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                   title="nathan@salesforce.com"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                   >
                     nathan@salesforce.com

--- a/components/data-table/__examples__/advanced-single-select-fixed-header.jsx
+++ b/components/data-table/__examples__/advanced-single-select-fixed-header.jsx
@@ -10,7 +10,7 @@ import IconSettings from '~/components/icon-settings';
 const CustomDataTableCell = ({ children, ...props }) => (
 	<DataTableCell title={children} {...props}>
 		<a
-			href="javascript:void(0);"
+			href="#"
 			onClick={(event) => {
 				event.preventDefault();
 			}}

--- a/components/data-table/__examples__/advanced-single-select.jsx
+++ b/components/data-table/__examples__/advanced-single-select.jsx
@@ -10,7 +10,7 @@ import IconSettings from '~/components/icon-settings';
 const CustomDataTableCell = ({ children, ...props }) => (
 	<DataTableCell title={children} {...props}>
 		<a
-			href="javascript:void(0);"
+			href="#"
 			onClick={(event) => {
 				event.preventDefault();
 			}}

--- a/components/data-table/__examples__/advanced.jsx
+++ b/components/data-table/__examples__/advanced.jsx
@@ -10,7 +10,7 @@ import IconSettings from '~/components/icon-settings';
 const CustomDataTableCell = ({ children, ...props }) => (
 	<DataTableCell title={children} {...props}>
 		<a
-			href="javascript:void(0);"
+			href="#"
 			onClick={(event) => {
 				event.preventDefault();
 			}}

--- a/components/data-table/__examples__/basic-fluid-column-bordered.jsx
+++ b/components/data-table/__examples__/basic-fluid-column-bordered.jsx
@@ -8,7 +8,7 @@ import IconSettings from '~/components/icon-settings';
 const CustomDataTableCell = ({ children, ...props }) => (
 	<DataTableCell {...props}>
 		<a
-			href="javascript:void(0);"
+			href="#"
 			onClick={(event) => {
 				event.preventDefault();
 			}}

--- a/components/data-table/__examples__/basic-fluid-no-row-hover.jsx
+++ b/components/data-table/__examples__/basic-fluid-no-row-hover.jsx
@@ -8,7 +8,7 @@ import IconSettings from '~/components/icon-settings';
 const CustomDataTableCell = ({ children, ...props }) => (
 	<DataTableCell {...props}>
 		<a
-			href="javascript:void(0);"
+			href="#"
 			onClick={(event) => {
 				event.preventDefault();
 			}}

--- a/components/data-table/__examples__/basic-fluid-striped.jsx
+++ b/components/data-table/__examples__/basic-fluid-striped.jsx
@@ -8,7 +8,7 @@ import IconSettings from '~/components/icon-settings';
 const CustomDataTableCell = ({ children, ...props }) => (
 	<DataTableCell {...props}>
 		<a
-			href="javascript:void(0);"
+			href="#"
 			onClick={(event) => {
 				event.preventDefault();
 			}}

--- a/components/data-table/__examples__/basic-fluid.jsx
+++ b/components/data-table/__examples__/basic-fluid.jsx
@@ -8,7 +8,7 @@ import IconSettings from '~/components/icon-settings';
 const CustomDataTableCell = ({ children, ...props }) => (
 	<DataTableCell {...props}>
 		<a
-			href="javascript:void(0);"
+			href="#"
 			onClick={(event) => {
 				event.preventDefault();
 			}}

--- a/components/data-table/__examples__/fixed-header-horizontal-scrolling.jsx
+++ b/components/data-table/__examples__/fixed-header-horizontal-scrolling.jsx
@@ -10,7 +10,7 @@ import IconSettings from '~/components/icon-settings';
 const CustomDataTableCell = ({ children, ...props }) => (
 	<DataTableCell title={children} {...props}>
 		<a
-			href="javascript:void(0);"
+			href="#"
 			onClick={(event) => {
 				event.preventDefault();
 			}}

--- a/components/data-table/__examples__/fixed-header.jsx
+++ b/components/data-table/__examples__/fixed-header.jsx
@@ -10,7 +10,7 @@ import IconSettings from '~/components/icon-settings';
 const CustomDataTableCell = ({ children, ...props }) => (
 	<DataTableCell title={children} {...props}>
 		<a
-			href="javascript:void(0);"
+			href="#"
 			onClick={(event) => {
 				event.preventDefault();
 			}}

--- a/components/data-table/__examples__/infinite-scrolling.jsx
+++ b/components/data-table/__examples__/infinite-scrolling.jsx
@@ -133,7 +133,7 @@ const ITEMS = [
 const CustomDataTableCell = ({ children, ...props }) => (
 	<DataTableCell title={children} {...props}>
 		<a
-			href="javascript:void(0);"
+			href="#"
 			onClick={(event) => {
 				event.preventDefault();
 			}}

--- a/components/data-table/__examples__/joined-with-page-header.jsx
+++ b/components/data-table/__examples__/joined-with-page-header.jsx
@@ -16,7 +16,7 @@ import PageHeaderControl from '~/components/page-header/control';
 const CustomDataTableCell = ({ children, ...props }) => (
 	<DataTableCell title={children} {...props}>
 		<a
-			href="javascript:void(0);"
+			href="#"
 			onClick={(event) => {
 				event.preventDefault();
 			}}

--- a/components/data-table/column.jsx
+++ b/components/data-table/column.jsx
@@ -30,7 +30,7 @@ DataTableColumn.propTypes = {
 	 * import DataTableCell from 'design-system-react/data-table/cell';
 	 * const CustomDataTableCell = ({ children, ...props }) => (
 	 *   <DataTableCell {...props} >
-	 *     <a href="javascript:void(0);">{children}</a>
+	 *     <a href="#">{children}</a>
 	 *   </DataTableCell>
 	 * );
 	 * CustomDataTableCell.displayName = DataTableCell.displayName;

--- a/components/data-table/index.jsx
+++ b/components/data-table/index.jsx
@@ -102,7 +102,7 @@ class DataTable extends React.Component {
 		 * import DataTableCell from 'design-system-react/data-table/cell';
 		 * const CustomDataTableCell = ({ children, ...props }) => (
 		 *   <DataTableCell {...props} >
-		 *   <a href="javascript:void(0);">{children}</a>
+		 *     <a href="#">{children}</a>
 		 *   </DataTableCell>
 		 * );
 		 * CustomDataTableCell.displayName = DataTableCell.displayName;

--- a/components/data-table/private/header-cell.jsx
+++ b/components/data-table/private/header-cell.jsx
@@ -96,6 +96,8 @@ class DataTableHeaderCell extends React.Component {
 	}
 
 	handleSort = (e) => {
+		e.preventDefault();
+
 		const oldSortDirection =
 			this.props.sortDirection || this.state.sortDirection;
 		// UX pattern: If sortable, and the DataTable's parent has not defined the sort order, then ascending (that is A->Z) is the default sort order on first click. Some columns, such as "last viewed" or "recently updated," should sort descending first, since that is what the user probably wants. Who wants to see the oldest files first?
@@ -145,7 +147,7 @@ class DataTableHeaderCell extends React.Component {
 		const fixedLayoutSubRenders = {
 			sortable: (
 				<a
-					href="javascript:void(0)" // eslint-disable-line no-script-url
+					href="#"
 					className="slds-th__action slds-text-link_reset"
 					onClick={this.handleSort}
 					role="button"

--- a/components/date-picker/__tests__/__snapshots__/datepicker.dom-snapshot-test.jsx.snap
+++ b/components/date-picker/__tests__/__snapshots__/datepicker.dom-snapshot-test.jsx.snap
@@ -858,7 +858,7 @@ exports[`Datepicker
               >
                 <a
                   className="slds-show_inline-block slds-p-bottom_x-small"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   onKeyDown={[Function]}
                   tabIndex="0"
@@ -1722,7 +1722,7 @@ exports[`Datepicker
                 >
                   <a
                     className="slds-show_inline-block slds-p-bottom_x-small"
-                    href="javascript:void(0)"
+                    href="#"
                     onClick={[Function]}
                     onKeyDown={[Function]}
                     tabIndex="0"
@@ -2585,7 +2585,7 @@ exports[`Datepicker
               >
                 <a
                   className="slds-show_inline-block slds-p-bottom_x-small"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   onKeyDown={[Function]}
                   tabIndex="0"
@@ -3445,7 +3445,7 @@ exports[`Datepicker Default DOM Snapshot 1`] = `
               >
                 <a
                   className="slds-show_inline-block slds-p-bottom_x-small"
-                  href="javascript:void(0)"
+                  href="#"
                   onClick={[Function]}
                   onKeyDown={[Function]}
                   tabIndex="0"
@@ -3558,7 +3558,7 @@ exports[`Datepicker Default HTML Snapshot 1`] = `
               <td aria-disabled=\\"true\\" aria-selected=\\"false\\" class=\\"slds-disabled-text\\"><span class=\\"slds-day \\"> </span></td>
             </tr>
             <tr>
-              <td colSpan=\\"7\\" role=\\"gridcell\\"><a href=\\"javascript:void(0)\\" tabindex=\\"0\\" class=\\"slds-show_inline-block slds-p-bottom_x-small\\">Today</a></td>
+              <td colSpan=\\"7\\" role=\\"gridcell\\"><a href=\\"#\\" tabindex=\\"0\\" class=\\"slds-show_inline-block slds-p-bottom_x-small\\">Today</a></td>
             </tr>
           </tbody>
         </table>

--- a/components/date-picker/private/calendar.jsx
+++ b/components/date-picker/private/calendar.jsx
@@ -306,10 +306,11 @@ class DatepickerCalendar extends React.Component {
 						<tr>
 							<td colSpan="7" role="gridcell">
 								<a
-									href="javascript:void(0)" // eslint-disable-line no-script-url
+									href="#"
 									tabIndex="0"
 									className="slds-show_inline-block slds-p-bottom_x-small"
 									onClick={(event) => {
+										event.preventDefault();
 										this.handleSelectDate(event, { date: new Date() });
 									}}
 									onKeyDown={this.props.onLastFocusableNodeKeyDown}

--- a/components/files/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/files/__docs__/__snapshots__/storybook-stories.storyshot
@@ -18,7 +18,8 @@ exports[`DOM snapshots SLDSFiles Cropped 1`] = `
         <figure>
           <a
             className="slds-file__crop slds-file__crop_1-by-1"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
           >
             <span
               className="slds-assistive-text"
@@ -74,7 +75,8 @@ exports[`DOM snapshots SLDSFiles Cropped 1`] = `
         <figure>
           <a
             className="slds-file__crop slds-file__crop_16-by-9"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
           >
             <span
               className="slds-assistive-text"
@@ -130,7 +132,8 @@ exports[`DOM snapshots SLDSFiles Cropped 1`] = `
         <figure>
           <a
             className="slds-file__crop slds-file__crop_4-by-3"
-            href="javascript:void(0);"
+            href="https://example.com"
+            onClick={[Function]}
           >
             <span
               className="slds-assistive-text"
@@ -198,7 +201,8 @@ exports[`DOM snapshots SLDSFiles Default 1`] = `
         <figure>
           <a
             className="slds-file__crop slds-file__crop_16-by-9"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
           >
             <span
               className="slds-assistive-text"
@@ -266,7 +270,8 @@ exports[`DOM snapshots SLDSFiles Loading 1`] = `
         <figure>
           <a
             className="slds-file__crop slds-file__crop_16-by-9"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
           >
             <span
               className="slds-assistive-text"
@@ -313,7 +318,8 @@ exports[`DOM snapshots SLDSFiles Loading 1`] = `
         <figure>
           <a
             className="slds-file__crop slds-file__crop_16-by-9"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
           >
             <span
               className="slds-assistive-text"
@@ -403,7 +409,8 @@ exports[`DOM snapshots SLDSFiles w/ Actions 1`] = `
         <figure>
           <a
             className="slds-file__crop slds-file__crop_16-by-9"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
           >
             <span
               className="slds-assistive-text"
@@ -507,7 +514,8 @@ exports[`DOM snapshots SLDSFiles w/ Actions 1`] = `
         <figure>
           <a
             className="slds-file__crop slds-file__crop_16-by-9"
-            href="javascript:void(0);"
+            href="https://example.com"
+            onClick={[Function]}
           >
             <span
               className="slds-assistive-text"
@@ -638,7 +646,8 @@ exports[`DOM snapshots SLDSFiles w/ Actions 1`] = `
         <figure>
           <a
             className="slds-file__crop slds-file__crop_16-by-9"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
           >
             <div
               className="slds-file_overlay"
@@ -706,7 +715,8 @@ exports[`DOM snapshots SLDSFiles w/ External Icon 1`] = `
         <figure>
           <a
             className="slds-file__crop slds-file__crop_16-by-9"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
           >
             <span
               className="slds-assistive-text"
@@ -805,7 +815,8 @@ exports[`DOM snapshots SLDSFiles w/o Image 1`] = `
         <figure>
           <a
             className="slds-file__crop slds-file__crop_16-by-9"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
           >
             <span
               className="slds-assistive-text"
@@ -887,7 +898,7 @@ exports[`DOM snapshots SLDSFiles w/o Title 1`] = `
         <figure>
           <a
             className="slds-file__crop slds-file__crop_16-by-9"
-            href="javascript:void(0);"
+            href="#"
             onClick={[Function]}
           >
             <span

--- a/components/files/__examples__/actions.jsx
+++ b/components/files/__examples__/actions.jsx
@@ -44,7 +44,7 @@ class Example extends React.Component {
 					/>
 					<File
 						id="file-with-title"
-						href="javascript:void(0);"
+						href="https://example.com"
 						labels={{
 							title: 'Proposal.pdf',
 						}}

--- a/components/files/__examples__/crops.jsx
+++ b/components/files/__examples__/crops.jsx
@@ -36,7 +36,7 @@ class Example extends React.Component {
 						}}
 						icon={<Icon category="doctype" name="pdf" />}
 						image="/assets/images/placeholder-img@16x9.jpg"
-						href="javascript:void(0);"
+						href="https://example.com"
 						crop="4-by-3"
 					/>
 				</Files>

--- a/components/files/file.jsx
+++ b/components/files/file.jsx
@@ -103,7 +103,7 @@ const defaultProps = {
 		moreActions: 'more actions',
 	},
 	crop: '16-by-9',
-	href: 'javascript:void(0);',
+	href: '#',
 	isLoading: false,
 	hasNoVisibleTitle: false,
 };
@@ -136,6 +136,16 @@ class File extends React.Component {
 		return this.props.id || this.generatedId;
 	}
 
+	handleOnClickImage = (event) => {
+		if (this.props.href === '#') {
+			event.preventDefault();
+		}
+
+		if (this.props.onClickImage) {
+			this.props.onClickImage(event);
+		}
+	};
+
 	render() {
 		const assistiveText = {
 			...defaultProps.assistiveText,
@@ -159,7 +169,7 @@ class File extends React.Component {
 							'slds-file__crop',
 							this.props.crop ? `slds-file__crop_${this.props.crop}` : null
 						)}
-						onClick={this.props.onClickImage}
+						onClick={this.handleOnClickImage}
 					>
 						<FileFigure
 							assistiveText={assistiveText}

--- a/components/files/more-files.jsx
+++ b/components/files/more-files.jsx
@@ -64,7 +64,7 @@ const defaultProps = {
 		link: 'Preview:',
 	},
 	crop: '16-by-9',
-	href: 'javascript:void(0);',
+	href: '#',
 };
 
 /**
@@ -98,6 +98,9 @@ class MoreFiles extends React.Component {
 							'slds-file__crop',
 							this.props.crop ? `slds-file__crop_${this.props.crop}` : null
 						)}
+						onClick={(event) =>
+							this.props.href === '#' && event.preventDefault()
+						}
 					>
 						<div className="slds-file_overlay" />
 						<span className="slds-assistive-text">{assistiveText.link}</span>

--- a/components/filter/index.jsx
+++ b/components/filter/index.jsx
@@ -1,8 +1,6 @@
 /* Copyright (c) 2015-present, salesforce.com, inc. All rights reserved */
 /* Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license */
 
-/* eslint-disable no-script-url */
-
 // # Filter
 
 // Implements part of the [Panel design pattern](https://www.lightningdesignsystem.com/components/panels) in React.

--- a/components/global-header/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/global-header/__docs__/__snapshots__/storybook-stories.storyshot
@@ -9,14 +9,14 @@ exports[`DOM snapshots SLDSGlobalHeader Doc site Default 1`] = `
   >
     <a
       className="slds-assistive-text slds-assistive-text_focus"
-      href="javascript:void(0);"
+      href="#"
       onClick={[Function]}
     >
       Skip to Navigation
     </a>
     <a
       className="slds-assistive-text slds-assistive-text_focus"
-      href="javascript:void(0);"
+      href="#"
       onClick={[Function]}
     >
       Skip to Main Content
@@ -501,14 +501,14 @@ exports[`DOM snapshots SLDSGlobalHeader Search + Navigation 1`] = `
   >
     <a
       className="slds-assistive-text slds-assistive-text_focus"
-      href="javascript:void(0);"
+      href="#"
       onClick={[Function]}
     >
       Skip to Navigation
     </a>
     <a
       className="slds-assistive-text slds-assistive-text_focus"
-      href="javascript:void(0);"
+      href="#"
       onClick={[Function]}
     >
       Skip to Main Content
@@ -884,14 +884,14 @@ exports[`DOM snapshots SLDSGlobalHeader With custom <Avatar/> 1`] = `
   >
     <a
       className="slds-assistive-text slds-assistive-text_focus"
-      href="javascript:void(0);"
+      href="#"
       onClick={[Function]}
     >
       Skip to Navigation
     </a>
     <a
       className="slds-assistive-text slds-assistive-text_focus"
-      href="javascript:void(0);"
+      href="#"
       onClick={[Function]}
     >
       Skip to Main Content

--- a/components/global-header/__docs__/storybook-stories.jsx
+++ b/components/global-header/__docs__/storybook-stories.jsx
@@ -17,11 +17,11 @@ import IconSettings from '../../icon-settings';
 import Popover from '../../popover';
 
 import { GLOBAL_HEADER } from '../../../utilities/constants';
+import EventUtil from '../../../utilities/event';
 
 import Default from '../__examples__/default';
 
 /* eslint-disable max-len */
-/* eslint-disable no-script-url */
 /* eslint-disable react/prop-types */
 
 const ipsum =
@@ -50,8 +50,9 @@ const HeaderNotificationsCustomContent = (props) => (
 					<div className="slds-media__body">
 						<div className="slds-grid slds-grid_align-spread">
 							<a
-								href="javascript:void(0);"
+								href="#"
 								className="slds-text-link_reset slds-has-flexi-truncate"
+								onClick={(event) => event.preventDefault()}
 							>
 								<h3
 									className="slds-truncate"
@@ -94,12 +95,12 @@ const HeaderProfileCustomContent = (props) => (
 					<p className="slds-truncate">
 						<a
 							className="slds-m-right_medium"
-							href="javascript:void(0)"
-							onClick={props.onClick}
+							href="#"
+							onClick={EventUtil.trappedHandler(props.onClick)}
 						>
 							Settings
 						</a>
-						<a href="javascript:void(0)" onClick={props.onClick}>
+						<a href="#" onClick={EventUtil.trappedHandler(props.onClick)}>
 							Log Out
 						</a>
 					</p>

--- a/components/global-header/__examples__/default.jsx
+++ b/components/global-header/__examples__/default.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import EventUtil from '~/utilities/event';
 
 import Combobox from '~/components/combobox';
 import Dropdown from '~/components/menu-dropdown';
@@ -14,7 +15,6 @@ import IconSettings from '~/components/icon-settings';
 import Popover from '~/components/popover';
 
 /* eslint-disable max-len */
-/* eslint-disable no-script-url */
 /* eslint-disable react/prop-types */
 
 const ipsum =
@@ -43,8 +43,9 @@ const HeaderNotificationsCustomContent = (props) => (
 					<div className="slds-media__body">
 						<div className="slds-grid slds-grid_align-spread">
 							<a
-								href="javascript:void(0);"
+								href="#"
 								className="slds-text-link_reset slds-has-flexi-truncate"
+								onClick={(event) => event.preventDefault()}
 							>
 								<h3
 									className="slds-truncate"
@@ -87,12 +88,12 @@ const HeaderProfileCustomContent = (props) => (
 					<p className="slds-truncate">
 						<a
 							className="slds-m-right_medium"
-							href="javascript:void(0)"
-							onClick={props.onClick}
+							href="#"
+							onClick={EventUtil.trappedHandler(props.onClick)}
 						>
 							Settings
 						</a>
-						<a href="javascript:void(0)" onClick={props.onClick}>
+						<a href="#" onClick={EventUtil.trappedHandler(props.onClick)}>
 							Log Out
 						</a>
 					</p>

--- a/components/global-header/index.jsx
+++ b/components/global-header/index.jsx
@@ -145,12 +145,12 @@ class GlobalHeader extends React.Component {
 			actions[GLOBAL_HEADER_PROFILE]
 		);
 
-		/* eslint-disable max-len, no-script-url */
+		/* eslint-disable max-len */
 		return (
 			<header className="slds-global-header_container">
 				{this.props.onSkipToNav ? (
 					<a
-						href="javascript:void(0);"
+						href="#"
 						className="slds-assistive-text slds-assistive-text_focus"
 						onClick={this.handleSkipToNav}
 					>
@@ -159,7 +159,7 @@ class GlobalHeader extends React.Component {
 				) : null}
 				{this.props.onSkipToContent ? (
 					<a
-						href="javascript:void(0);"
+						href="#"
 						className="slds-assistive-text slds-assistive-text_focus"
 						onClick={this.handleSkipToContent}
 					>
@@ -191,7 +191,7 @@ class GlobalHeader extends React.Component {
 				{this.props.navigation}
 			</header>
 		);
-		/* eslint-enable max-len, no-script-url */
+		/* eslint-enable max-len */
 	}
 }
 

--- a/components/global-navigation-bar/link.jsx
+++ b/components/global-navigation-bar/link.jsx
@@ -18,12 +18,6 @@ import isFunction from 'lodash.isfunction';
 // ## Constants
 import { GLOBAL_NAVIGATION_BAR_LINK } from '../../utilities/constants';
 
-function handleClick(event, href, onClick) {
-	event.preventDefault();
-
-	onClick(event, { href });
-}
-
 /**
  * Wraps a link in the proper markup to support use in the GlobalNavigationBar.
  */
@@ -56,6 +50,16 @@ const GlobalNavigationBarLink = (props) => {
 		  }
 		: null;
 
+	function handleOnClick(event) {
+		if (isFunction(onClick) || href === '#') {
+			event.preventDefault();
+		}
+
+		if (isFunction(onClick)) {
+			onClick(event, { href });
+		}
+	}
+
 	return (
 		<li
 			className={classNames('slds-context-bar__item', {
@@ -69,11 +73,7 @@ const GlobalNavigationBarLink = (props) => {
 				href={href}
 				className={classNames('slds-context-bar__label-action', className)}
 				onBlur={onBlur}
-				onClick={
-					isFunction(onClick)
-						? (event) => handleClick(event, href, onClick)
-						: null
-				}
+				onClick={handleOnClick}
 				onFocus={onFocus}
 				onKeyDown={onKeyDown}
 				onKeyPress={onKeyPress}
@@ -181,7 +181,7 @@ GlobalNavigationBarLink.defaultProps = {
 	assistiveText: {
 		activeDescriptor: 'Current page:',
 	},
-	href: 'javascript:void(0);', // eslint-disable-line no-script-url
+	href: '#',
 };
 
 export default GlobalNavigationBarLink;

--- a/components/lookup/footer.jsx
+++ b/components/lookup/footer.jsx
@@ -41,9 +41,12 @@ class DefaultFooter extends React.Component {
 				onMouseDown={EventUtil.trapImmediate}
 			>
 				{/* eslint-enable jsx-a11y/no-static-element-interactions */}
-				{/* eslint-disable no-script-url */}
-				<a id="newItem" href="javascript:void(0);" className={className}>
-					{/* eslint-enable no-script-url */}
+				<a
+					id="newItem"
+					href="#"
+					onClick={(event) => event.preventDefault()}
+					className={className}
+				>
 					<span className="lookup__item-action-label">
 						<Icon
 							name="add"

--- a/components/lookup/header.jsx
+++ b/components/lookup/header.jsx
@@ -41,9 +41,12 @@ class DefaultHeader extends React.Component {
 				onClick={this.handleClick}
 			>
 				{/* eslint-enable jsx-a11y/no-static-element-interactions */}
-				{/* eslint-disable no-script-url */}
-				<a id="searchRecords" href="javascript:void(0);" className={className}>
-					{/* eslint-enable no-script-url */}
+				<a
+					id="searchRecords"
+					href="#"
+					onClick={(event) => event.preventDefault()}
+					className={className}
+				>
 					<span className="lookup__item-action-label">
 						<Icon
 							name="search"

--- a/components/lookup/lookup.jsx
+++ b/components/lookup/lookup.jsx
@@ -697,16 +697,15 @@ const Lookup = class extends React.Component {
 		// i18n
 		return (
 			<div className="slds-pill__container">
-				{/* eslint-disable no-script-url */}
 				<a
-					href="javascript:void(0)"
+					href="#"
 					className="slds-pill"
 					ref={(pill) => {
 						this.pills[this.state.selectedIndex] = pill;
 					}}
+					onClick={(event) => event.preventDefault()}
 					onKeyDown={this.handlePillKeyDown}
 				>
-					{/* eslint-enable no-script-url */}
 					{renderIcon}
 					<span className={labelClassName}>{selectedItem}</span>
 					<Button

--- a/components/menu-dropdown/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/menu-dropdown/__docs__/__snapshots__/storybook-stories.storyshot
@@ -620,7 +620,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
                 <a
                   aria-disabled={true}
                   data-index={1}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -642,7 +642,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={2}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -713,7 +713,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={5}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -735,7 +735,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={6}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -757,7 +757,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={7}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -779,7 +779,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={8}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -801,7 +801,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={9}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -823,7 +823,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={10}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -845,7 +845,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={11}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -867,7 +867,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={12}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -950,7 +950,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
                 <a
                   aria-disabled={true}
                   data-index={1}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -972,7 +972,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={2}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -1043,7 +1043,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={5}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -1065,7 +1065,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={6}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -1087,7 +1087,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={7}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -1109,7 +1109,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={8}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -1131,7 +1131,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={9}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -1153,7 +1153,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={10}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -1175,7 +1175,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={11}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -1197,7 +1197,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={12}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -1280,7 +1280,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
                 <a
                   aria-disabled={true}
                   data-index={1}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -1302,7 +1302,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={2}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -1373,7 +1373,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={5}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -1395,7 +1395,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={6}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -1417,7 +1417,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={7}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -1439,7 +1439,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={8}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -1461,7 +1461,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={9}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -1483,7 +1483,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={10}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -1505,7 +1505,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={11}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -1527,7 +1527,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={12}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -1610,7 +1610,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
                 <a
                   aria-disabled={true}
                   data-index={1}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -1632,7 +1632,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={2}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -1703,7 +1703,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={5}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -1725,7 +1725,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={6}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -1747,7 +1747,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={7}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -1769,7 +1769,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={8}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -1791,7 +1791,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={9}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -1813,7 +1813,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={10}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -1835,7 +1835,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={11}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -1857,7 +1857,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={12}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -1940,7 +1940,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
                 <a
                   aria-disabled={true}
                   data-index={1}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -1962,7 +1962,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={2}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -2033,7 +2033,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={5}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -2055,7 +2055,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={6}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -2077,7 +2077,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={7}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -2099,7 +2099,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={8}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -2121,7 +2121,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={9}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -2143,7 +2143,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={10}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -2165,7 +2165,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={11}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -2187,7 +2187,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={12}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -2270,7 +2270,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
                 <a
                   aria-disabled={true}
                   data-index={1}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -2292,7 +2292,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={2}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -2363,7 +2363,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={5}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -2385,7 +2385,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={6}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -2407,7 +2407,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={7}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -2429,7 +2429,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={8}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -2451,7 +2451,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={9}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -2473,7 +2473,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={10}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -2495,7 +2495,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={11}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -2517,7 +2517,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins 1`] = `
               >
                 <a
                   data-index={12}
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="menuitem"
                   tabIndex="-1"
@@ -2658,7 +2658,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                   <a
                     aria-disabled={true}
                     data-index={1}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -2680,7 +2680,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={2}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -2751,7 +2751,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={5}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -2773,7 +2773,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={6}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -2795,7 +2795,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={7}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -2817,7 +2817,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={8}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -2839,7 +2839,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={9}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -2861,7 +2861,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={10}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -2883,7 +2883,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={11}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -2905,7 +2905,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={12}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -2988,7 +2988,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                   <a
                     aria-disabled={true}
                     data-index={1}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -3010,7 +3010,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={2}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -3081,7 +3081,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={5}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -3103,7 +3103,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={6}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -3125,7 +3125,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={7}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -3147,7 +3147,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={8}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -3169,7 +3169,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={9}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -3191,7 +3191,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={10}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -3213,7 +3213,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={11}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -3235,7 +3235,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={12}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -3318,7 +3318,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                   <a
                     aria-disabled={true}
                     data-index={1}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -3340,7 +3340,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={2}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -3411,7 +3411,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={5}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -3433,7 +3433,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={6}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -3455,7 +3455,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={7}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -3477,7 +3477,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={8}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -3499,7 +3499,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={9}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -3521,7 +3521,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={10}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -3543,7 +3543,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={11}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -3565,7 +3565,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={12}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -3648,7 +3648,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                   <a
                     aria-disabled={true}
                     data-index={1}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -3670,7 +3670,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={2}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -3741,7 +3741,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={5}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -3763,7 +3763,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={6}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -3785,7 +3785,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={7}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -3807,7 +3807,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={8}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -3829,7 +3829,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={9}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -3851,7 +3851,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={10}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -3873,7 +3873,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={11}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -3895,7 +3895,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={12}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -3978,7 +3978,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                   <a
                     aria-disabled={true}
                     data-index={1}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -4000,7 +4000,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={2}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -4071,7 +4071,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={5}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -4093,7 +4093,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={6}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -4115,7 +4115,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={7}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -4137,7 +4137,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={8}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -4159,7 +4159,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={9}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -4181,7 +4181,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={10}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -4203,7 +4203,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={11}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -4225,7 +4225,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={12}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -4308,7 +4308,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                   <a
                     aria-disabled={true}
                     data-index={1}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -4330,7 +4330,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={2}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -4401,7 +4401,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={5}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -4423,7 +4423,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={6}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -4445,7 +4445,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={7}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -4467,7 +4467,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={8}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -4489,7 +4489,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={9}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -4511,7 +4511,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={10}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -4533,7 +4533,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={11}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -4555,7 +4555,7 @@ exports[`DOM snapshots SLDSMenuDropdown Render inline w/ Nubbins, right-to-left 
                 >
                   <a
                     data-index={12}
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="menuitem"
                     tabIndex="-1"
@@ -4812,7 +4812,7 @@ exports[`DOM snapshots SLDSMenuDropdown With tooltips (open) 1`] = `
         >
           <a
             data-index={1}
-            href="javascript:void(0);"
+            href="#"
             onClick={[Function]}
             role="menuitem"
             tabIndex="-1"
@@ -4845,7 +4845,7 @@ exports[`DOM snapshots SLDSMenuDropdown With tooltips (open) 1`] = `
             <a
               aria-describedby="dropdown-with-tooltips-item-2-tooltip"
               data-index={2}
-              href="javascript:void(0);"
+              href="#"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -4891,7 +4891,7 @@ exports[`DOM snapshots SLDSMenuDropdown With tooltips (open) 1`] = `
         >
           <a
             data-index={3}
-            href="javascript:void(0);"
+            href="#"
             onClick={[Function]}
             role="menuitem"
             tabIndex="-1"
@@ -4929,7 +4929,7 @@ exports[`DOM snapshots SLDSMenuDropdown With tooltips (open) 1`] = `
             <a
               aria-describedby="dropdown-with-tooltips-item-5-tooltip"
               data-index={5}
-              href="javascript:void(0);"
+              href="#"
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
@@ -4975,7 +4975,7 @@ exports[`DOM snapshots SLDSMenuDropdown With tooltips (open) 1`] = `
         >
           <a
             data-index={6}
-            href="javascript:void(0);"
+            href="#"
             onClick={[Function]}
             role="menuitem"
             tabIndex="-1"
@@ -4997,7 +4997,7 @@ exports[`DOM snapshots SLDSMenuDropdown With tooltips (open) 1`] = `
         >
           <a
             data-index={7}
-            href="javascript:void(0);"
+            href="#"
             onClick={[Function]}
             role="menuitem"
             tabIndex="-1"
@@ -5024,7 +5024,7 @@ exports[`DOM snapshots SLDSMenuDropdown With tooltips (open) 1`] = `
         >
           <a
             data-index={9}
-            href="javascript:void(0);"
+            href="#"
             onClick={[Function]}
             role="menuitem"
             tabIndex="-1"

--- a/components/menu-dropdown/__docs__/storybook-stories.jsx
+++ b/components/menu-dropdown/__docs__/storybook-stories.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import IconSettings from '../../icon-settings';
+import EventUtil from '../../../utilities/event';
 
 import { MENU_DROPDOWN } from '../../../utilities/constants';
 import Dropdown from '../../menu-dropdown';
@@ -195,7 +196,6 @@ const getDropdownCustomTrigger = (props) => (
 );
 
 /* eslint-disable react/prop-types */
-/* eslint-disable no-script-url */
 const DropdownCustomContent = (props) => (
 	<div id="custom-dropdown-menu-content">
 		<div className="slds-m-around_medium">
@@ -205,12 +205,12 @@ const DropdownCustomContent = (props) => (
 					<p className="slds-truncate">
 						<a
 							className="slds-m-right_medium"
-							href="javascript:void(0)"
-							onClick={props.onClick}
+							href="#"
+							onClick={EventUtil.trappedHandler(props.onClick)}
 						>
 							Settings
 						</a>
-						<a href="javascript:void(0)" onClick={props.onClick}>
+						<a href="#" onClick={EventUtil.trappedHandler(props.onClick)}>
 							Log Out
 						</a>
 					</p>

--- a/components/menu-dropdown/__tests__/dropdown.browser-test.jsx
+++ b/components/menu-dropdown/__tests__/dropdown.browser-test.jsx
@@ -27,6 +27,7 @@ import IconSettings from '../../icon-settings';
 import Tooltip from '../../tooltip';
 import List from '../../utilities/menu-list';
 import { keyObjects } from '../../../utilities/key-code';
+import EventUtil from '../../../utilities/event';
 
 /* Set Chai to use chaiEnzyme for enzyme compatible assertions:
  * https://github.com/producthunt/chai-enzyme
@@ -63,12 +64,12 @@ const DropdownCustomContent = (props) => (
 						<a
 							id="custom-dropdown-menu-content-link"
 							className="slds-m-right_medium"
-							href="javascript:void(0);"
-							onClick={props.onClick}
+							href="#"
+							onClick={EventUtil.trappedHandler(props.onClick)}
 						>
 							Settings
 						</a>
-						<a href="javascript:void(0);" onClick={props.onClick}>
+						<a href="#" onClick={EventUtil.trappedHandler(props.onClick)}>
 							Log Out
 						</a>
 					</p>

--- a/components/modal/__examples__/taglines.jsx
+++ b/components/modal/__examples__/taglines.jsx
@@ -27,8 +27,7 @@ class Example extends React.Component {
 							<span>
 								Here’s a tagline if you need it. It is allowed to extend across
 								mulitple lines, so I’m making up content to show that to you. It
-								is allowed to{' '}
-								<a href="javascript:void(0);">contain links or be a link.</a>
+								is allowed to <a href="#">contain links or be a link.</a>
 							</span>
 						}
 						heading="Modal header"

--- a/components/notification/__docs__/storybook-stories.jsx
+++ b/components/notification/__docs__/storybook-stories.jsx
@@ -17,7 +17,7 @@ storiesOf(NOTIFICATION, module)
 		<Notification
 			content={[
 				'Your new contact ',
-				<a href="javascript:void(0);" key="0123">
+				<a href="#" key="0123">
 					Sara Smith
 				</a>,
 				' was successfully created.',

--- a/components/notification/__examples__/alerts.jsx
+++ b/components/notification/__examples__/alerts.jsx
@@ -49,7 +49,7 @@ class Example extends React.Component {
 						content={[
 							<span key="maintenance">
 								Scheduled Maintenance Notification: Sunday March 15, 8:00
-								AM–10:00 PST <a href="javascript:void(0);">More Information</a>
+								AM–10:00 PST <a href="#">More Information</a>
 							</span>,
 						]}
 						iconName="notification"
@@ -73,7 +73,7 @@ class Example extends React.Component {
 						content={[
 							<span key="browser">
 								Your browser is currently not supported. Your Salesforce may be
-								degraded. <a href="javascript:void(0);">More Information</a>
+								degraded. <a href="#">More Information</a>
 							</span>,
 						]}
 						iconName="ban"
@@ -96,8 +96,7 @@ class Example extends React.Component {
 					<Notification
 						content={[
 							<span key="offline">
-								You are in offline mode{' '}
-								<a href="javascript:void(0);">More Information</a>
+								You are in offline mode <a href="#">More Information</a>
 							</span>,
 						]}
 						iconName="offline"

--- a/components/notification/__examples__/toasts.jsx
+++ b/components/notification/__examples__/toasts.jsx
@@ -47,8 +47,8 @@ class Example extends React.Component {
 					<Notification
 						content={[
 							<span key="new-contact">
-								Your new contact <a href="javascript:void(0);">Sara Smith</a>{' '}
-								was successfully created.
+								Your new contact <a href="#">Sara Smith</a> was successfully
+								created.
 							</span>,
 						]}
 						iconName="notification"

--- a/components/page-header/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/page-header/__docs__/__snapshots__/storybook-stories.storyshot
@@ -558,7 +558,7 @@ exports[`DOM snapshots SLDSPageHeader Docs site RecordHome 1`] = `
               Field 3
             </div>
             <a
-              href="javascript:void(0);"
+              href="#link"
             >
               Hyperlink
             </a>
@@ -610,7 +610,7 @@ exports[`DOM snapshots SLDSPageHeader Docs site RelatedList 1`] = `
               className="slds-breadcrumb__item"
             >
               <a
-                href="javascript:void(0);"
+                href="#accounts"
               >
                 Accounts
               </a>
@@ -619,7 +619,7 @@ exports[`DOM snapshots SLDSPageHeader Docs site RelatedList 1`] = `
               className="slds-breadcrumb__item"
             >
               <a
-                href="javascript:void(0);"
+                href="#company-one"
               >
                 Company One
               </a>
@@ -1715,7 +1715,7 @@ exports[`DOM snapshots SLDSPageHeader Related List 1`] = `
               className="slds-breadcrumb__item"
             >
               <a
-                href="javascript:void(0);"
+                href="#accounts"
               >
                 Accounts
               </a>
@@ -1724,7 +1724,7 @@ exports[`DOM snapshots SLDSPageHeader Related List 1`] = `
               className="slds-breadcrumb__item"
             >
               <a
-                href="javascript:void(0);"
+                href="#company-one"
               >
                 Company One
               </a>
@@ -2036,7 +2036,7 @@ exports[`DOM snapshots SLDSPageHeader Setup 1`] = `
                   className="slds-breadcrumb__item"
                 >
                   <a
-                    href="javascript:void(0);"
+                    href="#setup"
                   >
                     Setup
                   </a>

--- a/components/page-header/__docs__/storybook-stories.jsx
+++ b/components/page-header/__docs__/storybook-stories.jsx
@@ -381,8 +381,8 @@ const relatedListControls = () => (
 );
 
 const relatedListTrail = [
-	<a href="javascript:void(0);">Accounts</a>,
-	<a href="javascript:void(0);">Company One</a>,
+	<a href="#accounts">Accounts</a>,
+	<a href="#company-one">Company One</a>,
 ];
 
 storiesOf(PAGE_HEADER, module)

--- a/components/page-header/__examples__/record-home.jsx
+++ b/components/page-header/__examples__/record-home.jsx
@@ -59,7 +59,7 @@ class Example extends React.Component {
 			{ label: 'Field 2', content: 'Multiple Values' },
 			{
 				label: 'Field 3',
-				content: <a href="javascript:void(0);">Hyperlink</a>,
+				content: <a href="#link">Hyperlink</a>,
 			},
 			{
 				label: 'Field 4',

--- a/components/page-header/__examples__/related-list.jsx
+++ b/components/page-header/__examples__/related-list.jsx
@@ -113,8 +113,8 @@ class Example extends React.Component {
 		);
 
 		const trail = [
-			<a href="javascript:void(0);">Accounts</a>,
-			<a href="javascript:void(0);">Company One</a>,
+			<a href="#accounts">Accounts</a>,
+			<a href="#company-one">Company One</a>,
 		];
 
 		return (

--- a/components/page-header/__examples__/setup.jsx
+++ b/components/page-header/__examples__/setup.jsx
@@ -58,7 +58,7 @@ class Example extends React.Component {
 					}
 					onRenderActions={actions}
 					title="Home"
-					trail={[<a href="javascript:void(0);">Setup</a>]}
+					trail={[<a href="#setup">Setup</a>]}
 					truncate
 					variant="object-home"
 				/>

--- a/components/pill/__docs__/.eslintrc
+++ b/components/pill/__docs__/.eslintrc
@@ -1,7 +1,6 @@
 {
   "rules": {
     "max-len": "off",
-    "no-script-url": "off",
     "no-alert": "off",
     "no-console": "off",
     "no-unused-vars": "off"

--- a/components/pill/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/pill/__docs__/__snapshots__/storybook-stories.storyshot
@@ -19,7 +19,7 @@ exports[`DOM snapshots SLDSPill Docs site Snapshot 1`] = `
       >
         <a
           className="slds-pill__action"
-          href="javascript:void(0);"
+          href="#"
           onClick={[Function]}
           title="Full pill label verbiage mirrored here"
         >
@@ -66,7 +66,8 @@ exports[`DOM snapshots SLDSPill Docs site Snapshot 1`] = `
       >
         <a
           className="slds-pill__action"
-          href="javascript:void(0);"
+          href="#"
+          onClick={[Function]}
           title="Full pill label verbiage mirrored here"
         >
           <span
@@ -130,7 +131,7 @@ exports[`DOM snapshots SLDSPill Docs site Snapshot 1`] = `
         </span>
         <a
           className="slds-pill__action"
-          href="javascript:void(0);"
+          href="#"
           onClick={[Function]}
           title="Full pill label verbiage mirrored here"
         >
@@ -193,7 +194,7 @@ exports[`DOM snapshots SLDSPill Docs site Snapshot 1`] = `
         </span>
         <a
           className="slds-pill__action"
-          href="javascript:void(0);"
+          href="#"
           onClick={[Function]}
           title="Full pill label verbiage mirrored here"
         >
@@ -257,7 +258,7 @@ exports[`DOM snapshots SLDSPill Docs site Snapshot 1`] = `
         </span>
         <a
           className="slds-pill__action"
-          href="javascript:void(0);"
+          href="#"
           onClick={[Function]}
           title="Full pill label verbiage mirrored here"
         >
@@ -375,7 +376,7 @@ exports[`DOM snapshots SLDSPill Icon, Avatar, Error 1`] = `
         </span>
         <a
           className="slds-pill__action"
-          href="javascript:void(0);"
+          href="#"
           onClick={[Function]}
           title="Full pill label verbiage mirrored here"
         >
@@ -438,7 +439,7 @@ exports[`DOM snapshots SLDSPill Icon, Avatar, Error 1`] = `
         </span>
         <a
           className="slds-pill__action"
-          href="javascript:void(0);"
+          href="#"
           onClick={[Function]}
           title="Full pill label verbiage mirrored here"
         >
@@ -502,7 +503,7 @@ exports[`DOM snapshots SLDSPill Icon, Avatar, Error 1`] = `
         </span>
         <a
           className="slds-pill__action"
-          href="javascript:void(0);"
+          href="#"
           onClick={[Function]}
           title="Full pill label verbiage mirrored here"
         >
@@ -560,7 +561,7 @@ exports[`DOM snapshots SLDSPill Linked, Unlinked, Truncated 1`] = `
       >
         <a
           className="slds-pill__action"
-          href="javascript:void(0);"
+          href="#"
           onClick={[Function]}
           title="Full pill label verbiage mirrored here"
         >
@@ -607,7 +608,8 @@ exports[`DOM snapshots SLDSPill Linked, Unlinked, Truncated 1`] = `
       >
         <a
           className="slds-pill__action"
-          href="javascript:void(0);"
+          href="#"
+          onClick={[Function]}
           title="Full pill label verbiage mirrored here"
         >
           <span
@@ -664,7 +666,7 @@ exports[`DOM snapshots SLDSPill Linked, Unlinked, Truncated 1`] = `
           >
             <a
               className="slds-pill__action"
-              href="javascript:void(0);"
+              href="#"
               onClick={[Function]}
               title="Pill label that is longer than the area that contains it"
             >

--- a/components/pill/__examples__/.eslintrc
+++ b/components/pill/__examples__/.eslintrc
@@ -1,7 +1,6 @@
 {
   "rules": {
     "max-len": "off",
-    "no-script-url": "off",
     "no-alert": "off",
     "no-console": "off",
     "no-unused-vars": "off",

--- a/components/pill/index.jsx
+++ b/components/pill/index.jsx
@@ -111,10 +111,7 @@ const propTypes = {
  * A pill displays a label that can contain links and can be removed from view. Use `PillContainer` for a list of pills in a container that resembles an `input` form field. A pill is useful for displaying read-only text that can be added and removed on demand.
  */
 class Pill extends React.Component {
-	getHref = () =>
-		typeof this.props.href === 'string'
-			? this.props.href
-			: 'javascript:void(0);'; // eslint-disable-line no-script-url
+	getHref = () => (typeof this.props.href === 'string' ? this.props.href : '#');
 
 	/**
 	 * Removes focus from the component.
@@ -167,6 +164,16 @@ class Pill extends React.Component {
 		this.root = root;
 	};
 
+	handleOnClick = (event) => {
+		if (this.getHref() === '#') {
+			event.preventDefault();
+		}
+
+		if (this.props.onClick) {
+			this.props.onClick(event);
+		}
+	};
+
 	/**
 	 * Extracts a set of custom properties. A custom property is a property, which is not described in propTypes of a component.
 	 */
@@ -206,7 +213,7 @@ class Pill extends React.Component {
 						href={this.getHref()}
 						className="slds-pill__action"
 						title={this.props.labels.title || this.props.labels.label}
-						onClick={this.props.onClick}
+						onClick={this.handleOnClick}
 					>
 						<span className="slds-pill__label">{this.props.labels.label}</span>
 					</a>

--- a/components/popover/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/popover/__docs__/__snapshots__/storybook-stories.storyshot
@@ -1586,7 +1586,7 @@ exports[`DOM snapshots SLDSPopover Error - Open 1`] = `
               Pellentesque magna tellus, dapibus vitae placerat nec, viverra vel mi.
                
               <a
-                href="javascript:void(0);"
+                href="#"
                 title="Learn More"
               >
                 Learn More
@@ -2393,7 +2393,7 @@ exports[`DOM snapshots SLDSPopover Warning  - Open 1`] = `
               Pellentesque magna tellus, dapibus vitae placerat nec, viverra vel mi.
                
               <a
-                href="javascript:void(0);"
+                href="#"
                 title="Learn More"
               >
                 Learn More

--- a/components/popover/__docs__/storybook-stories.jsx
+++ b/components/popover/__docs__/storybook-stories.jsx
@@ -1,5 +1,4 @@
 /* eslint-disable react/display-name */
-/* eslint-disable no-script-url */
 
 import React from 'react';
 import { storiesOf } from '@storybook/react';

--- a/components/popover/__examples__/alternative-header.jsx
+++ b/components/popover/__examples__/alternative-header.jsx
@@ -31,7 +31,7 @@ const panelContent = (
 			</dt>
 			<dd className="slds-tile">
 				<p className="slds-truncate" title="Tesla - Mule ESB">
-					<a href="javascript:void(0);">Tesla - Mule ESB</a>
+					<a href="#">Tesla - Mule ESB</a>
 				</p>
 				<div className="slds-tile__detail">
 					<dl className="slds-dl_horizontal slds-text-body_small">
@@ -59,7 +59,7 @@ const panelContent = (
 				</div>
 			</dd>
 			<dd className="slds-m-top_x-small slds-text-align_right">
-				<a href="javascript:void(0);" title="View all Opportunities">
+				<a href="#" title="View all Opportunities">
 					View All
 				</a>
 			</dd>

--- a/components/popover/__examples__/error.jsx
+++ b/components/popover/__examples__/error.jsx
@@ -28,7 +28,7 @@ class Example extends React.Component {
 							<p className="slds-p-bottom_x-small">
 								Pellentesque magna tellus, dapibus vitae placerat nec, viverra
 								vel mi.{' '}
-								<a href="javascript:void(0);" title="Learn More">
+								<a href="#" title="Learn More">
 									Learn More
 								</a>
 							</p>

--- a/components/popover/__examples__/warning.jsx
+++ b/components/popover/__examples__/warning.jsx
@@ -28,7 +28,7 @@ class Example extends React.Component {
 							<p className="slds-p-bottom_x-small">
 								Pellentesque magna tellus, dapibus vitae placerat nec, viverra
 								vel mi.{' '}
-								<a href="javascript:void(0);" title="Learn More">
+								<a href="#" title="Learn More">
 									Learn More
 								</a>
 							</p>

--- a/components/scoped-notification/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/scoped-notification/__docs__/__snapshots__/storybook-stories.storyshot
@@ -34,7 +34,7 @@ exports[`DOM snapshots SLDSScopedNotification Base 1`] = `
         It looks as if duplicates exist for this lead.
          
         <a
-          href="javascript:void(0);"
+          href="#"
         >
           View Duplicates.
         </a>
@@ -115,7 +115,7 @@ exports[`DOM snapshots SLDSScopedNotification Dark 1`] = `
         It looks as if duplicates exist for this lead.
          
         <a
-          href="javascript:void(0);"
+          href="#"
         >
           View Duplicates.
         </a>
@@ -159,7 +159,7 @@ exports[`DOM snapshots SLDSScopedNotification Light 1`] = `
         It looks as if duplicates exist for this lead.
          
         <a
-          href="javascript:void(0);"
+          href="#"
         >
           View Duplicates.
         </a>

--- a/components/scoped-notification/__examples__/base.jsx
+++ b/components/scoped-notification/__examples__/base.jsx
@@ -9,7 +9,7 @@ class Example extends React.Component {
 				<ScopedNotification>
 					<p>
 						It looks as if duplicates exist for this lead.{' '}
-						<a href="javascript:void(0);">View Duplicates.</a>{' '}
+						<a href="#">View Duplicates.</a>{' '}
 					</p>
 				</ScopedNotification>
 			</IconSettings>

--- a/components/scoped-notification/__examples__/dark.jsx
+++ b/components/scoped-notification/__examples__/dark.jsx
@@ -9,7 +9,7 @@ class Example extends React.Component {
 				<ScopedNotification theme="dark">
 					<p>
 						It looks as if duplicates exist for this lead.{' '}
-						<a href="javascript:void(0);">View Duplicates.</a>
+						<a href="#">View Duplicates.</a>
 					</p>
 				</ScopedNotification>
 			</IconSettings>

--- a/components/scoped-notification/__examples__/light.jsx
+++ b/components/scoped-notification/__examples__/light.jsx
@@ -9,7 +9,7 @@ class Example extends React.Component {
 				<ScopedNotification theme="light">
 					<p>
 						It looks as if duplicates exist for this lead.{' '}
-						<a href="javascript:void(0);">View Duplicates.</a>{' '}
+						<a href="#">View Duplicates.</a>{' '}
 					</p>
 				</ScopedNotification>
 			</IconSettings>

--- a/components/setup-assistant/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/setup-assistant/__docs__/__snapshots__/storybook-stories.storyshot
@@ -836,7 +836,7 @@ exports[`DOM snapshots SLDSSetupAssistant Hub with Expandable Steps 1`] = `
                       It looks as if duplicates exist for this lead.
                        
                       <a
-                        href="javascript:void(0);"
+                        href="#"
                       >
                         View Duplicates.
                       </a>
@@ -2249,7 +2249,7 @@ exports[`DOM snapshots SLDSSetupAssistant In a Card 1`] = `
                         It looks as if duplicates exist for this lead.
                          
                         <a
-                          href="javascript:void(0);"
+                          href="#"
                         >
                           View Duplicates.
                         </a>

--- a/components/setup-assistant/__examples__/card.jsx
+++ b/components/setup-assistant/__examples__/card.jsx
@@ -162,7 +162,7 @@ class Example extends React.Component {
 								>
 									<p>
 										It looks as if duplicates exist for this lead.{' '}
-										<a href="javascript:void(0);">View Duplicates.</a>
+										<a href="#">View Duplicates.</a>
 									</p>
 								</ScopedNotification>
 							</React.Fragment>

--- a/components/setup-assistant/__examples__/hub-expandable-steps.jsx
+++ b/components/setup-assistant/__examples__/hub-expandable-steps.jsx
@@ -234,7 +234,7 @@ class Example extends React.Component {
 								>
 									<p>
 										It looks as if duplicates exist for this lead.{' '}
-										<a href="javascript:void(0);">View Duplicates.</a>
+										<a href="#">View Duplicates.</a>
 									</p>
 								</ScopedNotification>
 							</React.Fragment>

--- a/components/split-view/__docs__/.eslintrc
+++ b/components/split-view/__docs__/.eslintrc
@@ -1,7 +1,6 @@
 {
   "rules": {
     "max-len": "off",
-    "no-script-url": "off",
     "no-alert": "off",
     "no-console": "off",
     "no-unused-vars": "off"

--- a/components/split-view/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/split-view/__docs__/__snapshots__/storybook-stories.storyshot
@@ -413,7 +413,7 @@ exports[`DOM snapshots SLDSSplitView Base: Multiple 1`] = `
             <a
               aria-live="polite"
               className="slds-split-view__list-header slds-grid slds-text-link_reset"
-              href="javascript:void(0);"
+              href="#"
               onClick={[Function]}
               role="button"
               style={
@@ -467,7 +467,7 @@ exports[`DOM snapshots SLDSSplitView Base: Multiple 1`] = `
                 <a
                   aria-selected={false}
                   className="slds-split-view__list-item-action slds-grow slds-has-flexi-truncate"
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="option"
                   tabIndex={-1}
@@ -524,7 +524,7 @@ exports[`DOM snapshots SLDSSplitView Base: Multiple 1`] = `
                 <a
                   aria-selected={false}
                   className="slds-split-view__list-item-action slds-grow slds-has-flexi-truncate"
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="option"
                   tabIndex={-1}
@@ -572,7 +572,7 @@ exports[`DOM snapshots SLDSSplitView Base: Multiple 1`] = `
                 <a
                   aria-selected={false}
                   className="slds-split-view__list-item-action slds-grow slds-has-flexi-truncate"
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="option"
                   tabIndex={-1}
@@ -629,7 +629,7 @@ exports[`DOM snapshots SLDSSplitView Base: Multiple 1`] = `
                 <a
                   aria-selected={false}
                   className="slds-split-view__list-item-action slds-grow slds-has-flexi-truncate"
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="option"
                   tabIndex={-1}
@@ -677,7 +677,7 @@ exports[`DOM snapshots SLDSSplitView Base: Multiple 1`] = `
                 <a
                   aria-selected={false}
                   className="slds-split-view__list-item-action slds-grow slds-has-flexi-truncate"
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="option"
                   tabIndex={-1}
@@ -725,7 +725,7 @@ exports[`DOM snapshots SLDSSplitView Base: Multiple 1`] = `
                 <a
                   aria-selected={false}
                   className="slds-split-view__list-item-action slds-grow slds-has-flexi-truncate"
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="option"
                   tabIndex={-1}
@@ -773,7 +773,7 @@ exports[`DOM snapshots SLDSSplitView Base: Multiple 1`] = `
                 <a
                   aria-selected={false}
                   className="slds-split-view__list-item-action slds-grow slds-has-flexi-truncate"
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="option"
                   tabIndex={-1}
@@ -821,7 +821,7 @@ exports[`DOM snapshots SLDSSplitView Base: Multiple 1`] = `
                 <a
                   aria-selected={true}
                   className="slds-split-view__list-item-action slds-grow slds-has-flexi-truncate"
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="option"
                   tabIndex={0}
@@ -869,7 +869,7 @@ exports[`DOM snapshots SLDSSplitView Base: Multiple 1`] = `
                 <a
                   aria-selected={false}
                   className="slds-split-view__list-item-action slds-grow slds-has-flexi-truncate"
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="option"
                   tabIndex={-1}
@@ -1270,7 +1270,7 @@ exports[`DOM snapshots SLDSSplitView Base: Open 1`] = `
             <a
               aria-live="polite"
               className="slds-split-view__list-header slds-grid slds-text-link_reset"
-              href="javascript:void(0);"
+              href="#"
               onClick={[Function]}
               role="button"
               style={
@@ -1323,7 +1323,7 @@ exports[`DOM snapshots SLDSSplitView Base: Open 1`] = `
                 <a
                   aria-selected={false}
                   className="slds-split-view__list-item-action slds-grow slds-has-flexi-truncate"
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="option"
                   tabIndex={-1}
@@ -1380,7 +1380,7 @@ exports[`DOM snapshots SLDSSplitView Base: Open 1`] = `
                 <a
                   aria-selected={false}
                   className="slds-split-view__list-item-action slds-grow slds-has-flexi-truncate"
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="option"
                   tabIndex={-1}
@@ -1428,7 +1428,7 @@ exports[`DOM snapshots SLDSSplitView Base: Open 1`] = `
                 <a
                   aria-selected={false}
                   className="slds-split-view__list-item-action slds-grow slds-has-flexi-truncate"
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="option"
                   tabIndex={-1}
@@ -1485,7 +1485,7 @@ exports[`DOM snapshots SLDSSplitView Base: Open 1`] = `
                 <a
                   aria-selected={false}
                   className="slds-split-view__list-item-action slds-grow slds-has-flexi-truncate"
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="option"
                   tabIndex={-1}
@@ -1533,7 +1533,7 @@ exports[`DOM snapshots SLDSSplitView Base: Open 1`] = `
                 <a
                   aria-selected={false}
                   className="slds-split-view__list-item-action slds-grow slds-has-flexi-truncate"
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="option"
                   tabIndex={-1}
@@ -1581,7 +1581,7 @@ exports[`DOM snapshots SLDSSplitView Base: Open 1`] = `
                 <a
                   aria-selected={false}
                   className="slds-split-view__list-item-action slds-grow slds-has-flexi-truncate"
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="option"
                   tabIndex={-1}
@@ -1629,7 +1629,7 @@ exports[`DOM snapshots SLDSSplitView Base: Open 1`] = `
                 <a
                   aria-selected={false}
                   className="slds-split-view__list-item-action slds-grow slds-has-flexi-truncate"
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="option"
                   tabIndex={-1}
@@ -1677,7 +1677,7 @@ exports[`DOM snapshots SLDSSplitView Base: Open 1`] = `
                 <a
                   aria-selected={true}
                   className="slds-split-view__list-item-action slds-grow slds-has-flexi-truncate"
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="option"
                   tabIndex={0}
@@ -1725,7 +1725,7 @@ exports[`DOM snapshots SLDSSplitView Base: Open 1`] = `
                 <a
                   aria-selected={false}
                   className="slds-split-view__list-item-action slds-grow slds-has-flexi-truncate"
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="option"
                   tabIndex={-1}
@@ -2126,7 +2126,7 @@ exports[`DOM snapshots SLDSSplitView Custom List 1`] = `
             <a
               aria-live="polite"
               className="slds-split-view__list-header slds-grid slds-text-link_reset"
-              href="javascript:void(0);"
+              href="#"
               onClick={[Function]}
               role="button"
               style={
@@ -2179,7 +2179,7 @@ exports[`DOM snapshots SLDSSplitView Custom List 1`] = `
                 <a
                   aria-selected={false}
                   className="slds-split-view__list-item-action slds-grow slds-has-flexi-truncate"
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="option"
                   tabIndex={-1}
@@ -2222,7 +2222,7 @@ exports[`DOM snapshots SLDSSplitView Custom List 1`] = `
                 <a
                   aria-selected={false}
                   className="slds-split-view__list-item-action slds-grow slds-has-flexi-truncate"
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="option"
                   tabIndex={-1}
@@ -2256,7 +2256,7 @@ exports[`DOM snapshots SLDSSplitView Custom List 1`] = `
                 <a
                   aria-selected={false}
                   className="slds-split-view__list-item-action slds-grow slds-has-flexi-truncate"
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="option"
                   tabIndex={-1}
@@ -2299,7 +2299,7 @@ exports[`DOM snapshots SLDSSplitView Custom List 1`] = `
                 <a
                   aria-selected={true}
                   className="slds-split-view__list-item-action slds-grow slds-has-flexi-truncate"
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="option"
                   tabIndex={0}
@@ -2333,7 +2333,7 @@ exports[`DOM snapshots SLDSSplitView Custom List 1`] = `
                 <a
                   aria-selected={false}
                   className="slds-split-view__list-item-action slds-grow slds-has-flexi-truncate"
-                  href="javascript:void(0);"
+                  href="#"
                   onClick={[Function]}
                   role="option"
                   tabIndex={-1}
@@ -2746,7 +2746,7 @@ exports[`DOM snapshots SLDSSplitView External State 1`] = `
               <a
                 aria-live="polite"
                 className="slds-split-view__list-header slds-grid slds-text-link_reset"
-                href="javascript:void(0);"
+                href="#"
                 onClick={[Function]}
                 role="button"
                 style={
@@ -2799,7 +2799,7 @@ exports[`DOM snapshots SLDSSplitView External State 1`] = `
                   <a
                     aria-selected={false}
                     className="slds-split-view__list-item-action slds-grow slds-has-flexi-truncate"
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="option"
                     tabIndex={-1}
@@ -2856,7 +2856,7 @@ exports[`DOM snapshots SLDSSplitView External State 1`] = `
                   <a
                     aria-selected={false}
                     className="slds-split-view__list-item-action slds-grow slds-has-flexi-truncate"
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="option"
                     tabIndex={-1}
@@ -2904,7 +2904,7 @@ exports[`DOM snapshots SLDSSplitView External State 1`] = `
                   <a
                     aria-selected={false}
                     className="slds-split-view__list-item-action slds-grow slds-has-flexi-truncate"
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="option"
                     tabIndex={-1}
@@ -2961,7 +2961,7 @@ exports[`DOM snapshots SLDSSplitView External State 1`] = `
                   <a
                     aria-selected={false}
                     className="slds-split-view__list-item-action slds-grow slds-has-flexi-truncate"
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="option"
                     tabIndex={-1}
@@ -3009,7 +3009,7 @@ exports[`DOM snapshots SLDSSplitView External State 1`] = `
                   <a
                     aria-selected={false}
                     className="slds-split-view__list-item-action slds-grow slds-has-flexi-truncate"
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="option"
                     tabIndex={-1}
@@ -3057,7 +3057,7 @@ exports[`DOM snapshots SLDSSplitView External State 1`] = `
                   <a
                     aria-selected={false}
                     className="slds-split-view__list-item-action slds-grow slds-has-flexi-truncate"
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="option"
                     tabIndex={-1}
@@ -3105,7 +3105,7 @@ exports[`DOM snapshots SLDSSplitView External State 1`] = `
                   <a
                     aria-selected={false}
                     className="slds-split-view__list-item-action slds-grow slds-has-flexi-truncate"
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="option"
                     tabIndex={-1}
@@ -3153,7 +3153,7 @@ exports[`DOM snapshots SLDSSplitView External State 1`] = `
                   <a
                     aria-selected={true}
                     className="slds-split-view__list-item-action slds-grow slds-has-flexi-truncate"
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="option"
                     tabIndex={0}
@@ -3201,7 +3201,7 @@ exports[`DOM snapshots SLDSSplitView External State 1`] = `
                   <a
                     aria-selected={false}
                     className="slds-split-view__list-item-action slds-grow slds-has-flexi-truncate"
-                    href="javascript:void(0);"
+                    href="#"
                     onClick={[Function]}
                     role="option"
                     tabIndex={-1}

--- a/components/split-view/listbox.jsx
+++ b/components/split-view/listbox.jsx
@@ -297,10 +297,10 @@ class SplitViewListbox extends React.Component {
 			<a
 				aria-live="polite"
 				style={{ borderTop: '0' }}
-				href="javascript:void(0);" // eslint-disable-line no-script-url
+				href="#"
 				role="button"
 				className="slds-split-view__list-header slds-grid slds-text-link_reset"
-				onClick={this.props.events.onSort}
+				onClick={eventUtil.trappedHandler(this.props.events.onSort)}
 			>
 				{children}
 			</a>

--- a/components/split-view/private/list-item-with-content.jsx
+++ b/components/split-view/private/list-item-with-content.jsx
@@ -77,13 +77,15 @@ const listItemWithContent = (ListItemContent) => {
 
 		static defaultProps = defaultProps;
 
-		onClick(event) {
+		onClick = (event) => {
+			event.preventDefault();
+
 			this.props.events.onClick(event, {
 				item: this.props.item,
 				isSelected: this.props.isSelected,
 				isUnread: this.props.isUnread,
 			});
-		}
+		};
 
 		unread() {
 			return this.props.isUnread ? (
@@ -116,8 +118,8 @@ const listItemWithContent = (ListItemContent) => {
 								: this.props.isSelected
 						}
 						tabIndex={this.props.isFocused ? 0 : -1}
-						href="javascript:void(0);" // eslint-disable-line no-script-url
-						onClick={(e) => this.onClick(e)}
+						href="#"
+						onClick={this.onClick}
 					>
 						{this.unread()}
 						<ListItemContent {...this.props} />

--- a/components/tabs/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/tabs/__docs__/__snapshots__/storybook-stories.storyshot
@@ -32,7 +32,8 @@ exports[`DOM snapshots SLDSTabs Base 1`] = `
             aria-controls="main-tabs-demo-slds-tabs_panel-0"
             aria-selected="true"
             className="slds-is-active slds-tabs_default__link"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
             role="tab"
             tabIndex="0"
           >
@@ -49,7 +50,8 @@ exports[`DOM snapshots SLDSTabs Base 1`] = `
             aria-controls="main-tabs-demo-slds-tabs_panel-1"
             aria-selected="false"
             className="slds-tabs_default__link"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
             role="tab"
             tabIndex="-1"
           >
@@ -66,7 +68,8 @@ exports[`DOM snapshots SLDSTabs Base 1`] = `
             aria-controls="main-tabs-demo-slds-tabs_panel-2"
             aria-selected="false"
             className="slds-tabs_default__link"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
             role="tab"
             tabIndex="-1"
           >
@@ -287,7 +290,8 @@ exports[`DOM snapshots SLDSTabs Conditional 1`] = `
             aria-disabled={false}
             aria-selected="true"
             className="slds-is-active slds-tabs_default__link"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
             role="tab"
             tabIndex="0"
           >
@@ -305,7 +309,8 @@ exports[`DOM snapshots SLDSTabs Conditional 1`] = `
             aria-disabled={true}
             aria-selected="false"
             className="slds-disabled slds-tabs_default__link"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
             role="tab"
             tabIndex="-1"
           >
@@ -323,7 +328,8 @@ exports[`DOM snapshots SLDSTabs Conditional 1`] = `
             aria-disabled={true}
             aria-selected="false"
             className="slds-disabled slds-tabs_default__link"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
             role="tab"
             tabIndex="-1"
           >
@@ -474,7 +480,8 @@ exports[`DOM snapshots SLDSTabs Custom Tab Contents 1`] = `
             aria-controls="getCustomContentTabs-slds-tabs_panel-0"
             aria-selected="true"
             className="slds-is-active slds-tabs_default__link"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
             role="tab"
             tabIndex="0"
           >
@@ -513,7 +520,8 @@ exports[`DOM snapshots SLDSTabs Custom Tab Contents 1`] = `
             aria-controls="getCustomContentTabs-slds-tabs_panel-1"
             aria-selected="false"
             className="slds-tabs_default__link"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
             role="tab"
             tabIndex="-1"
           >
@@ -590,7 +598,8 @@ exports[`DOM snapshots SLDSTabs Nested 1`] = `
             aria-controls="nested-tabs-demo-slds-tabs_panel-0"
             aria-selected="true"
             className="slds-is-active slds-tabs_default__link"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
             role="tab"
             tabIndex="0"
           >
@@ -607,7 +616,8 @@ exports[`DOM snapshots SLDSTabs Nested 1`] = `
             aria-controls="nested-tabs-demo-slds-tabs_panel-1"
             aria-selected="false"
             className="slds-tabs_default__link"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
             role="tab"
             tabIndex="-1"
           >
@@ -624,7 +634,8 @@ exports[`DOM snapshots SLDSTabs Nested 1`] = `
             aria-controls="nested-tabs-demo-slds-tabs_panel-2"
             aria-selected="false"
             className="slds-tabs_default__link"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
             role="tab"
             tabIndex="-1"
           >
@@ -723,7 +734,8 @@ exports[`DOM snapshots SLDSTabs Nested 1`] = `
                   aria-controls="nested-second-layer-slds-tabs_panel-0"
                   aria-selected="true"
                   className="slds-is-active slds-tabs_default__link"
-                  href="javascript:void(0);"
+                  href="#"
+                  onClick={[Function]}
                   role="tab"
                   tabIndex="0"
                 >
@@ -740,7 +752,8 @@ exports[`DOM snapshots SLDSTabs Nested 1`] = `
                   aria-controls="nested-second-layer-slds-tabs_panel-1"
                   aria-selected="false"
                   className="slds-tabs_default__link"
-                  href="javascript:void(0);"
+                  href="#"
+                  onClick={[Function]}
                   role="tab"
                   tabIndex="-1"
                 >
@@ -757,7 +770,8 @@ exports[`DOM snapshots SLDSTabs Nested 1`] = `
                   aria-controls="nested-second-layer-slds-tabs_panel-2"
                   aria-selected="false"
                   className="slds-tabs_default__link"
-                  href="javascript:void(0);"
+                  href="#"
+                  onClick={[Function]}
                   role="tab"
                   tabIndex="-1"
                 >
@@ -838,7 +852,8 @@ exports[`DOM snapshots SLDSTabs Nested 1`] = `
                         aria-controls="nested-third-layer-slds-tabs_panel-0"
                         aria-selected="true"
                         className="slds-is-active slds-tabs_default__link"
-                        href="javascript:void(0);"
+                        href="#"
+                        onClick={[Function]}
                         role="tab"
                         tabIndex="0"
                       >
@@ -989,7 +1004,8 @@ exports[`DOM snapshots SLDSTabs Outside Control 1`] = `
             aria-controls="DemoTabsOutsideControlTabs-slds-tabs_panel-0"
             aria-selected="true"
             className="slds-is-active slds-tabs_default__link"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
             role="tab"
             tabIndex="0"
           >
@@ -1006,7 +1022,8 @@ exports[`DOM snapshots SLDSTabs Outside Control 1`] = `
             aria-controls="DemoTabsOutsideControlTabs-slds-tabs_panel-1"
             aria-selected="false"
             className="slds-tabs_default__link"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
             role="tab"
             tabIndex="-1"
           >
@@ -1023,7 +1040,8 @@ exports[`DOM snapshots SLDSTabs Outside Control 1`] = `
             aria-controls="DemoTabsOutsideControlTabs-slds-tabs_panel-2"
             aria-selected="false"
             className="slds-tabs_default__link"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
             role="tab"
             tabIndex="-1"
           >
@@ -1040,7 +1058,8 @@ exports[`DOM snapshots SLDSTabs Outside Control 1`] = `
             aria-controls="DemoTabsOutsideControlTabs-slds-tabs_panel-3"
             aria-selected="false"
             className="slds-tabs_default__link"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
             role="tab"
             tabIndex="-1"
           >
@@ -1057,7 +1076,8 @@ exports[`DOM snapshots SLDSTabs Outside Control 1`] = `
             aria-controls="DemoTabsOutsideControlTabs-slds-tabs_panel-4"
             aria-selected="false"
             className="slds-tabs_default__link"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
             role="tab"
             tabIndex="-1"
           >
@@ -1161,7 +1181,8 @@ exports[`DOM snapshots SLDSTabs Scoped 1`] = `
             aria-controls="scoped-tabs-demo-slds-tabs_panel-0"
             aria-selected="true"
             className="slds-is-active slds-tabs_scoped__link"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
             role="tab"
             tabIndex="0"
           >
@@ -1178,7 +1199,8 @@ exports[`DOM snapshots SLDSTabs Scoped 1`] = `
             aria-controls="scoped-tabs-demo-slds-tabs_panel-1"
             aria-selected="false"
             className="slds-tabs_scoped__link"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
             role="tab"
             tabIndex="-1"
           >
@@ -1195,7 +1217,8 @@ exports[`DOM snapshots SLDSTabs Scoped 1`] = `
             aria-controls="scoped-tabs-demo-slds-tabs_panel-2"
             aria-selected="false"
             className="slds-tabs_scoped__link"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
             role="tab"
             tabIndex="-1"
           >
@@ -1299,7 +1322,8 @@ exports[`DOM snapshots SLDSTabs Tab Intercept Panel Select 1`] = `
             aria-controls="DemoTabsInterceptSelect-slds-tabs_panel-0"
             aria-selected="true"
             className="slds-is-active slds-tabs_default__link"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
             role="tab"
             tabIndex="0"
           >
@@ -1316,7 +1340,8 @@ exports[`DOM snapshots SLDSTabs Tab Intercept Panel Select 1`] = `
             aria-controls="DemoTabsInterceptSelect-slds-tabs_panel-1"
             aria-selected="false"
             className="slds-tabs_default__link"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
             role="tab"
             tabIndex="-1"
           >
@@ -1374,7 +1399,8 @@ exports[`DOM snapshots SLDSTabs Tab Intercept Panel Select 1`] = `
             aria-controls="DemoTabsInterceptSelect2-slds-tabs_panel-0"
             aria-selected="true"
             className="slds-is-active slds-tabs_default__link"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
             role="tab"
             tabIndex="0"
           >
@@ -1391,7 +1417,8 @@ exports[`DOM snapshots SLDSTabs Tab Intercept Panel Select 1`] = `
             aria-controls="DemoTabsInterceptSelect2-slds-tabs_panel-1"
             aria-selected="false"
             className="slds-tabs_default__link"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
             role="tab"
             tabIndex="-1"
           >
@@ -1456,7 +1483,8 @@ exports[`DOM snapshots SLDSTabs Unique Generated IDs 1`] = `
             aria-controls="tabs-demo-id-1-slds-tabs_panel-0"
             aria-selected="true"
             className="slds-is-active slds-tabs_default__link"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
             role="tab"
             tabIndex="0"
           >
@@ -1502,7 +1530,8 @@ exports[`DOM snapshots SLDSTabs Unique Generated IDs 1`] = `
             aria-controls="tabs-demo-id-2-slds-tabs_panel-0"
             aria-selected="true"
             className="slds-is-active slds-tabs_default__link"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
             role="tab"
             tabIndex="0"
           >
@@ -1563,7 +1592,8 @@ exports[`DOM snapshots SLDSTabs Vertical 1`] = `
             aria-controls="scoped-tabs-demo-slds-tabs_panel-0"
             aria-selected="true"
             className="slds-is-active slds-vertical-tabs__link"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
             role="tab"
             tabIndex="0"
           >
@@ -1580,7 +1610,8 @@ exports[`DOM snapshots SLDSTabs Vertical 1`] = `
             aria-controls="scoped-tabs-demo-slds-tabs_panel-1"
             aria-selected="false"
             className="slds-vertical-tabs__link"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
             role="tab"
             tabIndex="-1"
           >
@@ -1598,7 +1629,8 @@ exports[`DOM snapshots SLDSTabs Vertical 1`] = `
             aria-disabled={true}
             aria-selected="false"
             className="slds-disabled slds-vertical-tabs__link"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
             role="tab"
             tabIndex="-1"
           >
@@ -1615,7 +1647,8 @@ exports[`DOM snapshots SLDSTabs Vertical 1`] = `
             aria-controls="scoped-tabs-demo-slds-tabs_panel-3"
             aria-selected="false"
             className="slds-vertical-tabs__link"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
             role="tab"
             tabIndex="-1"
           >
@@ -1732,7 +1765,8 @@ exports[`DOM snapshots SLDSTabs With disabled tab 1`] = `
             aria-controls="disabled-tabs-demo-slds-tabs_panel-0"
             aria-selected="true"
             className="slds-is-active slds-tabs_default__link"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
             role="tab"
             tabIndex="0"
           >
@@ -1750,7 +1784,8 @@ exports[`DOM snapshots SLDSTabs With disabled tab 1`] = `
             aria-disabled={true}
             aria-selected="false"
             className="slds-disabled slds-tabs_default__link"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
             role="tab"
             tabIndex="-1"
           >
@@ -1767,7 +1802,8 @@ exports[`DOM snapshots SLDSTabs With disabled tab 1`] = `
             aria-controls="disabled-tabs-demo-slds-tabs_panel-2"
             aria-selected="false"
             className="slds-tabs_default__link"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
             role="tab"
             tabIndex="-1"
           >
@@ -1784,7 +1820,8 @@ exports[`DOM snapshots SLDSTabs With disabled tab 1`] = `
             aria-controls="disabled-tabs-demo-slds-tabs_panel-3"
             aria-selected="false"
             className="slds-tabs_default__link"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
             role="tab"
             tabIndex="-1"
           >
@@ -1912,7 +1949,8 @@ exports[`DOM snapshots SLDSTabs With error tab 1`] = `
             aria-controls="disabled-tabs-demo-slds-tabs_panel-0"
             aria-selected="true"
             className="slds-is-active slds-tabs_default__link"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
             role="tab"
             tabIndex="0"
           >
@@ -1929,7 +1967,8 @@ exports[`DOM snapshots SLDSTabs With error tab 1`] = `
             aria-controls="disabled-tabs-demo-slds-tabs_panel-1"
             aria-selected="false"
             className="slds-tabs_default__link"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
             role="tab"
             tabIndex="-1"
           >
@@ -1968,7 +2007,8 @@ exports[`DOM snapshots SLDSTabs With error tab 1`] = `
             aria-controls="disabled-tabs-demo-slds-tabs_panel-2"
             aria-selected="false"
             className="slds-tabs_default__link"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
             role="tab"
             tabIndex="-1"
           >
@@ -1985,7 +2025,8 @@ exports[`DOM snapshots SLDSTabs With error tab 1`] = `
             aria-controls="disabled-tabs-demo-slds-tabs_panel-3"
             aria-selected="false"
             className="slds-tabs_default__link"
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
             role="tab"
             tabIndex="-1"
           >

--- a/components/tabs/private/tab.jsx
+++ b/components/tabs/private/tab.jsx
@@ -171,7 +171,7 @@ class Tab extends React.Component {
 						'slds-tabs_scoped__link': variant === 'scoped',
 						'slds-vertical-tabs__link': variant === 'vertical',
 					})}
-					href="javascript:void(0);" // eslint-disable-line no-script-url
+					href="#"
 					role="tab"
 					ref={(node) => {
 						this.node = node;
@@ -180,6 +180,7 @@ class Tab extends React.Component {
 					aria-controls={panelId}
 					aria-disabled={disabled}
 					aria-selected={selected ? 'true' : 'false'}
+					onClick={(event) => event.preventDefault()}
 				>
 					{children}
 					{hasError && (

--- a/components/toast/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/toast/__docs__/__snapshots__/storybook-stories.storyshot
@@ -59,7 +59,8 @@ exports[`DOM snapshots SLDSToast Custom Class Names 1`] = `
           26 potential duplicate leads were found.
            
           <a
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
           >
             Select Leads to Merge
           </a>
@@ -135,7 +136,8 @@ exports[`DOM snapshots SLDSToast Custom Style 1`] = `
           26 potential duplicate leads were found.
            
           <a
-            href="javascript:void(0);"
+            href="#"
+            onClick={[Function]}
           >
             Select Leads to Merge
           </a>
@@ -207,7 +209,7 @@ exports[`DOM snapshots SLDSToast Duration Toast 1`] = `
             26 potential duplicate leads were found.
              
             <a
-              href="javascript:void(0);"
+              href="#"
               onClick={[Function]}
             >
               Select Leads to Merge
@@ -423,7 +425,7 @@ exports[`DOM snapshots SLDSToast Info 1`] = `
           26 potential duplicate leads were found.
            
           <a
-            href="javascript:void(0);"
+            href="#"
             onClick={[Function]}
           >
             Select Leads to Merge
@@ -494,7 +496,7 @@ exports[`DOM snapshots SLDSToast Success 1`] = `
         >
           Account 
           <a
-            href="javascript:void(0);"
+            href="#"
           >
             ACME - 100
           </a>

--- a/components/toast/__examples__/success.jsx
+++ b/components/toast/__examples__/success.jsx
@@ -12,7 +12,7 @@ class Example extends React.Component {
 						labels={{
 							heading: [
 								'Account ',
-								<a key="acme-100" href="javascript:void(0);">
+								<a key="acme-100" href="#">
 									ACME - 100
 								</a>,
 								' widgets was created.',

--- a/components/toast/index.jsx
+++ b/components/toast/index.jsx
@@ -11,6 +11,7 @@ import PropTypes from 'prop-types';
 import assign from 'lodash.assign';
 
 import classNames from '../../utilities/class-names';
+import EventUtil from '../../utilities/event';
 import Button from '../button';
 import Icon from '../icon';
 import checkProps from './check-props';
@@ -188,7 +189,6 @@ class Toast extends React.Component {
 			size: 'small',
 		});
 
-		/* eslint-disable no-script-url */
 		return (
 			<div
 				className={classNames(
@@ -215,8 +215,10 @@ class Toast extends React.Component {
 						{heading}{' '}
 						{labels.headingLink ? (
 							<a
-								onClick={this.props.onClickHeadingLink}
-								href="javascript:void(0);"
+								onClick={EventUtil.trappedHandler(
+									this.props.onClickHeadingLink
+								)}
+								href="#"
 							>
 								{labels.headingLink}
 							</a>

--- a/components/tooltip/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/tooltip/__docs__/__snapshots__/storybook-stories.storyshot
@@ -2140,7 +2140,7 @@ exports[`DOM snapshots SLDSPopoverTooltip Learn More 1`] = `
     }
   >
     <a
-      href="javascript:void(0)"
+      href="#"
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}

--- a/components/tooltip/index.jsx
+++ b/components/tooltip/index.jsx
@@ -13,6 +13,7 @@ import classNames from 'classnames';
 // shortid is a short, non-sequential, url-friendly, unique id generator
 import shortid from 'shortid';
 
+import EventUtil from '../../utilities/event';
 import { POPOVER_TOOLTIP } from '../../utilities/constants';
 
 import Dialog from '../utilities/dialog';
@@ -259,7 +260,10 @@ class Tooltip extends React.Component {
 
 		if (noChildrenProvided && this.props.onClickTrigger) {
 			children = [
-				<a href="javascript:void(0)" onClick={this.props.onClickTrigger}>
+				<a
+					href="#"
+					onClick={EventUtil.trappedHandler(this.props.onClickTrigger)}
+				>
 					<Icon
 						category="utility"
 						name="info"

--- a/components/tree/private/item.jsx
+++ b/components/tree/private/item.jsx
@@ -175,9 +175,7 @@ const Item = (props) => {
 					className="slds-m-right_small slds-is-disabled"
 					disabled
 				/>
-				{/* eslint-disable no-script-url */}
 				<span className="slds-size_1-of-1">
-					{/* eslint-enable no-script-url */}
 					<Highlighter
 						search={props.searchTerm}
 						className="slds-tree__item-label slds-truncate"

--- a/components/tree/private/render-branch.jsx
+++ b/components/tree/private/render-branch.jsx
@@ -317,17 +317,13 @@ const RenderBranch = (children, props) => {
 					}}
 					tabIndex="-1"
 				/>
-				{/* eslint-disable no-script-url */}
 				<span className="slds-size_1-of-1" id={`${props.htmlId}__label`}>
-					{/* eslint-enable no-script-url */}
-					{
-						<Highlighter
+					<Highlighter
 							search={props.searchTerm}
 							className="slds-tree__item-label slds-truncate"
 						>
 							{props.label}
 						</Highlighter>
-					}
 				</span>
 			</div>
 			{isLoading ? loader : null}

--- a/components/tree/private/render-branch.jsx
+++ b/components/tree/private/render-branch.jsx
@@ -319,11 +319,11 @@ const RenderBranch = (children, props) => {
 				/>
 				<span className="slds-size_1-of-1" id={`${props.htmlId}__label`}>
 					<Highlighter
-							search={props.searchTerm}
-							className="slds-tree__item-label slds-truncate"
-						>
-							{props.label}
-						</Highlighter>
+						search={props.searchTerm}
+						className="slds-tree__item-label slds-truncate"
+					>
+						{props.label}
+					</Highlighter>
 				</span>
 			</div>
 			{isLoading ? loader : null}

--- a/components/utilities/menu-list/item.jsx
+++ b/components/utilities/menu-list/item.jsx
@@ -67,7 +67,7 @@ class ListItem extends React.Component {
 
 	static defaultProps = {
 		data: {},
-		href: 'javascript:void(0);', // eslint-disable-line no-script-url
+		href: '#',
 		inverted: false,
 		isSelected: false,
 		label: '',
@@ -129,9 +129,9 @@ class ListItem extends React.Component {
 	handleClick = (event) => {
 		if (
 			this.props.type !== 'link' ||
-			this.props.href === 'javascript:void(0);' // eslint-disable-line no-script-url
+			this.props.href === 'javascript:void(0);' || // eslint-disable-line no-script-url
+			this.props.href === '#'
 		) {
-			// eslint-disable-line no-script-url
 			EventUtil.trapImmediate(event);
 		}
 

--- a/components/vertical-navigation/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/vertical-navigation/__docs__/__snapshots__/storybook-stories.storyshot
@@ -26,7 +26,7 @@ exports[`DOM snapshots SLDSVerticalNavigation DOM Snapshot 1`] = `
             aria-describedby="sample-navigation-reports"
             className="slds-nav-vertical__action"
             data-id="recent_reports"
-            href="javascript:void(0);"
+            href="#"
             onClick={[Function]}
           >
             Recent
@@ -39,7 +39,7 @@ exports[`DOM snapshots SLDSVerticalNavigation DOM Snapshot 1`] = `
             aria-describedby="sample-navigation-reports"
             className="slds-nav-vertical__action"
             data-id="my_reports"
-            href="javascript:void(0);"
+            href="#"
             onClick={[Function]}
           >
             Created by Me
@@ -52,7 +52,7 @@ exports[`DOM snapshots SLDSVerticalNavigation DOM Snapshot 1`] = `
             aria-describedby="sample-navigation-reports"
             className="slds-nav-vertical__action"
             data-id="private_reports"
-            href="javascript:void(0);"
+            href="#"
             onClick={[Function]}
           >
             Private Reports
@@ -65,7 +65,7 @@ exports[`DOM snapshots SLDSVerticalNavigation DOM Snapshot 1`] = `
             aria-describedby="sample-navigation-reports"
             className="slds-nav-vertical__action"
             data-id="public_reports"
-            href="javascript:void(0);"
+            href="#"
             onClick={[Function]}
           >
             Public Reports
@@ -78,7 +78,7 @@ exports[`DOM snapshots SLDSVerticalNavigation DOM Snapshot 1`] = `
             aria-describedby="sample-navigation-reports"
             className="slds-nav-vertical__action"
             data-id="all_reports"
-            href="javascript:void(0);"
+            href="#"
             onClick={[Function]}
           >
             All Reports
@@ -116,7 +116,7 @@ exports[`DOM snapshots SLDSVerticalNavigation DOM Snapshot 1`] = `
             aria-describedby="sample-navigation-folders"
             className="slds-nav-vertical__action"
             data-id="shared_folders"
-            href="javascript:void(0);"
+            href="#"
             onClick={[Function]}
           >
             Shared with Me
@@ -129,7 +129,7 @@ exports[`DOM snapshots SLDSVerticalNavigation DOM Snapshot 1`] = `
             aria-describedby="sample-navigation-folders"
             className="slds-nav-vertical__action"
             data-id="all_folders"
-            href="javascript:void(0);"
+            href="#"
             onClick={[Function]}
           >
             All Folders
@@ -174,7 +174,7 @@ exports[`DOM snapshots SLDSVerticalNavigation Default 1`] = `
               aria-describedby="sample-navigation-reports"
               className="slds-nav-vertical__action"
               data-id="recent_reports"
-              href="javascript:void(0);"
+              href="#"
               onClick={[Function]}
             >
               Recent
@@ -187,7 +187,7 @@ exports[`DOM snapshots SLDSVerticalNavigation Default 1`] = `
               aria-describedby="sample-navigation-reports"
               className="slds-nav-vertical__action"
               data-id="my_reports"
-              href="javascript:void(0);"
+              href="#"
               onClick={[Function]}
             >
               Created by Me
@@ -200,7 +200,7 @@ exports[`DOM snapshots SLDSVerticalNavigation Default 1`] = `
               aria-describedby="sample-navigation-reports"
               className="slds-nav-vertical__action"
               data-id="private_reports"
-              href="javascript:void(0);"
+              href="#"
               onClick={[Function]}
             >
               Private Reports
@@ -213,7 +213,7 @@ exports[`DOM snapshots SLDSVerticalNavigation Default 1`] = `
               aria-describedby="sample-navigation-reports"
               className="slds-nav-vertical__action"
               data-id="public_reports"
-              href="javascript:void(0);"
+              href="#"
               onClick={[Function]}
             >
               Public Reports
@@ -226,7 +226,7 @@ exports[`DOM snapshots SLDSVerticalNavigation Default 1`] = `
               aria-describedby="sample-navigation-reports"
               className="slds-nav-vertical__action"
               data-id="all_reports"
-              href="javascript:void(0);"
+              href="#"
               onClick={[Function]}
             >
               All Reports
@@ -251,7 +251,7 @@ exports[`DOM snapshots SLDSVerticalNavigation Default 1`] = `
               aria-describedby="sample-navigation-folders"
               className="slds-nav-vertical__action"
               data-id="my_folders"
-              href="javascript:void(0);"
+              href="#"
               onClick={[Function]}
             >
               Created by Me
@@ -264,7 +264,7 @@ exports[`DOM snapshots SLDSVerticalNavigation Default 1`] = `
               aria-describedby="sample-navigation-folders"
               className="slds-nav-vertical__action"
               data-id="shared_folders"
-              href="javascript:void(0);"
+              href="#"
               onClick={[Function]}
             >
               Shared with Me
@@ -277,7 +277,7 @@ exports[`DOM snapshots SLDSVerticalNavigation Default 1`] = `
               aria-describedby="sample-navigation-folders"
               className="slds-nav-vertical__action"
               data-id="all_folders"
-              href="javascript:void(0);"
+              href="#"
               onClick={[Function]}
             >
               All Folders

--- a/components/vertical-navigation/private/item.jsx
+++ b/components/vertical-navigation/private/item.jsx
@@ -16,6 +16,10 @@ import isFunction from 'lodash.isfunction';
 import { VERTICAL_NAVIGATION_ITEM } from '../../../utilities/constants';
 
 const handleClick = (event, props) => {
+	if (!props.item.url) {
+		event.preventDefault();
+	}
+
 	if (isFunction(props.onSelect)) {
 		props.onSelect(event, {
 			item: props.item,
@@ -31,7 +35,7 @@ const Item = (props) => (
 	>
 		<a
 			data-id={props.item.id}
-			href={props.item.url || 'javascript:void(0);'} // eslint-disable-line no-script-url
+			href={props.item.url || '#'}
 			className="slds-nav-vertical__action"
 			aria-describedby={props.categoryId}
 			aria-current={props.isSelected ? true : undefined}

--- a/components/visual-picker/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/visual-picker/__docs__/__snapshots__/storybook-stories.storyshot
@@ -366,7 +366,7 @@ exports[`DOM snapshots SLDSVisualPicker Links 1`] = `
     >
       <a
         className="slds-box slds-box_link slds-theme_default slds-box_x-small slds-media slds-visual-picker_vertical"
-        href="javascript:void(0);"
+        href="https://google.com"
       >
         <div
           className="slds-media__figure slds-media__figure_fixed-width slds-align_absolute-center slds-m-left_xx-small"
@@ -401,7 +401,7 @@ exports[`DOM snapshots SLDSVisualPicker Links 1`] = `
       </a>
       <a
         className="slds-box slds-box_link slds-theme_default slds-box_x-small slds-media slds-visual-picker_vertical"
-        href="javascript:void(0);"
+        href="https://google.com"
       >
         <div
           className="slds-media__figure slds-media__figure_fixed-width slds-align_absolute-center slds-m-left_xx-small"

--- a/components/visual-picker/__examples__/links.jsx
+++ b/components/visual-picker/__examples__/links.jsx
@@ -17,13 +17,13 @@ class Example extends React.Component {
 					<VisualPicker links>
 						<VisualPickerLink
 							title="Share the knowledge"
-							href="javascript:void(0);"
+							href="https://google.com"
 							description="Harness your team&#x27;s collective know-how with our powerful knowledge base"
 							icon={<Icon name="knowledge_base" category="utility" />}
 						/>
 						<VisualPickerLink
 							title="Share the knowledge"
-							href="javascript:void(0);"
+							href="https://google.com"
 							description="Harness your team&#x27;s collective know-how with our powerful knowledge base"
 							icon={<Icon name="knowledge_base" category="utility" />}
 						/>

--- a/components/welcome-mat/__examples__/default.jsx
+++ b/components/welcome-mat/__examples__/default.jsx
@@ -38,7 +38,7 @@ class Example extends React.Component {
 								description="Lorem ipsum dolor sit amet, lorem ipsum dolor sit amet."
 								icon={<Icon category="utility" name="animal_and_nature" />}
 								id="welcome-mat-tile-1"
-								href="javascript:void(0);"
+								href="https://example.com"
 								isComplete
 							/>
 							<WelcomeMatTile
@@ -46,28 +46,28 @@ class Example extends React.Component {
 								description="Lorem ipsum dolor sit amet, lorem ipsum dolor sit amet."
 								icon={<Icon category="utility" name="call" />}
 								id="welcome-mat-tile-2"
-								href="javascript:void(0);"
+								href="https://example.com"
 								isComplete
 							/>
 							<WelcomeMatTile
 								title="Power Up the Utility Bar"
 								description="Tap into case history or share notes with fellow agents—it all happens on the utility bar."
 								id="welcome-mat-tile-3"
-								href="javascript:void(0);"
+								href="https://example.com"
 								icon={<Icon category="utility" name="upload" />}
 							/>
 							<WelcomeMatTile
 								title="Customize your view"
 								description="Tailor your cases to your team&#x27;s workflow with custom list views."
 								id="welcome-mat-tile-4"
-								href="javascript:void(0);"
+								href="https://example.com"
 								icon={<Icon category="utility" name="magicwand" />}
 							/>
 							<WelcomeMatTile
 								title="Share the Knowledge"
 								description="Harness your team&#x27;s collective know-how with our powerful knowledge base."
 								id="welcome-mat-tile-5"
-								href="javascript:void(0);"
+								href="https://example.com"
 								icon={<Icon category="utility" name="knowledge_base" />}
 							/>
 						</WelcomeMat>

--- a/components/welcome-mat/__examples__/info-only.jsx
+++ b/components/welcome-mat/__examples__/info-only.jsx
@@ -59,34 +59,34 @@ class Example extends React.Component {
 								description="Lorem ipsum dolor sit amet, lorem ipsum dolor sit amet."
 								icon={<Icon category="utility" name="animal_and_nature" />}
 								id="welcome-mat-tile-1"
-								href="javascript:void(0);"
+								href="https://example.com"
 							/>
 							<WelcomeMatTile
 								title="Learn About OpenCTI!"
 								description="Lorem ipsum dolor sit amet, lorem ipsum dolor sit amet."
 								icon={<Icon category="utility" name="call" />}
 								id="welcome-mat-tile-2"
-								href="javascript:void(0);"
+								href="https://example.com"
 							/>
 							<WelcomeMatTile
 								title="Power Up the Utility Bar"
 								description="Tap into case history or share notes with fellow agents—it all happens on the utility bar."
 								icon={<Icon category="utility" name="upload" />}
 								id="welcome-mat-tile-3"
-								href="javascript:void(0);"
+								href="https://example.com"
 							/>
 							<WelcomeMatTile
 								title="Customize your view"
 								description="Tailor your cases to your team&#x27;s workflow with custom list views."
 								icon={<Icon category="utility" name="magicwand" />}
-								href="javascript:void(0);"
+								href="https://example.com"
 								id="welcome-mat-tile-4"
 							/>
 							<WelcomeMatTile
 								title="Share the Knowledge"
 								description="Harness your team&#x27;s collective know-how with our powerful knowledge base."
 								icon={<Icon category="utility" name="knowledge_base" />}
-								href="javascript:void(0);"
+								href="https://example.com"
 								id="welcome-mat-tile-5"
 							/>
 						</WelcomeMat>

--- a/components/welcome-mat/__examples__/steps-complete.jsx
+++ b/components/welcome-mat/__examples__/steps-complete.jsx
@@ -40,7 +40,7 @@ class Example extends React.Component {
 								title="Welcome to Salesforce!"
 								description="Lorem ipsum dolor sit amet, lorem ipsum dolor sit amet."
 								icon={<Icon category="utility" name="animal_and_nature" />}
-								href="javascript:void(0);"
+								href="https://example.com"
 								id="welcome-mat-steps-tile-1"
 								isComplete
 							/>
@@ -48,14 +48,14 @@ class Example extends React.Component {
 								title="Learn About OpenCTI!"
 								description="Lorem ipsum dolor sit amet, lorem ipsum dolor sit amet."
 								icon={<Icon category="utility" name="call" />}
-								href="javascript:void(0);"
+								href="https://example.com"
 								id="welcome-mat-steps-tile-2"
 								isComplete
 							/>
 							<WelcomeMatTile
 								title="Power Up the Utility Bar"
 								description="Tap into case history or share notes with fellow agents—it all happens on the utility bar."
-								href="javascript:void(0);"
+								href="https://example.com"
 								id="welcome-mat-steps-tile-3"
 								icon={<Icon category="utility" name="upload" />}
 								isComplete
@@ -63,7 +63,7 @@ class Example extends React.Component {
 							<WelcomeMatTile
 								title="Customize your view"
 								description="Tailor your cases to your team&#x27;s workflow with custom list views."
-								href="javascript:void(0);"
+								href="https://example.com"
 								id="welcome-mat-steps-tile-4"
 								icon={<Icon category="utility" name="magicwand" />}
 								isComplete
@@ -71,7 +71,7 @@ class Example extends React.Component {
 							<WelcomeMatTile
 								title="Share the Knowledge"
 								description="Harness your team&#x27;s collective know-how with our powerful knowledge base."
-								href="javascript:void(0);"
+								href="https://example.com"
 								id="welcome-mat-steps-tile-5"
 								icon={<Icon category="utility" name="knowledge_base" />}
 								isComplete

--- a/components/welcome-mat/__examples__/trailhead-complete.jsx
+++ b/components/welcome-mat/__examples__/trailhead-complete.jsx
@@ -63,7 +63,7 @@ class Example extends React.Component {
 								title="Welcome to Salesforce!"
 								description="Lorem ipsum dolor sit amet, lorem ipsum dolor sit amet."
 								icon={<Icon category="utility" name="animal_and_nature" />}
-								href="javascript:void(0);"
+								href="https://example.com"
 								id="welcome-mat-tile-1"
 								isComplete
 							/>
@@ -71,14 +71,14 @@ class Example extends React.Component {
 								title="Learn About OpenCTI!"
 								description="Lorem ipsum dolor sit amet, lorem ipsum dolor sit amet."
 								icon={<Icon category="utility" name="call" />}
-								href="javascript:void(0);"
+								href="https://example.com"
 								id="welcome-mat-tile-2"
 								isComplete
 							/>
 							<WelcomeMatTile
 								title="Power Up the Utility Bar"
 								description="Tap into case history or share notes with fellow agents—it all happens on the utility bar."
-								href="javascript:void(0);"
+								href="https://example.com"
 								id="welcome-mat-tile-3"
 								icon={<Icon category="utility" name="upload" />}
 								isComplete
@@ -86,7 +86,7 @@ class Example extends React.Component {
 							<WelcomeMatTile
 								title="Customize your view"
 								description="Tailor your cases to your team&#x27;s workflow with custom list views."
-								href="javascript:void(0);"
+								href="https://example.com"
 								id="welcome-mat-tile-4"
 								icon={<Icon category="utility" name="magicwand" />}
 								isComplete
@@ -94,7 +94,7 @@ class Example extends React.Component {
 							<WelcomeMatTile
 								title="Share the Knowledge"
 								description="Harness your team&#x27;s collective know-how with our powerful knowledge base."
-								href="javascript:void(0);"
+								href="https://example.com"
 								id="welcome-mat-tile-5"
 								icon={<Icon category="utility" name="knowledge_base" />}
 								isComplete

--- a/components/welcome-mat/__examples__/trailhead.jsx
+++ b/components/welcome-mat/__examples__/trailhead.jsx
@@ -60,7 +60,7 @@ class Example extends React.Component {
 								title="Welcome to Salesforce!"
 								description="Lorem ipsum dolor sit amet, lorem ipsum dolor sit amet."
 								icon={<Icon category="utility" name="animal_and_nature" />}
-								href="javascript:void(0);"
+								href="https://example.com"
 								id="welcome-mat-tile-1"
 								isComplete
 							/>
@@ -68,28 +68,28 @@ class Example extends React.Component {
 								title="Learn About OpenCTI!"
 								description="Lorem ipsum dolor sit amet, lorem ipsum dolor sit amet."
 								icon={<Icon category="utility" name="call" />}
-								href="javascript:void(0);"
+								href="https://example.com"
 								id="welcome-mat-tile-2"
 								isComplete
 							/>
 							<WelcomeMatTile
 								title="Power Up the Utility Bar"
 								description="Tap into case history or share notes with fellow agents—it all happens on the utility bar."
-								href="javascript:void(0);"
+								href="https://example.com"
 								id="welcome-mat-tile-3"
 								icon={<Icon category="utility" name="upload" />}
 							/>
 							<WelcomeMatTile
 								title="Customize your view"
 								description="Tailor your cases to your team&#x27;s workflow with custom list views."
-								href="javascript:void(0);"
+								href="https://example.com"
 								id="welcome-mat-tile-4"
 								icon={<Icon category="utility" name="magicwand" />}
 							/>
 							<WelcomeMatTile
 								title="Share the Knowledge"
 								description="Harness your team&#x27;s collective know-how with our powerful knowledge base."
-								href="javascript:void(0);"
+								href="https://example.com"
 								id="welcome-mat-tile-5"
 								icon={<Icon category="utility" name="knowledge_base" />}
 							/>

--- a/components/welcome-mat/__tests__/welcome-mat.browser-test.jsx
+++ b/components/welcome-mat/__tests__/welcome-mat.browser-test.jsx
@@ -72,32 +72,32 @@ describe('SLDSWelcomeMat: ', function () {
 			title="Welcome to Salesforce!"
 			description="Lorem ipsum dolor sit amet, lorem ipsum dolor sit amet."
 			icon="animal_and_nature"
-			href="javascript:void(0);"
+			href="https://example.com"
 			isComplete
 		/>,
 		<SLDSWelcomeMatTile
 			title="Learn About OpenCTI!"
 			description="Lorem ipsum dolor sit amet, lorem ipsum dolor sit amet."
 			icon="call"
-			href="javascript:void(0);"
+			href="https://example.com"
 			isComplete
 		/>,
 		<SLDSWelcomeMatTile
 			title="Power Up the Utility Bar"
 			description="Tap into case history or share notes with fellow agents—it all happens on the utility bar."
-			href="javascript:void(0);"
+			href="https://example.com"
 			icon="call"
 		/>,
 		<SLDSWelcomeMatTile
 			title="Customize your view"
 			description="Tailor your cases to your team&#x27;s workflow with custom list views."
-			href="javascript:void(0);"
+			href="https://example.com"
 			icon="upload"
 		/>,
 		<SLDSWelcomeMatTile
 			title="Share the Knowledge"
 			description="Harness your team&#x27;s collective know-how with our powerful knowledge base."
-			href="javascript:void(0);"
+			href="https://example.com"
 			icon="knowledge_base"
 		/>,
 	];
@@ -136,7 +136,7 @@ describe('SLDSWelcomeMat: ', function () {
 				'.slds-welcome-mat__tile a'
 			);
 			WelcomeMatTiles.forEach((tile) => {
-				expect(tile.href).to.eql.toString('javascript:void(0)');
+				expect(tile.href).to.eql.toString('https://example.com');
 			});
 		});
 		it('shows labels correctly', () => {

--- a/utilities/event.js
+++ b/utilities/event.js
@@ -28,6 +28,16 @@ const EventUtil = {
 
 		EventUtil.trap(event);
 	},
+
+	trappedHandler: (handler) => {
+		return (event) => {
+			EventUtil.trap(event);
+
+			if (handler) {
+				handler(event);
+			}
+		};
+	},
 };
 
 export default EventUtil;


### PR DESCRIPTION
This is a continuation of @xoob's work from https://github.com/salesforce/design-system-react/pull/2514.

I took his changes, updated the code with the latest from master, and made some additional adjustments for newly-added `javascript:` urls since he opened his original PR.

Fixes #2384 and #2493
