### PR TITLE
Revert "Update package publish"

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,10 +7,6 @@ on:
   release:
     types: [created]
 
-permissions:
-  id-token: write  # Required for OIDC
-  contents: read
-
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
@@ -25,3 +21,5 @@ jobs:
       - run: npm run build:npm-package
       - name: Publish package on NPM 📦
         run: npm publish .tmp-npm --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Reverts salesforce/design-system-react#3187 in order to release via GH Actions without upgrading to Node 24. Will re-evaluate OIDC at a later time.