### PR TITLE
Update design-system to wcag version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "design-system-react",
-	"version": "0.10.57-wcag",
+	"version": "0.10.58",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "design-system-react",
-	"version": "0.10.53",
+	"version": "0.10.57-wcag",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -5779,9 +5779,9 @@
 			}
 		},
 		"@salesforce-ux/design-system": {
-			"version": "2.20.1",
-			"resolved": "https://registry.npmjs.org/@salesforce-ux/design-system/-/design-system-2.20.1.tgz",
-			"integrity": "sha512-MZbOfmTOPZD6JOARmW+Co83Ypge5zNAXiu/C2RuVVSa14xS/kqcYuuyPgGPITu7TNMdQ706oQFJRqSj1HH6uZA==",
+			"version": "2.21.3-wcag",
+			"resolved": "https://artifactory.qapc-sfmc.com/artifactory/api/npm/sfmc-npm/@salesforce-ux/design-system/-/design-system-2.21.3-wcag.tgz",
+			"integrity": "sha512-HP2kz3to+06ka4AkQrngPvV1vTYXMas/xr3AmK6dgX8pAPCDXIMDuH18kifw4/B6qA812ZnubdzEhipu0Sn62w==",
 			"dev": true
 		},
 		"@salesforce-ux/icons": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "design-system-react",
-	"version": "0.10.57",
+	"version": "0.10.57-wcag",
 	"description": "Salesforce Lightning Design System for React",
 	"license": "BSD-3-Clause",
 	"engines": {
@@ -112,7 +112,7 @@
 		"warning": "^4.0.3"
 	},
 	"peerDependencies": {
-		"@salesforce-ux/design-system": "^2.20.1",
+		"@salesforce-ux/design-system": "2.21.3-wcag",
 		"react": ">=16.8",
 		"react-dom": ">=16.8"
 	},
@@ -130,7 +130,7 @@
 		"@babel/polyfill": "^7.12.1",
 		"@babel/preset-env": "^7.14.2",
 		"@babel/preset-react": "^7.12.7",
-		"@salesforce-ux/design-system": "^2.20.1",
+		"@salesforce-ux/design-system": "2.21.3-wcag",
 		"@salesforce-ux/icons": "10.x",
 		"@salesforce/eslint-plugin-slds-react": "^0.0.1",
 		"@storybook/addon-a11y": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "design-system-react",
-	"version": "0.10.57-wcag",
+	"version": "0.10.58",
 	"description": "Salesforce Lightning Design System for React",
 	"license": "BSD-3-Clause",
 	"engines": {


### PR DESCRIPTION
Salesforce teams are getting TDs to update all UI in MANAGED PACKAGE to have 3:1 color contrast for functional UI elements and 4.5:1 color contrast for text. Example TD (https://gus.lightning.force.com/lightning/r/ADM_Team_Dependency__c/a0nEE000000HnxBYAS/view)

For those apps that use @salesforce-ux/design-system, the newly updated version with wcag compliance is available with `2.21.3-wcag` (https://www.npmjs.com/package/@salesforce-ux/design-system/v/2.21.3-wcag)

I am simply updating the version to the wcag compliant one.
