### PR TITLE
Fix ID generation to ensure it produces valid CSS identifiers

### DIFF
--- a/components/accordion/index.jsx
+++ b/components/accordion/index.jsx
@@ -8,9 +8,9 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import shortid from 'shortid';
 
 import { ACCORDION } from '../../utilities/constants';
+import generateId from '../../utilities/generate-id';
 
 const propTypes = {
 	/**
@@ -49,7 +49,7 @@ class Accordion extends Component {
 		super(props);
 		this.state = { currButtonIndex: 0 };
 		this.summaryButtons = [];
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 	}
 
 	componentDidUpdate(prevProps, prevState) {

--- a/components/app-launcher/index.jsx
+++ b/components/app-launcher/index.jsx
@@ -10,7 +10,6 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import isFunction from 'lodash.isfunction';
-import shortid from 'shortid';
 
 // This component's `checkProps` which issues warnings to developers about properties when in development mode (similar to React's built in development tools)
 import checkProps from './check-props';
@@ -20,6 +19,7 @@ import componentDoc from './component.json';
 import Modal from '../modal';
 
 import { APP_LAUNCHER } from '../../utilities/constants';
+import generateId from '../../utilities/generate-id';
 
 const defaultProps = {
 	assistiveText: {
@@ -127,7 +127,7 @@ class AppLauncher extends React.Component {
 
 	constructor(props) {
 		super(props);
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 		this.state = {
 			isOpen: false,
 		};

--- a/components/badge/index.jsx
+++ b/components/badge/index.jsx
@@ -10,13 +10,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-// ### shortid
-// [npmjs.com/package/shortid](https://www.npmjs.com/package/shortid)
-// shortid is a short, non-sequential, url-friendly, unique id generator
-import shortid from 'shortid';
-
 // ## Constants
 import { BADGE } from '../../utilities/constants';
+
+import generateId from '../../utilities/generate-id';
 
 /**
  * Badges are labels which hold small amounts of information.
@@ -24,7 +21,7 @@ import { BADGE } from '../../utilities/constants';
 class Badge extends React.Component {
 	constructor(props) {
 		super(props);
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 	}
 
 	/**

--- a/components/brand-band/index.jsx
+++ b/components/brand-band/index.jsx
@@ -11,11 +11,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-// ### shortid
-// [npmjs.com/package/shortid](https://www.npmjs.com/package/shortid)
-// shortid is a short, non-sequential, url-friendly, unique id generator
-import shortid from 'shortid';
-
 // ### classNames
 // [github.com/JedWatson/classnames](https://github.com/JedWatson/classnames)
 // A simple javascript utility for conditionally joining classNames together.
@@ -27,6 +22,8 @@ import checkProps from './check-props';
 // ## Constants
 import { BRAND_BAND } from '../../utilities/constants';
 
+import generateId from '../../utilities/generate-id';
+
 /**
  * The brand band provides theming capability that adds personality and improves information density and contrast.
  */
@@ -35,7 +32,7 @@ class BrandBand extends React.Component {
 		super(props);
 
 		checkProps(BRAND_BAND, this.props);
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 	}
 
 	getId() {

--- a/components/button-group/index.jsx
+++ b/components/button-group/index.jsx
@@ -10,12 +10,8 @@ import classNames from 'classnames';
 
 import assign from 'lodash.assign';
 
-// ### shortid
-// [npmjs.com/package/shortid](https://www.npmjs.com/package/shortid)
-// shortid is a short, non-sequential, url-friendly, unique id generator
-import shortid from 'shortid';
-
 import { BUTTON_GROUP } from '../../utilities/constants';
+import generateId from '../../utilities/generate-id';
 
 const propTypes = {
 	/**
@@ -66,7 +62,7 @@ const defaultProps = { labels: {} };
 class ButtonGroup extends React.Component {
 	constructor(props) {
 		super(props);
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 	}
 
 	getId() {

--- a/components/card/__docs__/storybook-stories.jsx
+++ b/components/card/__docs__/storybook-stories.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import PropTypes from 'prop-types';
-import shortid from 'shortid';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import IconSettings from '../../icon-settings';
@@ -20,6 +19,8 @@ import MediaObject from '../../media-object';
 import InlineEdit from '../../forms/input/inline';
 
 import RelatedListWithTable from '../__examples__/related-list-with-table';
+
+import generateId from '../../../utilities/generate-id';
 
 const sampleItems = [
 	{ id: '0', name: 'Cloudhub' },
@@ -69,7 +70,7 @@ class DemoCard extends React.Component {
 		this.setState({
 			items: [
 				// eslint-disable-next-line no-plusplus
-				{ id: currentId++, name: `New item #${shortid.generate()}` },
+				{ id: currentId++, name: `New item #${generateId()}` },
 				...this.state.items,
 			],
 		});

--- a/components/carousel/index.jsx
+++ b/components/carousel/index.jsx
@@ -9,12 +9,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
-// ### shortid
-// [npmjs.com/package/shortid](https://www.npmjs.com/package/shortid)
-// shortid is a short, non-sequential, url-friendly, unique id generator
-import shortid from 'shortid';
-
 import { CAROUSEL } from '../../utilities/constants';
+
+import generateId from '../../utilities/generate-id';
 
 import {
 	canUseDOM,
@@ -151,7 +148,7 @@ class Carousel extends React.Component {
 			translateX: -1000000,
 		};
 
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 	}
 
 	componentDidMount() {

--- a/components/checkbox/index.jsx
+++ b/components/checkbox/index.jsx
@@ -11,11 +11,6 @@ import PropTypes from 'prop-types';
 
 import classNames from 'classnames';
 
-// ### shortid
-// [npmjs.com/package/shortid](https://www.npmjs.com/package/shortid)
-// shortid is a short, non-sequential, url-friendly, unique id generator
-import shortid from 'shortid';
-
 // ### Event Helpers
 import KEYS from '../../utilities/key-code';
 import EventUtil from '../../utilities/event';
@@ -28,6 +23,7 @@ import { CHECKBOX } from '../../utilities/constants';
 import Icon from '../icon';
 
 import getAriaProps from '../../utilities/get-aria-props';
+import generateId from '../../utilities/generate-id';
 
 const propTypes = {
 	/**
@@ -211,7 +207,7 @@ class Checkbox extends React.Component {
 		super(props);
 
 		checkProps(CHECKBOX, this.props, componentDoc);
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 	}
 
 	getId = () => this.props.id || this.generatedId;

--- a/components/color-picker/index.jsx
+++ b/components/color-picker/index.jsx
@@ -3,7 +3,6 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
-import shortid from 'shortid';
 import assign from 'lodash.assign';
 
 import checkProps from './check-props';
@@ -21,6 +20,7 @@ import Popover from '../popover';
 import ColorUtils from '../../utilities/color';
 
 import { COLOR_PICKER } from '../../utilities/constants';
+import generateId from '../../utilities/generate-id';
 
 import componentDoc from './component.json';
 
@@ -247,7 +247,7 @@ class ColorPicker extends React.Component {
 	constructor(props) {
 		super(props);
 
-		this.generatedId = props.id || shortid.generate();
+		this.generatedId = props.id || generateId();
 		const workingColor = ColorUtils.getNewColor(
 			{
 				hex: props.valueWorking || props.value,

--- a/components/combobox/combobox.jsx
+++ b/components/combobox/combobox.jsx
@@ -16,8 +16,6 @@ import isFunction from 'lodash.isfunction';
 
 import classNames from 'classnames';
 
-import shortid from 'shortid';
-
 import Button from '../button';
 import Dialog from '../utilities/dialog';
 import InnerInput from '../../components/input/private/inner-input';
@@ -37,6 +35,7 @@ import menuItemSelectScroll from '../../utilities/menu-item-select-scroll';
 import checkProps from './check-props';
 
 import { COMBOBOX } from '../../utilities/constants';
+import generateId from '../../utilities/generate-id';
 import componentDoc from './component.json';
 import { IconSettingsContext } from '../icon-settings';
 
@@ -446,8 +445,8 @@ class Combobox extends React.Component {
 		// `checkProps` issues warnings to developers about properties (similar to React's built in development tools)
 		checkProps(COMBOBOX, props, componentDoc);
 
-		this.generatedId = shortid.generate();
-		this.generatedErrorId = shortid.generate();
+		this.generatedId = generateId();
+		this.generatedErrorId = generateId();
 		this.deselectId = `${this.getId()}-deselect`;
 	}
 

--- a/components/component-docs.json
+++ b/components/component-docs.json
@@ -5771,6 +5771,17 @@
                     "computed": false
                 }
             },
+            "disabledSelection": {
+                "type": {
+                    "name": "array"
+                },
+                "required": false,
+                "description": "An array of objects of rows that selection is disabled. See `items` prop for shape of objects.",
+                "defaultValue": {
+                    "value": "[]",
+                    "computed": false
+                }
+            },
             "selectRows": {
                 "type": {
                     "name": "union",

--- a/components/data-table/index.jsx
+++ b/components/data-table/index.jsx
@@ -9,11 +9,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-// ### shortid
-// [npmjs.com/package/shortid](https://www.npmjs.com/package/shortid)
-// shortid is a short, non-sequential, url-friendly, unique id generator
-import shortid from 'shortid';
-
 import classNames from 'classnames';
 import assign from 'lodash.assign';
 import isEqual from 'lodash.isequal';
@@ -42,6 +37,7 @@ import Mode from './private/mode';
 import Spinner from '../spinner';
 
 import KEYS from '../../utilities/key-code';
+import generateId from '../../utilities/generate-id';
 import mapKeyEventCallbacks from '../../utilities/key-callbacks';
 
 import {
@@ -404,7 +400,7 @@ class DataTable extends React.Component {
 
 	constructor(props) {
 		super(props);
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 		this.headerRefs = {
 			action: [],
 			column: [],
@@ -1229,7 +1225,7 @@ class DataTable extends React.Component {
 										const rowId =
 											this.getId() && item.id
 												? `${this.getId()}-${DATA_TABLE_ROW}-${item.id}`
-												: shortid.generate();
+												: generateId();
 										return this.props.onRenderSubHeadingRow &&
 											item.type === 'header-row' ? (
 											this.props.onRenderSubHeadingRow({

--- a/components/data-table/interactive-element.jsx
+++ b/components/data-table/interactive-element.jsx
@@ -1,9 +1,10 @@
 /* eslint-disable fp/no-rest-parameters */
 import React from 'react';
-import shortid from 'shortid';
 import Mode from './private/mode';
 import CellContext from './private/cell-context';
 import TableContext from './private/table-context';
+
+import generateId from '../../utilities/generate-id';
 
 /**
  * Wrapper for interactive elements in the table.
@@ -21,7 +22,7 @@ export default (WrappedElement) => {
 	class InteractiveElement extends React.Component {
 		constructor(props) {
 			super(props);
-			this.elementId = shortid.generate();
+			this.elementId = generateId();
 		}
 
 		onFocus(tableContext, ...args) {

--- a/components/date-picker/date-picker.jsx
+++ b/components/date-picker/date-picker.jsx
@@ -13,11 +13,6 @@ import assign from 'lodash.assign';
 // joining classNames together."
 import classNames from 'classnames';
 
-// ### shortid
-// [npmjs.com/package/shortid](https://www.npmjs.com/package/shortid)
-// shortid is a short, non-sequential, url-friendly, unique id generator
-import shortid from 'shortid';
-
 import Dialog from '../utilities/dialog';
 import CalendarWrapper from './private/calendar-wrapper';
 import InputIcon from '../icon/input-icon';
@@ -33,6 +28,7 @@ import KEYS from '../../utilities/key-code';
 import lowPriorityWarning from '../../utilities/warning/low-priority-warning';
 
 import { DATE_PICKER } from '../../utilities/constants';
+import generateId from '../../utilities/generate-id';
 import { IconSettingsContext } from '../icon-settings';
 
 const propTypes = {
@@ -273,7 +269,7 @@ class Datepicker extends React.Component {
 			inputValue: initDate || '',
 		};
 
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 
 		// `checkProps` issues warnings to developers about properties (similar to React's built in development tools)
 		checkProps(DATE_PICKER, props, componentDoc);

--- a/components/docked-composer/index.jsx
+++ b/components/docked-composer/index.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import shortid from 'shortid';
 
 import Button from '../button';
+
+import generateId from '../../utilities/generate-id';
 
 const propTypes = {
 	/**
@@ -71,7 +72,7 @@ const defaultProps = {
 class DockedComposer extends React.Component {
 	constructor(props) {
 		super(props);
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 	}
 
 	getId() {

--- a/components/expandable-section/index.jsx
+++ b/components/expandable-section/index.jsx
@@ -9,7 +9,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import classNames from 'classnames';
-import shortid from 'shortid';
 
 import Button from '../button';
 
@@ -18,6 +17,7 @@ import Button from '../button';
 // import EventUtil from '../../utilities/event';
 
 import { EXPANDABLE_SECTION } from '../../utilities/constants';
+import generateId from '../../utilities/generate-id';
 
 const propTypes = {
 	/**
@@ -74,7 +74,7 @@ const defaultProps = {
 class ExpandableSection extends React.Component {
 	constructor(props) {
 		super(props);
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 		this.state = {
 			isOpen: true,
 		};

--- a/components/expression/condition.jsx
+++ b/components/expression/condition.jsx
@@ -7,12 +7,8 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import assign from 'lodash.assign';
 
-// ### shortid
-// [npmjs.com/package/shortid](https://www.npmjs.com/package/shortid)
-// shortid is a short, non-sequential, url-friendly, unique id generator
-import shortid from 'shortid';
-
 import { EXPRESSION_CONDITION } from '../../utilities/constants';
+import generateId from '../../utilities/generate-id';
 
 import Combobox from '../combobox';
 import Input from '../input';
@@ -141,7 +137,7 @@ const defaultProps = {
 class ExpressionCondition extends React.Component {
 	constructor(props) {
 		super(props);
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 	}
 
 	componentDidMount() {

--- a/components/expression/formula.jsx
+++ b/components/expression/formula.jsx
@@ -8,12 +8,8 @@ import classNames from 'classnames';
 import assign from 'lodash.assign';
 import ContentEditable from 'react-contenteditable';
 
-// ### shortid
-// [npmjs.com/package/shortid](https://www.npmjs.com/package/shortid)
-// shortid is a short, non-sequential, url-friendly, unique id generator
-import shortid from 'shortid';
-
 import { EXPRESSION_FORMULA } from '../../utilities/constants';
+import generateId from '../../utilities/generate-id';
 
 import Button from '../button';
 
@@ -95,7 +91,7 @@ class ExpressionFormula extends React.Component {
 		this.state = {
 			textEditorValue: 'Compose formula...', // default is set here to preserve functionality if not controlled by props.textEditorValue
 		};
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 	}
 
 	/**

--- a/components/expression/group.jsx
+++ b/components/expression/group.jsx
@@ -7,12 +7,8 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import assign from 'lodash.assign';
 
-// ### shortid
-// [npmjs.com/package/shortid](https://www.npmjs.com/package/shortid)
-// shortid is a short, non-sequential, url-friendly, unique id generator
-import shortid from 'shortid';
-
 import { EXPRESSION_GROUP } from '../../utilities/constants';
+import generateId from '../../utilities/generate-id';
 
 import Combobox from '../combobox';
 import Button from '../button';
@@ -142,7 +138,7 @@ class ExpressionGroup extends React.Component {
 
 	constructor(props) {
 		super(props);
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 	}
 
 	componentDidMount() {

--- a/components/expression/index.jsx
+++ b/components/expression/index.jsx
@@ -6,12 +6,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-// ### shortid
-// [npmjs.com/package/shortid](https://www.npmjs.com/package/shortid)
-// shortid is a short, non-sequential, url-friendly, unique id generator
-import shortid from 'shortid';
 import assign from 'lodash.assign';
 import { EXPRESSION } from '../../utilities/constants';
+import generateId from '../../utilities/generate-id';
 import ExpressionGroup from './group';
 
 const propTypes = {
@@ -91,7 +88,7 @@ class Expression extends React.Component {
 	constructor(props) {
 		super(props);
 
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 	}
 
 	/**

--- a/components/files/file.jsx
+++ b/components/files/file.jsx
@@ -7,11 +7,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-// ### shortid
-// [npmjs.com/package/shortid](https://www.npmjs.com/package/shortid)
-// shortid is a short, non-sequential, url-friendly, unique id generator
-import shortid from 'shortid';
 import { FILES_FILE } from '../../utilities/constants';
+import generateId from '../../utilities/generate-id';
 
 import FileFigure from './private/file-figure';
 import FileActions from './private/file-actions';
@@ -127,7 +124,7 @@ class File extends React.Component {
 	constructor(props) {
 		super(props);
 
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 	}
 
 	/**

--- a/components/files/index.jsx
+++ b/components/files/index.jsx
@@ -7,11 +7,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-// ### shortid
-// [npmjs.com/package/shortid](https://www.npmjs.com/package/shortid)
-// shortid is a short, non-sequential, url-friendly, unique id generator
-import shortid from 'shortid';
 import { FILES } from '../../utilities/constants';
+import generateId from '../../utilities/generate-id';
 
 const displayName = FILES;
 
@@ -49,7 +46,7 @@ class Files extends React.Component {
 	constructor(props) {
 		super(props);
 
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 	}
 
 	/**

--- a/components/files/more-files.jsx
+++ b/components/files/more-files.jsx
@@ -7,11 +7,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-// ### shortid
-// [npmjs.com/package/shortid](https://www.npmjs.com/package/shortid)
-// shortid is a short, non-sequential, url-friendly, unique id generator
-import shortid from 'shortid';
 import { FILES_MORE } from '../../utilities/constants';
+import generateId from '../../utilities/generate-id';
 
 const displayName = FILES_MORE;
 
@@ -74,7 +71,7 @@ class MoreFiles extends React.Component {
 	constructor(props) {
 		super(props);
 
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 	}
 
 	getId() {

--- a/components/filter/index.jsx
+++ b/components/filter/index.jsx
@@ -19,16 +19,13 @@ import assign from 'lodash.assign';
 // ### classNames
 import classNames from 'classnames';
 
-// ### shortid
-// [npmjs.com/package/shortid](https://www.npmjs.com/package/shortid)
-// shortid is a short, non-sequential, url-friendly, unique id generator
-import shortid from 'shortid';
-
 import Button from '../button';
 import Popover from '../popover';
 
 // ## Constants
 import { FILTER } from '../../utilities/constants';
+
+import generateId from '../../utilities/generate-id';
 
 /**
  * A Filter is a popover with custom trigger. It can be used by [Panel Filtering](/components/panels/). Menus within a Filter Popover will need to not have "portal mounts" and be inline.
@@ -126,7 +123,7 @@ class Filter extends React.Component {
 	constructor(props) {
 		super(props);
 
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 	}
 
 	getId = () => this.props.id || this.generatedId;

--- a/components/input/index.jsx
+++ b/components/input/index.jsx
@@ -19,11 +19,6 @@ import PropTypes from 'prop-types';
 // joining classNames together."
 import classNames from 'classnames';
 
-// ### shortid
-// [npmjs.com/package/shortid](https://www.npmjs.com/package/shortid)
-// shortid is a short, non-sequential, url-friendly, unique id generator
-import shortid from 'shortid';
-
 import Button from '../button';
 
 // ## Children
@@ -35,6 +30,7 @@ import Label from '../utilities/label';
 import checkProps from './check-props';
 
 import { INPUT } from '../../utilities/constants';
+import generateId from '../../utilities/generate-id';
 import componentDoc from './component.json';
 import FieldLevelHelpTooltip from '../tooltip/private/field-level-help-tooltip';
 
@@ -321,9 +317,9 @@ class Input extends React.Component {
 		// `checkProps` issues warnings to developers about properties (similar to React's built in development tools)
 		checkProps(INPUT, props, componentDoc);
 
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 		if (props.errorText) {
-			this.generatedErrorId = shortid.generate();
+			this.generatedErrorId = generateId();
 		}
 	}
 

--- a/components/location-map/index.jsx
+++ b/components/location-map/index.jsx
@@ -6,13 +6,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-// ### shortid
-// [npmjs.com/package/shortid](https://www.npmjs.com/package/shortid)
-// shortid is a short, non-sequential, url-friendly, unique id generator
-import shortid from 'shortid';
 
 import Icon from '../icon';
 import { LOCATION_MAP } from '../../utilities/constants';
+import generateId from '../../utilities/generate-id';
 
 const displayName = LOCATION_MAP;
 
@@ -102,7 +99,7 @@ const defaultProps = {
 class LocationMap extends React.Component {
 	constructor(props) {
 		super(props);
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 	}
 
 	/**

--- a/components/menu-dropdown/menu-dropdown.jsx
+++ b/components/menu-dropdown/menu-dropdown.jsx
@@ -15,8 +15,6 @@ import classNames from 'classnames';
 import isFunction from 'lodash.isfunction';
 import isEqual from 'lodash.isequal';
 
-import shortid from 'shortid';
-
 // ### Children
 import Dialog from '../utilities/dialog';
 import List from '../utilities/menu-list';
@@ -32,8 +30,9 @@ import checkProps from './check-props';
 import componentDoc from './component.json';
 
 import EventUtil from '../../utilities/event';
-import KeyBuffer from '../../utilities/key-buffer';
+import generateId from '../../utilities/generate-id';
 import keyboardNavigate from '../../utilities/keyboard-navigate';
+import KeyBuffer from '../../utilities/key-buffer';
 import KEYS from '../../utilities/key-code';
 import {
 	MENU_DROPDOWN,
@@ -435,7 +434,7 @@ class MenuDropdown extends React.Component {
 		// `checkProps` issues warnings to developers about properties (similar to React's built in development tools)
 		checkProps(MENU_DROPDOWN, props, componentDoc);
 
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 
 		const currentSelectedIndices = this.getCurrentSelectedIndices(props);
 
@@ -913,7 +912,7 @@ class MenuDropdown extends React.Component {
 			} else if (child) {
 				const clonedCustomContent = React.cloneElement(child, {
 					onClick: this.handleClickCustomContent,
-					key: shortid.generate(),
+					key: generateId(),
 				});
 				// eslint-disable-next-line fp/no-mutating-methods
 				customContentWithListPropInjection.push(clonedCustomContent);

--- a/components/menu-picklist/index.jsx
+++ b/components/menu-picklist/index.jsx
@@ -25,11 +25,6 @@ import isFunction from 'lodash.isfunction';
 // joining classNames together."
 import classNames from 'classnames';
 
-// ### shortid
-// [npmjs.com/package/shortid](https://www.npmjs.com/package/shortid)
-// shortid is a short, non-sequential, url-friendly, unique id generator
-import shortid from 'shortid';
-
 // This component's `checkProps` which issues warnings to developers about properties
 // when in development mode (similar to React's built in development tools)
 import checkProps from './check-props';
@@ -42,8 +37,9 @@ import ListItemLabel from '../utilities/menu-list/item-label';
 import Pill from '../utilities/pill';
 
 import EventUtil from '../../utilities/event';
-import KeyBuffer from '../../utilities/key-buffer';
+import generateId from '../../utilities/generate-id';
 import keyboardNavigate from '../../utilities/keyboard-navigate';
+import KeyBuffer from '../../utilities/key-buffer';
 import KEYS from '../../utilities/key-code';
 import { MENU_PICKLIST } from '../../utilities/constants';
 import { IconSettingsContext } from '../icon-settings';
@@ -200,9 +196,9 @@ const MenuPicklist = createReactClass({
 		// `checkProps` issues warnings to developers about properties (similar to React's built in development tools)
 		checkProps(MENU_PICKLIST, this.props);
 
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 		if (this.props.errorText) {
-			this.generatedErrorId = shortid.generate();
+			this.generatedErrorId = generateId();
 		}
 
 		if (typeof window !== 'undefined') {

--- a/components/modal/index.jsx
+++ b/components/modal/index.jsx
@@ -13,11 +13,6 @@ import ReactDOM from 'react-dom';
 import classNames from 'classnames';
 import ReactModal from 'react-modal';
 
-// ### shortid
-// [npmjs.com/package/shortid](https://www.npmjs.com/package/shortid)
-// shortid is a short, non-sequential, url-friendly, unique id generator
-import shortid from 'shortid';
-
 // This component's `checkProps` which issues warnings to developers about properties when in development mode (similar to React's built in development tools)
 import checkProps from './check-props';
 
@@ -26,6 +21,7 @@ import checkAppElementIsSet from '../../utilities/warning/check-app-element-set'
 import Button from '../button';
 
 import { MODAL } from '../../utilities/constants';
+import generateId from '../../utilities/generate-id';
 import componentDoc from './component.json';
 
 const documentDefined = typeof document !== 'undefined';
@@ -202,7 +198,7 @@ class Modal extends React.Component {
 			this
 		);
 
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 		checkProps(MODAL, props, componentDoc);
 		if (props.ariaHideApp) {
 			checkAppElementIsSet();

--- a/components/panel/filtering/list.jsx
+++ b/components/panel/filtering/list.jsx
@@ -13,13 +13,10 @@ import React from 'react';
 
 import PropTypes from 'prop-types';
 
-// ### shortid
-// [npmjs.com/package/shortid](https://www.npmjs.com/package/shortid)
-// shortid is a short, non-sequential, url-friendly, unique id generator
-import shortid from 'shortid';
-
 // ## Constants
 import { PANEL_FILTER_LIST } from '../../../utilities/constants';
+
+import generateId from '../../../utilities/generate-id';
 
 /**
  * A list of Filters. This is a higher order component for filters that decorates the filter to work within a Filtering Panel. It also adds support for a Filter error label.
@@ -38,8 +35,7 @@ class PanelFilterList extends React.Component {
 
 	constructor(props) {
 		super(props);
-
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 	}
 
 	render() {

--- a/components/pill-container/index.jsx
+++ b/components/pill-container/index.jsx
@@ -6,10 +6,10 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import shortid from 'shortid';
 import SelectedListBox from './private/selected-listbox';
 
 import { PILL_CONTAINER } from '../../utilities/constants';
+import generateId from '../../utilities/generate-id';
 
 const propTypes = {
 	/**
@@ -116,7 +116,7 @@ class PillContainer extends React.Component {
 		};
 
 		this.activeSelectedOptionRef = null;
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 		this.preserveFocus = false;
 	}
 

--- a/components/popover/popover.jsx
+++ b/components/popover/popover.jsx
@@ -20,11 +20,6 @@ import classNames from 'classnames';
 // ### isFunction
 import isFunction from 'lodash.isfunction';
 
-// ### shortid
-// [npmjs.com/package/shortid](https://www.npmjs.com/package/shortid)
-// shortid is a short, non-sequential, url-friendly, unique id generator
-import shortid from 'shortid';
-
 // This component's `checkProps` which issues warnings to developers about properties when in development mode (similar to React's built in development tools)
 import checkProps from './check-props';
 import componentDoc from './component.json';
@@ -41,6 +36,7 @@ import keyboardNavigableDialog from '../../utilities/keyboard-navigable-dialog';
 
 import KEYS from '../../utilities/key-code';
 import { POPOVER } from '../../utilities/constants';
+import generateId from '../../utilities/generate-id';
 import { IconSettingsContext } from '../icon-settings';
 
 const documentDefined = typeof document !== 'undefined';
@@ -278,7 +274,7 @@ class Popover extends React.Component {
 	constructor(props) {
 		super(props);
 
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 		// `checkProps` issues warnings to developers about properties (similar to React's built in development tools)
 		checkProps(POPOVER, props, componentDoc);
 	}

--- a/components/progress-bar/index.jsx
+++ b/components/progress-bar/index.jsx
@@ -8,11 +8,8 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import assign from 'lodash.assign';
 
-// ### shortid
-// [npmjs.com/package/shortid](https://www.npmjs.com/package/shortid)
-// shortid is a short, non-sequential, url-friendly, unique id generator
-import shortid from 'shortid';
 import { PROGRESS_BAR } from '../../utilities/constants';
+import generateId from '../../utilities/generate-id';
 
 const propTypes = {
 	/**
@@ -87,7 +84,7 @@ class ProgressBar extends React.Component {
 	constructor(props) {
 		super(props);
 
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 	}
 
 	/**

--- a/components/progress-indicator/index.jsx
+++ b/components/progress-indicator/index.jsx
@@ -8,11 +8,8 @@ import PropTypes from 'prop-types';
 
 import find from 'lodash.find';
 
-// ### shortid
-// [npmjs.com/package/shortid](https://www.npmjs.com/package/shortid)
-// shortid is a short, non-sequential, url-friendly, unique id generator
-import shortid from 'shortid';
 import { PROGRESS_INDICATOR } from '../../utilities/constants';
+import generateId from '../../utilities/generate-id';
 
 // Child components
 import Step from './private/step';
@@ -182,7 +179,7 @@ class ProgressIndicator extends React.Component {
 	constructor(props) {
 		super(props);
 
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 	}
 
 	componentWillUnmount() {

--- a/components/radio-group/index.jsx
+++ b/components/radio-group/index.jsx
@@ -9,10 +9,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-import shortid from 'shortid';
 import assign from 'lodash.assign';
 
 import { RADIO_GROUP } from '../../utilities/constants';
+import generateId from '../../utilities/generate-id';
 
 const propTypes = {
 	/**
@@ -86,8 +86,8 @@ class RadioGroup extends React.Component {
 	constructor(props) {
 		super(props);
 
-		this.generatedName = shortid.generate();
-		this.generatedErrorId = shortid.generate();
+		this.generatedName = generateId();
+		this.generatedErrorId = generateId();
 	}
 
 	getErrorId() {

--- a/components/radio/index.jsx
+++ b/components/radio/index.jsx
@@ -3,11 +3,11 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import shortid from 'shortid';
 import classNames from 'classnames';
 
 import KEYS from '../../utilities/key-code';
 import { RADIO } from '../../utilities/constants';
+import generateId from '../../utilities/generate-id';
 import getAriaProps from '../../utilities/get-aria-props';
 import getDataProps from '../../utilities/get-data-props';
 import Swatch from '../../components/color-picker/private/swatch';
@@ -153,7 +153,7 @@ class Radio extends React.Component {
 		super(props);
 		this.preventDuplicateChangeEvent = false;
 		checkProps(RADIO, this.props, componentDoc);
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 	}
 
 	getId() {

--- a/components/setup-assistant/index.jsx
+++ b/components/setup-assistant/index.jsx
@@ -7,15 +7,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-// ### shortid
-// [npmjs.com/package/shortid](https://www.npmjs.com/package/shortid)
-// shortid is a short, non-sequential, url-friendly, unique id generator
-import shortid from 'shortid';
-
 // This component's `checkProps` which issues warnings to developers about properties
 // when in development mode (similar to React's built in development tools)
 import checkProps from './check-props';
 import componentDoc from './component.json';
+
+import generateId from '../../utilities/generate-id';
 
 import {
 	SETUP_ASSISTANT,
@@ -65,7 +62,7 @@ class SetupAssistant extends React.Component {
 	constructor(props) {
 		super(props);
 
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 	}
 
 	componentDidMount() {

--- a/components/setup-assistant/step.jsx
+++ b/components/setup-assistant/step.jsx
@@ -5,10 +5,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-// ### shortid
-// [npmjs.com/package/shortid](https://www.npmjs.com/package/shortid)
-// shortid is a short, non-sequential, url-friendly, unique id generator
-import shortid from 'shortid';
 import assign from 'lodash.assign';
 
 // This component's `checkProps` which issues warnings to developers about properties
@@ -20,6 +16,7 @@ import Button from '../button';
 import ProgressRing from '../progress-ring';
 
 import { ICON, SETUP_ASSISTANT_STEP } from '../../utilities/constants';
+import generateId from '../../utilities/generate-id';
 
 const propTypes = {
 	/**
@@ -104,7 +101,7 @@ const defaultProps = {
 class Step extends React.Component {
 	constructor(props) {
 		super(props);
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 		this.state = {
 			isOpen: props.isOpen || false,
 		};

--- a/components/slider/index.jsx
+++ b/components/slider/index.jsx
@@ -15,14 +15,10 @@ import isFunction from 'lodash.isfunction';
 // ### classNames
 import classNames from 'classnames';
 
-// ### shortid
-// [npmjs.com/package/shortid](https://www.npmjs.com/package/shortid)
-// shortid is a short, non-sequential, url-friendly, unique id generator
-import shortid from 'shortid';
-
 import { SLIDER } from '../../utilities/constants';
 
 import getAriaProps from '../../utilities/get-aria-props';
+import generateId from '../../utilities/generate-id';
 
 const propTypes = {
 	/**
@@ -128,10 +124,10 @@ class Slider extends React.Component {
 	constructor(props) {
 		super(props);
 
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 
 		if (this.props.errorText) {
-			this.generatedErrorId = shortid.generate();
+			this.generatedErrorId = generateId();
 		}
 	}
 

--- a/components/split-view/index.jsx
+++ b/components/split-view/index.jsx
@@ -3,12 +3,12 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import shortid from 'shortid';
 import classNames from 'classnames';
 
 import ToggleButton, { TOGGLE_BUTTON_WIDTH } from './private/toggle-button';
 
 import { SPLIT_VIEW } from '../../utilities/constants';
+import generateId from '../../utilities/generate-id';
 
 const propTypes = {
 	/**
@@ -93,7 +93,7 @@ class SplitView extends React.Component {
 			isOpen: typeof props.isOpen === 'boolean' ? props.isOpen : true,
 		};
 
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 	}
 
 	getId() {

--- a/components/tabs/index.jsx
+++ b/components/tabs/index.jsx
@@ -12,10 +12,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-// ### shortid
-// `shortid` is a short, non-sequential, url-friendly, unique id generator. It is used here to provide unique strings for the HTML attribute `id` on the Tabs components. It is only used if the `id` prop is not provided on the man <Tabs /> component.
-import shortid from 'shortid';
-
 // ### classNames
 import classNames from 'classnames';
 
@@ -29,6 +25,7 @@ import TabPanel from './private/tab-panel';
 
 // ## Constants
 import { TABS } from '../../utilities/constants';
+import generateId from '../../utilities/generate-id';
 
 // ### Event Helpers
 import KEYS from '../../utilities/key-code';
@@ -139,7 +136,7 @@ class Tabs extends React.Component {
 		this.tabs = [];
 
 		// If no `id` is supplied in the props we generate one. An HTML ID is _required_ for several elements in a tabs component in order to leverage ARIA attributes for accessibility.
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 		this.flavor = this.getVariant();
 		this.state = {
 			selectedIndex: props.defaultSelectedIndex,

--- a/components/textarea/index.jsx
+++ b/components/textarea/index.jsx
@@ -21,17 +21,13 @@ import PropTypes from 'prop-types';
 // joining classNames together."
 import classNames from 'classnames';
 
-// ### shortid
-// [npmjs.com/package/shortid](https://www.npmjs.com/package/shortid)
-// shortid is a short, non-sequential, url-friendly, unique id generator
-import shortid from 'shortid';
-
 // ## Children
 // This component's `checkProps` which issues warnings to developers about properties when in development mode (similar to React's built in development tools)
 import checkProps from './check-props';
 
 import { TEXTAREA } from '../../utilities/constants';
 import getAriaProps from '../../utilities/get-aria-props';
+import generateId from '../../utilities/generate-id';
 
 import componentDoc from './component.json';
 
@@ -214,9 +210,9 @@ class Textarea extends React.Component {
 		// `checkProps` issues warnings to developers about properties (similar to React's built in development tools)
 		checkProps(TEXTAREA, props, componentDoc);
 
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 		if (props.errorText) {
-			this.generatedErrorId = shortid.generate();
+			this.generatedErrorId = generateId();
 		}
 	}
 

--- a/components/tooltip/index.jsx
+++ b/components/tooltip/index.jsx
@@ -8,13 +8,9 @@ import PropTypes from 'prop-types';
 
 import classNames from 'classnames';
 
-// ### shortid
-// [npmjs.com/package/shortid](https://www.npmjs.com/package/shortid)
-// shortid is a short, non-sequential, url-friendly, unique id generator
-import shortid from 'shortid';
-
 import EventUtil from '../../utilities/event';
 import { POPOVER_TOOLTIP } from '../../utilities/constants';
+import generateId from '../../utilities/generate-id';
 
 import Dialog from '../utilities/dialog';
 import Icon from '../icon';
@@ -180,7 +176,7 @@ class Tooltip extends React.Component {
 		// `checkProps` issues warnings to developers about properties (similar to React's built in development tools)
 		checkProps(POPOVER_TOOLTIP, props, componentDoc);
 
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 	}
 
 	componentWillUnmount() {

--- a/components/tree/private/branch.jsx
+++ b/components/tree/private/branch.jsx
@@ -4,7 +4,6 @@
 // # Tree Branch Component
 import React from 'react';
 import PropTypes from 'prop-types';
-import shortid from 'shortid';
 
 // Child components
 import Item from './item';
@@ -12,6 +11,7 @@ import RenderInitialBranch from './render-initial-branch';
 import RenderBranch from './render-branch';
 
 import { TREE_BRANCH } from '../../../utilities/constants';
+import generateId from '../../../utilities/generate-id';
 
 /**
  * A Tree Item is a non-branching node in a hierarchical list.
@@ -58,7 +58,7 @@ const Branch = (props) => {
 					<Item
 						label={node.label}
 						htmlId={htmlId}
-						key={shortid.generate()}
+						key={generateId()}
 						level={level + 1}
 						node={node}
 						flattenedNodes={props.flattenedNodes}

--- a/components/vertical-navigation/index.jsx
+++ b/components/vertical-navigation/index.jsx
@@ -14,14 +14,11 @@ import PropTypes from 'prop-types';
 // joining classNames together.'
 import classNames from 'classnames';
 
-// ### shortid
-// [npmjs.com/package/shortid](https://www.npmjs.com/package/shortid)
-// shortid is a short, non-sequential, url-friendly, unique id generator
-import shortid from 'shortid';
 import componentDoc from './component.json';
 import checkProps from './check-props';
 
 import { VERTICAL_NAVIGATION } from '../../utilities/constants';
+import generateId from '../../utilities/generate-id';
 
 // Child components
 import Item from './private/item';
@@ -64,7 +61,7 @@ class VerticalNavigation extends React.Component {
 	constructor(props) {
 		super(props);
 
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 		checkProps(VERTICAL_NAVIGATION, props, componentDoc);
 	}
 

--- a/components/visual-picker/index.jsx
+++ b/components/visual-picker/index.jsx
@@ -6,11 +6,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-// ### shortid
-// [npmjs.com/package/shortid](https://www.npmjs.com/package/shortid)
-// shortid is a short, non-sequential, url-friendly, unique id generator
-import shortid from 'shortid';
 import { VISUAL_PICKER } from '../../utilities/constants';
+import generateId from '../../utilities/generate-id';
 
 const propTypes = {
 	/**
@@ -64,7 +61,7 @@ class VisualPicker extends React.Component {
 	constructor(props) {
 		super(props);
 
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 	}
 
 	render() {

--- a/components/welcome-mat/index.jsx
+++ b/components/welcome-mat/index.jsx
@@ -6,10 +6,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-// ### shortid
-// [npmjs.com/package/shortid](https://www.npmjs.com/package/shortid)
-// shortid is a short, non-sequential, url-friendly, unique id generator
-import shortid from 'shortid';
 
 import assign from 'lodash.assign';
 
@@ -17,6 +13,7 @@ import Modal from '../modal';
 import ProgressBar from '../progress-bar';
 
 import { WELCOME_MAT } from '../../utilities/constants';
+import generateId from '../../utilities/generate-id';
 
 const displayName = WELCOME_MAT;
 
@@ -91,7 +88,7 @@ class WelcomeMat extends React.Component {
 	constructor(props) {
 		super(props);
 
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 		this.getCount();
 	}
 

--- a/components/welcome-mat/info-badge.jsx
+++ b/components/welcome-mat/info-badge.jsx
@@ -5,14 +5,10 @@
 // Based on SLDS v2.4.0
 import React from 'react';
 import PropTypes from 'prop-types';
-// ### shortid
-// [npmjs.com/package/shortid](https://www.npmjs.com/package/shortid)
-// shortid is a short, non-sequential, url-friendly, unique id generator
-import shortid from 'shortid';
-
 import Icon from '../icon';
 
 import { WELCOME_MAT_BADGE } from '../../utilities/constants';
+import generateId from '../../utilities/generate-id';
 
 const displayName = WELCOME_MAT_BADGE;
 
@@ -62,7 +58,7 @@ class InfoBadge extends React.Component {
 	constructor(props) {
 		super(props);
 
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 	}
 
 	/**

--- a/components/welcome-mat/tile.jsx
+++ b/components/welcome-mat/tile.jsx
@@ -6,14 +6,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-// ### shortid
-// [npmjs.com/package/shortid](https://www.npmjs.com/package/shortid)
-// shortid is a short, non-sequential, url-friendly, unique id generator
-import shortid from 'shortid';
 
 import Icon from '../icon';
 
 import { WELCOME_MAT_TILE } from '../../utilities/constants';
+import generateId from '../../utilities/generate-id';
 
 const displayName = WELCOME_MAT_TILE;
 
@@ -84,7 +81,7 @@ class Tile extends React.Component {
 	constructor(props) {
 		super(props);
 
-		this.generatedId = shortid.generate();
+		this.generatedId = generateId();
 	}
 
 	/**

--- a/docs/codebase-overview.md
+++ b/docs/codebase-overview.md
@@ -255,9 +255,9 @@ Internal architecture should promote readability and easy maintainance.
 ```javascript
 import React from 'react';
 import PropTypes from 'prop-types';
-import shortid from 'shortid';
 import checkProps from './check-props';
 import { EXTERNAL_CONSTANT } from '../../utilities/constants';
+import generateId from '../../utilities/generate-id';
 
 const propTypes = {
 	/**
@@ -281,7 +281,7 @@ class DemoComponent extends React.Component {
 		super(props);
 
 		// useful for unique DOM IDs
-		this.generatedId = this.props.id || shortid.generate();
+		this.generatedId = this.props.id || generateId();
 
 		// initial state
 		this.state = {};

--- a/utilities/generate-id.js
+++ b/utilities/generate-id.js
@@ -1,0 +1,29 @@
+import shortid from 'shortid';
+
+/**
+ * Generate unique ID that is also a valid CSS identifier.
+ * @returns {string} The unique ID.
+ */
+function generateId() {
+	/**
+	 * `shortid.generate()` by itself will generates IDs that
+	 * are not always valid [1] CSS identifiers (e.g. will start
+	 * with a digit). So, when other parts of the codebase will
+	 * use those IDs as a selector, a `SyntaxError`² will be thrown
+	 * (i.e. `'#...' is not a valid selector`).
+	 *
+	 * The `slds-` prefix is used so to keep things simple.
+	 * `shortid.characters()` requires "a string of all 64 unique
+	 * characters"³, which means that in order to generate valid
+	 * CSS identifiers a-z, A-Z, and some "ISO 10646 characters
+	 * U+00A0 and higher"¹ will need to be included.
+	 *
+	 * [1] https://www.w3.org/TR/CSS21/syndata.html#value-def-identifier
+	 * [2] https://dom.spec.whatwg.org/#selectors
+	 * [3] https://github.com/dylang/shortid/blob/937ce2c8dd7001baec1785cb8dce6e6fe1bcf61f/README.md#shortidcharactersstring
+	 */
+
+	return `slds-${shortid.generate()}`;
+}
+
+export default generateId;


### PR DESCRIPTION
### Description

* Move the logic of generating the ID into its own utility function.

* Ensure the utility function generates IDs that are valid CSS identifiers.

  `shortid.generate()` by itself will generates IDs that are not always valid [^1] CSS identifiers (e.g. will start with a digit). So, when other parts of the codebase will use those IDs as a selector, a `SyntaxError` [^2] will be thrown (i.e. `'#...' is not a valid selector`).

  The `slds-` prefix is used so to keep things simple. `shortid.characters()` requires _"a string of all 64 unique characters"_ [^3], which means that in order to generate valid CSS identifiers a-z, A-Z, and some _"ISO 10646 characters U+00A0 and higher"_ [^1] will need to be included.
 

[^1]: From https://www.w3.org/TR/CSS21/syndata.html#value-def-identifier
  In CSS, identifiers (including element names, classes, and IDs in selectors) can contain only the characters [a-zA-Z0-9] and ISO 10646 characters U+00A0 and higher, plus the hyphen (-) and the underscore (_); they cannot start with a digit, two hyphens, or a hyphen followed by a digit. "

[^2]: https://dom.spec.whatwg.org/#selectors

[^3]: https://github.com/dylang/shortid/blob/937ce2c8dd7001baec1785cb8dce6e6fe1bcf61f/README.md#shortidcharactersstring

---

### CONTRIBUTOR checklist (do not remove)
Please complete for every pull request

* [x] First-time contributors should sign the Contributor License Agreement. It's a fancy way of saying that you are giving away your contribution to this project. If you haven't before, wait a few minutes and a bot will comment on this pull request with instructions.
* [x] `npm run lint:fix` has been run and linting passes.
* [x] Mocha, Jest (Storyshots), and `components/component-docs.json` CI tests pass (`npm test`).
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [x] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### REVIEWER checklist (do not remove)

* [ ] CircleCI tests pass. This includes linting, Mocha, Jest, Storyshots, and `components/component-docs.json` tests.
* [ ] Tests have been added for new props to prevent regressions in the future. See [readme](https://github.com/salesforce/design-system-react/blob/master/tests/README.md).
* [ ] Review the appropriate Storybook stories. Open [http://localhost:9001/](http://localhost:9001/).
* [ ] The Accessibility panel of each Storybook story has 0 violations (aXe). Open [http://localhost:9001/](http://localhost:9001/).
* [ ] Review tests are passing in the browser. Open [http://localhost:8001/](http://localhost:8001/).
* [ ] Review markup conforms to [SLDS](https://www.lightningdesignsystem.com/) by looking at [DOM snapshot strings](https://facebook.github.io/jest/docs/en/snapshot-testing.html).
###### Required only if there are markup / UX changes
* [ ] Add year-first date and commit SHA to `last-slds-markup-review` in `package.json` and push.
* [ ] Request a review of the deployed Heroku app by the Salesforce UX Accessibility Team.
* [ ] Add year-first review date, and commit SHA, `last-accessibility-review`, to `package.json` and push.
* [ ] While the contributor's branch is checked out, run `npm run local-update` within locally cloned [site repo](https://github.com/salesforce-ux/design-system-react-site) to confirm the site will function correctly at the next release.
