### PR TITLE
Add Headless Data Table Support

### DIFF
--- a/components/card/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/card/__docs__/__snapshots__/storybook-stories.storyshot
@@ -131,7 +131,9 @@ exports[`DOM snapshots SLDSCard Custom Header 1`] = `
           onBlur={[Function]}
           role={null}
         >
-          <thead>
+          <thead
+            className=""
+          >
             <tr
               className="slds-line-height_reset"
             >
@@ -348,7 +350,9 @@ exports[`DOM snapshots SLDSCard Custom Heading 1`] = `
           onBlur={[Function]}
           role={null}
         >
-          <thead>
+          <thead
+            className=""
+          >
             <tr
               className="slds-line-height_reset"
             >
@@ -557,7 +561,9 @@ exports[`DOM snapshots SLDSCard Doc site Related List With Table 1`] = `
           onBlur={[Function]}
           role={null}
         >
-          <thead>
+          <thead
+            className=""
+          >
             <tr
               className="slds-line-height_reset"
             >
@@ -953,7 +959,9 @@ exports[`DOM snapshots SLDSCard w/ Items 1`] = `
           onBlur={[Function]}
           role={null}
         >
-          <thead>
+          <thead
+            className=""
+          >
             <tr
               className="slds-line-height_reset"
             >
@@ -1080,7 +1088,9 @@ exports[`DOM snapshots SLDSCard w/o Header 1`] = `
         onBlur={[Function]}
         role={null}
       >
-        <thead>
+        <thead
+          className=""
+        >
           <tr
             className="slds-line-height_reset"
           >

--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -5581,6 +5581,13 @@
                 "required": true,
                 "description": "The collection of items to render in the table. This is an array of objects with each object having keys that correspond with the  `property` prop of each `DataTableColumn`.\n\nUse the key `classNameRow` to add a custom class to the item's `<tr>` element."
             },
+            "isHeadless": {
+                "type": {
+                    "name": "bool"
+                },
+                "required": false,
+                "description": "Removes the header from the data table. Tested with snapshot testing"
+            },
             "joined": {
                 "type": {
                     "name": "bool"

--- a/components/data-table.d.ts
+++ b/components/data-table.d.ts
@@ -63,9 +63,17 @@ declare module '@salesforce/design-system-react/components/data-table' {
 		 */
 		fixedLayout?: boolean;
 		/**
+		 * When fixedHeader is true, specifies whether there's more data to be loaded and displays a spinner at the bottom of the table if so.
+		 */
+		hasMore?: boolean,
+		/**
 		 * A unique ID is needed in order to support keyboard navigation and ARIA support.
 		 */
 		id?: string;
+		/**
+		 * Removes the header from the data table
+		 */
+		isHeadless?: boolean,
 		/**
 		 * The collection of items to render in the table. This is an array of objects with each object having keys that correspond with the  `property` prop of each `DataTableColumn`.
 		 *

--- a/components/data-table/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/data-table/__docs__/__snapshots__/storybook-stories.storyshot
@@ -12,7 +12,9 @@ exports[`DOM snapshots SLDSDataTable Advanced (Fixed Layout) 1`] = `
       onBlur={[Function]}
       role="grid"
     >
-      <thead>
+      <thead
+        className=""
+      >
         <tr
           className="slds-line-height_reset"
         >
@@ -1067,7 +1069,9 @@ exports[`DOM snapshots SLDSDataTable Advanced Single Select (Fixed Header) 1`] =
           onBlur={[Function]}
           role="grid"
         >
-          <thead>
+          <thead
+            className=""
+          >
             <tr
               className="slds-line-height_reset"
             >
@@ -2426,7 +2430,9 @@ exports[`DOM snapshots SLDSDataTable Advanced Single Select (Fixed Layout) 1`] =
       onBlur={[Function]}
       role="grid"
     >
-      <thead>
+      <thead
+        className=""
+      >
         <tr
           className="slds-line-height_reset"
         >
