### PR TITLE
DataTable: Update resizable options to use `fit`

### DIFF
--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -5882,7 +5882,7 @@
                 "required": false,
                 "description": "Object with properties to be used in case of resizable: true\n\nresizeMode: It is used to set how the resize method works. Those are the possible values: 'fit', 'flex' and 'overflow'\nonResize: Callback function to be fired when the user has ended dragging a column\n`@salesforce/design-system-react/assets/styles/table.css` to be loaded. This prop is in prototype` state. a) It may change within a minor release. (b) Web Content Accessibility Guidelines may not be met. (c) CSS imports may be required.",
                 "defaultValue": {
-                    "value": "{\n\tresizeMode: 'flex',\n\tdraggingClass: 'slds-table-column-resizer',\n}",
+                    "value": "{\n\tresizeMode: 'fit',\n\tdraggingClass: 'slds-table-column-resizer',\n}",
                     "computed": false
                 }
             }

--- a/components/data-table/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/data-table/__docs__/__snapshots__/storybook-stories.storyshot
@@ -21598,7 +21598,8 @@ exports[`DOM snapshots SLDSDataTable Interactive Elements 1`] = `
         style={
           Object {
             "height": "100%",
-            "overflow": "auto",
+            "overflowX": "hidden",
+            "overflowY": "auto",
           }
         }
       >
@@ -22932,14 +22933,15 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
         style={
           Object {
             "height": "100%",
-            "overflow": "auto",
+            "overflowX": "hidden",
+            "overflowY": "auto",
           }
         }
       >
         <table
           aria-multiselectable="true"
           className="slds-table slds-table_fixed-layout slds-table_header-fixed slds-table_resizable-cols slds-table_bordered"
-          id="DataTableExample-FixedHeaders"
+          id="DataTableExample-JoinedWithPageHeader"
           onBlur={[Function]}
           role="grid"
         >
@@ -22987,7 +22989,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                       >
                         <input
                           checked={false}
-                          id="DataTableExample-FixedHeaders-SLDSDataTableHead-SelectAll-fixed-header"
+                          id="DataTableExample-JoinedWithPageHeader-SLDSDataTableHead-SelectAll-fixed-header"
                           onChange={[Function]}
                           onFocus={[Function]}
                           tabIndex="-1"
@@ -22995,7 +22997,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                         />
                         <label
                           className="slds-checkbox__label"
-                          htmlFor="DataTableExample-FixedHeaders-SLDSDataTableHead-SelectAll-fixed-header"
+                          htmlFor="DataTableExample-JoinedWithPageHeader-SLDSDataTableHead-SelectAll-fixed-header"
                         >
                           <span
                             className="slds-checkbox_faux"
@@ -23034,7 +23036,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                   >
                     <span
                       className="slds-assistive-text"
-                      id="DataTableExample-FixedHeaders-SLDSDataTableHead-column-group-header-row-select"
+                      id="DataTableExample-JoinedWithPageHeader-SLDSDataTableHead-column-group-header-row-select"
                     >
                       Select all rows
                     </span>
@@ -23049,7 +23051,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                         >
                           <input
                             checked={false}
-                            id="DataTableExample-FixedHeaders-SLDSDataTableHead-SelectAll"
+                            id="DataTableExample-JoinedWithPageHeader-SLDSDataTableHead-SelectAll"
                             name="SelectAll"
                             onChange={[Function]}
                             onFocus={[Function]}
@@ -23058,7 +23060,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                           />
                           <label
                             className="slds-checkbox__label"
-                            htmlFor="DataTableExample-FixedHeaders-SLDSDataTableHead-SelectAll"
+                            htmlFor="DataTableExample-JoinedWithPageHeader-SLDSDataTableHead-SelectAll"
                           >
                             <span
                               className="slds-checkbox_faux"
@@ -23079,7 +23081,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                 aria-label="Name"
                 aria-sort="ascending"
                 className="slds-is-sortable slds-is-sorted"
-                id="DataTableExample-FixedHeaders-opportunityName-th"
+                id="DataTableExample-JoinedWithPageHeader-opportunityName-th"
                 onFocus={[Function]}
                 onKeyDown={[Function]}
                 scope="col"
@@ -23203,7 +23205,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                 aria-label="Account Name"
                 aria-sort="none"
                 className=""
-                id="DataTableExample-FixedHeaders-accountName-th"
+                id="DataTableExample-JoinedWithPageHeader-accountName-th"
                 onFocus={[Function]}
                 onKeyDown={[Function]}
                 scope="col"
@@ -23272,7 +23274,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                 aria-label="Close Date"
                 aria-sort="none"
                 className=""
-                id="DataTableExample-FixedHeaders-closeDate-th"
+                id="DataTableExample-JoinedWithPageHeader-closeDate-th"
                 onFocus={[Function]}
                 onKeyDown={[Function]}
                 scope="col"
@@ -23341,7 +23343,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                 aria-label="Stage"
                 aria-sort="none"
                 className=""
-                id="DataTableExample-FixedHeaders-stage-th"
+                id="DataTableExample-JoinedWithPageHeader-stage-th"
                 onFocus={[Function]}
                 onKeyDown={[Function]}
                 scope="col"
@@ -23410,7 +23412,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                 aria-label="Confidence"
                 aria-sort="none"
                 className="slds-is-sortable"
-                id="DataTableExample-FixedHeaders-confidence-th"
+                id="DataTableExample-JoinedWithPageHeader-confidence-th"
                 onFocus={[Function]}
                 onKeyDown={[Function]}
                 scope="col"
@@ -23522,7 +23524,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                 aria-label="Amount"
                 aria-sort="none"
                 className=""
-                id="DataTableExample-FixedHeaders-amount-th"
+                id="DataTableExample-JoinedWithPageHeader-amount-th"
                 onFocus={[Function]}
                 onKeyDown={[Function]}
                 scope="col"
@@ -23591,7 +23593,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                 aria-label="Contact"
                 aria-sort="none"
                 className=""
-                id="DataTableExample-FixedHeaders-contact-th"
+                id="DataTableExample-JoinedWithPageHeader-contact-th"
                 onFocus={[Function]}
                 onKeyDown={[Function]}
                 scope="col"
@@ -23743,9 +23745,9 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                       className="slds-checkbox"
                     >
                       <input
-                        aria-labelledby="DataTableExample-FixedHeaders-SLDSDataTableRow-896a6a60-SelectRow-label DataTableExample-FixedHeaders-SLDSDataTableHead-column-group-header-row-select"
+                        aria-labelledby="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-896a6a60-SelectRow-label DataTableExample-JoinedWithPageHeader-SLDSDataTableHead-column-group-header-row-select"
                         checked={false}
-                        id="DataTableExample-FixedHeaders-SLDSDataTableRow-896a6a60-SelectRow"
+                        id="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-896a6a60-SelectRow"
                         name="SelectRow1"
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -23754,8 +23756,8 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                       />
                       <label
                         className="slds-checkbox__label"
-                        htmlFor="DataTableExample-FixedHeaders-SLDSDataTableRow-896a6a60-SelectRow"
-                        id="DataTableExample-FixedHeaders-SLDSDataTableRow-896a6a60-SelectRow-label"
+                        htmlFor="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-896a6a60-SelectRow"
+                        id="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-896a6a60-SelectRow-label"
                       >
                         <span
                           className="slds-checkbox_faux"
@@ -23905,7 +23907,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
               >
                 <div
                   className="slds-dropdown-trigger slds-dropdown-trigger_click"
-                  id="DataTableExample-FixedHeaders-SLDSDataTableRow-896a6a60-SLDSDataTableRowActions"
+                  id="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-896a6a60-SLDSDataTableRowActions"
                   onClick={[Function]}
                   onFocus={[Function]}
                   onKeyDown={[Function]}
@@ -23915,7 +23917,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                   <button
                     aria-expanded={false}
                     aria-haspopup={true}
-                    className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-FixedHeaders-SLDSDataTableRow-896a6a60-SLDSDataTableRowActions slds-button_icon-x-small"
+                    className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-896a6a60-SLDSDataTableRowActions slds-button_icon-x-small"
                     disabled={false}
                     onClick={[Function]}
                     tabIndex="-1"
@@ -23963,9 +23965,9 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                       className="slds-checkbox"
                     >
                       <input
-                        aria-labelledby="DataTableExample-FixedHeaders-SLDSDataTableRow-44da9dcd-SelectRow-label DataTableExample-FixedHeaders-SLDSDataTableHead-column-group-header-row-select"
+                        aria-labelledby="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-44da9dcd-SelectRow-label DataTableExample-JoinedWithPageHeader-SLDSDataTableHead-column-group-header-row-select"
                         checked={false}
-                        id="DataTableExample-FixedHeaders-SLDSDataTableRow-44da9dcd-SelectRow"
+                        id="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-44da9dcd-SelectRow"
                         name="SelectRow2"
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -23974,8 +23976,8 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                       />
                       <label
                         className="slds-checkbox__label"
-                        htmlFor="DataTableExample-FixedHeaders-SLDSDataTableRow-44da9dcd-SelectRow"
-                        id="DataTableExample-FixedHeaders-SLDSDataTableRow-44da9dcd-SelectRow-label"
+                        htmlFor="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-44da9dcd-SelectRow"
+                        id="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-44da9dcd-SelectRow-label"
                       >
                         <span
                           className="slds-checkbox_faux"
@@ -24124,7 +24126,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
               >
                 <div
                   className="slds-dropdown-trigger slds-dropdown-trigger_click"
-                  id="DataTableExample-FixedHeaders-SLDSDataTableRow-44da9dcd-SLDSDataTableRowActions"
+                  id="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-44da9dcd-SLDSDataTableRowActions"
                   onClick={[Function]}
                   onFocus={[Function]}
                   onKeyDown={[Function]}
@@ -24134,7 +24136,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                   <button
                     aria-expanded={false}
                     aria-haspopup={true}
-                    className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-FixedHeaders-SLDSDataTableRow-44da9dcd-SLDSDataTableRowActions slds-button_icon-x-small"
+                    className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-44da9dcd-SLDSDataTableRowActions slds-button_icon-x-small"
                     disabled={false}
                     onClick={[Function]}
                     tabIndex="-1"
@@ -24182,9 +24184,9 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                       className="slds-checkbox"
                     >
                       <input
-                        aria-labelledby="DataTableExample-FixedHeaders-SLDSDataTableRow-f988a721-SelectRow-label DataTableExample-FixedHeaders-SLDSDataTableHead-column-group-header-row-select"
+                        aria-labelledby="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-f988a721-SelectRow-label DataTableExample-JoinedWithPageHeader-SLDSDataTableHead-column-group-header-row-select"
                         checked={false}
-                        id="DataTableExample-FixedHeaders-SLDSDataTableRow-f988a721-SelectRow"
+                        id="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-f988a721-SelectRow"
                         name="SelectRow3"
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -24193,8 +24195,8 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                       />
                       <label
                         className="slds-checkbox__label"
-                        htmlFor="DataTableExample-FixedHeaders-SLDSDataTableRow-f988a721-SelectRow"
-                        id="DataTableExample-FixedHeaders-SLDSDataTableRow-f988a721-SelectRow-label"
+                        htmlFor="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-f988a721-SelectRow"
+                        id="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-f988a721-SelectRow-label"
                       >
                         <span
                           className="slds-checkbox_faux"
@@ -24343,7 +24345,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
               >
                 <div
                   className="slds-dropdown-trigger slds-dropdown-trigger_click"
-                  id="DataTableExample-FixedHeaders-SLDSDataTableRow-f988a721-SLDSDataTableRowActions"
+                  id="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-f988a721-SLDSDataTableRowActions"
                   onClick={[Function]}
                   onFocus={[Function]}
                   onKeyDown={[Function]}
@@ -24353,7 +24355,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                   <button
                     aria-expanded={false}
                     aria-haspopup={true}
-                    className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-FixedHeaders-SLDSDataTableRow-f988a721-SLDSDataTableRowActions slds-button_icon-x-small"
+                    className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-f988a721-SLDSDataTableRowActions slds-button_icon-x-small"
                     disabled={false}
                     onClick={[Function]}
                     tabIndex="-1"
@@ -24401,9 +24403,9 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                       className="slds-checkbox"
                     >
                       <input
-                        aria-labelledby="DataTableExample-FixedHeaders-SLDSDataTableRow-d7679cdd-SelectRow-label DataTableExample-FixedHeaders-SLDSDataTableHead-column-group-header-row-select"
+                        aria-labelledby="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-d7679cdd-SelectRow-label DataTableExample-JoinedWithPageHeader-SLDSDataTableHead-column-group-header-row-select"
                         checked={false}
-                        id="DataTableExample-FixedHeaders-SLDSDataTableRow-d7679cdd-SelectRow"
+                        id="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-d7679cdd-SelectRow"
                         name="SelectRow4"
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -24412,8 +24414,8 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                       />
                       <label
                         className="slds-checkbox__label"
-                        htmlFor="DataTableExample-FixedHeaders-SLDSDataTableRow-d7679cdd-SelectRow"
-                        id="DataTableExample-FixedHeaders-SLDSDataTableRow-d7679cdd-SelectRow-label"
+                        htmlFor="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-d7679cdd-SelectRow"
+                        id="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-d7679cdd-SelectRow-label"
                       >
                         <span
                           className="slds-checkbox_faux"
@@ -24562,7 +24564,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
               >
                 <div
                   className="slds-dropdown-trigger slds-dropdown-trigger_click"
-                  id="DataTableExample-FixedHeaders-SLDSDataTableRow-d7679cdd-SLDSDataTableRowActions"
+                  id="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-d7679cdd-SLDSDataTableRowActions"
                   onClick={[Function]}
                   onFocus={[Function]}
                   onKeyDown={[Function]}
@@ -24572,7 +24574,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                   <button
                     aria-expanded={false}
                     aria-haspopup={true}
-                    className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-FixedHeaders-SLDSDataTableRow-d7679cdd-SLDSDataTableRowActions slds-button_icon-x-small"
+                    className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-d7679cdd-SLDSDataTableRowActions slds-button_icon-x-small"
                     disabled={false}
                     onClick={[Function]}
                     tabIndex="-1"
@@ -24620,9 +24622,9 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                       className="slds-checkbox"
                     >
                       <input
-                        aria-labelledby="DataTableExample-FixedHeaders-SLDSDataTableRow-0085f7a0-SelectRow-label DataTableExample-FixedHeaders-SLDSDataTableHead-column-group-header-row-select"
+                        aria-labelledby="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-0085f7a0-SelectRow-label DataTableExample-JoinedWithPageHeader-SLDSDataTableHead-column-group-header-row-select"
                         checked={false}
-                        id="DataTableExample-FixedHeaders-SLDSDataTableRow-0085f7a0-SelectRow"
+                        id="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-0085f7a0-SelectRow"
                         name="SelectRow5"
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -24631,8 +24633,8 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                       />
                       <label
                         className="slds-checkbox__label"
-                        htmlFor="DataTableExample-FixedHeaders-SLDSDataTableRow-0085f7a0-SelectRow"
-                        id="DataTableExample-FixedHeaders-SLDSDataTableRow-0085f7a0-SelectRow-label"
+                        htmlFor="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-0085f7a0-SelectRow"
+                        id="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-0085f7a0-SelectRow-label"
                       >
                         <span
                           className="slds-checkbox_faux"
@@ -24781,7 +24783,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
               >
                 <div
                   className="slds-dropdown-trigger slds-dropdown-trigger_click"
-                  id="DataTableExample-FixedHeaders-SLDSDataTableRow-0085f7a0-SLDSDataTableRowActions"
+                  id="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-0085f7a0-SLDSDataTableRowActions"
                   onClick={[Function]}
                   onFocus={[Function]}
                   onKeyDown={[Function]}
@@ -24791,7 +24793,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                   <button
                     aria-expanded={false}
                     aria-haspopup={true}
-                    className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-FixedHeaders-SLDSDataTableRow-0085f7a0-SLDSDataTableRowActions slds-button_icon-x-small"
+                    className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-0085f7a0-SLDSDataTableRowActions slds-button_icon-x-small"
                     disabled={false}
                     onClick={[Function]}
                     tabIndex="-1"
@@ -24839,9 +24841,9 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                       className="slds-checkbox"
                     >
                       <input
-                        aria-labelledby="DataTableExample-FixedHeaders-SLDSDataTableRow-b7acc778-SelectRow-label DataTableExample-FixedHeaders-SLDSDataTableHead-column-group-header-row-select"
+                        aria-labelledby="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-b7acc778-SelectRow-label DataTableExample-JoinedWithPageHeader-SLDSDataTableHead-column-group-header-row-select"
                         checked={false}
-                        id="DataTableExample-FixedHeaders-SLDSDataTableRow-b7acc778-SelectRow"
+                        id="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-b7acc778-SelectRow"
                         name="SelectRow6"
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -24850,8 +24852,8 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                       />
                       <label
                         className="slds-checkbox__label"
-                        htmlFor="DataTableExample-FixedHeaders-SLDSDataTableRow-b7acc778-SelectRow"
-                        id="DataTableExample-FixedHeaders-SLDSDataTableRow-b7acc778-SelectRow-label"
+                        htmlFor="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-b7acc778-SelectRow"
+                        id="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-b7acc778-SelectRow-label"
                       >
                         <span
                           className="slds-checkbox_faux"
@@ -25000,7 +25002,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
               >
                 <div
                   className="slds-dropdown-trigger slds-dropdown-trigger_click"
-                  id="DataTableExample-FixedHeaders-SLDSDataTableRow-b7acc778-SLDSDataTableRowActions"
+                  id="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-b7acc778-SLDSDataTableRowActions"
                   onClick={[Function]}
                   onFocus={[Function]}
                   onKeyDown={[Function]}
@@ -25010,7 +25012,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                   <button
                     aria-expanded={false}
                     aria-haspopup={true}
-                    className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-FixedHeaders-SLDSDataTableRow-b7acc778-SLDSDataTableRowActions slds-button_icon-x-small"
+                    className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-b7acc778-SLDSDataTableRowActions slds-button_icon-x-small"
                     disabled={false}
                     onClick={[Function]}
                     tabIndex="-1"
@@ -25058,9 +25060,9 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                       className="slds-checkbox"
                     >
                       <input
-                        aria-labelledby="DataTableExample-FixedHeaders-SLDSDataTableRow-17991de5-SelectRow-label DataTableExample-FixedHeaders-SLDSDataTableHead-column-group-header-row-select"
+                        aria-labelledby="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-17991de5-SelectRow-label DataTableExample-JoinedWithPageHeader-SLDSDataTableHead-column-group-header-row-select"
                         checked={false}
-                        id="DataTableExample-FixedHeaders-SLDSDataTableRow-17991de5-SelectRow"
+                        id="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-17991de5-SelectRow"
                         name="SelectRow7"
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -25069,8 +25071,8 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                       />
                       <label
                         className="slds-checkbox__label"
-                        htmlFor="DataTableExample-FixedHeaders-SLDSDataTableRow-17991de5-SelectRow"
-                        id="DataTableExample-FixedHeaders-SLDSDataTableRow-17991de5-SelectRow-label"
+                        htmlFor="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-17991de5-SelectRow"
+                        id="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-17991de5-SelectRow-label"
                       >
                         <span
                           className="slds-checkbox_faux"
@@ -25219,7 +25221,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
               >
                 <div
                   className="slds-dropdown-trigger slds-dropdown-trigger_click"
-                  id="DataTableExample-FixedHeaders-SLDSDataTableRow-17991de5-SLDSDataTableRowActions"
+                  id="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-17991de5-SLDSDataTableRowActions"
                   onClick={[Function]}
                   onFocus={[Function]}
                   onKeyDown={[Function]}
@@ -25229,7 +25231,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                   <button
                     aria-expanded={false}
                     aria-haspopup={true}
-                    className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-FixedHeaders-SLDSDataTableRow-17991de5-SLDSDataTableRowActions slds-button_icon-x-small"
+                    className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-17991de5-SLDSDataTableRowActions slds-button_icon-x-small"
                     disabled={false}
                     onClick={[Function]}
                     tabIndex="-1"
@@ -25277,9 +25279,9 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                       className="slds-checkbox"
                     >
                       <input
-                        aria-labelledby="DataTableExample-FixedHeaders-SLDSDataTableRow-09b2cee9-SelectRow-label DataTableExample-FixedHeaders-SLDSDataTableHead-column-group-header-row-select"
+                        aria-labelledby="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-09b2cee9-SelectRow-label DataTableExample-JoinedWithPageHeader-SLDSDataTableHead-column-group-header-row-select"
                         checked={false}
-                        id="DataTableExample-FixedHeaders-SLDSDataTableRow-09b2cee9-SelectRow"
+                        id="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-09b2cee9-SelectRow"
                         name="SelectRow8"
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -25288,8 +25290,8 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                       />
                       <label
                         className="slds-checkbox__label"
-                        htmlFor="DataTableExample-FixedHeaders-SLDSDataTableRow-09b2cee9-SelectRow"
-                        id="DataTableExample-FixedHeaders-SLDSDataTableRow-09b2cee9-SelectRow-label"
+                        htmlFor="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-09b2cee9-SelectRow"
+                        id="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-09b2cee9-SelectRow-label"
                       >
                         <span
                           className="slds-checkbox_faux"
@@ -25438,7 +25440,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
               >
                 <div
                   className="slds-dropdown-trigger slds-dropdown-trigger_click"
-                  id="DataTableExample-FixedHeaders-SLDSDataTableRow-09b2cee9-SLDSDataTableRowActions"
+                  id="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-09b2cee9-SLDSDataTableRowActions"
                   onClick={[Function]}
                   onFocus={[Function]}
                   onKeyDown={[Function]}
@@ -25448,7 +25450,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                   <button
                     aria-expanded={false}
                     aria-haspopup={true}
-                    className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-FixedHeaders-SLDSDataTableRow-09b2cee9-SLDSDataTableRowActions slds-button_icon-x-small"
+                    className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-09b2cee9-SLDSDataTableRowActions slds-button_icon-x-small"
                     disabled={false}
                     onClick={[Function]}
                     tabIndex="-1"
@@ -25496,9 +25498,9 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                       className="slds-checkbox"
                     >
                       <input
-                        aria-labelledby="DataTableExample-FixedHeaders-SLDSDataTableRow-d0035700-SelectRow-label DataTableExample-FixedHeaders-SLDSDataTableHead-column-group-header-row-select"
+                        aria-labelledby="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-d0035700-SelectRow-label DataTableExample-JoinedWithPageHeader-SLDSDataTableHead-column-group-header-row-select"
                         checked={false}
-                        id="DataTableExample-FixedHeaders-SLDSDataTableRow-d0035700-SelectRow"
+                        id="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-d0035700-SelectRow"
                         name="SelectRow9"
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -25507,8 +25509,8 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                       />
                       <label
                         className="slds-checkbox__label"
-                        htmlFor="DataTableExample-FixedHeaders-SLDSDataTableRow-d0035700-SelectRow"
-                        id="DataTableExample-FixedHeaders-SLDSDataTableRow-d0035700-SelectRow-label"
+                        htmlFor="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-d0035700-SelectRow"
+                        id="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-d0035700-SelectRow-label"
                       >
                         <span
                           className="slds-checkbox_faux"
@@ -25657,7 +25659,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
               >
                 <div
                   className="slds-dropdown-trigger slds-dropdown-trigger_click"
-                  id="DataTableExample-FixedHeaders-SLDSDataTableRow-d0035700-SLDSDataTableRowActions"
+                  id="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-d0035700-SLDSDataTableRowActions"
                   onClick={[Function]}
                   onFocus={[Function]}
                   onKeyDown={[Function]}
@@ -25667,7 +25669,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                   <button
                     aria-expanded={false}
                     aria-haspopup={true}
-                    className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-FixedHeaders-SLDSDataTableRow-d0035700-SLDSDataTableRowActions slds-button_icon-x-small"
+                    className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-d0035700-SLDSDataTableRowActions slds-button_icon-x-small"
                     disabled={false}
                     onClick={[Function]}
                     tabIndex="-1"
@@ -25715,9 +25717,9 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                       className="slds-checkbox"
                     >
                       <input
-                        aria-labelledby="DataTableExample-FixedHeaders-SLDSDataTableRow-4a526f0c-SelectRow-label DataTableExample-FixedHeaders-SLDSDataTableHead-column-group-header-row-select"
+                        aria-labelledby="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-4a526f0c-SelectRow-label DataTableExample-JoinedWithPageHeader-SLDSDataTableHead-column-group-header-row-select"
                         checked={false}
-                        id="DataTableExample-FixedHeaders-SLDSDataTableRow-4a526f0c-SelectRow"
+                        id="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-4a526f0c-SelectRow"
                         name="SelectRow10"
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -25726,8 +25728,8 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                       />
                       <label
                         className="slds-checkbox__label"
-                        htmlFor="DataTableExample-FixedHeaders-SLDSDataTableRow-4a526f0c-SelectRow"
-                        id="DataTableExample-FixedHeaders-SLDSDataTableRow-4a526f0c-SelectRow-label"
+                        htmlFor="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-4a526f0c-SelectRow"
+                        id="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-4a526f0c-SelectRow-label"
                       >
                         <span
                           className="slds-checkbox_faux"
@@ -25876,7 +25878,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
               >
                 <div
                   className="slds-dropdown-trigger slds-dropdown-trigger_click"
-                  id="DataTableExample-FixedHeaders-SLDSDataTableRow-4a526f0c-SLDSDataTableRowActions"
+                  id="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-4a526f0c-SLDSDataTableRowActions"
                   onClick={[Function]}
                   onFocus={[Function]}
                   onKeyDown={[Function]}
@@ -25886,7 +25888,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                   <button
                     aria-expanded={false}
                     aria-haspopup={true}
-                    className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-FixedHeaders-SLDSDataTableRow-4a526f0c-SLDSDataTableRowActions slds-button_icon-x-small"
+                    className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-4a526f0c-SLDSDataTableRowActions slds-button_icon-x-small"
                     disabled={false}
                     onClick={[Function]}
                     tabIndex="-1"
@@ -25934,9 +25936,9 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                       className="slds-checkbox"
                     >
                       <input
-                        aria-labelledby="DataTableExample-FixedHeaders-SLDSDataTableRow-9a5dbdb2-SelectRow-label DataTableExample-FixedHeaders-SLDSDataTableHead-column-group-header-row-select"
+                        aria-labelledby="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-9a5dbdb2-SelectRow-label DataTableExample-JoinedWithPageHeader-SLDSDataTableHead-column-group-header-row-select"
                         checked={false}
-                        id="DataTableExample-FixedHeaders-SLDSDataTableRow-9a5dbdb2-SelectRow"
+                        id="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-9a5dbdb2-SelectRow"
                         name="SelectRow11"
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -25945,8 +25947,8 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                       />
                       <label
                         className="slds-checkbox__label"
-                        htmlFor="DataTableExample-FixedHeaders-SLDSDataTableRow-9a5dbdb2-SelectRow"
-                        id="DataTableExample-FixedHeaders-SLDSDataTableRow-9a5dbdb2-SelectRow-label"
+                        htmlFor="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-9a5dbdb2-SelectRow"
+                        id="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-9a5dbdb2-SelectRow-label"
                       >
                         <span
                           className="slds-checkbox_faux"
@@ -26095,7 +26097,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
               >
                 <div
                   className="slds-dropdown-trigger slds-dropdown-trigger_click"
-                  id="DataTableExample-FixedHeaders-SLDSDataTableRow-9a5dbdb2-SLDSDataTableRowActions"
+                  id="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-9a5dbdb2-SLDSDataTableRowActions"
                   onClick={[Function]}
                   onFocus={[Function]}
                   onKeyDown={[Function]}
@@ -26105,7 +26107,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                   <button
                     aria-expanded={false}
                     aria-haspopup={true}
-                    className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-FixedHeaders-SLDSDataTableRow-9a5dbdb2-SLDSDataTableRowActions slds-button_icon-x-small"
+                    className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-9a5dbdb2-SLDSDataTableRowActions slds-button_icon-x-small"
                     disabled={false}
                     onClick={[Function]}
                     tabIndex="-1"
@@ -26153,9 +26155,9 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                       className="slds-checkbox"
                     >
                       <input
-                        aria-labelledby="DataTableExample-FixedHeaders-SLDSDataTableRow-356dbb52-SelectRow-label DataTableExample-FixedHeaders-SLDSDataTableHead-column-group-header-row-select"
+                        aria-labelledby="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-356dbb52-SelectRow-label DataTableExample-JoinedWithPageHeader-SLDSDataTableHead-column-group-header-row-select"
                         checked={false}
-                        id="DataTableExample-FixedHeaders-SLDSDataTableRow-356dbb52-SelectRow"
+                        id="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-356dbb52-SelectRow"
                         name="SelectRow12"
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -26164,8 +26166,8 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                       />
                       <label
                         className="slds-checkbox__label"
-                        htmlFor="DataTableExample-FixedHeaders-SLDSDataTableRow-356dbb52-SelectRow"
-                        id="DataTableExample-FixedHeaders-SLDSDataTableRow-356dbb52-SelectRow-label"
+                        htmlFor="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-356dbb52-SelectRow"
+                        id="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-356dbb52-SelectRow-label"
                       >
                         <span
                           className="slds-checkbox_faux"
@@ -26314,7 +26316,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
               >
                 <div
                   className="slds-dropdown-trigger slds-dropdown-trigger_click"
-                  id="DataTableExample-FixedHeaders-SLDSDataTableRow-356dbb52-SLDSDataTableRowActions"
+                  id="DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-356dbb52-SLDSDataTableRowActions"
                   onClick={[Function]}
                   onFocus={[Function]}
                   onKeyDown={[Function]}
@@ -26324,7 +26326,7 @@ exports[`DOM snapshots SLDSDataTable Joined with Page Header 1`] = `
                   <button
                     aria-expanded={false}
                     aria-haspopup={true}
