### PR TITLE
fix: Popover should stop propagating Escape key event on closing

### DIFF
--- a/components/popover/__tests__/popover.browser-test.jsx
+++ b/components/popover/__tests__/popover.browser-test.jsx
@@ -238,6 +238,34 @@ describe('SLDSPopover', function () {
 				const trigger = wrapper.find(defaultIds.trigger);
 				trigger.simulate('click');
 			});
+
+			it('stops event propagation after closing on ESC', function (done) {
+				const mockEvent = {
+					key: 'Esc',
+					keyCode: 27,
+					which: 27,
+					stopPropagation: sinon.spy(),
+				};
+				wrapper = mount(
+					<DemoComponent
+						onOpen={() => {
+							wrapper.update();
+							const popover = wrapper.find(`#${defaultIds.popover}`);
+							popover.simulate('keyDown', mockEvent);
+						}}
+						onKeyDown={() => {
+							setTimeout(() => {
+								expect(mockEvent.stopPropagation.callCount).to.equal(1);
+								done();
+							}, 0);
+						}}
+					/>,
+					{ attachTo: mountNode }
+				);
+
+				const trigger = wrapper.find(defaultIds.trigger);
+				trigger.simulate('click');
+			});
 		});
 	});
 

--- a/utilities/keyboard-navigable-dialog.js
+++ b/utilities/keyboard-navigable-dialog.js
@@ -22,6 +22,7 @@ import ReactDOM from 'react-dom';
 
 // ### Event Helpers
 import KEYS from './key-code';
+import EventUtil from './event';
 
 /* eslint-disable react/no-find-dom-node */
 
@@ -33,6 +34,7 @@ const internalHandleClick = ({ trigger, eventTarget, handleClick }) => {
 };
 
 const KeyboardNavigableDialog = ({
+	event,
 	isOpen,
 	handleClick,
 	keyCode,
@@ -44,6 +46,7 @@ const KeyboardNavigableDialog = ({
 		case KEYS.ESCAPE:
 			if (isOpen) {
 				toggleOpen();
+				EventUtil.trapEvent(event);
 			}
 			break;
 		case KEYS.ENTER:


### PR DESCRIPTION
Fixes #3031 
Verified the updated behavior in a Popover-inside-Modal storybook example (not included in the PR).

### Additional description

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [ ] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [x] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] CircleCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
