### PR TITLE
@W-16255012 : Updated combobox.jsx for combobox to open and close on enter key pressed

### DIFF
--- a/components/combobox/combobox.jsx
+++ b/components/combobox/combobox.jsx
@@ -751,6 +751,17 @@ class Combobox extends React.Component {
 	};
 
 	handleInputSubmit = (event) => {
+		if (
+			this.state.activeOption === undefined &&
+			this.state.activeOptionIndex === -1
+		) {
+			if (this.state.isOpen === false) {
+				if (!event.shiftKey) {
+					this.openDialog();
+				}
+			} else this.handleRequestClose(event, {});
+		}
+
 		if (this.state.activeOption && this.state.activeOption.disabled) {
 			return;
 		}


### PR DESCRIPTION
The combobox should be accessible via the enter key pressed just like how its accessible with the down key pressed.
