### PR TITLE
Patch release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "design-system-react",
-	"version": "0.10.52",
+	"version": "0.10.53",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -5779,9 +5779,9 @@
 			}
 		},
 		"@salesforce-ux/design-system": {
-			"version": "2.17.4",
-			"resolved": "https://registry.npmjs.org/@salesforce-ux/design-system/-/design-system-2.17.4.tgz",
-			"integrity": "sha512-LbYTj2SluY/TcbJ6G2ratRmDI3c1YJzxPJayX4LYMjaKW2z+GF6Zzsk6ygP8hqIglGKvxConb0UA1oq8v1wX4w==",
+			"version": "2.20.1",
+			"resolved": "https://registry.npmjs.org/@salesforce-ux/design-system/-/design-system-2.20.1.tgz",
+			"integrity": "sha512-MZbOfmTOPZD6JOARmW+Co83Ypge5zNAXiu/C2RuVVSa14xS/kqcYuuyPgGPITu7TNMdQ706oQFJRqSj1HH6uZA==",
 			"dev": true
 		},
 		"@salesforce-ux/icons": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "design-system-react",
-	"version": "0.10.52",
+	"version": "0.10.53",
 	"description": "Salesforce Lightning Design System for React",
 	"license": "BSD-3-Clause",
 	"engines": {
@@ -112,7 +112,7 @@
 		"warning": "^4.0.3"
 	},
 	"peerDependencies": {
-		"@salesforce-ux/design-system": "^2.19.x",
+		"@salesforce-ux/design-system": "^2.20.1",
 		"react": ">=16.8",
 		"react-dom": ">=16.8"
 	},
@@ -130,7 +130,7 @@
 		"@babel/polyfill": "^7.12.1",
 		"@babel/preset-env": "^7.14.2",
 		"@babel/preset-react": "^7.12.7",
-		"@salesforce-ux/design-system": "^2.14.3",
+		"@salesforce-ux/design-system": "^2.20.1",
 		"@salesforce-ux/icons": "10.x",
 		"@salesforce/eslint-plugin-slds-react": "^0.0.1",
 		"@storybook/addon-a11y": "^6.2.0",


### PR DESCRIPTION
Patch release

### Additional description

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [ ] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [ ] `npm run lint:fix` has been run and linting passes.
* [ ] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] CircleCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
