### PR TITLE
Fix: Datepicker: Unable to enter date manually

### DIFF
--- a/components/date-picker/__tests__/date-picker.browser-test.jsx
+++ b/components/date-picker/__tests__/date-picker.browser-test.jsx
@@ -431,6 +431,130 @@ describe('SLDSDatepicker', function describeFunction() {
 				input.simulate('change', { target: { value: '1/1/2020' } });
 				expect(wrapper.find('.slds-datepicker').length).to.equal(0);
 			});
+
+			it('typing partial date resets after pressing enter', function () {
+				const handleChangeSpy = sinon.spy();
+				wrapper = mount(
+					<DemoComponent menuPosition="relative" onChange={handleChangeSpy} />
+				);
+
+				// Calendar is closed
+				expect(wrapper.find('.slds-datepicker').length).to.equal(0);
+
+				// Click on input to open the calendar
+				const trigger = wrapper.find(triggerClassSelector);
+				trigger.simulate('click', {});
+				expect(wrapper.find('.slds-datepicker').length).to.equal(1);
+
+				// Changing input value closes the calendar
+				const input = wrapper.find('input#sample-datepicker');
+
+				input.simulate('change', { target: { value: '' } });
+				input.simulate('click', {});
+				input.simulate('keyDown', { key: '9', keyCode: 49, which: 49 });
+				input.simulate('keyDown', { key: '/', keyCode: 191, which: 191 });
+				input.simulate('change', { target: { value: '9/' } });
+				expect(input.instance().value).to.equal('9/');
+				input.simulate('keyDown', {
+					key: 'Enter',
+					keyCode: KEYS.ENTER,
+					which: KEYS.ENTER,
+				});
+				expect(input.instance().value).to.equal('1/6/2007');
+				expect(handleChangeSpy.calledOnce).to.equal(true);
+			});
+
+			it('typing partial date resets after pressing escape', function () {
+				const handleChangeSpy = sinon.spy();
+				wrapper = mount(
+					<DemoComponent menuPosition="relative" onChange={handleChangeSpy} />
+				);
+
+				// Calendar is closed
+				expect(wrapper.find('.slds-datepicker').length).to.equal(0);
+
+				// Click on input to open the calendar
+				const trigger = wrapper.find(triggerClassSelector);
+				trigger.simulate('click', {});
+				expect(wrapper.find('.slds-datepicker').length).to.equal(1);
+
+				// Changing input value closes the calendar
+				const input = wrapper.find('input#sample-datepicker');
+
+				input.simulate('change', { target: { value: '' } });
+				input.simulate('click', {});
+				input.simulate('keyDown', { key: '9', keyCode: 49, which: 49 });
+				input.simulate('keyDown', { key: '/', keyCode: 191, which: 191 });
+				input.simulate('change', { target: { value: '9/' } });
+				input.simulate('change', { target: { value: '9/' } });
+				expect(input.instance().value).to.equal('9/');
+				input.simulate('keyDown', {
+					key: 'Escape',
+					keyCode: KEYS.ESCAPE,
+					which: KEYS.ESCAPE,
+				});
+				expect(input.instance().value).to.equal('1/6/2007');
+				expect(handleChangeSpy.calledOnce).to.equal(false);
+			});
+
+			it('typing complete date resets after pressing escape', function () {
+				const handleChangeSpy = sinon.spy();
+				wrapper = mount(
+					<DemoComponent menuPosition="relative" onChange={handleChangeSpy} />
+				);
+
+				// Calendar is closed
+				expect(wrapper.find('.slds-datepicker').length).to.equal(0);
+
+				// Click on input to open the calendar
+				const trigger = wrapper.find(triggerClassSelector);
+				trigger.simulate('click', {});
+				expect(wrapper.find('.slds-datepicker').length).to.equal(1);
+
+				// Changing input value closes the calendar
+				const input = wrapper.find('input#sample-datepicker');
+
+				input.simulate('change', { target: { value: '' } });
+				input.simulate('click', {});
+				input.simulate('change', { target: { value: '12/31/2007' } });
+				expect(input.instance().value).to.equal('12/31/2007');
+				input.simulate('keyDown', {
+					key: 'Escape',
+					keyCode: KEYS.ESCAPE,
+					which: KEYS.ESCAPE,
+				});
+				expect(input.instance().value).to.equal('1/6/2007');
+				expect(handleChangeSpy.calledOnce).to.equal(false);
+			});
+
+			it('typing complete date saves after pressing enter', function () {
+				const handleChangeSpy = sinon.spy();
+				wrapper = mount(
+					<DemoComponent menuPosition="relative" onChange={handleChangeSpy} />
+				);
+
+				// Calendar is closed
+				expect(wrapper.find('.slds-datepicker').length).to.equal(0);
+
+				// Click on input to open the calendar
+				const trigger = wrapper.find(triggerClassSelector);
+				trigger.simulate('click', {});
+				expect(wrapper.find('.slds-datepicker').length).to.equal(1);
+
+				// Changing input value closes the calendar
+				const input = wrapper.find('input#sample-datepicker');
+
+				input.simulate('change', { target: { value: '' } });
+				input.simulate('click', {});
+				input.simulate('change', { target: { value: '12/31/2007' } });
+				expect(input.instance().value).to.equal('12/31/2007');
+				input.simulate('keyDown', {
+					key: 'Enter',
+					keyCode: KEYS.ENTER,
+					which: KEYS.ENTER,
+				});
+				expect(handleChangeSpy.calledOnce).to.equal(true);
+			});
 		});
 	});
 

