### PR TITLE
Update the Portal component to use the new react portal api (when overflowBoundaryElement is used for position)

### DIFF
--- a/components/utilities/dialog/portal.jsx
+++ b/components/utilities/dialog/portal.jsx
@@ -168,10 +168,6 @@ Portal.propTypes = {
 	 */
 	onMount: PropTypes.func,
 	/*
-	 * Triggers when the portal is mounted.
-	 */
-	onOpen: PropTypes.func,
-	/*
 	 * Triggers when Portal re-renders its tree.
 	 */
 	onUpdate: PropTypes.func,
@@ -198,7 +194,6 @@ Portal.defaultProps = {
 	renderTag: 'span',
 	renderTo: null,
 	onMount: () => null,
-	onOpen: () => null,
 	onUpdate: () => null,
 	onUnmount: () => null,
 };

--- a/components/utilities/dialog/portal.jsx
+++ b/components/utilities/dialog/portal.jsx
@@ -71,6 +71,7 @@ class Portal extends Component {
 				: this.portalNode;
 
 			if (!this.props.portalMount) {
+				this.updatePortal();
 				this.setState({ portalContainer: this.portalNode });
 			}
 		}

--- a/components/utilities/dialog/portal.jsx
+++ b/components/utilities/dialog/portal.jsx
@@ -126,6 +126,11 @@ class Portal extends Component {
 					this.updatePortal(); // update after subtree renders
 				},
 			});
+		} else if (this.state.isOpen === false) {
+			if (this.props.onOpen) {
+				this.props.onOpen(undefined, { portal: this.getChildren() });
+			}
+			this.setState({ isOpen: true });
 		}
 	}
 
@@ -168,6 +173,10 @@ Portal.propTypes = {
 	 */
 	onMount: PropTypes.func,
 	/*
+	 * Triggers when the portal is mounted.
+	 */
+	onOpen: PropTypes.func,
+	/*
 	 * Triggers when Portal re-renders its tree.
 	 */
 	onUpdate: PropTypes.func,
@@ -194,6 +203,7 @@ Portal.defaultProps = {
 	renderTag: 'span',
 	renderTo: null,
 	onMount: () => null,
+	onOpen: () => null,
 	onUpdate: () => null,
 	onUnmount: () => null,
 };

--- a/components/utilities/dialog/portal.jsx
+++ b/components/utilities/dialog/portal.jsx
@@ -17,6 +17,7 @@ class Portal extends Component {
 		this.portalNode = null;
 		this.state = {
 			isOpen: false,
+			portalContainer: null,
 		};
 	}
 
@@ -68,12 +69,18 @@ class Portal extends Component {
 			this.portalNodeInstance = this.props.onMount
 				? this.props.onMount(undefined, { portal: this.portalNode })
 				: this.portalNode;
+
+			if (!this.props.portalMount) {
+				this.setState({ portalContainer: this.portalNode });
+			}
 		}
 	}
 
 	unmountPortal() {
 		if (this.portalNode) {
-			ReactDOM.unmountComponentAtNode(this.portalNode);
+			if (this.portalMount) {
+				ReactDOM.unmountComponentAtNode(this.portalNode);
+			}
 			this.portalNode.parentNode.removeChild(this.portalNode);
 		}
 		this.portalNode = null;
@@ -119,28 +126,13 @@ class Portal extends Component {
 					this.updatePortal(); // update after subtree renders
 				},
 			});
-		} else {
-			// actual render
-			ReactDOM.unstable_renderSubtreeIntoContainer(
-				this,
-				this.getChildren(),
-				this.portalNode,
-				() => {
-					this.updatePortal(); // update after subtree renders
-
-					if (this.state.isOpen === false) {
-						if (this.props.onOpen) {
-							this.props.onOpen(undefined, { portal: this.getChildren() });
-						}
-						this.setState({ isOpen: true });
-					}
-				}
-			);
 		}
 	}
 
 	render() {
-		return null;
+		return !this.props.portalMount && this.state.portalContainer
+			? ReactDOM.createPortal(this.props.children, this.state.portalContainer)
+			: null;
 	}
 }
 


### PR DESCRIPTION
Fixing Portal component by switching from ReactDOM.unstable_renderSubtreeIntoContainer to React.createPortal, so that the context from PortalSettings, carries through when having multiple layers of overflowBoundaryElement.

This would also get you one step closer to using react 18 in the future, since the ReactDOM unstable_renderSubtreeIntoContainer method will be deprecated and will need to change to the react portals api.

Fixes #3028 

### Additional description

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [x] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [x] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] CircleCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
