### PR TITLE
Prevent onSelect callback when menu-list ListItem has property 'disab…

### DIFF
--- a/components/utilities/menu-list/item.d.ts
+++ b/components/utilities/menu-list/item.d.ts
@@ -5,6 +5,7 @@ declare module '@salesforce/design-system-react/components/utilities/menu-list/i
 		className?: any[] | Record<string, any> | string;
 		checkmark?: boolean;
 		data?: Record<string, any>;
+		disabled?: boolean;
 		divider?: 'top' | 'bottom';
 		href?: string;
 		id: string /*.isRequired*/;

--- a/components/utilities/menu-list/item.jsx
+++ b/components/utilities/menu-list/item.jsx
@@ -42,6 +42,7 @@ class ListItem extends React.Component {
 		]),
 		checkmark: PropTypes.bool,
 		data: PropTypes.object,
+		disabled: PropTypes.bool,
 		divider: PropTypes.oneOf(['top', 'bottom']),
 		href: PropTypes.string,
 		id: PropTypes.string.isRequired,
@@ -136,7 +137,7 @@ class ListItem extends React.Component {
 			EventUtil.trapImmediate(event);
 		}
 
-		if (this.props.onSelect) {
+		if (this.props.onSelect && !this.props.disabled) {
 			this.props.onSelect(this.props.index);
 		}
 	};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,11 @@
 {
 	"name": "design-system-react",
-	"version": "0.10.45",
+	"version": "0.10.47",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "design-system-react",
-			"version": "0.10.45",
+			"version": "0.10.47",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@salesforce/babel-preset-design-system-react": "^3.0.0",


### PR DESCRIPTION
Fixes #2987

### Additional description
Introduced the `disabled` property in `item.d.ts` on the Props. It was already used in the menu-list but was missing from the typescript declaration. 

Changes affect the `handleClick` function.
```
	handleClick = (event) => {
		if (
			this.props.type !== 'link' ||
			this.props.href === 'javascript:void(0);' || // eslint-disable-line no-script-url
			this.props.href === '#'
		) {
			EventUtil.trapImmediate(event);
		}

		if (this.props.onSelect && !this.props.disabled) {
			this.props.onSelect(this.props.index);
		}
	};
```

The `disabled` property is used to prevent calling `onSelect`. I was unsure if it also should call `EventUtil.trapImmediate(event)` if the item is disabled. This could be added in the if statement if necessary.

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [x] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [x] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [x] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [x] CircleCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [x] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [x] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [x] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
