### PR TITLE
fix event propagation for combobox

### DIFF
--- a/components/combobox/__tests__/combobox.browser-test.jsx
+++ b/components/combobox/__tests__/combobox.browser-test.jsx
@@ -31,6 +31,8 @@ import IconSettings from '../../../components/icon-settings';
  */
 chai.use(chaiEnzyme());
 
+const callbacks = require('../../../utilities/key-callbacks');
+
 const accounts = [
 	{
 		id: '1',
@@ -479,6 +481,22 @@ describe('SLDSCombobox', function describeFunction() {
 
 			const { scrollTop: scrollTop2 } = nodes.menuListbox.instance();
 			expect(scrollTop2 === 4 || scrollTop2 === 0).to.eql(true); // done because menu and menu item size in phantomjs is weird
+		});
+
+		it('propagates keyboard events when menu is closed', function () {
+			const spiedCallbacks = sinon.spy(callbacks, 'default');
+			wrapper = mount(<DemoComponent variant="inline-listbox" />, {
+				attachTo: mountNode,
+			});
+			const nodes = getNodes({ wrapper });
+			// click in the input to open up menu
+			nodes.input.simulate('click', {});
+			// esc to close the menu and stop event propagation
+			nodes.input.simulate('keyDown', keyObjects.ESCAPE);
+			expect(spiedCallbacks.getCall(0).lastArg.stopPropagation).to.equal(true);
+			// esc to propagate the events further up
+			nodes.input.simulate('keyDown', keyObjects.ESCAPE);
+			expect(spiedCallbacks.getCall(1).lastArg.stopPropagation).to.equal(false);
 		});
 	});
 

--- a/components/combobox/combobox.jsx
+++ b/components/combobox/combobox.jsx
@@ -804,8 +804,11 @@ class Combobox extends React.Component {
 			};
 		}
 
+		// Propagate events when menu is closed
+		const stopPropagation = this.getIsOpen();
+
 		// Helper function that takes an object literal of callbacks that are triggered with a key event
-		mapKeyEventCallbacks(event, { callbacks });
+		mapKeyEventCallbacks(event, { callbacks, stopPropagation });
 	};
 
 	handleKeyDownDown = (event) => {


### PR DESCRIPTION
Fixes #

Combobox keyboard events such as ESC are not getting propagated further up even when drop-down menu is in closed status (Refer to the below clip). This fix will bubble up such events when the menu is in closed state.

![](https://files.slack.com/files-pri/T7T5PNK3P-F02T33CQUUR/2022-01-04_14-49-53__1_.gif)

### Additional description

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [x] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [x] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [x] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] CircleCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
