### PR TITLE
Fix: ColorPicker typescript definition events did not match propTypes

### DIFF
--- a/components/color-picker.d.ts
+++ b/components/color-picker.d.ts
@@ -1,5 +1,8 @@
 declare module '@salesforce/design-system-react/components/color-picker' {
 	import React from 'react';
+
+	type OnRequestCloseTriggerTypes = 'cancel' | 'clickOutside' | 'newPopover';
+
 	type Props = {
 		/**
 		 * **Assistive text for accessibility**
@@ -40,7 +43,7 @@ declare module '@salesforce/design-system-react/components/color-picker' {
 		/**
 		 * Event Callbacks
 		 * * `onChange`: This function is triggered when done is clicked. This function returns `{event, { color: [string] }}`, which is a hex representation of the color.
-		 * * `onClose`: This function is triggered when the menu is closed. This function returns `{event, { trigger, componentWillUnmount }}`. Trigger can have the values `cancel`, `clickOutside`, or `newPopover`.
+		 * * `onClose`: This function is triggered when the menu is closed. This function returns `{event, { componentWillUnmount }}`.
 		 * * `onOpen`: This function is triggered when the color-picker menu is mounted and added to the DOM. The parameters are `event, { portal: }`. `portal` can be used as a React tree root node.
 		 * * `onRequestClose`:  This function is triggered when the user clicks outside the menu or clicks the close button. You will want to define this if color-picker is to be a controlled component. Most of the time you will want to set `isOpen` to `false` when this is triggered unless you need to validate something.
 		 * 						This function returns `{event, {trigger: [string]}}` where `trigger` is either `cancel` or `clickOutside`.
@@ -51,14 +54,26 @@ declare module '@salesforce/design-system-react/components/color-picker' {
 		 * _Tested with Mocha framework._
 		 */
 		events?: Partial<{
-			onChange?: (v: any) => any;
-			onClose?: (v: any) => any;
-			onOpen?: (v: any) => any;
-			onRequestClose?: (v: any) => any;
-			onRequestOpen?: (v: any) => any;
-			onValidateColor?: (v: any) => any;
-			onValidateWorkingColor?: (v: any) => any;
-			onWorkingColorChange?: (v: any) => any;
+			onChange?: (
+				event: React.ChangeEvent<HTMLInputElement>,
+				{ color: string, isValid: boolean }
+			) => void;
+			onClose?: (
+				event: React.ChangeEvent<HTMLInputElement>,
+				{ componentWillUnmount: boolean }
+			) => void;
+			onOpen?: (v: undefined, { portal: HTMLElement }) => void;
+			onRequestClose?: (
+				event: React.ChangeEvent<HTMLInputElement> | undefined,
+				{ trigger: OnRequestCloseTriggerTypes }
+			) => void;
+			onRequestOpen?: () => void;
+			onValidateColor?: (color: string) => boolean;
+			onValidateWorkingColor?: (color: string) => boolean;
+			onWorkingColorChange?: (
+				event: React.ChangeEvent<HTMLInputElement>,
+				{ color: string }
+			) => void;
 		}>;
 		/**
 		 * By default, dialogs will flip their alignment (such as bottom to top) if they extend beyond a boundary element such as a scrolling parent or a window/viewpoint. `hasStaticAlignment` disables this behavior and allows this component to extend beyond boundary elements. _Not tested._


### PR DESCRIPTION
Fixes #3008 

### Additional description

Took a first stab at it, let me know if you see anything else.

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [x] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [x] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [x] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] CircleCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