@@ -3392,7 +3398,9 @@ exports[`DOM snapshots SLDSDataTable Advanced with Header Row 1`] = `
       onBlur={[Function]}
       role="grid"
     >
-      <thead>
+      <thead
+        className=""
+      >
         <tr
           className="slds-line-height_reset"
         >
@@ -4591,7 +4599,9 @@ exports[`DOM snapshots SLDSDataTable Basic Fixed Layout 1`] = `
       onBlur={[Function]}
       role="grid"
     >
-      <thead>
+      <thead
+        className=""
+      >
         <tr
           className="slds-line-height_reset"
         >
@@ -5249,7 +5259,9 @@ exports[`DOM snapshots SLDSDataTable Basic Fluid Layout (Default) 1`] = `
       onBlur={[Function]}
       role={null}
     >
-      <thead>
+      <thead
+        className=""
+      >
         <tr
           className="slds-line-height_reset"
         >
@@ -5748,7 +5760,510 @@ exports[`DOM snapshots SLDSDataTable Basic Fluid Layout - Column Bordered 1`] = 
       onBlur={[Function]}
       role={null}
     >
-      <thead>
+      <thead
+        className=""
+      >
+        <tr
+          className="slds-line-height_reset"
+        >
+          <th
+            aria-label="Opportunity Name"
+            aria-sort="none"
+            className=""
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            scope="col"
+            style={null}
+          >
+            <div
+              className="slds-truncate"
+              title="Opportunity Name"
+            >
+              Opportunity Name
+            </div>
+          </th>
+          <th
+            aria-label="Account Name"
+            aria-sort="none"
+            className=""
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            scope="col"
+            style={null}
+          >
+            <div
+              className="slds-truncate"
+              title="Account Name"
+            >
+              Account Name
+            </div>
+          </th>
+          <th
+            aria-label="Close Date"
+            aria-sort="none"
+            className=""
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            scope="col"
+            style={null}
+          >
+            <div
+              className="slds-truncate"
+              title="Close Date"
+            >
+              Close Date
+            </div>
+          </th>
+          <th
+            aria-label="Stage"
+            aria-sort="none"
+            className=""
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            scope="col"
+            style={null}
+          >
+            <div
+              className="slds-truncate"
+              title="Stage"
+            >
+              Stage
+            </div>
+          </th>
+          <th
+            aria-label="Confidence"
+            aria-sort="none"
+            className=""
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            scope="col"
+            style={null}
+          >
+            <div
+              className="slds-truncate"
+              title="Confidence"
+            >
+              Confidence
+            </div>
+          </th>
+          <th
+            aria-label="Amount"
+            aria-sort="none"
+            className=""
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            scope="col"
+            style={null}
+          >
+            <div
+              className="slds-truncate"
+              title="Amount"
+            >
+              Amount
+            </div>
+          </th>
+          <th
+            aria-label="Contact"
+            aria-sort="none"
+            className=""
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            scope="col"
+            style={null}
+          >
+            <div
+              className="slds-truncate"
+              title="Contact"
+            >
+              Contact
+            </div>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          className=""
+        >
+          <td
+            className=""
+            data-label="Opportunity Name"
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            role={null}
+            style={null}
+          >
+            <div
+              className=""
+              title="Cloudhub"
+            >
+              <a
+                href="#"
+                onClick={[Function]}
+              >
+                Cloudhub
+              </a>
+            </div>
+          </td>
+          <td
+            className=""
+            data-label="Account Name"
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            role={null}
+            style={null}
+          >
+            <div
+              className=""
+              title="Cloudhub"
+            >
+              Cloudhub
+            </div>
+          </td>
+          <td
+            className=""
+            data-label="Close Date"
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            role={null}
+            style={null}
+          >
+            <div
+              className=""
+              title="4/14/2015"
+            >
+              4/14/2015
+            </div>
+          </td>
+          <td
+            className=""
+            data-label="Stage"
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            role={null}
+            style={null}
+          >
+            <div
+              className=""
+              title="Prospecting"
+            >
+              Prospecting
+            </div>
+          </td>
+          <td
+            className=""
+            data-label="Confidence"
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            role={null}
+            style={null}
+          >
+            <div
+              className=""
+              title="20%"
+            >
+              20%
+            </div>
+          </td>
+          <td
+            className=""
+            data-label="Amount"
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            role={null}
+            style={null}
+          >
+            <div
+              className=""
+              title="$25k"
+            >
+              $25k
+            </div>
+          </td>
+          <td
+            className=""
+            data-label="Contact"
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            role={null}
+            style={null}
+          >
+            <div
+              className=""
+              title="jrogers@cloudhub.com"
+            >
+              <a
+                href="#"
+                onClick={[Function]}
+              >
+                jrogers@cloudhub.com
+              </a>
+            </div>
+          </td>
+        </tr>
+        <tr
+          className=""
+        >
+          <td
+            className=""
+            data-label="Opportunity Name"
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            role={null}
+            style={null}
+          >
+            <div
+              className=""
+              title="Cloudhub + Anypoint Connectors"
+            >
+              <a
+                href="#"
+                onClick={[Function]}
+              >
+                Cloudhub + Anypoint Connectors
+              </a>
+            </div>
+          </td>
+          <td
+            className=""
+            data-label="Account Name"
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            role={null}
+            style={null}
+          >
+            <div
+              className=""
+              title="Cloudhub"
+            >
+              Cloudhub
+            </div>
+          </td>
+          <td
+            className=""
+            data-label="Close Date"
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            role={null}
+            style={null}
+          >
+            <div
+              className=""
+              title="4/14/2015"
+            >
+              4/14/2015
+            </div>
+          </td>
+          <td
+            className=""
+            data-label="Stage"
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            role={null}
+            style={null}
+          >
+            <div
+              className=""
+              title="Prospecting"
+            >
+              Prospecting
+            </div>
+          </td>
+          <td
+            className=""
+            data-label="Confidence"
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            role={null}
+            style={null}
+          >
+            <div
+              className=""
+              title="20%"
+            >
+              20%
+            </div>
+          </td>
+          <td
+            className=""
+            data-label="Amount"
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            role={null}
+            style={null}
+          >
+            <div
+              className=""
+              title="$25k"
+            >
+              $25k
+            </div>
+          </td>
+          <td
+            className=""
+            data-label="Contact"
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            role={null}
+            style={null}
+          >
+            <div
+              className=""
+              title="jrogers@cloudhub.com"
+            >
+              <a
+                href="#"
+                onClick={[Function]}
+              >
+                jrogers@cloudhub.com
+              </a>
+            </div>
+          </td>
+        </tr>
+        <tr
+          className=""
+        >
+          <td
+            className=""
+            data-label="Opportunity Name"
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            role={null}
+            style={null}
+          >
+            <div
+              className=""
+              title="Cloudhub"
+            >
+              <a
+                href="#"
+                onClick={[Function]}
+              >
+                Cloudhub
+              </a>
+            </div>
+          </td>
+          <td
+            className=""
+            data-label="Account Name"
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            role={null}
+            style={null}
+          >
+            <div
+              className=""
+              title="Cloudhub"
+            >
+              Cloudhub
+            </div>
+          </td>
+          <td
+            className=""
+            data-label="Close Date"
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            role={null}
+            style={null}
+          >
+            <div
+              className=""
+              title="4/14/2015"
+            >
+              4/14/2015
+            </div>
+          </td>
+          <td
+            className=""
+            data-label="Stage"
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            role={null}
+            style={null}
+          >
+            <div
+              className=""
+              title="Prospecting"
+            >
+              Prospecting
+            </div>
+          </td>
+          <td
+            className=""
+            data-label="Confidence"
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            role={null}
+            style={null}
+          >
+            <div
+              className=""
+              title="20%"
+            >
+              20%
+            </div>
+          </td>
+          <td
+            className=""
+            data-label="Amount"
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            role={null}
+            style={null}
+          >
+            <div
+              className=""
+              title="$25k"
+            >
+              $25k
+            </div>
+          </td>
+          <td
+            className=""
+            data-label="Contact"
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            role={null}
+            style={null}
+          >
+            <div
+              className=""
+              title="jrogers@cloudhub.com"
+            >
+              <a
+                href="#"
+                onClick={[Function]}
+              >
+                jrogers@cloudhub.com
+              </a>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
+exports[`DOM snapshots SLDSDataTable Basic Fluid Layout - Headless 1`] = `
+<div
+  className="slds-p-around_medium"
+>
+  <div
+    style={
+      Object {
+        "overflow": "auto",
+      }
+    }
+  >
+    <table
+      className="slds-table slds-table_bordered slds-table_cell-buffer slds-table_header-hidden"
+      id="DataTableExample-headless"
+      onBlur={[Function]}
+      role={null}
+    >
+      <thead
+        className="slds-assistive-text"
+      >
         <tr
           className="slds-line-height_reset"
         >
