### PR TITLE
Upgrade react-text-truncate to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "design-system-react",
-	"version": "0.10.45",
+	"version": "0.10.48",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "design-system-react",
-			"version": "0.10.45",
+			"version": "0.10.48",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@salesforce/babel-preset-design-system-react": "^3.0.0",
@@ -29,7 +29,7 @@
 				"react-modal": "3.14.3",
 				"react-onclickoutside": "^6.10.0",
 				"react-required-if": "^1.0.3",
-				"react-text-truncate": "^0.16.0",
+				"react-text-truncate": "^0.19.0",
 				"shortid": "^2.2.15",
 				"warning": "^4.0.3"
 			},
@@ -39307,15 +39307,15 @@
 			"dev": true
 		},
 		"node_modules/react-text-truncate": {
-			"version": "0.16.0",
-			"resolved": "https://registry.npmjs.org/react-text-truncate/-/react-text-truncate-0.16.0.tgz",
-			"integrity": "sha512-hMFXhUHgIBCCDaOfOsZAFeO4DGfG/paLyaS/F+X11CXseuScpxmMBUW6Luwjk9/FlGrVJWNGy1FSfK6b4yyiIg==",
+			"version": "0.19.0",
+			"resolved": "https://registry.npmjs.org/react-text-truncate/-/react-text-truncate-0.19.0.tgz",
+			"integrity": "sha512-QxHpZABfGG0Z3WEYbRTZ+rXdZn50Zvp+sWZXgVAd7FCKAMzv/kcwctTpNmWgXDTpAoHhMjOVwmgRtX3x5yeF4w==",
 			"dependencies": {
 				"prop-types": "^15.5.7"
 			},
 			"peerDependencies": {
-				"react": "^15.4.1 || ^16.0.0",
-				"react-dom": "^15.4.1 || ^16.0.0"
+				"react": "^15.4.1 || ^16.0.0 || ^17.0.0 ||  || ^18.0.0",
+				"react-dom": "^15.4.1 || ^16.0.0 || ^17.0.0 || ^18.0.0"
 			}
 		},
 		"node_modules/react-textarea-autosize": {
@@ -77991,9 +77991,9 @@
 			}
 		},
 		"react-text-truncate": {
-			"version": "0.16.0",
-			"resolved": "https://registry.npmjs.org/react-text-truncate/-/react-text-truncate-0.16.0.tgz",
-			"integrity": "sha512-hMFXhUHgIBCCDaOfOsZAFeO4DGfG/paLyaS/F+X11CXseuScpxmMBUW6Luwjk9/FlGrVJWNGy1FSfK6b4yyiIg==",
+			"version": "0.19.0",
+			"resolved": "https://registry.npmjs.org/react-text-truncate/-/react-text-truncate-0.19.0.tgz",
+			"integrity": "sha512-QxHpZABfGG0Z3WEYbRTZ+rXdZn50Zvp+sWZXgVAd7FCKAMzv/kcwctTpNmWgXDTpAoHhMjOVwmgRtX3x5yeF4w==",
 			"requires": {
 				"prop-types": "^15.5.7"
 			}

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
 		"react-modal": "3.14.3",
 		"react-onclickoutside": "^6.10.0",
 		"react-required-if": "^1.0.3",
-		"react-text-truncate": "^0.16.0",
+		"react-text-truncate": "^0.19.0",
 		"shortid": "^2.2.15",
 		"warning": "^4.0.3"
 	},


### PR DESCRIPTION
Fixes the following warnings on React 17 and React 18 due to the currently included version of `react-text-truncate` not having up to date peer dependencies.

 
<img width="669" alt="Screen Shot 2022-06-21 at 2 08 20 PM" src="https://user-images.githubusercontent.com/12063278/174803068-accc8174-d27a-41b6-a2be-eeacfd76d4f7.png">

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [x] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [x] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/). **2 combobox tests failing, but also failing for me on main**
* [x] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] CircleCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