-                    className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-FixedHeaders-SLDSDataTableRow-356dbb52-SLDSDataTableRowActions slds-button_icon-x-small"
+                    className="slds-button slds-button_icon-border-filled slds-button_icon-small ignore-click-DataTableExample-JoinedWithPageHeader-SLDSDataTableRow-356dbb52-SLDSDataTableRowActions slds-button_icon-x-small"
                     disabled={false}
                     onClick={[Function]}
                     tabIndex="-1"
@@ -26386,7 +26388,8 @@ exports[`DOM snapshots SLDSDataTable Resizable Columns 1`] = `
         style={
           Object {
             "height": "100%",
-            "overflow": "auto",
+            "overflowX": "hidden",
+            "overflowY": "auto",
           }
         }
       >
@@ -28397,7 +28400,8 @@ exports[`DOM snapshots SLDSDataTable Resizable Columns 1`] = `
         style={
           Object {
             "height": "100%",
-            "overflow": "auto",
+            "overflowX": "hidden",
+            "overflowY": "auto",
           }
         }
       >

--- a/components/data-table/__examples__/joined-with-page-header.jsx
+++ b/components/data-table/__examples__/joined-with-page-header.jsx
@@ -371,7 +371,6 @@ class Example extends React.Component {
 						variant="object-home"
 					/>
 					<DataTable
-						fixedHeader
 						fixedLayout
 						resizable
 						keyboardNavigation

--- a/components/data-table/__examples__/joined-with-page-header.jsx
+++ b/components/data-table/__examples__/joined-with-page-header.jsx
@@ -375,7 +375,7 @@ class Example extends React.Component {
 						resizable
 						keyboardNavigation
 						items={this.state.items}
-						id="DataTableExample-FixedHeaders"
+						id="DataTableExample-JoinedWithPageHeader"
 						joined
 						onRowChange={this.handleChanged}
 						onSort={this.handleSort}

--- a/components/data-table/__examples__/resizable-columns.jsx
+++ b/components/data-table/__examples__/resizable-columns.jsx
@@ -195,7 +195,6 @@ class Example extends React.Component {
 								keyboardNavigation
 								fixedLayout
 								resizableOptions={{
-									resizeMode: 'overflow',
 									onResize: (columnsResized) => {
 										console.log(JSON.stringify(columnsResized));
 									},
@@ -219,7 +218,6 @@ class Example extends React.Component {
 								resizable
 								keyboardNavigation
 								resizableOptions={{
-									resizeMode: 'overflow',
 									onResize: (columnsResized) => {
 										console.log(JSON.stringify(columnsResized));
 									},

--- a/components/data-table/__tests__/data-table.browser-test.jsx
+++ b/components/data-table/__tests__/data-table.browser-test.jsx
@@ -742,7 +742,7 @@ describe('DataTable: ', function describeFunction() {
 				</DataTable>
 			).call(this);
 
-      // actions column is not resizable
+			// actions column is not resizable
 			expect(this.dom.querySelectorAll('.grip-resizable').length).to.eql(4);
 			expect(this.dom.querySelectorAll('.grip-container').length).to.eql(1);
 		});

--- a/components/data-table/__tests__/data-table.browser-test.jsx
+++ b/components/data-table/__tests__/data-table.browser-test.jsx
@@ -742,7 +742,8 @@ describe('DataTable: ', function describeFunction() {
 				</DataTable>
 			).call(this);
 
-			expect(this.dom.querySelectorAll('.grip-resizable').length).to.eql(5);
+      // actions column is not resizable
+			expect(this.dom.querySelectorAll('.grip-resizable').length).to.eql(4);
 			expect(this.dom.querySelectorAll('.grip-container').length).to.eql(1);
 		});
 	});

--- a/components/data-table/component.json
+++ b/components/data-table/component.json
@@ -69,10 +69,6 @@
       "path": "/__examples__/joined-with-page-header.jsx"
 		},
 		{
-			"heading": "Custom Classes",
-			"path": "/__examples__/custom-classes.jsx"
-		},
-		{
 			"heading": "Infinite Scrolling",
 			"path": "/__examples__/infinite-scrolling.jsx"
 		},

--- a/components/data-table/index.jsx
+++ b/components/data-table/index.jsx
@@ -500,14 +500,12 @@ class DataTable extends React.Component {
 			this.headerRefs.action
 		);
 
-		const tableOffset = this.tableRef.getBoundingClientRect();
-
-		if (this.gripRefs) {
+		if (this.gripRefs && this.tableRef) {
+			const tableOffset = this.tableRef.getBoundingClientRect();
 			this.gripRefs.forEach((grip, index) => {
 				const header = headers[index].getBoundingClientRect();
 				const relativeOffset = header.left - tableOffset.left;
-				const newPosition =
-					tableOffset.left + relativeOffset + header.width - 30;
+				const newPosition = relativeOffset + header.width;
 				// eslint-disable-next-line no-param-reassign
 				grip.style.left = `${newPosition}px`;
 			});
@@ -613,10 +611,17 @@ class DataTable extends React.Component {
 		if (canUseDOM) {
 			const remoteTable = this.tableRef;
 			const fixedHeader = this.getFixedHeader();
+			const disabledColumns = [];
+
+			if (this.props.selectRows) {
+				// eslint-disable-next-line fp/no-mutating-methods
+				disabledColumns.push(0);
+			}
 
 			if (!this.resizer) {
 				const options = {
 					...defaultProps.resizableOptions,
+					...{ disabledColumns },
 					...this.props.resizableOptions,
 				};
 
@@ -1219,6 +1224,17 @@ class DataTable extends React.Component {
 				styles.borderRadius = tableBorderRadius;
 			}
 
+			const fixedScrollerStyle = {
+				height: '100%',
+			};
+
+			if (this.props.resizable) {
+				fixedScrollerStyle.overflowY = 'auto';
+				fixedScrollerStyle.overflowX = 'hidden';
+			} else {
+				fixedScrollerStyle.overflow = 'auto';
+			}
+
 			component = (
 				<div
 					className="slds-table_header-fixed_container"
@@ -1242,12 +1258,7 @@ class DataTable extends React.Component {
 						ref={(ref) => {
 							this.scrollerRef = ref;
 						}}
-						style={{
-							height: '100%',
-							overflow: this.props.resizable ? undefined : 'auto',
-							overflowY: this.props.resizable ? 'auto' : undefined,
-							overflowX: this.props.resizable ? 'hidden' : undefined,
-						}}
+						style={fixedScrollerStyle}
 					>
 						{component}
 					</div>

--- a/components/data-table/index.jsx
+++ b/components/data-table/index.jsx
@@ -500,10 +500,13 @@ class DataTable extends React.Component {
 			this.headerRefs.action
 		);
 
+    const tableOffset = this.tableRef.getBoundingClientRect();
+
 		if (this.gripRefs) {
 			this.gripRefs.forEach((grip, index) => {
 				const header = headers[index].getBoundingClientRect();
-				const newPosition = header.left + header.width - 30;
+        const relativeOffset = header.left - tableOffset.left;
+				const newPosition = tableOffset.left + relativeOffset + header.width - 30;
 				// eslint-disable-next-line no-param-reassign
 				grip.style.left = `${newPosition}px`;
 			});

--- a/components/data-table/index.jsx
+++ b/components/data-table/index.jsx
@@ -69,7 +69,7 @@ const defaultProps = {
 	loadMoreOffset: 20,
 	resizable: false,
 	resizableOptions: {
-		resizeMode: 'flex',
+		resizeMode: 'fit',
 		draggingClass: 'slds-table-column-resizer',
 	},
 };
@@ -500,13 +500,14 @@ class DataTable extends React.Component {
 			this.headerRefs.action
 		);
 
-    const tableOffset = this.tableRef.getBoundingClientRect();
+		const tableOffset = this.tableRef.getBoundingClientRect();
 
 		if (this.gripRefs) {
 			this.gripRefs.forEach((grip, index) => {
 				const header = headers[index].getBoundingClientRect();
-        const relativeOffset = header.left - tableOffset.left;
-				const newPosition = tableOffset.left + relativeOffset + header.width - 30;
+				const relativeOffset = header.left - tableOffset.left;
+				const newPosition =
+					tableOffset.left + relativeOffset + header.width - 30;
 				// eslint-disable-next-line no-param-reassign
 				grip.style.left = `${newPosition}px`;
 			});
@@ -596,9 +597,9 @@ class DataTable extends React.Component {
 		const table = this.fixedHeaderContainer;
 
 		if (table) {
-			const grips = table.getElementsByClassName('grip-handle');
+			const grips = Array.from(table.getElementsByClassName('grip-handle'));
 
-			if (grips) {
+			if (grips.length) {
 				this.gripRefs = grips;
 				this.gripRefs.forEach((grip) => {
 					// eslint-disable-next-line no-param-reassign
@@ -1243,7 +1244,9 @@ class DataTable extends React.Component {
 						}}
 						style={{
 							height: '100%',
-							overflow: 'auto',
+							overflow: this.props.resizable ? undefined : 'auto',
+							overflowY: this.props.resizable ? 'auto' : undefined,
+							overflowX: this.props.resizable ? 'hidden' : undefined,
 						}}
 					>
 						{component}

--- a/components/site-stories.js
+++ b/components/site-stories.js
@@ -316,10 +316,6 @@ const documentationSiteLiveExamples = {
 			path: require('raw-loader!@salesforce/design-system-react/components/data-table/__examples__/joined-with-page-header.jsx'),
 		},
 		{
-			heading: 'Custom Classes',
-			path: require('raw-loader!@salesforce/design-system-react/components/data-table/__examples__/custom-classes.jsx'),
-		},
-		{
 			heading: 'Infinite Scrolling',
 			path: require('raw-loader!@salesforce/design-system-react/components/data-table/__examples__/infinite-scrolling.jsx'),
 		},

--- a/package.json
+++ b/package.json
@@ -787,10 +787,6 @@
 					"path": "/__examples__/joined-with-page-header.jsx"
 				},
 				{
-					"heading": "Custom Classes",
-					"path": "/__examples__/custom-classes.jsx"
-				},
-				{
 					"heading": "Infinite Scrolling",
 					"path": "/__examples__/infinite-scrolling.jsx"
 				},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "design-system-react",
-	"version": "0.10.35",
+	"version": "0.10.36",
 	"description": "Salesforce Lightning Design System for React",
 	"license": "SEE LICENSE IN README.md",
 	"engines": {


### PR DESCRIPTION
Fixes #2957 and #2960

### Additional description
This also makes the default behavior of column resizing limited to the width of the table instead of overflow:hidden. Scrolling horizontally affects the table container vs column X-axis offset. 

This is what happens after this update: Single columns get smaller and larger without pushing columns to the right and creating a horizontal scroll. Previous column resizing could create a scroll, but scrolling would change the table/column offset here: https://github.com/salesforce/design-system-react/pull/2958/files#diff-80546a80112c877ab129ec5ea2105e98a77c44c98e0be20f51060a011a078ac5R504

![2021-08-20 14 18 55](https://user-images.githubusercontent.com/1290832/130289231-c9aea804-e49f-436d-ad54-ec2fbb582c66.gif)



---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [ ] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [ ] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] CircleCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