@@ -6247,7 +6762,9 @@ exports[`DOM snapshots SLDSDataTable Basic Fluid Layout - No Row Hover 1`] = `
       onBlur={[Function]}
       role={null}
     >
-      <thead>
+      <thead
+        className=""
+      >
         <tr
           className="slds-line-height_reset"
         >
@@ -6746,7 +7263,9 @@ exports[`DOM snapshots SLDSDataTable Basic Fluid Layout - Striped 1`] = `
       onBlur={[Function]}
       role={null}
     >
-      <thead>
+      <thead
+        className=""
+      >
         <tr
           className="slds-line-height_reset"
         >
@@ -7245,7 +7764,9 @@ exports[`DOM snapshots SLDSDataTable Custom Classes 1`] = `
       onBlur={[Function]}
       role={null}
     >
-      <thead>
+      <thead
+        className=""
+      >
         <tr
           className="slds-line-height_reset"
         >
@@ -7734,7 +8255,9 @@ exports[`DOM snapshots SLDSDataTable Fixed Header 1`] = `
           onBlur={[Function]}
           role="grid"
         >
-          <thead>
+          <thead
+            className=""
+          >
             <tr
               className="slds-line-height_reset"
             >
@@ -11156,7 +11679,9 @@ exports[`DOM snapshots SLDSDataTable Fixed Header Horizontal Scrolling 1`] = `
             }
           }
         >
-          <thead>
+          <thead
+            className=""
+          >
             <tr
               className="slds-line-height_reset"
             >
@@ -14572,7 +15097,9 @@ exports[`DOM snapshots SLDSDataTable Infinite Scrolling 1`] = `
           onBlur={[Function]}
           role="grid"
         >
