### PR TITLE
Card component destructure aria data props

### DIFF
--- a/components/card/__docs__/__snapshots__/storybook-stories.storyshot
+++ b/components/card/__docs__/__snapshots__/storybook-stories.storyshot
@@ -8,7 +8,9 @@ exports[`DOM snapshots SLDSCard Custom Header 1`] = `
     className="slds-grid slds-grid_vertical"
   >
     <article
+      aria-label="SLDSCard Component"
       className="slds-card"
+      data-description="Description of the Card component"
       id="ExampleCard"
     >
       <div
@@ -247,7 +249,9 @@ exports[`DOM snapshots SLDSCard Custom Heading 1`] = `
     className="slds-grid slds-grid_vertical"
   >
     <article
+      aria-label="SLDSCard Component"
       className="slds-card"
+      data-description="Description of the Card component"
       id="ExampleCard"
     >
       <div
@@ -662,7 +666,9 @@ exports[`DOM snapshots SLDSCard Empty 1`] = `
     className="slds-grid slds-grid_vertical"
   >
     <article
+      aria-label="SLDSCard Component"
       className="slds-card"
+      data-description="Description of the Card component"
       id="ExampleCard"
     >
       <div
@@ -866,7 +872,9 @@ exports[`DOM snapshots SLDSCard w/ Items 1`] = `
     className="slds-grid slds-grid_vertical"
   >
     <article
+      aria-label="SLDSCard Component"
       className="slds-card"
+      data-description="Description of the Card component"
       id="ExampleCard"
     >
       <div

--- a/components/card/__docs__/storybook-stories.jsx
+++ b/components/card/__docs__/storybook-stories.jsx
@@ -114,6 +114,8 @@ class DemoCard extends React.Component {
 					heading={heading}
 					icon={<Icon category="standard" name="document" size="small" />}
 					empty={isEmpty ? <CardEmpty heading="No Related Items" /> : null}
+					aria-label="SLDSCard Component"
+					data-description="Description of the Card component"
 				>
 					<DataTable id="SLDSDataTableExample-1" items={items}>
 						<DataTableColumn label="Opportunity Name" property="name" truncate>

--- a/components/card/__tests__/card.browser-test.jsx
+++ b/components/card/__tests__/card.browser-test.jsx
@@ -118,6 +118,8 @@ describe('Card: ', () => {
 		name: 'default',
 		size: 'small',
 	});
+	const ariaLabel = 'aria-label';
+	const dataLabel = 'data-label';
 
 	const optionalProps = assign(requiredProps, {
 		bodyClassName: 'this-is-a-custom-body-class',
@@ -127,6 +129,8 @@ describe('Card: ', () => {
 		filter: renderFilter,
 		icon: renderIcon,
 		style: { background: 'rgb(18, 49, 35)' },
+		[ariaLabel]: ariaLabel,
+		[dataLabel]: dataLabel,
 	});
 
 	describe('Optional Structure', () => {
@@ -186,6 +190,16 @@ describe('Card: ', () => {
 				'#sampleHeaderActions'
 			)[0];
 			headerActionsChildren.should.not.be.undefined;
+		});
+
+		it('correctly destructures `aria-` props', function () {
+			const card = getCard(this.dom);
+			card.ariaLabel.should.equal(ariaLabel);
+		});
+
+		it('correctly destructures `data-` props', function () {
+			const card = getCard(this.dom);
+			card.dataset.label.should.equal(dataLabel);
 		});
 	});
 

--- a/components/card/__tests__/card.browser-test.jsx
+++ b/components/card/__tests__/card.browser-test.jsx
@@ -194,7 +194,7 @@ describe('Card: ', () => {
 
 		it('correctly destructures `aria-` props', function () {
 			const card = getCard(this.dom);
-			card.ariaLabel.should.equal(ariaLabel);
+			card.getAttribute(ariaLabel).should.equal(ariaLabel);
 		});
 
 		it('correctly destructures `data-` props', function () {

--- a/components/card/index.jsx
+++ b/components/card/index.jsx
@@ -23,6 +23,8 @@ import Footer from './private/footer';
 import Empty from './empty';
 
 import { CARD } from '../../utilities/constants';
+import getAriaProps from '../../utilities/get-aria-props';
+import getDataProps from '../../utilities/get-data-props';
 
 const idSuffixes = {
 	body: '__body',
@@ -32,9 +34,11 @@ const idSuffixes = {
 };
 
 /**
- * Cards are used to apply a container around a related grouping of information. It has a header, a body, and an optional footer. It often contains a DataTable or Tile (coming soon). Actions associated with selected items or with all items are included within the header actions. Footer often contains pagination.
+ * Cards are used to apply a container around a related grouping of information. It has a header, a body, and an optional footer. It often contains a DataTable or Tile (coming soon). Actions associated with selected items or with all items are included within the header actions. Footer often contains pagination. `aria-` and `data-` props can be provided and will be destructured on the root `article` element.
  */
 const Card = (props) => {
+	const ariaProps = getAriaProps(props);
+	const dataProps = getDataProps(props);
 	const bodyId = props.id ? props.id + idSuffixes.body : null;
 	const filterId = props.id ? props.id + idSuffixes.filter : null;
 	const headingId = props.id ? props.id + idSuffixes.heading : null;
@@ -51,6 +55,8 @@ const Card = (props) => {
 			id={props.id}
 			className={classnames('slds-card', props.className)}
 			style={props.style}
+			{...ariaProps}
+			{...dataProps}
 		>
 			{!props.hasNoHeader && (
 				<Header

--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -2497,7 +2497,7 @@
         "dependencies": []
     },
     "card": {
-        "description": "Cards are used to apply a container around a related grouping of information. It has a header, a body, and an optional footer. It often contains a DataTable or Tile (coming soon). Actions associated with selected items or with all items are included within the header actions. Footer often contains pagination.",
+        "description": "Cards are used to apply a container around a related grouping of information. It has a header, a body, and an optional footer. It often contains a DataTable or Tile (coming soon). Actions associated with selected items or with all items are included within the header actions. Footer often contains pagination. `aria-` and `data-` props can be provided and will be destructured on the root `article` element.",
         "methods": [],
         "props": {
             "bodyClassName": {


### PR DESCRIPTION
Fixes #3068 

### Additional description
Adds functionality to destructured `aria-` and `data-` props on the SLDSCard component.

These props will be destructured on to the root `article` element.

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

### Note:
**The tests at http://localhost:8001/** have 2 failing (for SLDSComboBox), but it looks like this is also present on the master branch, so not addressed in this PR.

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [x] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [x] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [x] CircleCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [x] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [x] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [x] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [x] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [x] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
