### PR TITLE
Fix keyboard navigation when using menu dropdown with multiple option

### DIFF
--- a/components/menu-dropdown/__tests__/dropdown.browser-test.jsx
+++ b/components/menu-dropdown/__tests__/dropdown.browser-test.jsx
@@ -394,6 +394,21 @@ describe('SLDSMenuDropdown', function () {
 			);
 			expect(firstNode).attr('role', 'menuitemcheckbox');
 		});
+
+		it('moves focus to next item after keyboard selection', function () {
+			const nodes = getNodes({ wrapper: this.wrapper });
+			nodes.trigger.simulate('click', {});
+			const openNodes = getNodes({ wrapper: this.wrapper });
+			openNodes.menu.simulate('keyDown', keyObjects.DOWN);
+			openNodes.menu.simulate('keyDown', keyObjects.ENTER);
+			openNodes.menu.simulate('keyDown', keyObjects.DOWN);
+			openNodes.menu.simulate('keyDown', keyObjects.ENTER);
+
+			const secondNode = openNodes.menu.find('.slds-dropdown__item a').at(1);
+			expect(secondNode.getDOMNode().getAttribute('aria-checked')).to.not.equal(
+				'true'
+			);
+		});
 	});
 
 	// Hover and hybrid hover UX patterns are not approved UX patterns due to accessibility concerns

--- a/components/menu-dropdown/menu-dropdown.jsx
+++ b/components/menu-dropdown/menu-dropdown.jsx
@@ -806,7 +806,10 @@ class MenuDropdown extends React.Component {
 
 	// This is a bit of an anti-pattern, but it has the upside of being a nice default. Component authors can always override to only set state and do their own focusing in their subcomponents.
 	handleKeyboardFocus = (focusedIndex) => {
-		if (this.state.focusedIndex !== focusedIndex) {
+		if (
+			this.state.focusedIndex !== focusedIndex &&
+			focusedIndex !== undefined
+		) {
 			this.setState({ focusedIndex });
 		}
 


### PR DESCRIPTION
Fixes #

Fixes keyboard navigation in menu dropdown component when using the multiple option.

### Additional description
Fixes this issue: Use the keyboard to select an option in the menu dropdown component.  Use the keyboard's up or down arrow keys to advance to the next or previous item. The focus jumps to the first item in the list when pressing the down arrow key or to the last item when pressing the up arrow key.

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [X] `npm run lint:fix` has been run and linting passes.
* [X] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [X] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [X] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [X] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [X] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] CircleCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