-          <thead>
+          <thead
+            className=""
+          >
             <tr
               className="slds-line-height_reset"
             >
@@ -17934,7 +18461,9 @@ exports[`DOM snapshots SLDSDataTable Interactive Elements 1`] = `
       onBlur={[Function]}
       role="grid"
     >
-      <thead>
+      <thead
+        className=""
+      >
         <tr
           className="slds-line-height_reset"
         >
@@ -18685,7 +19214,9 @@ exports[`DOM snapshots SLDSDataTable Interactive Elements 1`] = `
       onBlur={[Function]}
       role="grid"
     >
-      <thead>
+      <thead
+        className=""
+      >
         <tr
           className="slds-line-height_reset"
         >
@@ -19436,7 +19967,9 @@ exports[`DOM snapshots SLDSDataTable Interactive Elements 1`] = `
       onBlur={[Function]}
       role="grid"
     >
-      <thead>
+      <thead
+        className=""
+      >
         <tr
           className="slds-line-height_reset"
         >
@@ -20187,7 +20720,9 @@ exports[`DOM snapshots SLDSDataTable Interactive Elements 1`] = `
       onBlur={[Function]}
       role="grid"
     >
-      <thead>
+      <thead
+        className=""
+      >
         <tr
           className="slds-line-height_reset"
         >
@@ -21342,7 +21877,9 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
           onBlur={[Function]}
           role="grid"
         >
-          <thead>
+          <thead
+            className=""
+          >
             <tr
               className="slds-line-height_reset"
             >

--- a/components/data-table/__docs__/storybook-stories.jsx
+++ b/components/data-table/__docs__/storybook-stories.jsx
@@ -14,6 +14,7 @@ import BasicFluid from '../__examples__/basic-fluid';
 import BasicFluidColumnBordered from '../__examples__/basic-fluid-column-bordered';
 import BasicFluidNoRowHover from '../__examples__/basic-fluid-no-row-hover';
 import BasicFluidStriped from '../__examples__/basic-fluid-striped';
