### PR TITLE
PageHeader: Remove tooltip from default details field

### DIFF
--- a/components/page-header/private/detail-block.jsx
+++ b/components/page-header/private/detail-block.jsx
@@ -6,7 +6,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import Tooltip from '../../tooltip';
 
 const displayName = 'PageHeaderDetailRow';
 const propTypes = {
@@ -43,21 +42,6 @@ const defaultProps = {
 };
 
 class DetailBlock extends Component {
-	constructor(props) {
-		super(props);
-		this.state = { showTooltip: false };
-	}
-
-	componentDidMount() {
-		this.renderFieldTruncation();
-	}
-
-	componentDidUpdate(prevProps) {
-		if (this.props.content !== prevProps.content) {
-			this.renderFieldTruncation();
-		}
-	}
-
 	renderContent() {
 		const { content, truncate } = this.props;
 
@@ -78,35 +62,6 @@ class DetailBlock extends Component {
 		}
 
 		return content;
-	}
-
-	renderContentWithTooltip() {
-		const { content, truncate } = this.props;
-		const labelClasses = classnames({ 'slds-truncate': truncate });
-
-		return (
-			<Tooltip
-				align="top"
-				content={content}
-				triggerStyle={{ display: 'inline' }}
-			>
-				<div className={labelClasses} tabIndex="0" title={content}>
-					{content}
-				</div>
-			</Tooltip>
-		);
-	}
-
-	renderFieldTruncation() {
-		const fieldContent = this.fieldContentRef;
-		const isTruncated =
-			fieldContent && fieldContent.scrollWidth > fieldContent.offsetWidth;
-
-		if (isTruncated) {
-			this.setState({ showTooltip: true });
-		} else {
-			this.setState({ showTooltip: false });
-		}
 	}
 
 	renderLabel() {
@@ -137,9 +92,7 @@ class DetailBlock extends Component {
 		return (
 			<li className={classes}>
 				{this.renderLabel()}
-				{this.state.showTooltip
-					? this.renderContentWithTooltip()
-					: this.renderContent()}
+				{this.renderContent()}
 			</li>
 		);
 	}


### PR DESCRIPTION
Fixes https://github.com/salesforce/design-system-react/pull/3091#issuecomment-1441214335

### Additional description
This removes the dual title and tooltip now that truncate is present. If you want a Tooltip, add it yourself.

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [ ] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [ ] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] CircleCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
