### PR TITLE
add title support for combobox multiple selections

### DIFF
--- a/components/combobox/combobox.d.ts
+++ b/components/combobox/combobox.d.ts
@@ -162,6 +162,7 @@ declare module '@salesforce/design-system-react/components/combobox/combobox' {
 		 * * `id`: A unique identifier string.
 		 * * `label`: A primary string of text for a menu item or group separator.
 		 * * `subTitle`: A secondary string of text added for clarity. (optional)
+		 * * `title`: A string of text shown as the title of the selected item (optional)
 		 * * `type`: 'separator' is the only type currently used
 		 * * `disabled`: Set to true to disable this menu item.
 		 * * `tooltipContent`: Content that is displayed in tooltip when item is disabled
@@ -170,6 +171,7 @@ declare module '@salesforce/design-system-react/components/combobox/combobox' {
 		 * 	id: '2',
 		 * 	label: 'Salesforce.com, Inc.',
 		 * 	subTitle: 'Account • San Francisco',
+		 * 	title: 'Salesforce',
 		 * 	type: 'account',
 		 *  disabled: true,
 		 *  tooltipContent: "You don't have permission to select this item."
@@ -182,6 +184,7 @@ declare module '@salesforce/design-system-react/components/combobox/combobox' {
 			icon?: React.ReactNode;
 			label?: string;
 			subTitle?: string;
+			title?: string;
 			type?: string;
 			disabled?: boolean;
 			tooltipContent?: React.ReactNode;

--- a/components/combobox/combobox.jsx
+++ b/components/combobox/combobox.jsx
@@ -244,7 +244,7 @@ const propTypes = {
 	 * 	id: '2',
 	 * 	label: 'Salesforce.com, Inc.',
 	 * 	subTitle: 'Account • San Francisco',
-	 *  title: 'Salesforce',
+	 * 	title: 'Salesforce',
 	 * 	type: 'account',
 	 *  disabled: true,
 	 *  tooltipContent: "You don't have permission to select this item."

--- a/components/combobox/combobox.jsx
+++ b/components/combobox/combobox.jsx
@@ -235,6 +235,7 @@ const propTypes = {
 	 * * `id`: A unique identifier string.
 	 * * `label`: A primary string of text for a menu item or group separator.
 	 * * `subTitle`: A secondary string of text added for clarity. (optional)
+	 * * `title`: A string of text shown as the title of the selected item (optional)
 	 * * `type`: 'separator' is the only type currently used
 	 * * `disabled`: Set to true to disable this menu item.
 	 * * `tooltipContent`: Content that is displayed in tooltip when item is disabled
@@ -243,6 +244,7 @@ const propTypes = {
 	 * 	id: '2',
 	 * 	label: 'Salesforce.com, Inc.',
 	 * 	subTitle: 'Account • San Francisco',
+	 *  title: 'Salesforce',
 	 * 	type: 'account',
 	 *  disabled: true,
 	 *  tooltipContent: "You don't have permission to select this item."
@@ -256,6 +258,7 @@ const propTypes = {
 			icon: PropTypes.node,
 			label: PropTypes.string,
 			subTitle: PropTypes.string,
+			title: PropTypes.string,
 			type: PropTypes.string,
 			disabled: PropTypes.boolean,
 			tooltipContent: PropTypes.node,

--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -4958,6 +4958,10 @@
                                 "name": "string",
                                 "required": false
                             },
+                            "title": {
+                                "name": "string",
+                                "required": false
+                            },
                             "type": {
                                 "name": "string",
                                 "required": false
@@ -4975,7 +4979,7 @@
                     }
                 },
                 "required": false,
-                "description": "**Array of item objects in the dropdown menu.**\nEach object can contain:\n* `icon`: An `Icon` component. (not used in read-only variant)\n* `id`: A unique identifier string.\n* `label`: A primary string of text for a menu item or group separator.\n* `subTitle`: A secondary string of text added for clarity. (optional)\n* `type`: 'separator' is the only type currently used\n* `disabled`: Set to true to disable this menu item.\n* `tooltipContent`: Content that is displayed in tooltip when item is disabled\n```\n{\n\tid: '2',\n\tlabel: 'Salesforce.com, Inc.',\n\tsubTitle: 'Account • San Francisco',\n\ttype: 'account',\n disabled: true,\n tooltipContent: \"You don't have permission to select this item.\"\n},\n```\nNote: At the moment, Combobox does not support two consecutive separators. _Tested with snapshot testing._"
+                "description": "**Array of item objects in the dropdown menu.**\nEach object can contain:\n* `icon`: An `Icon` component. (not used in read-only variant)\n* `id`: A unique identifier string.\n* `label`: A primary string of text for a menu item or group separator.\n* `subTitle`: A secondary string of text added for clarity. (optional)\n* `title`: A string of text shown as the title of the selected item (optional)\n* `type`: 'separator' is the only type currently used\n* `disabled`: Set to true to disable this menu item.\n* `tooltipContent`: Content that is displayed in tooltip when item is disabled\n```\n{\n\tid: '2',\n\tlabel: 'Salesforce.com, Inc.',\n\tsubTitle: 'Account • San Francisco',\n title: 'Salesforce',\n\ttype: 'account',\n disabled: true,\n tooltipContent: \"You don't have permission to select this item.\"\n},\n```\nNote: At the moment, Combobox does not support two consecutive separators. _Tested with snapshot testing._"
             },
             "menuItemVisibleLength": {
                 "type": {

--- a/components/pill-container/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/pill-container/__docs__/__snapshots__/storybook-stories.storyshot
@@ -43,7 +43,7 @@ exports[`DOM snapshots SLDSPillContainer Bare Pill Container 1`] = `
             >
               <span
                 className="slds-pill__label"
-                title="Pill Label 1"
+                title="Full pill label verbiage mirrored here"
               >
                 Pill Label 1
               </span>
@@ -89,7 +89,7 @@ exports[`DOM snapshots SLDSPillContainer Bare Pill Container 1`] = `
             >
               <span
                 className="slds-pill__label"
-                title="Pill Label 2"
+                title="Full pill label verbiage mirrored here"
               >
                 Pill Label 2
               </span>
@@ -169,7 +169,7 @@ exports[`DOM snapshots SLDSPillContainer Base Pill Container 1`] = `
             >
               <span
                 className="slds-pill__label"
-                title="Pill Label 1"
+                title="Full pill label verbiage mirrored here"
               >
                 Pill Label 1
               </span>
@@ -215,7 +215,7 @@ exports[`DOM snapshots SLDSPillContainer Base Pill Container 1`] = `
             >
               <span
                 className="slds-pill__label"
-                title="Pill Label 2"
+                title="Full pill label verbiage mirrored here"
               >
                 Pill Label 2
               </span>
@@ -311,7 +311,7 @@ exports[`DOM snapshots SLDSPillContainer Pill Container With Avatars 1`] = `
               </span>
               <span
                 className="slds-pill__label"
-                title="Pill Label 1"
+                title="Full pill label verbiage mirrored here"
               >
                 Pill Label 1
               </span>
@@ -373,7 +373,7 @@ exports[`DOM snapshots SLDSPillContainer Pill Container With Avatars 1`] = `
               </span>
               <span
                 className="slds-pill__label"
-                title="Pill Label 2"
+                title="Full pill label verbiage mirrored here"
               >
                 Pill Label 2
               </span>
@@ -471,7 +471,7 @@ exports[`DOM snapshots SLDSPillContainer Pill Container With Icons 1`] = `
               </span>
               <span
                 className="slds-pill__label"
-                title="Pill Label 1"
+                title="Full pill label verbiage mirrored here"
               >
                 Pill Label 1
               </span>
@@ -535,7 +535,7 @@ exports[`DOM snapshots SLDSPillContainer Pill Container With Icons 1`] = `
               </span>
               <span
                 className="slds-pill__label"
-                title="Pill Label 2"
+                title="Full pill label verbiage mirrored here"
               >
                 Pill Label 2
               </span>
@@ -598,7 +598,7 @@ exports[`DOM snapshots SLDSPillContainer Pill Container With Icons 1`] = `
               </span>
               <span
                 className="slds-pill__label"
-                title="Pill Label 3"
+                title="Full pill label verbiage mirrored here"
               >
                 Pill Label 3
               </span>
@@ -662,7 +662,7 @@ exports[`DOM snapshots SLDSPillContainer Pill Container With Icons 1`] = `
               </span>
               <span
                 className="slds-pill__label"
-                title="Pill Label 4"
+                title="Full pill label verbiage mirrored here"
               >
                 Pill Label 4
               </span>
@@ -726,7 +726,7 @@ exports[`DOM snapshots SLDSPillContainer Pill Container With Icons 1`] = `
               </span>
               <span
                 className="slds-pill__label"
-                title="Pill Label 5"
+                title="Full pill label verbiage mirrored here"
               >
                 Pill Label 5
               </span>
@@ -790,7 +790,7 @@ exports[`DOM snapshots SLDSPillContainer Pill Container With Icons 1`] = `
               </span>
               <span
                 className="slds-pill__label"
-                title="Pill Label 6"
+                title="Full pill label verbiage mirrored here"
               >
                 Pill Label 6
               </span>
@@ -854,7 +854,7 @@ exports[`DOM snapshots SLDSPillContainer Pill Container With Icons 1`] = `
               </span>
               <span
                 className="slds-pill__label"
-                title="Pill Label 7"
+                title="Full pill label verbiage mirrored here"
               >
                 Pill Label 7
               </span>
@@ -918,7 +918,7 @@ exports[`DOM snapshots SLDSPillContainer Pill Container With Icons 1`] = `
               </span>
               <span
                 className="slds-pill__label"
-                title="Pill Label 8"
+                title="Full pill label verbiage mirrored here"
               >
                 Pill Label 8
               </span>
@@ -982,7 +982,7 @@ exports[`DOM snapshots SLDSPillContainer Pill Container With Icons 1`] = `
               </span>
               <span
                 className="slds-pill__label"
-                title="Pill Label 9"
+                title="Full pill label verbiage mirrored here"
               >
                 Pill Label 9
               </span>

--- a/components/pill-container/private/selected-listbox.jsx
+++ b/components/pill-container/private/selected-listbox.jsx
@@ -251,7 +251,7 @@ const SelectedListBox = (props) =>
 								icon={icon}
 								labels={{
 									label: option.label,
-									title: option.title || option.label,
+									title: option.title ?? option.label,
 									removeTitle: props.labels.removePillTitle,
 								}}
 								requestFocus={props.listboxHasFocus}

--- a/components/pill-container/private/selected-listbox.jsx
+++ b/components/pill-container/private/selected-listbox.jsx
@@ -251,6 +251,7 @@ const SelectedListBox = (props) =>
 								icon={icon}
 								labels={{
 									label: option.label,
+									title: option.title || option.label,
 									removeTitle: props.labels.removePillTitle,
 								}}
 								requestFocus={props.listboxHasFocus}


### PR DESCRIPTION
### Additional description
This change is to add the ability to show different title of the the multiple selection list. Currently the `title` field is same as the label of the selected option. After that change, user is able to use an optional field `title` in the option, and it will be used  as the `title` property of the selection list

![image](https://user-images.githubusercontent.com/1280615/157299405-828d3e3c-71bc-41fd-8125-dad1e5af2f26.png)

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [X] `npm run lint:fix` has been run and linting passes.
* [X] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [X] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [X] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [X] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [X] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] CircleCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