+import BasicFluidHeadless from '../__examples__/basic-fluid-headless';
 import FixedHeader from '../__examples__/fixed-header';
 import InteractiveElements from '../__examples__/interactive-elements';
 import FixedHeaderHorizontalScroller from '../__examples__/fixed-header-horizontal-scrolling';
@@ -33,6 +34,7 @@ storiesOf(DATA_TABLE, module)
 	.add('Basic Fluid Layout - Column Bordered', () => (
 		<BasicFluidColumnBordered />
 	))
+	.add('Basic Fluid Layout - Headless', () => <BasicFluidHeadless />)
 	.add('Basic Fixed Layout', () => <BasicFixedLayout />)
 	.add('Advanced (Fixed Layout)', () => <Advanced log={action} />)
 	.add('Advanced Single Select (Fixed Layout)', () => (

--- a/components/data-table/__examples__/basic-fluid-headless.jsx
+++ b/components/data-table/__examples__/basic-fluid-headless.jsx
@@ -1,0 +1,105 @@
+import React from 'react';
+
+import DataTable from '~/components/data-table'; // `~` is replaced with design-system-react at runtime
+import DataTableColumn from '~/components/data-table/column';
+import DataTableCell from '~/components/data-table/cell';
+import IconSettings from '~/components/icon-settings';
+
+const CustomDataTableCell = ({ children, ...props }) => (
+	<DataTableCell {...props}>
+		<a
+			href="#"
+			onClick={(event) => {
+				event.preventDefault();
+			}}
+		>
+			{children}
+		</a>
+	</DataTableCell>
+);
+CustomDataTableCell.displayName = DataTableCell.displayName;
+
+const columns = [
+	<DataTableColumn
+		key="opportunity"
+		label="Opportunity Name"
+		property="opportunityName"
+	>
+		<CustomDataTableCell />
+	</DataTableColumn>,
+
+	<DataTableColumn
+		key="account-name"
+		label="Account Name"
+		property="accountName"
+	/>,
+
+	<DataTableColumn key="close-date" label="Close Date" property="closeDate" />,
+
+	<DataTableColumn key="stage" label="Stage" property="stage" />,
+
+	<DataTableColumn key="confidence" label="Confidence" property="confidence" />,
+
+	<DataTableColumn key="amount" label="Amount" property="amount" />,
+
+	<DataTableColumn key="contact" label="Contact" property="contact">
+		<CustomDataTableCell />
+	</DataTableColumn>,
+];
+
+class Example extends React.Component {
+	static displayName = 'DataTableExample';
+
+	state = {
+		items: [
+			{
+				id: '8IKZHZZV80',
+				opportunityName: 'Cloudhub',
+				accountName: 'Cloudhub',
+				closeDate: '4/14/2015',
+				stage: 'Prospecting',
+				confidence: '20%',
+				amount: '$25k',
+				contact: 'jrogers@cloudhub.com',
+			},
+			{
+				id: '5GJOOOPWU7',
+				opportunityName: 'Cloudhub + Anypoint Connectors',
+				accountName: 'Cloudhub',
+				closeDate: '4/14/2015',
+				stage: 'Prospecting',
+				confidence: '20%',
+				amount: '$25k',
+				contact: 'jrogers@cloudhub.com',
+			},
+			{
+				id: '8IKZHZZV81',
+				opportunityName: 'Cloudhub',
+				accountName: 'Cloudhub',
+				closeDate: '4/14/2015',
+				stage: 'Prospecting',
+				confidence: '20%',
+				amount: '$25k',
+				contact: 'jrogers@cloudhub.com',
+			},
+		],
+	};
+
+	render() {
+		return (
+			<IconSettings iconPath="/assets/icons">
+				<div style={{ overflow: 'auto' }}>
+					<DataTable
+						items={this.state.items}
+						id="DataTableExample-headless"
+						isHeadless
+					>
+						{columns}
+					</DataTable>
+				</div>
+			</IconSettings>
+		);
+	}
+}
+
+export default Example; // export is replaced with `ReactDOM.render(<Example />, mountNode);` at runtime

--- a/components/data-table/component.json
+++ b/components/data-table/component.json
@@ -45,6 +45,10 @@
 			"path": "/__examples__/basic-fluid-column-bordered.jsx"
 		},
 		{
+			"heading": "Basic: Headless",
+			"path": "/__examples__/basic-fluid-headless.jsx"
+		},
+		{
 			"heading": "Fixed Layout",
 			"path": "/__examples__/basic-fixed-layout.jsx"
 		},

--- a/components/data-table/index.jsx
+++ b/components/data-table/index.jsx
@@ -203,6 +203,10 @@ class DataTable extends React.Component {
 			})
 		).isRequired,
 		/**
+		 * Removes the header from the data table. Tested with snapshot testing
+		 */
+		isHeadless: PropTypes.bool,
+		/**
 		 * Makes DataTable joinable with PageHeader by adding appropriate classes/styling
 		 */
 		joined: PropTypes.bool,
