### PR TITLE
Update react-modal from 3.13.1 to 3.14.2 to add bugfix-PR 7e732d7 Wrapping getComputedStyle i…

### DIFF
--- a/components/modal/__tests__/modal.browser-test.jsx
+++ b/components/modal/__tests__/modal.browser-test.jsx
@@ -28,10 +28,16 @@ describe('SLDSModal: ', function () {
 		appNode = null;
 	});
 
-	afterEach(() => {
-		ReactDOM.unmountComponentAtNode(container);
-		document.body.removeChild(container);
-		container = null;
+	afterEach((done) => {
+		// We run into a race condition if we do not have this wait
+		// with the changes to react-modal, we end up trying to set state
+		// on an unmounted component
+		setTimeout(() => {
+			ReactDOM.unmountComponentAtNode(container);
+			document.body.removeChild(container);
+			container = null;
+			done();
+		}, 100);
 	});
 
 	const defaultProps = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
 	"name": "design-system-react",
-	"version": "0.10.33",
+	"version": "0.10.34",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"version": "0.10.33",
+			"version": "0.10.34",
 			"license": "SEE LICENSE IN README.md",
 			"dependencies": {
 				"@salesforce/babel-preset-design-system-react": "^3.0.0",
@@ -24,7 +24,7 @@
 				"prop-types": ">=15.7.2",
 				"react-contenteditable": "^3.3.5",
 				"react-highlighter": "^0.4.3",
-				"react-modal": "3.13.1",
+				"react-modal": "3.14.2",
 				"react-onclickoutside": "^6.10.0",
 				"react-required-if": "^1.0.3",
 				"react-text-truncate": "^0.16.0",
@@ -35472,7 +35472,6 @@
 			"version": "17.0.2",
 			"resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
 			"integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-			"dev": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"
@@ -35979,7 +35978,6 @@
 			"version": "17.0.2",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
 			"integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-			"dev": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -36054,17 +36052,21 @@
 			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
 		},
 		"node_modules/react-modal": {
-			"version": "3.13.1",
-			"resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.13.1.tgz",
-			"integrity": "sha512-m6yXK7I4YKssQnsjHK7xITSXy2O81BSOHOsg0/uWAsdKtuT9HF2tdoYhRuxNNQg2V+LgepsoHUPJKS8m6no+eg==",
+			"version": "3.14.2",
+			"resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.14.2.tgz",
+			"integrity": "sha512-CYasEJanwneDsmvtx/fisXhgDxtt3I8jWTVX/tP9dM/J1NgDKU9lgjR9zuCCl33ub2jrTWhXyijCxCzYGN8sJg==",
 			"dependencies": {
 				"exenv": "^1.2.0",
-				"prop-types": "^15.5.10",
+				"prop-types": "^15.7.2",
 				"react-lifecycles-compat": "^3.0.0",
 				"warning": "^4.0.3"
 			},
 			"engines": {
 				"node": ">=8"
+			},
+			"peerDependencies": {
+				"react": "^0.14.0 || ^15.0.0 || ^16 || ^17",
+				"react-dom": "^0.14.0 || ^15.0.0 || ^16 || ^17"
 			}
 		},
 		"node_modules/react-onclickoutside": {
@@ -37220,7 +37222,6 @@
 			"version": "0.20.2",
 			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
 			"integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
-			"dev": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"
@@ -73585,7 +73586,6 @@
 			"version": "17.0.2",
 			"resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
 			"integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-			"dev": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"
@@ -73981,7 +73981,6 @@
 			"version": "17.0.2",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
 			"integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-			"dev": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -74056,12 +74055,12 @@
 			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
 		},
 		"react-modal": {
-			"version": "3.13.1",
-			"resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.13.1.tgz",
-			"integrity": "sha512-m6yXK7I4YKssQnsjHK7xITSXy2O81BSOHOsg0/uWAsdKtuT9HF2tdoYhRuxNNQg2V+LgepsoHUPJKS8m6no+eg==",
+			"version": "3.14.2",
+			"resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.14.2.tgz",
+			"integrity": "sha512-CYasEJanwneDsmvtx/fisXhgDxtt3I8jWTVX/tP9dM/J1NgDKU9lgjR9zuCCl33ub2jrTWhXyijCxCzYGN8sJg==",
 			"requires": {
 				"exenv": "^1.2.0",
-				"prop-types": "^15.5.10",
+				"prop-types": "^15.7.2",
 				"react-lifecycles-compat": "^3.0.0",
 				"warning": "^4.0.3"
 			}
@@ -75046,7 +75045,6 @@
 			"version": "0.20.2",
 			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
 			"integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
-			"dev": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
 		"prop-types": ">=15.7.2",
 		"react-contenteditable": "^3.3.5",
 		"react-highlighter": "^0.4.3",
-		"react-modal": "^3.14.2",
+		"react-modal": "3.14.2",
 		"react-onclickoutside": "^6.10.0",
 		"react-required-if": "^1.0.3",
 		"react-text-truncate": "^0.16.0",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
 		"prop-types": ">=15.7.2",
 		"react-contenteditable": "^3.3.5",
 		"react-highlighter": "^0.4.3",
-		"react-modal": "3.14.2",
+		"react-modal": "^3.14.2",
 		"react-onclickoutside": "^6.10.0",
 		"react-required-if": "^1.0.3",
 		"react-text-truncate": "^0.16.0",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
 		"prop-types": ">=15.7.2",
 		"react-contenteditable": "^3.3.5",
 		"react-highlighter": "^0.4.3",
-		"react-modal": "3.13.1",
+		"react-modal": "3.14.2",
 		"react-onclickoutside": "^6.10.0",
 		"react-required-if": "^1.0.3",
 		"react-text-truncate": "^0.16.0",


### PR DESCRIPTION
This request is to update the react-modal package to 3.14.2 - the fix this targets is - https://github.com/reactjs/react-modal/pull/864
Fixes #
This fixes an issue where using the slds-modal, and the modal contains an iframe which in turn contains webcomponents, the modal does not lock focus to the modal

### Additional description

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [ done] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [done ] `npm run lint:fix` has been run and linting passes.
* [ done] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [NA ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [done ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ done] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [done ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
