### PR TITLE
Revert "Combobox: Set role='combobox' on input element (#2756)"

### DIFF
--- a/components/combobox/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/combobox/__docs__/__snapshots__/storybook-stories.storyshot
@@ -20,6 +20,8 @@ exports[`DOM snapshots SLDSCombobox Base 1`] = `
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
           role="combobox"
         >
@@ -30,8 +32,6 @@ exports[`DOM snapshots SLDSCombobox Base 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-expanded={false}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-base"
@@ -43,7 +43,7 @@ exports[`DOM snapshots SLDSCombobox Base 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -228,6 +228,8 @@ exports[`DOM snapshots SLDSCombobox Base Custom Menu Item 1`] = `
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
           role="combobox"
         >
@@ -238,8 +240,6 @@ exports[`DOM snapshots SLDSCombobox Base Custom Menu Item 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-expanded={false}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-base-custom-menu-item"
@@ -251,7 +251,7 @@ exports[`DOM snapshots SLDSCombobox Base Custom Menu Item 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -291,6 +291,8 @@ exports[`DOM snapshots SLDSCombobox Base Custom Menu Item Disabled 1`] = `
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
           role="combobox"
         >
@@ -301,8 +303,6 @@ exports[`DOM snapshots SLDSCombobox Base Custom Menu Item Disabled 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-expanded={false}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-unique-id"
@@ -314,7 +314,7 @@ exports[`DOM snapshots SLDSCombobox Base Custom Menu Item Disabled 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -373,6 +373,9 @@ exports[`DOM snapshots SLDSCombobox Base Inherit Menu Width - Right to Left (RTL
           className="slds-combobox_container"
         >
           <div
+            aria-expanded={true}
+            aria-haspopup="listbox"
+            aria-owns="combobox-base-inherit-menu-width-listbox"
             className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
             role="combobox"
           >
@@ -384,8 +387,6 @@ exports[`DOM snapshots SLDSCombobox Base Inherit Menu Width - Right to Left (RTL
                 aria-activedescendant={null}
                 aria-autocomplete="list"
                 aria-controls="combobox-base-inherit-menu-width-listbox"
-                aria-expanded={true}
-                aria-haspopup="listbox"
                 autoComplete="off"
                 className="slds-input slds-combobox__input"
                 id="combobox-base-inherit-menu-width"
@@ -397,7 +398,7 @@ exports[`DOM snapshots SLDSCombobox Base Inherit Menu Width - Right to Left (RTL
                 placeholder="Search Salesforce"
                 readOnly={false}
                 required={false}
-                role="combobox"
+                role="textbox"
                 type="text"
                 value=""
               />
@@ -815,6 +816,8 @@ exports[`DOM snapshots SLDSCombobox Base Inherit Menu Width 1`] = `
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
           role="combobox"
         >
@@ -825,8 +828,6 @@ exports[`DOM snapshots SLDSCombobox Base Inherit Menu Width 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-expanded={false}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-base-inherit-menu-width"
@@ -838,7 +839,7 @@ exports[`DOM snapshots SLDSCombobox Base Inherit Menu Width 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -921,6 +922,8 @@ exports[`DOM snapshots SLDSCombobox Base Inline Help 1`] = `
           className="slds-combobox_container"
         >
           <div
+            aria-expanded={false}
+            aria-haspopup="listbox"
             className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
             role="combobox"
           >
@@ -931,8 +934,6 @@ exports[`DOM snapshots SLDSCombobox Base Inline Help 1`] = `
               <input
                 aria-activedescendant={null}
                 aria-autocomplete="list"
-                aria-expanded={false}
-                aria-haspopup="listbox"
                 autoComplete="off"
                 className="slds-input slds-combobox__input"
                 id="combobox-base-inline-help"
@@ -944,7 +945,7 @@ exports[`DOM snapshots SLDSCombobox Base Inline Help 1`] = `
                 placeholder="Search Salesforce"
                 readOnly={false}
                 required={false}
-                role="combobox"
+                role="textbox"
                 type="text"
                 value=""
               />
@@ -1130,6 +1131,8 @@ exports[`DOM snapshots SLDSCombobox Base Menu Item Disabled 1`] = `
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
           role="combobox"
         >
@@ -1140,8 +1143,6 @@ exports[`DOM snapshots SLDSCombobox Base Menu Item Disabled 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-expanded={false}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-base"
@@ -1153,7 +1154,7 @@ exports[`DOM snapshots SLDSCombobox Base Menu Item Disabled 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -1340,6 +1341,8 @@ exports[`DOM snapshots SLDSCombobox Base Menu Item Disabled With Tooltip 1`] = `
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
           role="combobox"
         >
@@ -1350,8 +1353,6 @@ exports[`DOM snapshots SLDSCombobox Base Menu Item Disabled With Tooltip 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-expanded={false}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-base"
@@ -1363,7 +1364,7 @@ exports[`DOM snapshots SLDSCombobox Base Menu Item Disabled With Tooltip 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -1550,6 +1551,9 @@ exports[`DOM snapshots SLDSCombobox Base Menu Item Disabled With Tooltip Open 1`
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={true}
+          aria-haspopup="listbox"
+          aria-owns="combobox-base-listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
           role="combobox"
         >
@@ -1561,8 +1565,6 @@ exports[`DOM snapshots SLDSCombobox Base Menu Item Disabled With Tooltip Open 1`
               aria-activedescendant={null}
               aria-autocomplete="list"
               aria-controls="combobox-base-listbox"
-              aria-expanded={true}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-base"
@@ -1574,7 +1576,7 @@ exports[`DOM snapshots SLDSCombobox Base Menu Item Disabled With Tooltip Open 1`
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -2184,6 +2186,8 @@ exports[`DOM snapshots SLDSCombobox Base Menu Separator 1`] = `
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
           role="combobox"
         >
@@ -2194,8 +2198,6 @@ exports[`DOM snapshots SLDSCombobox Base Menu Separator 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-expanded={false}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-base-menu-separator"
@@ -2207,7 +2209,7 @@ exports[`DOM snapshots SLDSCombobox Base Menu Separator 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -2247,6 +2249,8 @@ exports[`DOM snapshots SLDSCombobox Base Menu Sub Headers 1`] = `
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
           role="combobox"
         >
@@ -2257,8 +2261,6 @@ exports[`DOM snapshots SLDSCombobox Base Menu Sub Headers 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-expanded={false}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-base-menu-subheader"
@@ -2270,7 +2272,7 @@ exports[`DOM snapshots SLDSCombobox Base Menu Sub Headers 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -2310,6 +2312,8 @@ exports[`DOM snapshots SLDSCombobox Base Pre-defined Options Only 1`] = `
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
           role="combobox"
         >
@@ -2320,8 +2324,6 @@ exports[`DOM snapshots SLDSCombobox Base Pre-defined Options Only 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-expanded={false}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-base-predefined-options"
@@ -2333,7 +2335,7 @@ exports[`DOM snapshots SLDSCombobox Base Pre-defined Options Only 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -2518,6 +2520,9 @@ exports[`DOM snapshots SLDSCombobox Base With Input 1`] = `
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={true}
+          aria-haspopup="listbox"
+          aria-owns="combobox-base-listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
           role="combobox"
         >
@@ -2529,8 +2534,6 @@ exports[`DOM snapshots SLDSCombobox Base With Input 1`] = `
               aria-activedescendant={null}
               aria-autocomplete="list"
               aria-controls="combobox-base-listbox"
-              aria-expanded={true}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-base"
@@ -2542,7 +2545,7 @@ exports[`DOM snapshots SLDSCombobox Base With Input 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value="b"
             />
@@ -2872,6 +2875,8 @@ exports[`DOM snapshots SLDSCombobox Base With Scroll 1`] = `
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
           role="combobox"
         >
@@ -2882,8 +2887,6 @@ exports[`DOM snapshots SLDSCombobox Base With Scroll 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-expanded={false}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-base"
@@ -2895,7 +2898,7 @@ exports[`DOM snapshots SLDSCombobox Base With Scroll 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -3080,6 +3083,8 @@ exports[`DOM snapshots SLDSCombobox Dialog 1`] = `
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={false}
+          aria-haspopup="dialog"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
           role="combobox"
         >
@@ -3097,7 +3102,6 @@ exports[`DOM snapshots SLDSCombobox Dialog 1`] = `
               <input
                 aria-autocomplete="none"
                 aria-describedby={null}
-                aria-expanded={false}
                 aria-haspopup="dialog"
                 autoComplete="off"
                 className="slds-input slds-combobox__input"
@@ -3110,7 +3114,7 @@ exports[`DOM snapshots SLDSCombobox Dialog 1`] = `
                 placeholder="Select an option"
                 readOnly={true}
                 required={false}
-                role="combobox"
+                role="textbox"
                 tabIndex="0"
                 type="text"
                 value="Select an option"
@@ -3303,6 +3307,8 @@ exports[`DOM snapshots SLDSCombobox Inline Multiple Selection 1`] = `
           </ul>
         </div>
         <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
           role="combobox"
         >
@@ -3313,8 +3319,6 @@ exports[`DOM snapshots SLDSCombobox Inline Multiple Selection 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-expanded={false}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-inline-multiple"
@@ -3326,7 +3330,7 @@ exports[`DOM snapshots SLDSCombobox Inline Multiple Selection 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -3366,6 +3370,8 @@ exports[`DOM snapshots SLDSCombobox Inline Multiple Selection Loading 1`] = `
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
           role="combobox"
         >
@@ -3376,8 +3382,6 @@ exports[`DOM snapshots SLDSCombobox Inline Multiple Selection Loading 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-expanded={false}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-unique-id"
@@ -3389,7 +3393,7 @@ exports[`DOM snapshots SLDSCombobox Inline Multiple Selection Loading 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -3447,6 +3451,8 @@ exports[`DOM snapshots SLDSCombobox Inline Single Entity Selection 1`] = `
                 className="slds-combobox_container"
               >
                 <div
+                  aria-expanded={false}
+                  aria-haspopup="listbox"
                   className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
                   role="combobox"
                 >
@@ -3457,8 +3463,6 @@ exports[`DOM snapshots SLDSCombobox Inline Single Entity Selection 1`] = `
                     <input
                       aria-activedescendant={null}
                       aria-autocomplete="list"
-                      aria-expanded={false}
-                      aria-haspopup="listbox"
                       autoComplete="off"
                       className="slds-input slds-combobox__input"
                       disabled={false}
@@ -3471,7 +3475,7 @@ exports[`DOM snapshots SLDSCombobox Inline Single Entity Selection 1`] = `
                       placeholder="Select an Option"
                       readOnly={true}
                       required={false}
-                      role="combobox"
+                      role="textbox"
                       type="text"
                       value="All"
                     />
@@ -3506,6 +3510,8 @@ exports[`DOM snapshots SLDSCombobox Inline Single Entity Selection 1`] = `
                 className="slds-combobox_container"
               >
                 <div
+                  aria-expanded={false}
+                  aria-haspopup="listbox"
                   className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
                   role="combobox"
                 >
@@ -3516,8 +3522,6 @@ exports[`DOM snapshots SLDSCombobox Inline Single Entity Selection 1`] = `
                     <input
                       aria-activedescendant={null}
                       aria-autocomplete="list"
-                      aria-expanded={false}
-                      aria-haspopup="listbox"
                       autoComplete="off"
                       className="slds-input slds-combobox__input"
                       id="combobox-unique-id"
@@ -3529,7 +3533,7 @@ exports[`DOM snapshots SLDSCombobox Inline Single Entity Selection 1`] = `
                       placeholder="Search Salesforce"
                       readOnly={false}
                       required={false}
-                      role="combobox"
+                      role="textbox"
                       type="text"
                       value=""
                     />
@@ -3573,6 +3577,8 @@ exports[`DOM snapshots SLDSCombobox Inline Single Search/Add Entities - Open 1`]
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={true}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
           role="combobox"
         >
@@ -3584,8 +3590,6 @@ exports[`DOM snapshots SLDSCombobox Inline Single Search/Add Entities - Open 1`]
               aria-activedescendant={null}
               aria-autocomplete="list"
               aria-controls="combobox-unique-id-listbox"
-              aria-expanded={true}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               disabled={false}
@@ -3598,7 +3602,7 @@ exports[`DOM snapshots SLDSCombobox Inline Single Search/Add Entities - Open 1`]
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -3977,6 +3981,8 @@ exports[`DOM snapshots SLDSCombobox Inline Single Search/Add Entities 1`] = `
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
           role="combobox"
         >
@@ -3987,8 +3993,6 @@ exports[`DOM snapshots SLDSCombobox Inline Single Search/Add Entities 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-expanded={false}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               disabled={false}
@@ -4001,7 +4005,7 @@ exports[`DOM snapshots SLDSCombobox Inline Single Search/Add Entities 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -4041,6 +4045,8 @@ exports[`DOM snapshots SLDSCombobox Inline Single Selection 1`] = `
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
           role="combobox"
         >
@@ -4051,8 +4057,6 @@ exports[`DOM snapshots SLDSCombobox Inline Single Selection 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-expanded={false}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               disabled={false}
@@ -4065,7 +4069,7 @@ exports[`DOM snapshots SLDSCombobox Inline Single Selection 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -4105,6 +4109,8 @@ exports[`DOM snapshots SLDSCombobox Inline Single Selection Predefined Options O
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
           role="combobox"
         >
@@ -4115,8 +4121,6 @@ exports[`DOM snapshots SLDSCombobox Inline Single Selection Predefined Options O
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-expanded={false}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               disabled={false}
@@ -4129,7 +4133,7 @@ exports[`DOM snapshots SLDSCombobox Inline Single Selection Predefined Options O
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -4169,6 +4173,8 @@ exports[`DOM snapshots SLDSCombobox Inline Single Selection With Custom Open Sta
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
           role="combobox"
         >
@@ -4179,8 +4185,6 @@ exports[`DOM snapshots SLDSCombobox Inline Single Selection With Custom Open Sta
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-expanded={false}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               disabled={false}
@@ -4193,7 +4197,7 @@ exports[`DOM snapshots SLDSCombobox Inline Single Selection With Custom Open Sta
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -4233,6 +4237,8 @@ exports[`DOM snapshots SLDSCombobox Input Component as a Prop 1`] = `
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
           role="combobox"
         >
@@ -4243,8 +4249,6 @@ exports[`DOM snapshots SLDSCombobox Input Component as a Prop 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-expanded={false}
-              aria-haspopup="listbox"
               autoComplete="test"
               className="slds-input slds-combobox__input"
               id="combobox-input-prop-example"
@@ -4256,7 +4260,7 @@ exports[`DOM snapshots SLDSCombobox Input Component as a Prop 1`] = `
               placeholder="My overridden placeholder"
               readOnly={false}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -4441,6 +4445,8 @@ exports[`DOM snapshots SLDSCombobox Readonly Multiple Selection 1`] = `
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
           role="combobox"
         >
@@ -4451,8 +4457,6 @@ exports[`DOM snapshots SLDSCombobox Readonly Multiple Selection 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-expanded={false}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-readonly-multiple"
@@ -4464,7 +4468,7 @@ exports[`DOM snapshots SLDSCombobox Readonly Multiple Selection 1`] = `
               placeholder="Select an Option"
               readOnly={true}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -4508,6 +4512,8 @@ exports[`DOM snapshots SLDSCombobox Readonly Multiple Selection Deselect 1`] = `
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
           role="combobox"
         >
@@ -4518,8 +4524,6 @@ exports[`DOM snapshots SLDSCombobox Readonly Multiple Selection Deselect 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-expanded={false}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-readonly-multiple"
@@ -4531,7 +4535,7 @@ exports[`DOM snapshots SLDSCombobox Readonly Multiple Selection Deselect 1`] = `
               placeholder="Select an Option"
               readOnly={true}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -4575,6 +4579,8 @@ exports[`DOM snapshots SLDSCombobox Readonly Single Menu Item Disabled 1`] = `
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
           role="combobox"
         >
@@ -4585,8 +4591,6 @@ exports[`DOM snapshots SLDSCombobox Readonly Single Menu Item Disabled 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-expanded={false}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               disabled={false}
@@ -4599,7 +4603,7 @@ exports[`DOM snapshots SLDSCombobox Readonly Single Menu Item Disabled 1`] = `
               placeholder="Select an Option"
               readOnly={true}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -4667,6 +4671,8 @@ exports[`DOM snapshots SLDSCombobox Readonly Single Selection - Right to Left (R
           className="slds-combobox_container"
         >
           <div
+            aria-expanded={false}
+            aria-haspopup="listbox"
             className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
             role="combobox"
           >
@@ -4677,8 +4683,6 @@ exports[`DOM snapshots SLDSCombobox Readonly Single Selection - Right to Left (R
               <input
                 aria-activedescendant={null}
                 aria-autocomplete="list"
-                aria-expanded={false}
-                aria-haspopup="listbox"
                 autoComplete="off"
                 className="slds-input slds-combobox__input"
                 disabled={false}
@@ -4691,7 +4695,7 @@ exports[`DOM snapshots SLDSCombobox Readonly Single Selection - Right to Left (R
                 placeholder="Select an Option"
                 readOnly={true}
                 required={false}
-                role="combobox"
+                role="textbox"
                 type="text"
                 value=""
               />
@@ -4736,6 +4740,8 @@ exports[`DOM snapshots SLDSCombobox Readonly Single Selection 1`] = `
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
           role="combobox"
         >
@@ -4746,8 +4752,6 @@ exports[`DOM snapshots SLDSCombobox Readonly Single Selection 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-expanded={false}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               disabled={false}
@@ -4760,7 +4764,7 @@ exports[`DOM snapshots SLDSCombobox Readonly Single Selection 1`] = `
               placeholder="Select an Option"
               readOnly={true}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -4804,6 +4808,8 @@ exports[`DOM snapshots SLDSCombobox Readonly Single Selection Custom Menu Item 1
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
           role="combobox"
         >
@@ -4814,8 +4820,6 @@ exports[`DOM snapshots SLDSCombobox Readonly Single Selection Custom Menu Item 1
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-expanded={false}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               disabled={false}
@@ -4828,7 +4832,7 @@ exports[`DOM snapshots SLDSCombobox Readonly Single Selection Custom Menu Item 1
               placeholder="Select company"
               readOnly={true}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -4872,6 +4876,8 @@ exports[`DOM snapshots SLDSCombobox Readonly Single Selection Deselect 1`] = `
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
           role="combobox"
         >
@@ -4882,8 +4888,6 @@ exports[`DOM snapshots SLDSCombobox Readonly Single Selection Deselect 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-expanded={false}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               disabled={false}
@@ -4896,7 +4900,7 @@ exports[`DOM snapshots SLDSCombobox Readonly Single Selection Deselect 1`] = `
               placeholder="Select an Option"
               readOnly={true}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -4940,6 +4944,8 @@ exports[`DOM snapshots SLDSCombobox Readonly Single Selection Disabled 1`] = `
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
           role="combobox"
         >
@@ -4950,8 +4956,6 @@ exports[`DOM snapshots SLDSCombobox Readonly Single Selection Disabled 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-expanded={false}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               disabled={true}
@@ -4964,7 +4968,7 @@ exports[`DOM snapshots SLDSCombobox Readonly Single Selection Disabled 1`] = `
               placeholder="Select an Option"
               readOnly={true}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -5014,6 +5018,8 @@ exports[`DOM snapshots SLDSCombobox Required Input in Error State 1`] = `
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-has-error"
           role="combobox"
         >
@@ -5025,8 +5031,6 @@ exports[`DOM snapshots SLDSCombobox Required Input in Error State 1`] = `
               aria-activedescendant={null}
               aria-autocomplete="list"
               aria-describedby="description-unique-id"
-              aria-expanded={false}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-required-error-state"
@@ -5038,7 +5042,7 @@ exports[`DOM snapshots SLDSCombobox Required Input in Error State 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={true}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -5088,6 +5092,9 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Custom Menu Item Open 1`] = `
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={true}
+          aria-haspopup="listbox"
+          aria-owns="combobox-base-custom-menu-item-listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
           role="combobox"
         >
@@ -5099,8 +5106,6 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Custom Menu Item Open 1`] = `
               aria-activedescendant={null}
               aria-autocomplete="list"
               aria-controls="combobox-base-custom-menu-item-listbox"
-              aria-expanded={true}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-base-custom-menu-item"
@@ -5112,7 +5117,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Custom Menu Item Open 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -5378,6 +5383,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Label Required 1`] = `
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-has-error"
           role="combobox"
         >
@@ -5389,8 +5396,6 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Label Required 1`] = `
               aria-activedescendant={null}
               aria-autocomplete="list"
               aria-describedby="description-unique-id"
-              aria-expanded={false}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-required-error-state"
@@ -5402,7 +5407,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Label Required 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={true}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -5452,6 +5457,9 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Open 1`] = `
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={true}
+          aria-haspopup="listbox"
+          aria-owns="combobox-unique-id-listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
           role="combobox"
         >
@@ -5463,8 +5471,6 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Open 1`] = `
               aria-activedescendant={null}
               aria-autocomplete="list"
               aria-controls="combobox-unique-id-listbox"
-              aria-expanded={true}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-unique-id"
@@ -5476,7 +5482,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Open 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -5636,6 +5642,9 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Open Menu Sub Header Separator
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={true}
+          aria-haspopup="listbox"
+          aria-owns="combobox-unique-id-listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
           role="combobox"
         >
@@ -5647,8 +5656,6 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Open Menu Sub Header Separator
               aria-activedescendant={null}
               aria-autocomplete="list"
               aria-controls="combobox-unique-id-listbox"
-              aria-expanded={true}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-unique-id"
@@ -5660,7 +5667,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Open Menu Sub Header Separator
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -5760,6 +5767,9 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Open Menu inheritWidthOf prop 
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={true}
+          aria-haspopup="listbox"
+          aria-owns="combobox-unique-id-listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
           role="combobox"
         >
@@ -5771,8 +5781,6 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Open Menu inheritWidthOf prop 
               aria-activedescendant={null}
               aria-autocomplete="list"
               aria-controls="combobox-unique-id-listbox"
-              aria-expanded={true}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-unique-id"
@@ -5784,7 +5792,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Open Menu inheritWidthOf prop 
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -5884,6 +5892,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Selected 1`] = `
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
           role="combobox"
         >
@@ -5894,8 +5904,6 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Selected 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-expanded={false}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-unique-id"
@@ -5907,7 +5915,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Base Selected 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -6025,6 +6033,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Dialog Open 1`] = `
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={true}
+          aria-haspopup="dialog"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
           role="combobox"
         >
@@ -6042,7 +6052,6 @@ exports[`DOM snapshots SLDSCombobox Snapshot Dialog Open 1`] = `
               <input
                 aria-autocomplete="none"
                 aria-controls="combobox-unique-id-popover"
-                aria-expanded={true}
                 aria-haspopup="dialog"
                 autoComplete="off"
                 className="slds-input slds-combobox__input"
@@ -6055,7 +6064,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Dialog Open 1`] = `
                 placeholder="Select an option"
                 readOnly={true}
                 required={false}
-                role="combobox"
+                role="textbox"
                 tabIndex="0"
                 type="text"
                 value="Select an option"
@@ -6178,6 +6187,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Multiple Open Loading 1`] = 
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={true}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
           role="combobox"
         >
@@ -6189,8 +6200,6 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Multiple Open Loading 1`] = 
               aria-activedescendant={null}
               aria-autocomplete="list"
               aria-controls="combobox-unique-id-listbox"
-              aria-expanded={true}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-unique-id"
@@ -6202,7 +6211,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Multiple Open Loading 1`] = 
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -6545,6 +6554,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Multiple Selection 1`] = `
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
           role="combobox"
         >
@@ -6555,8 +6566,6 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Multiple Selection 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-expanded={false}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-unique-id"
@@ -6568,7 +6577,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Multiple Selection 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -6755,6 +6764,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Multiple Selection Selected 
           </ul>
         </div>
         <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
           role="combobox"
         >
@@ -6765,8 +6776,6 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Multiple Selection Selected 
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-expanded={false}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-unique-id"
@@ -6778,7 +6787,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Multiple Selection Selected 
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -6836,6 +6845,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Single Entity Selection 1`] 
                 className="slds-combobox_container"
               >
                 <div
+                  aria-expanded={false}
+                  aria-haspopup="listbox"
                   className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
                   role="combobox"
                 >
@@ -6846,8 +6857,6 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Single Entity Selection 1`] 
                     <input
                       aria-activedescendant={null}
                       aria-autocomplete="list"
-                      aria-expanded={false}
-                      aria-haspopup="listbox"
                       autoComplete="off"
                       className="slds-input slds-combobox__input"
                       disabled={false}
@@ -6860,7 +6869,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Single Entity Selection 1`] 
                       placeholder="entity"
                       readOnly={false}
                       required={false}
-                      role="combobox"
+                      role="textbox"
                       type="text"
                       value=""
                     />
@@ -6891,6 +6900,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Single Entity Selection 1`] 
                 className="slds-combobox_container"
               >
                 <div
+                  aria-expanded={false}
+                  aria-haspopup="listbox"
                   className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
                   role="combobox"
                 >
@@ -6901,8 +6912,6 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Single Entity Selection 1`] 
                     <input
                       aria-activedescendant={null}
                       aria-autocomplete="list"
-                      aria-expanded={false}
-                      aria-haspopup="listbox"
                       autoComplete="off"
                       className="slds-input slds-combobox__input"
                       id="combobox-unique-id"
@@ -6914,7 +6923,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Single Entity Selection 1`] 
                       placeholder="Search Salesforce"
                       readOnly={false}
                       required={false}
-                      role="combobox"
+                      role="textbox"
                       type="text"
                       value=""
                     />
@@ -6958,6 +6967,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Single Search/Add Entities O
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={true}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
           role="combobox"
         >
@@ -6969,8 +6980,6 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Single Search/Add Entities O
               aria-activedescendant={null}
               aria-autocomplete="list"
               aria-controls="combobox-unique-id-listbox"
-              aria-expanded={true}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               disabled={false}
@@ -6983,7 +6992,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Single Search/Add Entities O
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -7274,6 +7283,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Single Selection 1`] = `
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
           role="combobox"
         >
@@ -7284,8 +7295,6 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Single Selection 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-expanded={false}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               disabled={false}
@@ -7298,7 +7307,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Single Selection 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -7338,6 +7347,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Single Selection Selected 1`
         className="slds-combobox_container slds-has-inline-listbox"
       >
         <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
           role="combobox"
         >
@@ -7365,8 +7376,6 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Single Selection Selected 1`
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-expanded={false}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               disabled={false}
@@ -7379,7 +7388,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Inline Single Selection Selected 1`
               placeholder="Search Salesforce"
               readOnly={true}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value="Acme"
             />
@@ -7431,6 +7440,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Multiple Selection 1`] = `
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
           role="combobox"
         >
@@ -7441,8 +7452,6 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Multiple Selection 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-expanded={false}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-unique-id"
@@ -7454,7 +7463,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Multiple Selection 1`] = `
               placeholder="Select an Option"
               readOnly={true}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -7498,6 +7507,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Multiple Selection Multipl
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
           role="combobox"
         >
@@ -7508,8 +7519,6 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Multiple Selection Multipl
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-expanded={false}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-unique-id"
@@ -7521,7 +7530,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Multiple Selection Multipl
               placeholder="Select an Option"
               readOnly={true}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value="2 options selected"
             />
@@ -7668,6 +7677,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Multiple Selection Single 
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
           role="combobox"
         >
@@ -7678,8 +7689,6 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Multiple Selection Single 
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-expanded={false}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-unique-id"
@@ -7691,7 +7700,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Multiple Selection Single 
               placeholder="Select an Option"
               readOnly={true}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value="Acme"
             />
@@ -7735,6 +7744,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Single Selection 1`] = `
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
           role="combobox"
         >
@@ -7745,8 +7756,6 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Single Selection 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-expanded={false}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               disabled={false}
@@ -7759,7 +7768,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Single Selection 1`] = `
               placeholder="Select an Option"
               readOnly={true}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -7803,6 +7812,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Single Selection Custom Me
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={true}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
           role="combobox"
         >
@@ -7814,8 +7825,6 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Single Selection Custom Me
               aria-activedescendant={null}
               aria-autocomplete="list"
               aria-controls="combobox-readonly-single-custom-item-listbox"
-              aria-expanded={true}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               disabled={false}
@@ -7828,7 +7837,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Single Selection Custom Me
               placeholder="Select company"
               readOnly={true}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -8436,6 +8445,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Single Selection Disabled 
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
           role="combobox"
         >
@@ -8446,8 +8457,6 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Single Selection Disabled 
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-expanded={false}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               disabled={true}
@@ -8460,7 +8469,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Single Selection Disabled 
               placeholder="Select an Option"
               readOnly={true}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -8504,6 +8513,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Single Selection Selected 
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
           role="combobox"
         >
@@ -8514,8 +8525,6 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Single Selection Selected 
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-expanded={false}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               disabled={false}
@@ -8528,7 +8537,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Single Selection Selected 
               placeholder="Select an Option"
               readOnly={true}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value="Acme"
             />
@@ -8572,6 +8581,8 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Single Selection Selected 
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={true}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-is-open"
           role="combobox"
         >
@@ -8583,8 +8594,6 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Single Selection Selected 
               aria-activedescendant="combobox-unique-id-listbox-option-1"
               aria-autocomplete="list"
               aria-controls="combobox-unique-id-listbox"
-              aria-expanded={true}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               disabled={false}
@@ -8597,7 +8606,7 @@ exports[`DOM snapshots SLDSCombobox Snapshot Readonly Single Selection Selected 
               placeholder="Select an Option"
               readOnly={true}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value="Acme"
             />

--- a/components/combobox/__tests__/combobox.browser-test.jsx
+++ b/components/combobox/__tests__/combobox.browser-test.jsx
@@ -225,17 +225,16 @@ describe('SLDSCombobox', function describeFunction() {
 			destroyMountNode({ wrapper, mountNode });
 		});
 
-		it('has aria-haspopup, role is combobox, aria-expanded is false when closed, aria-expanded is true when open', function () {
+		it('has aria-haspopup, aria-expanded is false when closed, aria-expanded is true when open', function () {
 			wrapper = mount(<DemoComponent multiple />, { attachTo: mountNode });
 			const nodes = getNodes({ wrapper });
+			expect(nodes.combobox).attr('aria-haspopup', 'listbox');
 			expect(nodes.combobox).attr('role', 'combobox');
-			expect(nodes.input).attr('aria-haspopup', 'listbox');
-			expect(nodes.input).attr('role', 'combobox');
 			// closed
-			expect(nodes.input).attr('aria-expanded', 'false');
+			expect(nodes.combobox).attr('aria-expanded', 'false');
 			// open
 			nodes.input.simulate('click', {});
-			expect(nodes.input).attr('aria-expanded', 'true');
+			expect(nodes.combobox).attr('aria-expanded', 'true');
 		});
 
 		it('menu filters to second item, menu listbox menu item 2 aria-selected is true, input activedescendent has item 2 id, after pressing down arrow, enter selects item 2', function () {

--- a/components/combobox/combobox.jsx
+++ b/components/combobox/combobox.jsx
@@ -1110,6 +1110,11 @@ class Combobox extends React.Component {
 					)}
 					// Not in ARIA 1.2 spec, temporary for SLDS styles
 					role="combobox" // eslint-disable-line jsx-a11y/role-supports-aria-props, jsx-a11y/role-has-required-aria-props
+					aria-expanded={this.getIsOpen()}
+					aria-haspopup="listbox" // eslint-disable-line jsx-a11y/aria-proptypes
+					// used on menu's listbox
+					aria-owns={this.getIsOpen() ? `${this.getId()}-listbox` : undefined} // eslint-disable-line jsx-a11y/aria-proptypes
+					role="combobox"
 				>
 					<InnerInput
 						aria-autocomplete="list"
@@ -1122,9 +1127,6 @@ class Combobox extends React.Component {
 								: null
 						}
 						aria-describedby={this.getErrorId()}
-						aria-expanded={this.getIsOpen()}
-						aria-haspopup="listbox"
-						role="combobox"
 						autoComplete="off"
 						className="slds-combobox__input"
 						containerProps={{
@@ -1154,6 +1156,7 @@ class Combobox extends React.Component {
 							!!(props.predefinedOptionsOnly && this.state.activeOption)
 						}
 						required={props.required}
+						role="textbox"
 						value={
 							props.predefinedOptionsOnly
 								? (this.state.activeOption && this.state.activeOption.label) ||
@@ -1250,6 +1253,9 @@ class Combobox extends React.Component {
 					)}
 					// Not in ARIA 1.2 spec, temporary for SLDS styles
 					role="combobox" // eslint-disable-line jsx-a11y/role-supports-aria-props, jsx-a11y/role-has-required-aria-props
+					aria-expanded={this.getIsOpen()}
+					aria-haspopup="listbox" // eslint-disable-line jsx-a11y/aria-proptypes
+					role="combobox"
 				>
 					<InnerInput
 						aria-autocomplete="list"
@@ -1262,9 +1268,6 @@ class Combobox extends React.Component {
 								: null
 						}
 						aria-describedby={this.getErrorId()}
-						aria-expanded={this.getIsOpen()}
-						aria-haspopup="listbox" // eslint-disable-line jsx-a11y/aria-proptypes
-						role="combobox"
 						defaultValue={props.defaultValue}
 						autoComplete="off"
 						className="slds-combobox__input"
@@ -1294,6 +1297,7 @@ class Combobox extends React.Component {
 							!!(props.predefinedOptionsOnly && this.state.activeOption)
 						}
 						required={props.required}
+						role="textbox"
 						value={
 							props.predefinedOptionsOnly
 								? (this.state.activeOption && this.state.activeOption.label) ||
@@ -1351,6 +1355,9 @@ class Combobox extends React.Component {
 						)}
 						// Not in ARIA 1.2 spec, temporary for SLDS styles
 						role="combobox" // eslint-disable-line jsx-a11y/role-supports-aria-props, jsx-a11y/role-has-required-aria-props
+						aria-expanded={this.getIsOpen()}
+						aria-haspopup="listbox" // eslint-disable-line jsx-a11y/aria-proptypes
+						role="combobox"
 					>
 						<InnerInput
 							defaultValue={props.defaultValue}
@@ -1366,9 +1373,6 @@ class Combobox extends React.Component {
 									: null
 							}
 							aria-describedby={this.getErrorId()}
-							aria-expanded={this.getIsOpen()}
-							aria-haspopup="listbox" // eslint-disable-line jsx-a11y/aria-proptypes
-							role="combobox"
 							autoComplete="off"
 							className="slds-combobox__input"
 							containerProps={{
@@ -1419,6 +1423,7 @@ class Combobox extends React.Component {
 								!!props.selection.length
 							}
 							required={props.required}
+							role="textbox"
 							value={
 								props.predefinedOptionsOnly
 									? (this.state.activeOption &&
@@ -1519,6 +1524,9 @@ class Combobox extends React.Component {
 						)}
 						// Not in ARIA 1.2 spec, temporary for SLDS styles
 						role="combobox" // eslint-disable-line jsx-a11y/role-supports-aria-props, jsx-a11y/role-has-required-aria-props
+						aria-expanded={this.getIsOpen()}
+						aria-haspopup="dialog" // eslint-disable-line jsx-a11y/aria-proptypes
+						role="combobox"
 					>
 						<Popover {...popoverProps}>
 							<InnerInput
@@ -1527,9 +1535,6 @@ class Combobox extends React.Component {
 									this.getIsOpen() ? `${this.getId()}-popover` : undefined
 								}
 								aria-describedby={this.getErrorId()}
-								aria-expanded={this.getIsOpen()}
-								aria-haspopup="dialog" // eslint-disable-line jsx-a11y/aria-proptypes
-								role="combobox"
 								autoComplete="off"
 								className="slds-combobox__input"
 								containerProps={{
@@ -1555,6 +1560,7 @@ class Combobox extends React.Component {
 								placeholder={labels.placeholder}
 								readOnly
 								required={props.required}
+								role="textbox"
 								value={props.value}
 							/>
 						</Popover>
@@ -1605,6 +1611,9 @@ class Combobox extends React.Component {
 						)}
 						// Not in ARIA 1.2 spec, temporary for SLDS styles
 						role="combobox" // eslint-disable-line jsx-a11y/role-supports-aria-props, jsx-a11y/role-has-required-aria-props
+						aria-expanded={this.getIsOpen()}
+						aria-haspopup="listbox" // eslint-disable-line jsx-a11y/aria-proptypes
+						role="combobox"
 					>
 						<InnerInput
 							defaultValue={props.defaultValue}
@@ -1620,9 +1629,6 @@ class Combobox extends React.Component {
 									: null
 							}
 							aria-describedby={this.getErrorId()}
-							aria-expanded={this.getIsOpen()}
-							aria-haspopup="listbox" // eslint-disable-line jsx-a11y/aria-proptypes
-							role="combobox"
 							autoComplete="off"
 							className="slds-combobox__input"
 							containerProps={{
@@ -1648,6 +1654,7 @@ class Combobox extends React.Component {
 							placeholder={labels.placeholderReadOnly}
 							readOnly
 							required={props.required}
+							role="textbox"
 							value={value}
 							{...userDefinedProps.input}
 						/>
@@ -1724,6 +1731,9 @@ class Combobox extends React.Component {
 						)}
 						// Not in ARIA 1.2 spec, temporary for SLDS styles
 						role="combobox" // eslint-disable-line jsx-a11y/role-supports-aria-props, jsx-a11y/role-has-required-aria-props
+						aria-expanded={this.getIsOpen()}
+						aria-haspopup="listbox" // eslint-disable-line jsx-a11y/aria-proptypes
+						role="combobox"
 					>
 						<InnerInput
 							defaultValue={props.defaultValue}
@@ -1739,9 +1749,6 @@ class Combobox extends React.Component {
 									: null
 							}
 							aria-describedby={this.getErrorId()}
-							aria-expanded={this.getIsOpen()}
-							aria-haspopup="listbox" // eslint-disable-line jsx-a11y/aria-proptypes
-							role="combobox"
 							autoComplete="off"
 							className="slds-combobox__input"
 							containerProps={{
@@ -1768,6 +1775,7 @@ class Combobox extends React.Component {
 							placeholder={labels.placeholderReadOnly}
 							readOnly
 							required={props.required}
+							role="textbox"
 							value={inputValue}
 							{...userDefinedProps.input}
 						/>

--- a/components/combobox/combobox.jsx
+++ b/components/combobox/combobox.jsx
@@ -1114,7 +1114,6 @@ class Combobox extends React.Component {
 					aria-haspopup="listbox" // eslint-disable-line jsx-a11y/aria-proptypes
 					// used on menu's listbox
 					aria-owns={this.getIsOpen() ? `${this.getId()}-listbox` : undefined} // eslint-disable-line jsx-a11y/aria-proptypes
-					role="combobox"
 				>
 					<InnerInput
 						aria-autocomplete="list"
@@ -1255,7 +1254,6 @@ class Combobox extends React.Component {
 					role="combobox" // eslint-disable-line jsx-a11y/role-supports-aria-props, jsx-a11y/role-has-required-aria-props
 					aria-expanded={this.getIsOpen()}
 					aria-haspopup="listbox" // eslint-disable-line jsx-a11y/aria-proptypes
-					role="combobox"
 				>
 					<InnerInput
 						aria-autocomplete="list"
@@ -1357,7 +1355,6 @@ class Combobox extends React.Component {
 						role="combobox" // eslint-disable-line jsx-a11y/role-supports-aria-props, jsx-a11y/role-has-required-aria-props
 						aria-expanded={this.getIsOpen()}
 						aria-haspopup="listbox" // eslint-disable-line jsx-a11y/aria-proptypes
-						role="combobox"
 					>
 						<InnerInput
 							defaultValue={props.defaultValue}
@@ -1526,7 +1523,6 @@ class Combobox extends React.Component {
 						role="combobox" // eslint-disable-line jsx-a11y/role-supports-aria-props, jsx-a11y/role-has-required-aria-props
 						aria-expanded={this.getIsOpen()}
 						aria-haspopup="dialog" // eslint-disable-line jsx-a11y/aria-proptypes
-						role="combobox"
 					>
 						<Popover {...popoverProps}>
 							<InnerInput
@@ -1613,7 +1609,6 @@ class Combobox extends React.Component {
 						role="combobox" // eslint-disable-line jsx-a11y/role-supports-aria-props, jsx-a11y/role-has-required-aria-props
 						aria-expanded={this.getIsOpen()}
 						aria-haspopup="listbox" // eslint-disable-line jsx-a11y/aria-proptypes
-						role="combobox"
 					>
 						<InnerInput
 							defaultValue={props.defaultValue}
@@ -1733,7 +1728,6 @@ class Combobox extends React.Component {
 						role="combobox" // eslint-disable-line jsx-a11y/role-supports-aria-props, jsx-a11y/role-has-required-aria-props
 						aria-expanded={this.getIsOpen()}
 						aria-haspopup="listbox" // eslint-disable-line jsx-a11y/aria-proptypes
-						role="combobox"
 					>
 						<InnerInput
 							defaultValue={props.defaultValue}

--- a/components/date-picker/__tests__/__snapshots__/datepicker.dom-snapshot-test.jsx.snap
+++ b/components/date-picker/__tests__/__snapshots__/datepicker.dom-snapshot-test.jsx.snap
@@ -170,6 +170,8 @@ exports[`Datepicker
                 className="slds-combobox_container"
               >
                 <div
+                  aria-expanded={false}
+                  aria-haspopup="listbox"
                   className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-shrink-none"
                   role="combobox"
                 >
@@ -180,8 +182,6 @@ exports[`Datepicker
                     <input
                       aria-activedescendant={null}
                       aria-autocomplete="list"
-                      aria-expanded={false}
-                      aria-haspopup="listbox"
                       autoComplete="off"
                       className="slds-input slds-combobox__input"
                       disabled={false}
@@ -194,7 +194,7 @@ exports[`Datepicker
                       placeholder="Select an Option"
                       readOnly={true}
                       required={false}
-                      role="combobox"
+                      role="textbox"
                       type="text"
                       value="2007"
                     />
@@ -1034,6 +1034,8 @@ exports[`Datepicker
                   className="slds-combobox_container"
                 >
                   <div
+                    aria-expanded={false}
+                    aria-haspopup="listbox"
                     className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-shrink-none"
                     role="combobox"
                   >
@@ -1044,8 +1046,6 @@ exports[`Datepicker
                       <input
                         aria-activedescendant={null}
                         aria-autocomplete="list"
-                        aria-expanded={false}
-                        aria-haspopup="listbox"
                         autoComplete="off"
                         className="slds-input slds-combobox__input"
                         disabled={false}
@@ -1058,7 +1058,7 @@ exports[`Datepicker
                         placeholder="Select an Option"
                         readOnly={true}
                         required={false}
-                        role="combobox"
+                        role="textbox"
                         type="text"
                         value="2007"
                       />
@@ -1897,6 +1897,8 @@ exports[`Datepicker
                 className="slds-combobox_container"
               >
                 <div
+                  aria-expanded={false}
+                  aria-haspopup="listbox"
                   className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-shrink-none"
                   role="combobox"
                 >
@@ -1907,8 +1909,6 @@ exports[`Datepicker
                     <input
                       aria-activedescendant={null}
                       aria-autocomplete="list"
-                      aria-expanded={false}
-                      aria-haspopup="listbox"
                       autoComplete="off"
                       className="slds-input slds-combobox__input"
                       disabled={false}
@@ -1921,7 +1921,7 @@ exports[`Datepicker
                       placeholder="Select an Option"
                       readOnly={true}
                       required={false}
-                      role="combobox"
+                      role="textbox"
                       type="text"
                       value="2014"
                     />
@@ -2757,6 +2757,8 @@ exports[`Datepicker Default DOM Snapshot 1`] = `
                 className="slds-combobox_container"
               >
                 <div
+                  aria-expanded={false}
+                  aria-haspopup="listbox"
                   className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-shrink-none"
                   role="combobox"
                 >
@@ -2767,8 +2769,6 @@ exports[`Datepicker Default DOM Snapshot 1`] = `
                     <input
                       aria-activedescendant={null}
                       aria-autocomplete="list"
-                      aria-expanded={false}
-                      aria-haspopup="listbox"
                       autoComplete="off"
                       className="slds-input slds-combobox__input"
                       disabled={false}
@@ -2781,7 +2781,7 @@ exports[`Datepicker Default DOM Snapshot 1`] = `
                       placeholder="Select an Option"
                       readOnly={true}
                       required={false}
-                      role="combobox"
+                      role="textbox"
                       type="text"
                       value="2014"
                     />
@@ -3485,8 +3485,8 @@ exports[`Datepicker Default HTML Snapshot 1`] = `
           <div class=\\"slds-form-element\\"><label class=\\"slds-form-element__label slds-assistive-text\\" for=\\"sample-datepicker-year-picklist\\">Year</label>
             <div class=\\"slds-form-element__control\\">
               <div class=\\"slds-combobox_container\\">
-                <div class=\\"slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-shrink-none\\" role=\\"combobox\\">
-                  <div class=\\"slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right\\" role=\\"none\\"><input type=\\"text\\" autoComplete=\\"off\\" class=\\"slds-input slds-combobox__input\\" id=\\"sample-datepicker-year-picklist\\" placeholder=\\"Select an Option\\" readonly=\\"\\" role=\\"combobox\\" aria-autocomplete=\\"list\\" aria-expanded=\\"false\\" aria-haspopup=\\"listbox\\" value=\\"2014\\" /><span class=\\"slds-icon_container slds-input__icon slds-input__icon_right\\"><svg aria-hidden=\\"true\\" class=\\"slds-icon slds-icon_x-small slds-icon-text-default\\">
+                <div class=\\"slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-shrink-none\\" role=\\"combobox\\" aria-expanded=\\"false\\" aria-haspopup=\\"listbox\\">
+                  <div class=\\"slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right\\" role=\\"none\\"><input type=\\"text\\" autoComplete=\\"off\\" class=\\"slds-input slds-combobox__input\\" id=\\"sample-datepicker-year-picklist\\" placeholder=\\"Select an Option\\" readonly=\\"\\" role=\\"textbox\\" aria-autocomplete=\\"list\\" value=\\"2014\\" /><span class=\\"slds-icon_container slds-input__icon slds-input__icon_right\\"><svg aria-hidden=\\"true\\" class=\\"slds-icon slds-icon_x-small slds-icon-text-default\\">
                         <use href=\\"/assets/icons/utility-sprite/svg/symbols.svg#down\\"></use>
                       </svg></span></div>
                 </div>
@@ -3723,6 +3723,8 @@ exports[`ErrorPicker 1`] = `
                 className="slds-combobox_container"
               >
                 <div
+                  aria-expanded={false}
+                  aria-haspopup="listbox"
                   className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside slds-shrink-none"
                   role="combobox"
                 >
@@ -3733,8 +3735,6 @@ exports[`ErrorPicker 1`] = `
                     <input
                       aria-activedescendant={null}
                       aria-autocomplete="list"
-                      aria-expanded={false}
-                      aria-haspopup="listbox"
                       autoComplete="off"
                       className="slds-input slds-combobox__input"
                       disabled={false}
@@ -3747,7 +3747,7 @@ exports[`ErrorPicker 1`] = `
                       placeholder="Select an Option"
                       readOnly={true}
                       required={false}
-                      role="combobox"
+                      role="textbox"
                       type="text"
                       value="2014"
                     />

--- a/components/expression/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/expression/__docs__/__snapshots__/storybook-stories.storyshot
@@ -36,6 +36,8 @@ exports[`DOM snapshots SLDSExpression Initial State 1`] = `
               className="slds-combobox_container"
             >
               <div
+                aria-expanded={false}
+                aria-haspopup="listbox"
                 className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
                 role="combobox"
               >
@@ -46,8 +48,6 @@ exports[`DOM snapshots SLDSExpression Initial State 1`] = `
                   <input
                     aria-activedescendant={null}
                     aria-autocomplete="list"
-                    aria-expanded={false}
-                    aria-haspopup="listbox"
                     autoComplete="off"
                     className="slds-input slds-combobox__input"
                     disabled={false}
@@ -60,7 +60,7 @@ exports[`DOM snapshots SLDSExpression Initial State 1`] = `
                     placeholder="Select an Option"
                     readOnly={true}
                     required={false}
-                    role="combobox"
+                    role="textbox"
                     type="text"
                     value="All Conditions Are Met"
                   />
@@ -122,6 +122,8 @@ exports[`DOM snapshots SLDSExpression Initial State 1`] = `
                       className="slds-combobox_container"
                     >
                       <div
+                        aria-expanded={false}
+                        aria-haspopup="listbox"
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
                         role="combobox"
                       >
@@ -132,8 +134,6 @@ exports[`DOM snapshots SLDSExpression Initial State 1`] = `
                           <input
                             aria-activedescendant={null}
                             aria-autocomplete="list"
-                            aria-expanded={false}
-                            aria-haspopup="listbox"
                             autoComplete="off"
                             className="slds-input slds-combobox__input"
                             disabled={false}
@@ -146,7 +146,7 @@ exports[`DOM snapshots SLDSExpression Initial State 1`] = `
                             placeholder="Select an Option"
                             readOnly={true}
                             required={false}
-                            role="combobox"
+                            role="textbox"
                             type="text"
                             value=""
                           />
@@ -187,6 +187,8 @@ exports[`DOM snapshots SLDSExpression Initial State 1`] = `
                       className="slds-combobox_container"
                     >
                       <div
+                        aria-expanded={false}
+                        aria-haspopup="listbox"
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
                         role="combobox"
                       >
@@ -197,8 +199,6 @@ exports[`DOM snapshots SLDSExpression Initial State 1`] = `
                           <input
                             aria-activedescendant={null}
                             aria-autocomplete="list"
-                            aria-expanded={false}
-                            aria-haspopup="listbox"
                             autoComplete="off"
                             className="slds-input slds-combobox__input"
                             disabled={true}
@@ -211,7 +211,7 @@ exports[`DOM snapshots SLDSExpression Initial State 1`] = `
                             placeholder="Select an Option"
                             readOnly={true}
                             required={false}
-                            role="combobox"
+                            role="textbox"
                             type="text"
                             value=""
                           />
@@ -381,6 +381,8 @@ exports[`DOM snapshots SLDSExpression w/ Custom Logic 1`] = `
               className="slds-combobox_container"
             >
               <div
+                aria-expanded={false}
+                aria-haspopup="listbox"
                 className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
                 role="combobox"
               >
@@ -391,8 +393,6 @@ exports[`DOM snapshots SLDSExpression w/ Custom Logic 1`] = `
                   <input
                     aria-activedescendant={null}
                     aria-autocomplete="list"
-                    aria-expanded={false}
-                    aria-haspopup="listbox"
                     autoComplete="off"
                     className="slds-input slds-combobox__input"
                     disabled={false}
@@ -405,7 +405,7 @@ exports[`DOM snapshots SLDSExpression w/ Custom Logic 1`] = `
                     placeholder="Select an Option"
                     readOnly={true}
                     required={false}
-                    role="combobox"
+                    role="textbox"
                     type="text"
                     value="Custom Logic Is Met"
                   />
@@ -488,6 +488,8 @@ exports[`DOM snapshots SLDSExpression w/ Custom Logic 1`] = `
                       className="slds-combobox_container"
                     >
                       <div
+                        aria-expanded={false}
+                        aria-haspopup="listbox"
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
                         role="combobox"
                       >
@@ -498,8 +500,6 @@ exports[`DOM snapshots SLDSExpression w/ Custom Logic 1`] = `
                           <input
                             aria-activedescendant={null}
                             aria-autocomplete="list"
-                            aria-expanded={false}
-                            aria-haspopup="listbox"
                             autoComplete="off"
                             className="slds-input slds-combobox__input"
                             disabled={false}
@@ -512,7 +512,7 @@ exports[`DOM snapshots SLDSExpression w/ Custom Logic 1`] = `
                             placeholder="Select an Option"
                             readOnly={true}
                             required={false}
-                            role="combobox"
+                            role="textbox"
                             type="text"
                             value="Resource 1"
                           />
@@ -553,6 +553,8 @@ exports[`DOM snapshots SLDSExpression w/ Custom Logic 1`] = `
                       className="slds-combobox_container"
                     >
                       <div
+                        aria-expanded={false}
+                        aria-haspopup="listbox"
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
                         role="combobox"
                       >
@@ -563,8 +565,6 @@ exports[`DOM snapshots SLDSExpression w/ Custom Logic 1`] = `
                           <input
                             aria-activedescendant={null}
                             aria-autocomplete="list"
-                            aria-expanded={false}
-                            aria-haspopup="listbox"
                             autoComplete="off"
                             className="slds-input slds-combobox__input"
                             disabled={false}
@@ -577,7 +577,7 @@ exports[`DOM snapshots SLDSExpression w/ Custom Logic 1`] = `
                             placeholder="Select an Option"
                             readOnly={true}
                             required={false}
-                            role="combobox"
+                            role="textbox"
                             type="text"
                             value=""
                           />
@@ -706,6 +706,8 @@ exports[`DOM snapshots SLDSExpression w/ Custom Logic 1`] = `
                       className="slds-combobox_container"
                     >
                       <div
+                        aria-expanded={false}
+                        aria-haspopup="listbox"
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
                         role="combobox"
                       >
@@ -716,8 +718,6 @@ exports[`DOM snapshots SLDSExpression w/ Custom Logic 1`] = `
                           <input
                             aria-activedescendant={null}
                             aria-autocomplete="list"
-                            aria-expanded={false}
-                            aria-haspopup="listbox"
                             autoComplete="off"
                             className="slds-input slds-combobox__input"
                             disabled={false}
@@ -730,7 +730,7 @@ exports[`DOM snapshots SLDSExpression w/ Custom Logic 1`] = `
                             placeholder="Select an Option"
                             readOnly={true}
                             required={false}
-                            role="combobox"
+                            role="textbox"
                             type="text"
                             value=""
                           />
@@ -771,6 +771,8 @@ exports[`DOM snapshots SLDSExpression w/ Custom Logic 1`] = `
                       className="slds-combobox_container"
                     >
                       <div
+                        aria-expanded={false}
+                        aria-haspopup="listbox"
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
                         role="combobox"
                       >
@@ -781,8 +783,6 @@ exports[`DOM snapshots SLDSExpression w/ Custom Logic 1`] = `
                           <input
                             aria-activedescendant={null}
                             aria-autocomplete="list"
-                            aria-expanded={false}
-                            aria-haspopup="listbox"
                             autoComplete="off"
                             className="slds-input slds-combobox__input"
                             disabled={true}
@@ -795,7 +795,7 @@ exports[`DOM snapshots SLDSExpression w/ Custom Logic 1`] = `
                             placeholder="Select an Option"
                             readOnly={true}
                             required={false}
-                            role="combobox"
+                            role="textbox"
                             type="text"
                             value=""
                           />
@@ -961,6 +961,8 @@ exports[`DOM snapshots SLDSExpression w/ Formula Logic 1`] = `
             className="slds-combobox_container"
           >
             <div
+              aria-expanded={false}
+              aria-haspopup="listbox"
               className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
               role="combobox"
             >
@@ -971,8 +973,6 @@ exports[`DOM snapshots SLDSExpression w/ Formula Logic 1`] = `
                 <input
                   aria-activedescendant={null}
                   aria-autocomplete="list"
-                  aria-expanded={false}
-                  aria-haspopup="listbox"
                   autoComplete="off"
                   className="slds-input slds-combobox__input"
                   disabled={false}
@@ -985,7 +985,7 @@ exports[`DOM snapshots SLDSExpression w/ Formula Logic 1`] = `
                   placeholder="Select an Option"
                   readOnly={true}
                   required={false}
-                  role="combobox"
+                  role="textbox"
                   type="text"
                   value="Formula Evaluates To True"
                 />
@@ -1048,6 +1048,8 @@ exports[`DOM snapshots SLDSExpression w/ Formula Logic 1`] = `
                       className="slds-combobox_container"
                     >
                       <div
+                        aria-expanded={false}
+                        aria-haspopup="listbox"
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
                         role="combobox"
                       >
@@ -1058,8 +1060,6 @@ exports[`DOM snapshots SLDSExpression w/ Formula Logic 1`] = `
                           <input
                             aria-activedescendant={null}
                             aria-autocomplete="list"
-                            aria-expanded={false}
-                            aria-haspopup="listbox"
                             autoComplete="off"
                             className="slds-input slds-combobox__input"
                             disabled={false}
@@ -1072,7 +1072,7 @@ exports[`DOM snapshots SLDSExpression w/ Formula Logic 1`] = `
                             placeholder="Insert a Resource"
                             readOnly={false}
                             required={false}
-                            role="combobox"
+                            role="textbox"
                             type="text"
                           />
                           <svg
@@ -1108,6 +1108,8 @@ exports[`DOM snapshots SLDSExpression w/ Formula Logic 1`] = `
                       className="slds-combobox_container"
                     >
                       <div
+                        aria-expanded={false}
+                        aria-haspopup="listbox"
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
                         role="combobox"
                       >
@@ -1118,8 +1120,6 @@ exports[`DOM snapshots SLDSExpression w/ Formula Logic 1`] = `
                           <input
                             aria-activedescendant={null}
                             aria-autocomplete="list"
-                            aria-expanded={false}
-                            aria-haspopup="listbox"
                             autoComplete="off"
                             className="slds-input slds-combobox__input"
                             disabled={false}
@@ -1132,7 +1132,7 @@ exports[`DOM snapshots SLDSExpression w/ Formula Logic 1`] = `
                             placeholder="Insert a Function"
                             readOnly={false}
                             required={false}
-                            role="combobox"
+                            role="textbox"
                             type="text"
                           />
                           <svg
@@ -1279,6 +1279,8 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
               className="slds-combobox_container"
             >
               <div
+                aria-expanded={false}
+                aria-haspopup="listbox"
                 className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
                 role="combobox"
               >
@@ -1289,8 +1291,6 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                   <input
                     aria-activedescendant={null}
                     aria-autocomplete="list"
-                    aria-expanded={false}
-                    aria-haspopup="listbox"
                     autoComplete="off"
                     className="slds-input slds-combobox__input"
                     disabled={false}
@@ -1303,7 +1303,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                     placeholder="Select an Option"
                     readOnly={true}
                     required={false}
-                    role="combobox"
+                    role="textbox"
                     type="text"
                     value="All Conditions Are Met"
                   />
@@ -1365,6 +1365,8 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                       className="slds-combobox_container"
                     >
                       <div
+                        aria-expanded={false}
+                        aria-haspopup="listbox"
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
                         role="combobox"
                       >
@@ -1375,8 +1377,6 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                           <input
                             aria-activedescendant={null}
                             aria-autocomplete="list"
-                            aria-expanded={false}
-                            aria-haspopup="listbox"
                             autoComplete="off"
                             className="slds-input slds-combobox__input"
                             disabled={false}
@@ -1389,7 +1389,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                             placeholder="Select an Option"
                             readOnly={true}
                             required={false}
-                            role="combobox"
+                            role="textbox"
                             type="text"
                             value="Resource 1"
                           />
@@ -1430,6 +1430,8 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                       className="slds-combobox_container"
                     >
                       <div
+                        aria-expanded={false}
+                        aria-haspopup="listbox"
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
                         role="combobox"
                       >
@@ -1440,8 +1442,6 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                           <input
                             aria-activedescendant={null}
                             aria-autocomplete="list"
-                            aria-expanded={false}
-                            aria-haspopup="listbox"
                             autoComplete="off"
                             className="slds-input slds-combobox__input"
                             disabled={false}
@@ -1454,7 +1454,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                             placeholder="Select an Option"
                             readOnly={true}
                             required={false}
-                            role="combobox"
+                            role="textbox"
                             type="text"
                             value=""
                           />
@@ -1578,6 +1578,8 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                     className="slds-combobox_container"
                   >
                     <div
+                      aria-expanded={false}
+                      aria-haspopup="listbox"
                       className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
                       role="combobox"
                     >
@@ -1588,8 +1590,6 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                         <input
                           aria-activedescendant={null}
                           aria-autocomplete="list"
-                          aria-expanded={false}
-                          aria-haspopup="listbox"
                           autoComplete="off"
                           className="slds-input slds-combobox__input"
                           disabled={false}
@@ -1602,7 +1602,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                           placeholder="Select an Option"
                           readOnly={true}
                           required={false}
-                          role="combobox"
+                          role="textbox"
                           type="text"
                           value="Any Condition Is Met"
                         />
@@ -1664,6 +1664,8 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                             className="slds-combobox_container"
                           >
                             <div
+                              aria-expanded={false}
+                              aria-haspopup="listbox"
                               className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
                               role="combobox"
                             >
@@ -1674,8 +1676,6 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                                 <input
                                   aria-activedescendant={null}
                                   aria-autocomplete="list"
-                                  aria-expanded={false}
-                                  aria-haspopup="listbox"
                                   autoComplete="off"
                                   className="slds-input slds-combobox__input"
                                   disabled={false}
@@ -1688,7 +1688,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                                   placeholder="Select an Option"
                                   readOnly={true}
                                   required={false}
-                                  role="combobox"
+                                  role="textbox"
                                   type="text"
                                   value="Resource 1"
                                 />
@@ -1729,6 +1729,8 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                             className="slds-combobox_container"
                           >
                             <div
+                              aria-expanded={false}
+                              aria-haspopup="listbox"
                               className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
                               role="combobox"
                             >
@@ -1739,8 +1741,6 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                                 <input
                                   aria-activedescendant={null}
                                   aria-autocomplete="list"
-                                  aria-expanded={false}
-                                  aria-haspopup="listbox"
                                   autoComplete="off"
                                   className="slds-input slds-combobox__input"
                                   disabled={false}
@@ -1753,7 +1753,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                                   placeholder="Select an Option"
                                   readOnly={true}
                                   required={false}
-                                  role="combobox"
+                                  role="textbox"
                                   type="text"
                                   value=""
                                 />
@@ -1882,6 +1882,8 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                             className="slds-combobox_container"
                           >
                             <div
+                              aria-expanded={false}
+                              aria-haspopup="listbox"
                               className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
                               role="combobox"
                             >
@@ -1892,8 +1894,6 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                                 <input
                                   aria-activedescendant={null}
                                   aria-autocomplete="list"
-                                  aria-expanded={false}
-                                  aria-haspopup="listbox"
                                   autoComplete="off"
                                   className="slds-input slds-combobox__input"
                                   disabled={false}
@@ -1906,7 +1906,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                                   placeholder="Select an Option"
                                   readOnly={true}
                                   required={false}
-                                  role="combobox"
+                                  role="textbox"
                                   type="text"
                                   value=""
                                 />
@@ -1947,6 +1947,8 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                             className="slds-combobox_container"
                           >
                             <div
+                              aria-expanded={false}
+                              aria-haspopup="listbox"
                               className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
                               role="combobox"
                             >
@@ -1957,8 +1959,6 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                                 <input
                                   aria-activedescendant={null}
                                   aria-autocomplete="list"
-                                  aria-expanded={false}
-                                  aria-haspopup="listbox"
                                   autoComplete="off"
                                   className="slds-input slds-combobox__input"
                                   disabled={true}
@@ -1971,7 +1971,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                                   placeholder="Select an Option"
                                   readOnly={true}
                                   required={false}
-                                  role="combobox"
+                                  role="textbox"
                                   type="text"
                                   value=""
                                 />
@@ -2119,6 +2119,8 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                     className="slds-combobox_container"
                   >
                     <div
+                      aria-expanded={false}
+                      aria-haspopup="listbox"
                       className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
                       role="combobox"
                     >
@@ -2129,8 +2131,6 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                         <input
                           aria-activedescendant={null}
                           aria-autocomplete="list"
-                          aria-expanded={false}
-                          aria-haspopup="listbox"
                           autoComplete="off"
                           className="slds-input slds-combobox__input"
                           disabled={false}
@@ -2143,7 +2143,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                           placeholder="Select an Option"
                           readOnly={true}
                           required={false}
-                          role="combobox"
+                          role="textbox"
                           type="text"
                           value="Custom Logic Is Met"
                         />
@@ -2226,6 +2226,8 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                             className="slds-combobox_container"
                           >
                             <div
+                              aria-expanded={false}
+                              aria-haspopup="listbox"
                               className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
                               role="combobox"
                             >
@@ -2236,8 +2238,6 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                                 <input
                                   aria-activedescendant={null}
                                   aria-autocomplete="list"
-                                  aria-expanded={false}
-                                  aria-haspopup="listbox"
                                   autoComplete="off"
                                   className="slds-input slds-combobox__input"
                                   disabled={false}
@@ -2250,7 +2250,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                                   placeholder="Select an Option"
                                   readOnly={true}
                                   required={false}
-                                  role="combobox"
+                                  role="textbox"
                                   type="text"
                                   value="Resource 1"
                                 />
@@ -2291,6 +2291,8 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                             className="slds-combobox_container"
                           >
                             <div
+                              aria-expanded={false}
+                              aria-haspopup="listbox"
                               className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
                               role="combobox"
                             >
@@ -2301,8 +2303,6 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                                 <input
                                   aria-activedescendant={null}
                                   aria-autocomplete="list"
-                                  aria-expanded={false}
-                                  aria-haspopup="listbox"
                                   autoComplete="off"
                                   className="slds-input slds-combobox__input"
                                   disabled={false}
@@ -2315,7 +2315,7 @@ exports[`DOM snapshots SLDSExpression w/ Group 1`] = `
                                   placeholder="Select an Option"
                                   readOnly={true}
                                   required={false}
-                                  role="combobox"
+                                  role="textbox"
                                   type="text"
                                   value=""
                                 />
@@ -2509,6 +2509,8 @@ exports[`DOM snapshots SLDSExpression w/ Multiple Conditions 1`] = `
               className="slds-combobox_container"
             >
               <div
+                aria-expanded={false}
+                aria-haspopup="listbox"
                 className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
                 role="combobox"
               >
@@ -2519,8 +2521,6 @@ exports[`DOM snapshots SLDSExpression w/ Multiple Conditions 1`] = `
                   <input
                     aria-activedescendant={null}
                     aria-autocomplete="list"
-                    aria-expanded={false}
-                    aria-haspopup="listbox"
                     autoComplete="off"
                     className="slds-input slds-combobox__input"
                     disabled={false}
@@ -2533,7 +2533,7 @@ exports[`DOM snapshots SLDSExpression w/ Multiple Conditions 1`] = `
                     placeholder="Select an Option"
                     readOnly={true}
                     required={false}
-                    role="combobox"
+                    role="textbox"
                     type="text"
                     value="Any Condition Is Met"
                   />
@@ -2595,6 +2595,8 @@ exports[`DOM snapshots SLDSExpression w/ Multiple Conditions 1`] = `
                       className="slds-combobox_container"
                     >
                       <div
+                        aria-expanded={false}
+                        aria-haspopup="listbox"
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
                         role="combobox"
                       >
@@ -2605,8 +2607,6 @@ exports[`DOM snapshots SLDSExpression w/ Multiple Conditions 1`] = `
                           <input
                             aria-activedescendant={null}
                             aria-autocomplete="list"
-                            aria-expanded={false}
-                            aria-haspopup="listbox"
                             autoComplete="off"
                             className="slds-input slds-combobox__input"
                             disabled={false}
@@ -2619,7 +2619,7 @@ exports[`DOM snapshots SLDSExpression w/ Multiple Conditions 1`] = `
                             placeholder="Select an Option"
                             readOnly={true}
                             required={false}
-                            role="combobox"
+                            role="textbox"
                             type="text"
                             value="Resource 1"
                           />
@@ -2660,6 +2660,8 @@ exports[`DOM snapshots SLDSExpression w/ Multiple Conditions 1`] = `
                       className="slds-combobox_container"
                     >
                       <div
+                        aria-expanded={false}
+                        aria-haspopup="listbox"
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
                         role="combobox"
                       >
@@ -2670,8 +2672,6 @@ exports[`DOM snapshots SLDSExpression w/ Multiple Conditions 1`] = `
                           <input
                             aria-activedescendant={null}
                             aria-autocomplete="list"
-                            aria-expanded={false}
-                            aria-haspopup="listbox"
                             autoComplete="off"
                             className="slds-input slds-combobox__input"
                             disabled={false}
@@ -2684,7 +2684,7 @@ exports[`DOM snapshots SLDSExpression w/ Multiple Conditions 1`] = `
                             placeholder="Select an Option"
                             readOnly={true}
                             required={false}
-                            role="combobox"
+                            role="textbox"
                             type="text"
                             value=""
                           />
@@ -2813,6 +2813,8 @@ exports[`DOM snapshots SLDSExpression w/ Multiple Conditions 1`] = `
                       className="slds-combobox_container"
                     >
                       <div
+                        aria-expanded={false}
+                        aria-haspopup="listbox"
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
                         role="combobox"
                       >
@@ -2823,8 +2825,6 @@ exports[`DOM snapshots SLDSExpression w/ Multiple Conditions 1`] = `
                           <input
                             aria-activedescendant={null}
                             aria-autocomplete="list"
-                            aria-expanded={false}
-                            aria-haspopup="listbox"
                             autoComplete="off"
                             className="slds-input slds-combobox__input"
                             disabled={false}
@@ -2837,7 +2837,7 @@ exports[`DOM snapshots SLDSExpression w/ Multiple Conditions 1`] = `
                             placeholder="Select an Option"
                             readOnly={true}
                             required={false}
-                            role="combobox"
+                            role="textbox"
                             type="text"
                             value="Resource 2"
                           />
@@ -2878,6 +2878,8 @@ exports[`DOM snapshots SLDSExpression w/ Multiple Conditions 1`] = `
                       className="slds-combobox_container"
                     >
                       <div
+                        aria-expanded={false}
+                        aria-haspopup="listbox"
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
                         role="combobox"
                       >
@@ -2888,8 +2890,6 @@ exports[`DOM snapshots SLDSExpression w/ Multiple Conditions 1`] = `
                           <input
                             aria-activedescendant={null}
                             aria-autocomplete="list"
-                            aria-expanded={false}
-                            aria-haspopup="listbox"
                             autoComplete="off"
                             className="slds-input slds-combobox__input"
                             disabled={false}
@@ -2902,7 +2902,7 @@ exports[`DOM snapshots SLDSExpression w/ Multiple Conditions 1`] = `
                             placeholder="Select an Option"
                             readOnly={true}
                             required={false}
-                            role="combobox"
+                            role="textbox"
                             type="text"
                             value=""
                           />
@@ -3072,6 +3072,8 @@ exports[`DOM snapshots SLDSExpression w/ Resource Selected 1`] = `
               className="slds-combobox_container"
             >
               <div
+                aria-expanded={false}
+                aria-haspopup="listbox"
                 className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
                 role="combobox"
               >
@@ -3082,8 +3084,6 @@ exports[`DOM snapshots SLDSExpression w/ Resource Selected 1`] = `
                   <input
                     aria-activedescendant={null}
                     aria-autocomplete="list"
-                    aria-expanded={false}
-                    aria-haspopup="listbox"
                     autoComplete="off"
                     className="slds-input slds-combobox__input"
                     disabled={false}
@@ -3096,7 +3096,7 @@ exports[`DOM snapshots SLDSExpression w/ Resource Selected 1`] = `
                     placeholder="Select an Option"
                     readOnly={true}
                     required={false}
-                    role="combobox"
+                    role="textbox"
                     type="text"
                     value="All Conditions Are Met"
                   />
@@ -3158,6 +3158,8 @@ exports[`DOM snapshots SLDSExpression w/ Resource Selected 1`] = `
                       className="slds-combobox_container"
                     >
                       <div
+                        aria-expanded={false}
+                        aria-haspopup="listbox"
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
                         role="combobox"
                       >
@@ -3168,8 +3170,6 @@ exports[`DOM snapshots SLDSExpression w/ Resource Selected 1`] = `
                           <input
                             aria-activedescendant={null}
                             aria-autocomplete="list"
-                            aria-expanded={false}
-                            aria-haspopup="listbox"
                             autoComplete="off"
                             className="slds-input slds-combobox__input"
                             disabled={false}
@@ -3182,7 +3182,7 @@ exports[`DOM snapshots SLDSExpression w/ Resource Selected 1`] = `
                             placeholder="Select an Option"
                             readOnly={true}
                             required={false}
-                            role="combobox"
+                            role="textbox"
                             type="text"
                             value="Resource 1"
                           />
@@ -3223,6 +3223,8 @@ exports[`DOM snapshots SLDSExpression w/ Resource Selected 1`] = `
                       className="slds-combobox_container"
                     >
                       <div
+                        aria-expanded={false}
+                        aria-haspopup="listbox"
                         className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
                         role="combobox"
                       >
@@ -3233,8 +3235,6 @@ exports[`DOM snapshots SLDSExpression w/ Resource Selected 1`] = `
                           <input
                             aria-activedescendant={null}
                             aria-autocomplete="list"
-                            aria-expanded={false}
-                            aria-haspopup="listbox"
                             autoComplete="off"
                             className="slds-input slds-combobox__input"
                             disabled={false}
@@ -3247,7 +3247,7 @@ exports[`DOM snapshots SLDSExpression w/ Resource Selected 1`] = `
                             placeholder="Select an Option"
                             readOnly={true}
                             required={false}
-                            role="combobox"
+                            role="textbox"
                             type="text"
                             value=""
                           />

--- a/components/global-header/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/global-header/__docs__/__snapshots__/storybook-stories.storyshot
@@ -55,6 +55,8 @@ exports[`DOM snapshots SLDSGlobalHeader Doc site Default 1`] = `
               className="slds-combobox_container"
             >
               <div
+                aria-expanded={false}
+                aria-haspopup="listbox"
                 className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
                 role="combobox"
               >
@@ -65,8 +67,6 @@ exports[`DOM snapshots SLDSGlobalHeader Doc site Default 1`] = `
                   <input
                     aria-activedescendant={null}
                     aria-autocomplete="list"
-                    aria-expanded={false}
-                    aria-haspopup="listbox"
                     autoComplete="off"
                     className="slds-input slds-combobox__input"
                     id="header-search-custom-id"
@@ -78,7 +78,7 @@ exports[`DOM snapshots SLDSGlobalHeader Doc site Default 1`] = `
                     placeholder="Search Salesforce"
                     readOnly={false}
                     required={false}
-                    role="combobox"
+                    role="textbox"
                     type="text"
                   />
                   <svg
@@ -547,6 +547,8 @@ exports[`DOM snapshots SLDSGlobalHeader Search + Navigation 1`] = `
               className="slds-combobox_container"
             >
               <div
+                aria-expanded={false}
+                aria-haspopup="listbox"
                 className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
                 role="combobox"
               >
@@ -557,8 +559,6 @@ exports[`DOM snapshots SLDSGlobalHeader Search + Navigation 1`] = `
                   <input
                     aria-activedescendant={null}
                     aria-autocomplete="list"
-                    aria-expanded={false}
-                    aria-haspopup="listbox"
                     autoComplete="off"
                     className="slds-input slds-combobox__input"
                     id="header-search-custom-id"
@@ -570,7 +570,7 @@ exports[`DOM snapshots SLDSGlobalHeader Search + Navigation 1`] = `
                     placeholder="Search Salesforce"
                     readOnly={false}
                     required={false}
-                    role="combobox"
+                    role="textbox"
                     type="text"
                   />
                   <svg
@@ -930,6 +930,8 @@ exports[`DOM snapshots SLDSGlobalHeader With custom <Avatar/> 1`] = `
               className="slds-combobox_container"
             >
               <div
+                aria-expanded={false}
+                aria-haspopup="listbox"
                 className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
                 role="combobox"
               >
@@ -940,8 +942,6 @@ exports[`DOM snapshots SLDSGlobalHeader With custom <Avatar/> 1`] = `
                   <input
                     aria-activedescendant={null}
                     aria-autocomplete="list"
-                    aria-expanded={false}
-                    aria-haspopup="listbox"
                     autoComplete="off"
                     className="slds-input slds-combobox__input"
                     id="header-search-custom-id"
@@ -953,7 +953,7 @@ exports[`DOM snapshots SLDSGlobalHeader With custom <Avatar/> 1`] = `
                     placeholder="Search Salesforce"
                     readOnly={false}
                     required={false}
-                    role="combobox"
+                    role="textbox"
                     type="text"
                   />
                   <svg

--- a/components/portal-settings/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/portal-settings/__docs__/__snapshots__/storybook-stories.storyshot
@@ -20,6 +20,8 @@ exports[`DOM snapshots SLDSPortalSettings Default, not used 1`] = `
         className="slds-combobox_container"
       >
         <div
+          aria-expanded={false}
+          aria-haspopup="listbox"
           className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
           role="combobox"
         >
@@ -30,8 +32,6 @@ exports[`DOM snapshots SLDSPortalSettings Default, not used 1`] = `
             <input
               aria-activedescendant={null}
               aria-autocomplete="list"
-              aria-expanded={false}
-              aria-haspopup="listbox"
               autoComplete="off"
               className="slds-input slds-combobox__input"
               id="combobox-base"
@@ -43,7 +43,7 @@ exports[`DOM snapshots SLDSPortalSettings Default, not used 1`] = `
               placeholder="Search Salesforce"
               readOnly={false}
               required={false}
-              role="combobox"
+              role="textbox"
               type="text"
               value=""
             />
@@ -234,6 +234,8 @@ exports[`DOM snapshots SLDSPortalSettings Override 1`] = `
           className="slds-combobox_container"
         >
           <div
+            aria-expanded={false}
+            aria-haspopup="listbox"
             className="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click ignore-react-onclickoutside"
             role="combobox"
           >
@@ -244,8 +246,6 @@ exports[`DOM snapshots SLDSPortalSettings Override 1`] = `
               <input
                 aria-activedescendant={null}
                 aria-autocomplete="list"
-                aria-expanded={false}
-                aria-haspopup="listbox"
                 autoComplete="off"
                 className="slds-input slds-combobox__input"
                 id="combobox-base"
@@ -257,7 +257,7 @@ exports[`DOM snapshots SLDSPortalSettings Override 1`] = `
                 placeholder="Search Salesforce"
                 readOnly={false}
                 required={false}
-                role="combobox"
+                role="textbox"
                 type="text"
                 value=""
               />


### PR DESCRIPTION
This reverts commit 2b249fcae550465f56ef56d6fca683b368ff1d99.

and moves Combobox back to ARIA 1.1 spec

Fixes #2971

### Additional description

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [ ] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [x] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] CircleCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
