### PR TITLE
replace usage of findDOMNode with creating selfRef in constructor

### DIFF
--- a/components/modal/index.jsx
+++ b/components/modal/index.jsx
@@ -226,7 +226,6 @@ class Modal extends React.Component {
 				// and manager.jsx are removed. They appear to have
 				// been created in order to do modals in portals.
 				if (!this.isUnmounting) {
-					// const el = ReactDOM.findDOMNode(this); // eslint-disable-line react/no-find-dom-node
 					if (
 						this.selfRef &&
 						this.selfRef.parentNode &&

--- a/components/modal/index.jsx
+++ b/components/modal/index.jsx
@@ -207,6 +207,8 @@ class Modal extends React.Component {
 		if (props.ariaHideApp) {
 			checkAppElementIsSet();
 		}
+
+		this.selfRef = React.createRef();
 	}
 
 	componentDidMount() {
@@ -224,14 +226,14 @@ class Modal extends React.Component {
 				// and manager.jsx are removed. They appear to have
 				// been created in order to do modals in portals.
 				if (!this.isUnmounting) {
-					const el = ReactDOM.findDOMNode(this); // eslint-disable-line react/no-find-dom-node
+					// const el = ReactDOM.findDOMNode(this); // eslint-disable-line react/no-find-dom-node
 					if (
-						el &&
-						el.parentNode &&
-						el.parentNode.getAttribute('data-slds-modal')
+						this.selfRef &&
+						this.selfRef.parentNode &&
+						this.selfRef.parentNode.getAttribute('data-slds-modal')
 					) {
-						ReactDOM.unmountComponentAtNode(el);
-						document.body.removeChild(el);
+						ReactDOM.unmountComponentAtNode(this.selfRef);
+						document.body.removeChild(this.selfRef);
 					}
 				}
 			}


### PR DESCRIPTION
Fixes # Deprecation warning in console for `findDOMNode` in StrictMode.

### Additional description
`findDOMNode` is deprecated in StrictMode as it "breaks abstraction levels" and "creates a refactoring hazard" - [React Documentation](https://reactjs.org/docs/strict-mode.html#warning-about-deprecated-finddomnode-usage). The React documentation instead encourages the use of references. 

This pull request follows this advice and creates a self-reference in the constructor(`selfRef`). This reference is then used in `componentDidUpdate` when it is checked whether the modal is closing. If it is, then instead of using `findDOMNode` to get a reference to the modal and using that for unmounting and removing from the DOM, it instead uses the `selfRef` now.

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [x] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md). - **Not Applicable**
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/). - **2 tests for SLDSCombobox fail("_selects a menu item and scrolls when a letter key is pressed in read-only mode_" and "_selects menu items and scrolls when the down/up keys are pressed_"), but they also did not pass after a clean install.**(Same as previous PR 
* [x] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html). - **Not Applicable**

### REVIEWER checklist (do not remove)

* [ ] CircleCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