--- a/components/date-picker/date-picker.jsx
+++ b/components/date-picker/date-picker.jsx
@@ -260,23 +260,31 @@ const defaultProps = {
 class Datepicker extends React.Component {
 	constructor(props) {
 		super(props);
-		// Please remove `strValue` on the next breaking change.
-		const formattedValue = props.formattedValue || props.strValue; // eslint-disable-line react/prop-types
-		const dateString = props.formatter(props.value);
-		const initDate = props.value ? dateString : formattedValue;
-
 		this.state = {
 			isOpen: false,
 			isOpenFromIcon: false,
-			value: props.value,
-			formattedValue: initDate || '',
-			inputValue: initDate || '',
 		};
 
 		this.generatedId = shortid.generate();
 
 		// `checkProps` issues warnings to developers about properties (similar to React's built in development tools)
 		checkProps(DATE_PICKER, props, componentDoc);
+	}
+
+	static getDerivedStateFromProps(props, state) {
+		if (props.value !== state.value) {
+			const formattedValue = props.formattedValue || props.strValue; // eslint-disable-line react/prop-types
+			const dateString = props.formatter(props.value);
+			const initDate = props.value ? dateString : formattedValue;
+			return {
+				isOpen: false,
+				isOpenFromIcon: false,
+				value: props.value,
+				formattedValue: initDate || '',
+				inputValue: initDate || '',
+			};
+		}
+		return state;
 	}
 
 	getDatePicker = ({ labels, assistiveText }) => {
@@ -416,9 +424,7 @@ class Datepicker extends React.Component {
 				this.openDialog();
 			},
 			onKeyDown: this.handleKeyDown,
-			value: this.props.value
-				? this.props.formatter(this.props.value)
-				: this.state.inputValue,
+			value: this.state.inputValue,
 		};
 
 		// eslint-disable react/prop-types
@@ -512,16 +518,6 @@ class Datepicker extends React.Component {
 			formattedValue: event.target.value,
 			inputValue: event.target.value,
 		});
-
-		const date = this.props.parser(event.target.value);
-
-		if (this.props.onChange) {
-			this.props.onChange(event, {
-				date,
-				formattedDate: event.target.value,
-				timezoneOffset: date.getTimezoneOffset(),
-			});
-		}
 	};
 
 	handleKeyDown = (event) => {
@@ -535,9 +531,31 @@ class Datepicker extends React.Component {
 			this.setState({ isOpen: true });
 		}
 
-		if (event.keyCode === KEYS.ESCAPE || event.keyCode === KEYS.ENTER) {
+		if (event.keyCode === KEYS.ESCAPE) {
 			EventUtil.trapEvent(event);
-			this.setState({ isOpen: false });
+			this.setState(Datepicker.getDerivedStateFromProps(this.props, {}));
+		}
+
+		if (event.keyCode === KEYS.ENTER || event.keyCode === KEYS.TAB) {
+			const date = this.props.parser(event.target.value);
+			const formattedDate = this.props.formatter(date);
+			if (formattedDate !== 'Invalid date') {
+				this.setState({
+					value: date,
+					formattedValue: formattedDate,
+					inputValue: formattedDate,
+					isOpen: false,
+				});
+				if (this.props.onChange) {
+					this.props.onChange(event, {
+						date,
+						formattedDate,
+						timezoneOffset: date.getTimezoneOffset(),
+					});
+				}
+			} else {
+				this.setState(Datepicker.getDerivedStateFromProps(this.props, {}));
+			}
 		}
 
 		// Please remove `onKeyDown` on the next breaking change.
@@ -563,9 +581,10 @@ class Datepicker extends React.Component {
 			this.props.onRequestClose();
 		}
 
-		if (this.getIsOpen()) {
-			this.setState({ isOpen: false, isOpenFromIcon: false });
+		const wasOpen = this.getIsOpen();
+		this.setState(Datepicker.getDerivedStateFromProps(this.props, {}));
 
+		if (wasOpen) {
 			if (this.inputRef) {
 				this.inputRef.focus();
 			}


### PR DESCRIPTION
Fixes #2956

### Additional description
Previously, the DatePicker would try to format the value in the input box after every keystroke, preventing the user from actually typing out a date or changing an existing date by pressing the delete key in front of a character and replacing it with a new character. Additionally, passing in a new date value to the component did not update the value displayed in the input box.

This fix includes changes for:
* Initialization of input state variables has been moved to getDerivedStateFromProps to allow updates from parent component
* handleInputChange no longer calls parent onChange callback but instead waits until user presses ENTER or TAB
* Pressing ESCAPE from within the input box resets the component to initial state

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [x] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [x] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [x] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] CircleCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
