### PR TITLE
Add new prop to configure tree node selectable

### DIFF
--- a/components/tree/index.jsx
+++ b/components/tree/index.jsx
@@ -103,11 +103,16 @@ const propTypes = {
 	 * Styles to be added to the top-level `ul` element. Useful for `overflow:hidden`.
 	 */
 	listStyle: PropTypes.object,
+	/**
+	 * Indicate whether a tree node is selectable
+	 */
+	 treeNodeSelectable: PropTypes.boolean,
 };
 
 const defaultProps = {
 	assistiveText: {},
 	getNodes: (node) => node.nodes,
+	treeNodeSelectable: true,
 };
 
 /* Flattens hierarchical tree structure into a flat array. The
@@ -189,6 +194,9 @@ class Tree extends React.Component {
 	}
 
 	handleSelect = ({ event, data, clearSelectedNodes, fromFocus }) => {
+		if (!this.props.treeNodeSelectable) {
+			return;
+		}
 		// When triggered by a key event, other nodes should be deselected.
 		if (clearSelectedNodes) {
 			// TODO: This bad design. This is state modfication. State should be changed via setState only.


### PR DESCRIPTION
Fixes #

In some cases, we don't want the tree node to be selectable and keep refreshing itself, the issue description: https://github.com/salesforce/design-system-react/issues/3081

So I'm thinking to introduce this new prop for the Tree component to make the selectable node configurable.

### Additional description

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [ ] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [ ] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] CircleCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