@@ -766,6 +770,7 @@ class DataTable extends React.Component {
 								'slds-table_striped': this.props.striped,
 								'slds-table_col-bordered': this.props.columnBordered,
 								'slds-no-row-hover': this.props.noRowHover,
+								'slds-table_header-hidden': this.props.isHeadless,
 							},
 							this.props.className
 						)}
@@ -806,6 +811,7 @@ class DataTable extends React.Component {
 									this.headerRefs.column[index] = ref;
 								}
 							}}
+							isHidden={this.props.isHeadless}
 							indeterminateSelected={indeterminateSelected}
 							canSelectRows={canSelectRows}
 							columns={columns}

--- a/components/data-table/private/head.jsx
+++ b/components/data-table/private/head.jsx
@@ -40,6 +40,7 @@ class DataTableHead extends React.Component {
 		}),
 		allSelected: PropTypes.bool,
 		headerRefs: PropTypes.func,
+		isHidden: PropTypes.bool,
 		indeterminateSelected: PropTypes.bool,
 		canSelectRows: PropTypes.oneOfType([
 			PropTypes.bool,
@@ -267,7 +268,11 @@ class DataTableHead extends React.Component {
 		const selectHeader = this.getSelectHeader();
 
 		return (
-			<thead>
+			<thead
+				className={classNames({
+					'slds-assistive-text': this.props.isHidden,
+				})}
+			>
 				<tr className="slds-line-height_reset">
 					{selectHeader}
 					{this.props.columns.map((column, index) => (

--- a/components/site-stories.js
+++ b/components/site-stories.js
@@ -292,6 +292,10 @@ const documentationSiteLiveExamples = {
 			path: require('raw-loader!@salesforce/design-system-react/components/data-table/__examples__/basic-fluid-column-bordered.jsx'),
 		},
 		{
+			heading: 'Basic: Headless',
+			path: require('raw-loader!@salesforce/design-system-react/components/data-table/__examples__/basic-fluid-headless.jsx'),
+		},
+		{
 			heading: 'Fixed Layout',
 			path: require('raw-loader!@salesforce/design-system-react/components/data-table/__examples__/basic-fixed-layout.jsx'),
 		},

--- a/package.json
+++ b/package.json
@@ -762,6 +762,10 @@
 					"path": "/__examples__/basic-fluid-column-bordered.jsx"
 				},
 				{
+					"heading": "Basic: Headless",
+					"path": "/__examples__/basic-fluid-headless.jsx"
+				},
+				{
 					"heading": "Fixed Layout",
 					"path": "/__examples__/basic-fixed-layout.jsx"
 				},


### PR DESCRIPTION
closes #2920

### Additional description

This commit adds a new DataTable prop, `isHeadless: boolean`. Setting
this prop to `true` hides the header by applying
`slds-table_header-hidden` to `table` and `slds-assistive-text` to
`thead`.

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [X] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [X] `npm run lint:fix` has been run and linting passes.
* [X] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [X] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [X] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [X] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [X] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] TravisCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
