### PR TITLE
Fix the event handlers parameter types for the color-picker component.

### DIFF
--- a/components/color-picker.d.ts
+++ b/components/color-picker.d.ts
@@ -51,14 +51,14 @@ declare module '@salesforce/design-system-react/components/color-picker' {
 		 * _Tested with Mocha framework._
 		 */
 		events?: Partial<{
-			onChange?: (v: any) => any;
-			onClose?: (v: any) => any;
-			onOpen?: (v: any) => any;
-			onRequestClose?: (v: any) => any;
+			onChange?: (event: React.SyntheticEvent, v: any) => any;
+			onClose?: (event: React.SyntheticEvent, v: any) => any;
+			onOpen?: (event: React.SyntheticEvent, v: any) => any;
+			onRequestClose?: (event: React.SyntheticEvent, v: any) => any;
 			onRequestOpen?: (v: any) => any;
 			onValidateColor?: (v: any) => any;
 			onValidateWorkingColor?: (v: any) => any;
-			onWorkingColorChange?: (v: any) => any;
+			onWorkingColorChange?: (event: React.SyntheticEvent, v: any) => any;
 		}>;
 		/**
 		 * By default, dialogs will flip their alignment (such as bottom to top) if they extend beyond a boundary element such as a scrolling parent or a window/viewpoint. `hasStaticAlignment` disables this behavior and allows this component to extend beyond boundary elements. _Not tested._


### PR DESCRIPTION
This adds types to the additional event handler parameters needed for the event prop in the ColorPicker component, so typescript doesn't fail when type checking.

Fixes #3020 

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [x] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [x] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] CircleCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
