### PR TITLE
Remove deprecated UNSAFE_componentWillUpdate in SLDSDataTable

### DIFF
--- a/components/data-table/index.jsx
+++ b/components/data-table/index.jsx
@@ -499,6 +499,13 @@ class DataTable extends React.Component {
 		return [];
 	}
 
+	getSnapshotBeforeUpdate(prevProps) {
+		if (prevProps.items !== this.props.items) {
+			this.interactiveElements = {};
+		}
+		return null;
+	}
+
 	getId() {
 		return this.props.id || this.generatedId;
 	}
@@ -689,13 +696,6 @@ class DataTable extends React.Component {
 			}
 		}
 	};
-
-	// eslint-disable-next-line camelcase
-	UNSAFE_componentWillUpdate(nextProps) {
-		if (this.props.items !== nextProps.items) {
-			this.interactiveElements = {};
-		}
-	}
 
 	isResizable() {
 		return this.props.fixedLayout && this.props.resizable;


### PR DESCRIPTION
Fixes # Deprecation Warning in console about UNSAFE_componentWillUpdate which "promotes unsafe coding practices" - [React Blog](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html)

### Additional description
While `UNSAFE_componentWillUpdate` is called right before render, `getSnapshotBeforeUpdate` is called right before mutating the DOM. According to the [React Documentation](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#new-lifecycle-getsnapshotbeforeupdate), the combination of `getSnapshotBeforeUpdate` and `componentDidUpdate` _should cover all use cases for the legacy `componentWillUpdate`_.

In this case since the purpose of using `UNSAFE_componentWillUpdate` appeared to be resetting the interactive elements for the datatable if the props differed, I moved this logic into `getSnapshotBeforeUpdate`. However, since `getSnapshotBeforeUpdate` gets the previous props rather than the next props, the if-statement had to be slightly adjusted. Additionally, because `getSnapshotBeforeUpdate` must contain a return statement(the return is passed as the third parameter to `componentDidUpdate`), it simply returns null. This change avoid the deprecation warning and enables the same behavior as with `UNSAFE_componentWillUpdate`.

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [x] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md). - **Not Applicable**
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/). - **2 tests for SLDSCombobox fail("_selects a menu item and scrolls when a letter key is pressed in read-only mode_" and "_selects menu items and scrolls when the down/up keys are pressed_"), but they also did not pass after a clean install.**
* [x] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html). - **Not Applicable**

### REVIEWER checklist (do not remove)

* [ ] CircleCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
