### PR TITLE
fix: Update default Modal heading element to h1

### DIFF
--- a/components/modal/__tests__/modal.browser-test.jsx
+++ b/components/modal/__tests__/modal.browser-test.jsx
@@ -234,6 +234,11 @@ describe('SLDSModal: ', function () {
 			modal = getModalNode(document.body);
 		});
 
+		it('adds the default h1 heading element', () => {
+			const header = modal.querySelector('.slds-modal__header h1');
+			expect(header).to.not.be.null;
+		});
+
 		it('adds the footer', () => {
 			const footer = modal.querySelector('.slds-modal__footer');
 			expect(footer.className).to.include('slds-theme_default');

--- a/components/modal/__tests__/modal.browser-test.jsx
+++ b/components/modal/__tests__/modal.browser-test.jsx
@@ -235,7 +235,7 @@ describe('SLDSModal: ', function () {
 		});
 
 		it('adds the default h1 heading element', () => {
-			const header = modal.querySelector('.slds-modal__header h1');
+			const header = modal.querySelector('section .slds-modal__header h1');
 			expect(header).to.not.be.null;
 		});
 

--- a/components/modal/index.jsx
+++ b/components/modal/index.jsx
@@ -449,7 +449,7 @@ class Modal extends React.Component {
 			headerContent = (
 				<div>
 					{this.props.toast}
-					<h2
+					<h1
 						className={classNames({
 							'slds-text-heading_small': this.isPrompt(),
 							'slds-text-heading_medium': !this.isPrompt(),
@@ -457,7 +457,7 @@ class Modal extends React.Component {
 						id={`${this.getId()}-heading`}
 					>
 						{this.props.heading ? this.props.heading : this.props.title}
-					</h2>
+					</h1>
 					{this.props.tagline ? (
 						<p className="slds-m-top_x-small">{this.props.tagline}</p>
 					) : null}


### PR DESCRIPTION
Fixes #3047
The modal contents (including header and footer) are already wrapped inside a `section` element. https://github.com/salesforce/design-system-react/blob/master/components/modal/index.jsx#L309

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [x] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [x] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [x] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] CircleCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
