### PR TITLE
Fix Tooltip for PageHeader components

### DIFF
--- a/components/page-header/private/detail-block.jsx
+++ b/components/page-header/private/detail-block.jsx
@@ -85,7 +85,11 @@ class DetailBlock extends Component {
 		const labelClasses = classnames({ 'slds-truncate': truncate });
 
 		return (
-			<Tooltip align="top" title={content} triggerStyle={{ display: 'inline' }}>
+			<Tooltip
+				align="top"
+				content={content}
+				triggerStyle={{ display: 'inline' }}
+			>
 				<div className={labelClasses} tabIndex="0" title={content}>
 					{content}
 				</div>


### PR DESCRIPTION
Fixes #3090 

### Additional description
[UI] Shows truncated text in tooltip.
<img width="1904" alt="Screenshot 2023-01-18 at 2 15 42 PM" src="https://user-images.githubusercontent.com/17942697/213308251-5df44e86-c8e9-4b00-9efa-75e71cc8b055.png">

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [ ] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [X] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [X] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [X] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [X] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [X] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] CircleCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [X] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [X] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [X] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [X] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
